### PR TITLE
Move pgUnionAll pagination to runtime

### DIFF
--- a/.changeset/eighty-clocks-pay.md
+++ b/.changeset/eighty-clocks-pay.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Unary steps will no longer be pushed down in step diagrams. Fix types for
+connection().

--- a/.changeset/nervous-tomatoes-remain.md
+++ b/.changeset/nervous-tomatoes-remain.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+pgUnionAll now performs pagination logic at runtime rather than plantime.

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-default-description.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-default-description.deopt.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,20 +22,26 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant52 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant53 --> Lambda38
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda38 --> Access39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object43 --> Lambda44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant54 --> Lambda49
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant49 & Constant50 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant50 & Constant51 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -37,22 +49,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈2] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect23
-    Object42{{"Object[42∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
+    Object15 & PgClassExpression22 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Constant51 --> Lambda35
-    Constant52 --> Lambda38
-    Object42 --> Lambda43
-    Constant53 --> Lambda48
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -67,13 +69,13 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-default-description"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant39,Constant40,Constant41,Constant49,Constant50,Constant51,Constant52,Constant53 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 49, 50, 51, 52, 39, 40, 41, 53<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant50,Constant51,Constant52,Constant53,Constant54 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 50, 51, 35, 39, 44, 49<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 51, 52, 39, 40, 41, 53, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 35, 38, 48, 42, 43<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 35, 39, 44, 49, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Lambda35,Lambda38,Object42,Lambda43,Lambda48 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-default-description.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-default-description.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,20 +22,26 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant52 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant53 --> Lambda38
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda38 --> Access39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object43 --> Lambda44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant54 --> Lambda49
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant49 & Constant50 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant50 & Constant51 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -37,22 +49,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈2] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect23
-    Object42{{"Object[42∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
+    Object15 & PgClassExpression22 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Constant51 --> Lambda35
-    Constant52 --> Lambda38
-    Object42 --> Lambda43
-    Constant53 --> Lambda48
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -67,13 +69,13 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-default-description"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant39,Constant40,Constant41,Constant49,Constant50,Constant51,Constant52,Constant53 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 49, 50, 51, 52, 39, 40, 41, 53<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant50,Constant51,Constant52,Constant53,Constant54 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 50, 51, 35, 39, 44, 49<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 51, 52, 39, 40, 41, 53, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 35, 38, 48, 42, 43<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 35, 39, 44, 49, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Lambda35,Lambda38,Object42,Lambda43,Lambda48 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.deopt.mermaid
@@ -9,132 +9,157 @@ graph TD
 
 
     %% plan dependencies
-    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object266{{"Object[266∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant264{{"Constant[264∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda258 & Constant262 & Constant263 & Constant264 --> Object265
-    Object279{{"Object[279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant276{{"Constant[276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant277{{"Constant[277∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant278{{"Constant[278∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda258 & Constant276 & Constant277 & Constant278 --> Object279
-    Object293{{"Object[293∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant290{{"Constant[290∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant291{{"Constant[291∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant292{{"Constant[292∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda258 & Constant290 & Constant291 & Constant292 --> Object293
-    Object307{{"Object[307∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant306{{"Constant[306∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda258 & Constant304 & Constant305 & Constant306 --> Object307
-    Object321{{"Object[321∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant318{{"Constant[318∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant319{{"Constant[319∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant320{{"Constant[320∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda258 & Constant318 & Constant319 & Constant320 --> Object321
-    Object349{{"Object[349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant346 & Constant347 & Constant264 --> Object349
-    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant360{{"Constant[360∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant360 & Constant361 & Constant278 --> Object363
-    Object377{{"Object[377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant374 & Constant375 & Constant292 --> Object377
-    Object391{{"Object[391∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant388 & Constant389 & Constant306 --> Object391
-    Object405{{"Object[405∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant402 & Constant403 & Constant320 --> Object405
-    Object433{{"Object[433∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant430 & Constant431 & Constant264 --> Object433
-    Object447{{"Object[447∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant444 & Constant445 & Constant278 --> Object447
+    Constant263{{"Constant[263∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant264{{"Constant[264∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant265{{"Constant[265∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda258 & Constant263 & Constant264 & Constant265 --> Object266
+    Object281{{"Object[281∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda258 & Constant278 & Constant279 & Constant280 --> Object281
+    Object296{{"Object[296∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant294{{"Constant[294∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant295{{"Constant[295∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda258 & Constant293 & Constant294 & Constant295 --> Object296
+    Object311{{"Object[311∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant308{{"Constant[308∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant309{{"Constant[309∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant310{{"Constant[310∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda258 & Constant308 & Constant309 & Constant310 --> Object311
+    Object326{{"Object[326∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant324{{"Constant[324∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant325{{"Constant[325∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda258 & Constant323 & Constant324 & Constant325 --> Object326
+    Object341{{"Object[341∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant338{{"Constant[338∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant339{{"Constant[339∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant340{{"Constant[340∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda258 & Constant338 & Constant339 & Constant340 --> Object341
+    Object356{{"Object[356∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant353{{"Constant[353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant354{{"Constant[354∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant353 & Constant354 & Constant265 --> Object356
+    Object371{{"Object[371∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant369{{"Constant[369∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant368 & Constant369 & Constant280 --> Object371
+    Object386{{"Object[386∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant384{{"Constant[384∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant383 & Constant384 & Constant295 --> Object386
+    Object401{{"Object[401∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant398 & Constant399 & Constant310 --> Object401
+    Object416{{"Object[416∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant414{{"Constant[414∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant413 & Constant414 & Constant325 --> Object416
+    Object431{{"Object[431∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant428{{"Constant[428∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant428 & Constant429 & Constant340 --> Object431
+    Object446{{"Object[446∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant443 & Constant444 & Constant265 --> Object446
     Object461{{"Object[461∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant458{{"Constant[458∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant459{{"Constant[459∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant458 & Constant459 & Constant292 --> Object461
-    Object475{{"Object[475∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant473{{"Constant[473∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant472 & Constant473 & Constant306 --> Object475
-    Object489{{"Object[489∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant487{{"Constant[487∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant486 & Constant487 & Constant320 --> Object489
-    Object517{{"Object[517∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant514{{"Constant[514∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant515{{"Constant[515∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant514 & Constant515 & Constant264 --> Object517
-    Object531{{"Object[531∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant528{{"Constant[528∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant529{{"Constant[529∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant528 & Constant529 & Constant278 --> Object531
-    Object545{{"Object[545∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant542{{"Constant[542∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant542 & Constant543 & Constant292 --> Object545
-    Object559{{"Object[559∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant556 & Constant557 & Constant306 --> Object559
-    Object573{{"Object[573∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant570{{"Constant[570∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant571{{"Constant[571∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant570 & Constant571 & Constant320 --> Object573
-    Object601{{"Object[601∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant598{{"Constant[598∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant599{{"Constant[599∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant598 & Constant599 & Constant264 --> Object601
-    Object615{{"Object[615∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant612{{"Constant[612∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant613{{"Constant[613∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant612 & Constant613 & Constant278 --> Object615
-    Object629{{"Object[629∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant626{{"Constant[626∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant627{{"Constant[627∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant626 & Constant627 & Constant292 --> Object629
-    Object643{{"Object[643∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant640{{"Constant[640∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant641{{"Constant[641∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant640 & Constant641 & Constant306 --> Object643
-    Object657{{"Object[657∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant654{{"Constant[654∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant655{{"Constant[655∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant654 & Constant655 & Constant320 --> Object657
-    Object685{{"Object[685∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant682{{"Constant[682∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant683{{"Constant[683∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant682 & Constant683 & Constant264 --> Object685
-    Object699{{"Object[699∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant696{{"Constant[696∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant697{{"Constant[697∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant696 & Constant697 & Constant278 --> Object699
-    Object713{{"Object[713∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant710{{"Constant[710∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant711{{"Constant[711∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant710 & Constant711 & Constant292 --> Object713
-    Object727{{"Object[727∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant724{{"Constant[724∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant725{{"Constant[725∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant724 & Constant725 & Constant306 --> Object727
-    Object741{{"Object[741∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant738{{"Constant[738∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant739{{"Constant[739∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant738 & Constant739 & Constant320 --> Object741
+    Constant459{{"Constant[459∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant458 & Constant459 & Constant280 --> Object461
+    Object476{{"Object[476∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant473 & Constant474 & Constant295 --> Object476
+    Object491{{"Object[491∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant488{{"Constant[488∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant489{{"Constant[489∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant488 & Constant489 & Constant310 --> Object491
+    Object506{{"Object[506∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant503{{"Constant[503∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant504{{"Constant[504∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant503 & Constant504 & Constant325 --> Object506
+    Object521{{"Object[521∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant518{{"Constant[518∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant519{{"Constant[519∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant518 & Constant519 & Constant340 --> Object521
+    Object536{{"Object[536∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant533{{"Constant[533∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant534{{"Constant[534∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant533 & Constant534 & Constant265 --> Object536
+    Object551{{"Object[551∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant548{{"Constant[548∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant549{{"Constant[549∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant548 & Constant549 & Constant280 --> Object551
+    Object566{{"Object[566∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant563{{"Constant[563∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant564{{"Constant[564∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant563 & Constant564 & Constant295 --> Object566
+    Object581{{"Object[581∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant579{{"Constant[579∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant578 & Constant579 & Constant310 --> Object581
+    Object596{{"Object[596∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant593{{"Constant[593∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant594{{"Constant[594∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant593 & Constant594 & Constant325 --> Object596
+    Object611{{"Object[611∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant608{{"Constant[608∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant609{{"Constant[609∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant608 & Constant609 & Constant340 --> Object611
+    Object626{{"Object[626∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant623 & Constant624 & Constant265 --> Object626
+    Object641{{"Object[641∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant638{{"Constant[638∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant639{{"Constant[639∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant638 & Constant639 & Constant280 --> Object641
+    Object656{{"Object[656∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant653{{"Constant[653∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant654{{"Constant[654∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant653 & Constant654 & Constant295 --> Object656
+    Object671{{"Object[671∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant668{{"Constant[668∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant669{{"Constant[669∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant668 & Constant669 & Constant310 --> Object671
+    Object686{{"Object[686∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant683{{"Constant[683∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant684{{"Constant[684∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant683 & Constant684 & Constant325 --> Object686
+    Object701{{"Object[701∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant698{{"Constant[698∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant699{{"Constant[699∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant698 & Constant699 & Constant340 --> Object701
+    Object716{{"Object[716∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant713{{"Constant[713∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant714{{"Constant[714∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant713 & Constant714 & Constant265 --> Object716
+    Object731{{"Object[731∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant728{{"Constant[728∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant729{{"Constant[729∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant728 & Constant729 & Constant280 --> Object731
+    Object746{{"Object[746∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant743{{"Constant[743∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant744{{"Constant[744∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant743 & Constant744 & Constant295 --> Object746
+    Object761{{"Object[761∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant758{{"Constant[758∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant759{{"Constant[759∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant758 & Constant759 & Constant310 --> Object761
+    Object776{{"Object[776∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant773{{"Constant[773∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant774{{"Constant[774∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant773 & Constant774 & Constant325 --> Object776
+    Object791{{"Object[791∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant788{{"Constant[788∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant789{{"Constant[789∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant788 & Constant789 & Constant340 --> Object791
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -142,198 +167,211 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Constant774{{"Constant[774∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant774 --> Lambda258
+    Constant810{{"Constant[810∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant810 --> Lambda258
     Lambda261{{"Lambda[261∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant775{{"Constant[775∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant775 --> Lambda261
-    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object265 --> Lambda266
-    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant776{{"Constant[776∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant776 --> Lambda271
-    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object279 --> Lambda280
-    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant777{{"Constant[777∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant777 --> Lambda285
-    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object293 --> Lambda294
-    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant778{{"Constant[778∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant778 --> Lambda299
-    Lambda308{{"Lambda[308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object307 --> Lambda308
-    Lambda313{{"Lambda[313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant779{{"Constant[779∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant779 --> Lambda313
-    Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object321 --> Lambda322
+    Constant811{{"Constant[811∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant811 --> Lambda261
+    Access262{{"Access[262∈0] ➊<br />ᐸ261.0ᐳ"}}:::plan
+    Lambda261 --> Access262
+    Lambda267{{"Lambda[267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object266 --> Lambda267
+    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant812{{"Constant[812∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant812 --> Lambda272
+    Lambda282{{"Lambda[282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object281 --> Lambda282
+    Lambda287{{"Lambda[287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant813{{"Constant[813∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant813 --> Lambda287
+    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object296 --> Lambda297
+    Lambda302{{"Lambda[302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant814{{"Constant[814∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant814 --> Lambda302
+    Lambda312{{"Lambda[312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object311 --> Lambda312
+    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant815{{"Constant[815∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant815 --> Lambda317
     Lambda327{{"Lambda[327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant780{{"Constant[780∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant780 --> Lambda327
-    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object349 --> Lambda350
-    Lambda355{{"Lambda[355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant782{{"Constant[782∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant782 --> Lambda355
-    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object363 --> Lambda364
-    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant783{{"Constant[783∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant783 --> Lambda369
-    Lambda378{{"Lambda[378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object377 --> Lambda378
-    Lambda383{{"Lambda[383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant784{{"Constant[784∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant784 --> Lambda383
+    Object326 --> Lambda327
+    Lambda332{{"Lambda[332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant816{{"Constant[816∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant816 --> Lambda332
+    Lambda342{{"Lambda[342∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object341 --> Lambda342
+    Lambda347{{"Lambda[347∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant817{{"Constant[817∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant817 --> Lambda347
+    Lambda357{{"Lambda[357∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object356 --> Lambda357
+    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant818{{"Constant[818∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant818 --> Lambda362
+    Lambda372{{"Lambda[372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object371 --> Lambda372
+    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant819{{"Constant[819∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant819 --> Lambda377
+    Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object386 --> Lambda387
     Lambda392{{"Lambda[392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object391 --> Lambda392
-    Lambda397{{"Lambda[397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant785{{"Constant[785∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant785 --> Lambda397
-    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object405 --> Lambda406
-    Lambda411{{"Lambda[411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant786{{"Constant[786∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant786 --> Lambda411
-    Lambda434{{"Lambda[434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object433 --> Lambda434
-    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant788{{"Constant[788∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant788 --> Lambda439
-    Lambda448{{"Lambda[448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object447 --> Lambda448
-    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant789{{"Constant[789∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant789 --> Lambda453
+    Constant820{{"Constant[820∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant820 --> Lambda392
+    Lambda402{{"Lambda[402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object401 --> Lambda402
+    Lambda407{{"Lambda[407∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant821{{"Constant[821∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant821 --> Lambda407
+    Lambda417{{"Lambda[417∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object416 --> Lambda417
+    Lambda422{{"Lambda[422∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant822{{"Constant[822∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant822 --> Lambda422
+    Lambda432{{"Lambda[432∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object431 --> Lambda432
+    Lambda437{{"Lambda[437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant823{{"Constant[823∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant823 --> Lambda437
+    Lambda447{{"Lambda[447∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object446 --> Lambda447
+    Lambda452{{"Lambda[452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant824{{"Constant[824∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant824 --> Lambda452
     Lambda462{{"Lambda[462∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object461 --> Lambda462
     Lambda467{{"Lambda[467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant790{{"Constant[790∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant790 --> Lambda467
-    Lambda476{{"Lambda[476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object475 --> Lambda476
-    Lambda481{{"Lambda[481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant791{{"Constant[791∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant791 --> Lambda481
-    Lambda490{{"Lambda[490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object489 --> Lambda490
-    Lambda495{{"Lambda[495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant792{{"Constant[792∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant792 --> Lambda495
-    Lambda518{{"Lambda[518∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object517 --> Lambda518
-    Lambda523{{"Lambda[523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant794{{"Constant[794∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant794 --> Lambda523
-    Lambda532{{"Lambda[532∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object531 --> Lambda532
+    Constant825{{"Constant[825∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant825 --> Lambda467
+    Lambda477{{"Lambda[477∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object476 --> Lambda477
+    Lambda482{{"Lambda[482∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant826{{"Constant[826∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant826 --> Lambda482
+    Lambda492{{"Lambda[492∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object491 --> Lambda492
+    Lambda497{{"Lambda[497∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant827{{"Constant[827∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant827 --> Lambda497
+    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object506 --> Lambda507
+    Lambda512{{"Lambda[512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant828{{"Constant[828∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant828 --> Lambda512
+    Lambda522{{"Lambda[522∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object521 --> Lambda522
+    Lambda527{{"Lambda[527∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant829{{"Constant[829∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant829 --> Lambda527
     Lambda537{{"Lambda[537∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant795{{"Constant[795∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant795 --> Lambda537
-    Lambda546{{"Lambda[546∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object545 --> Lambda546
-    Lambda551{{"Lambda[551∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant796{{"Constant[796∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant796 --> Lambda551
-    Lambda560{{"Lambda[560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object559 --> Lambda560
-    Lambda565{{"Lambda[565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant797{{"Constant[797∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant797 --> Lambda565
-    Lambda574{{"Lambda[574∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object573 --> Lambda574
-    Lambda579{{"Lambda[579∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant798{{"Constant[798∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant798 --> Lambda579
+    Object536 --> Lambda537
+    Lambda542{{"Lambda[542∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant830{{"Constant[830∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant830 --> Lambda542
+    Lambda552{{"Lambda[552∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object551 --> Lambda552
+    Lambda557{{"Lambda[557∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant831{{"Constant[831∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant831 --> Lambda557
+    Lambda567{{"Lambda[567∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object566 --> Lambda567
+    Lambda572{{"Lambda[572∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant832{{"Constant[832∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant832 --> Lambda572
+    Lambda582{{"Lambda[582∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object581 --> Lambda582
+    Lambda587{{"Lambda[587∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant833{{"Constant[833∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant833 --> Lambda587
+    Lambda597{{"Lambda[597∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object596 --> Lambda597
     Lambda602{{"Lambda[602∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object601 --> Lambda602
-    Lambda607{{"Lambda[607∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant800{{"Constant[800∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant800 --> Lambda607
-    Lambda616{{"Lambda[616∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object615 --> Lambda616
-    Lambda621{{"Lambda[621∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant801{{"Constant[801∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant801 --> Lambda621
-    Lambda630{{"Lambda[630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object629 --> Lambda630
-    Lambda635{{"Lambda[635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant802{{"Constant[802∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant802 --> Lambda635
-    Lambda644{{"Lambda[644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object643 --> Lambda644
-    Lambda649{{"Lambda[649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant803{{"Constant[803∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant803 --> Lambda649
-    Lambda658{{"Lambda[658∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object657 --> Lambda658
-    Lambda663{{"Lambda[663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant804{{"Constant[804∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant804 --> Lambda663
-    Lambda686{{"Lambda[686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object685 --> Lambda686
-    Lambda691{{"Lambda[691∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant806{{"Constant[806∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant806 --> Lambda691
-    Lambda700{{"Lambda[700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object699 --> Lambda700
-    Lambda705{{"Lambda[705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant807{{"Constant[807∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant807 --> Lambda705
-    Lambda714{{"Lambda[714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object713 --> Lambda714
-    Lambda719{{"Lambda[719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant808{{"Constant[808∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant808 --> Lambda719
-    Lambda728{{"Lambda[728∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object727 --> Lambda728
-    Lambda733{{"Lambda[733∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant809{{"Constant[809∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant809 --> Lambda733
-    Lambda742{{"Lambda[742∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object741 --> Lambda742
+    Constant834{{"Constant[834∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant834 --> Lambda602
+    Lambda612{{"Lambda[612∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object611 --> Lambda612
+    Lambda617{{"Lambda[617∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant835{{"Constant[835∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant835 --> Lambda617
+    Lambda627{{"Lambda[627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object626 --> Lambda627
+    Lambda632{{"Lambda[632∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant836{{"Constant[836∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant836 --> Lambda632
+    Lambda642{{"Lambda[642∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object641 --> Lambda642
+    Lambda647{{"Lambda[647∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant837{{"Constant[837∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant837 --> Lambda647
+    Lambda657{{"Lambda[657∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object656 --> Lambda657
+    Lambda662{{"Lambda[662∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant838{{"Constant[838∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant838 --> Lambda662
+    Lambda672{{"Lambda[672∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object671 --> Lambda672
+    Lambda677{{"Lambda[677∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant839{{"Constant[839∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant839 --> Lambda677
+    Lambda687{{"Lambda[687∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object686 --> Lambda687
+    Lambda692{{"Lambda[692∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant840{{"Constant[840∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant840 --> Lambda692
+    Lambda702{{"Lambda[702∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object701 --> Lambda702
+    Lambda707{{"Lambda[707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant841{{"Constant[841∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant841 --> Lambda707
+    Lambda717{{"Lambda[717∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object716 --> Lambda717
+    Lambda722{{"Lambda[722∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant842{{"Constant[842∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant842 --> Lambda722
+    Lambda732{{"Lambda[732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object731 --> Lambda732
+    Lambda737{{"Lambda[737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant843{{"Constant[843∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant843 --> Lambda737
     Lambda747{{"Lambda[747∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant810{{"Constant[810∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant810 --> Lambda747
+    Object746 --> Lambda747
+    Lambda752{{"Lambda[752∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant844{{"Constant[844∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant844 --> Lambda752
+    Lambda762{{"Lambda[762∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object761 --> Lambda762
+    Lambda767{{"Lambda[767∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant845{{"Constant[845∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant845 --> Lambda767
+    Lambda777{{"Lambda[777∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object776 --> Lambda777
+    Lambda782{{"Lambda[782∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant846{{"Constant[846∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant846 --> Lambda782
+    Lambda792{{"Lambda[792∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object791 --> Lambda792
+    Lambda797{{"Lambda[797∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant847{{"Constant[847∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant847 --> Lambda797
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant332{{"Constant[332∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant333{{"Constant[333∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant334{{"Constant[334∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant500{{"Constant[500∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant501{{"Constant[501∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant584{{"Constant[584∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant585{{"Constant[585∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant668{{"Constant[668∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant669{{"Constant[669∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant752{{"Constant[752∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant753{{"Constant[753∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant762{{"Constant[762∈0] ➊<br />ᐸ'My Relational Post 1'ᐳ"}}:::plan
-    Constant763{{"Constant[763∈0] ➊<br />ᐸ'A post, innit? 1'ᐳ"}}:::plan
-    Constant764{{"Constant[764∈0] ➊<br />ᐸ'Such a great post. 1'ᐳ"}}:::plan
-    Constant765{{"Constant[765∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
-    Constant766{{"Constant[766∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
-    Constant767{{"Constant[767∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
-    Constant768{{"Constant[768∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
-    Constant769{{"Constant[769∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
-    Constant770{{"Constant[770∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
-    Constant771{{"Constant[771∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
-    Constant772{{"Constant[772∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
-    Constant773{{"Constant[773∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
-    Constant781{{"Constant[781∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant787{{"Constant[787∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant793{{"Constant[793∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant805{{"Constant[805∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant811{{"Constant[811∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant798{{"Constant[798∈0] ➊<br />ᐸ'My Relational Post 1'ᐳ"}}:::plan
+    Constant799{{"Constant[799∈0] ➊<br />ᐸ'A post, innit? 1'ᐳ"}}:::plan
+    Constant800{{"Constant[800∈0] ➊<br />ᐸ'Such a great post. 1'ᐳ"}}:::plan
+    Constant801{{"Constant[801∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
+    Constant802{{"Constant[802∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
+    Constant803{{"Constant[803∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
+    Constant804{{"Constant[804∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
+    Constant805{{"Constant[805∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
+    Constant806{{"Constant[806∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
+    Constant807{{"Constant[807∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
+    Constant808{{"Constant[808∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
+    Constant809{{"Constant[809∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant762 & Constant763 & Constant764 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant798 & Constant799 & Constant800 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -342,7 +380,7 @@ graph TD
     PgInsertSingle33[["PgInsertSingle[33∈3] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object31{{"Object[31∈3] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression32{{"PgClassExpression[32∈3] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object31 & PgClassExpression32 & Constant765 & Constant766 & Constant767 --> PgInsertSingle33
+    Object31 & PgClassExpression32 & Constant801 & Constant802 & Constant803 --> PgInsertSingle33
     PgInsertSingle28[["PgInsertSingle[28∈3] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object31 & Constant10 & Constant11 --> PgInsertSingle28
     Access29{{"Access[29∈3] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -354,64 +392,46 @@ graph TD
     PgClassExpression37{{"PgClassExpression[37∈3] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgInsertSingle33 --> PgClassExpression37
     PgSelect39[["PgSelect[39∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda336{{"Lambda[336∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda341{{"Lambda[341∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object31 & Constant768 & Lambda258 & Lambda261 & Lambda336 & Lambda341 --> PgSelect39
+    Object31 & Constant804 & Lambda258 & Access262 & Lambda342 & Lambda347 --> PgSelect39
     PgSelect74[["PgSelect[74∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda420{{"Lambda[420∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda425{{"Lambda[425∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object31 & Constant769 & Lambda258 & Lambda261 & Lambda420 & Lambda425 --> PgSelect74
+    Object31 & Constant805 & Lambda258 & Access262 & Lambda432 & Lambda437 --> PgSelect74
     PgSelect107[["PgSelect[107∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda504{{"Lambda[504∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda509{{"Lambda[509∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object31 & Constant770 & Lambda258 & Lambda261 & Lambda504 & Lambda509 --> PgSelect107
-    Object335{{"Object[335∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant332 & Constant333 & Constant334 --> Object335
-    Object419{{"Object[419∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant416 & Constant417 & Constant334 --> Object419
-    Object503{{"Object[503∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant500 & Constant501 & Constant334 --> Object503
+    Object31 & Constant806 & Lambda258 & Access262 & Lambda522 & Lambda527 --> PgSelect107
+    PgPolymorphic46{{"PgPolymorphic[46∈4] ➊"}}:::plan
+    PgSelectSingle44{{"PgSelectSingle[44∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression45{{"PgClassExpression[45∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle44 & PgClassExpression45 --> PgPolymorphic46
+    PgPolymorphic79{{"PgPolymorphic[79∈4] ➊"}}:::plan
+    PgSelectSingle77{{"PgSelectSingle[77∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression78{{"PgClassExpression[78∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle77 & PgClassExpression78 --> PgPolymorphic79
+    PgPolymorphic112{{"PgPolymorphic[112∈4] ➊"}}:::plan
+    PgSelectSingle110{{"PgSelectSingle[110∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression111{{"PgClassExpression[111∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle110 & PgClassExpression111 --> PgPolymorphic112
     First43{{"First[43∈4] ➊"}}:::plan
     PgSelect39 --> First43
-    PgSelectSingle44{{"PgSelectSingle[44∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First43 --> PgSelectSingle44
+    PgSelectSingle44 --> PgClassExpression45
     First76{{"First[76∈4] ➊"}}:::plan
     PgSelect74 --> First76
-    PgSelectSingle77{{"PgSelectSingle[77∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First76 --> PgSelectSingle77
+    PgSelectSingle77 --> PgClassExpression78
     First109{{"First[109∈4] ➊"}}:::plan
     PgSelect107 --> First109
-    PgSelectSingle110{{"PgSelectSingle[110∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First109 --> PgSelectSingle110
-    Object335 --> Lambda336
-    Constant781 --> Lambda341
-    Object419 --> Lambda420
-    Constant787 --> Lambda425
-    Object503 --> Lambda504
-    Constant793 --> Lambda509
-    PgPolymorphic46{{"PgPolymorphic[46∈5] ➊"}}:::plan
-    PgClassExpression45{{"PgClassExpression[45∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle44 & PgClassExpression45 --> PgPolymorphic46
-    PgPolymorphic79{{"PgPolymorphic[79∈5] ➊"}}:::plan
-    PgClassExpression78{{"PgClassExpression[78∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle77 & PgClassExpression78 --> PgPolymorphic79
-    PgPolymorphic112{{"PgPolymorphic[112∈5] ➊"}}:::plan
-    PgClassExpression111{{"PgClassExpression[111∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle110 & PgClassExpression111 --> PgPolymorphic112
-    PgSelectSingle44 --> PgClassExpression45
-    PgSelectSingle77 --> PgClassExpression78
     PgSelectSingle110 --> PgClassExpression111
     PgSelect48[["PgSelect[48∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression47{{"PgClassExpression[47∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda266 & Lambda271 --> PgSelect48
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda267 & Lambda272 --> PgSelect48
     PgSelect54[["PgSelect[54∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda280 & Lambda285 --> PgSelect54
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda282 & Lambda287 --> PgSelect54
     PgSelect61[["PgSelect[61∈6] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda294 & Lambda299 --> PgSelect61
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda297 & Lambda302 --> PgSelect61
     PgSelect65[["PgSelect[65∈6] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda308 & Lambda313 --> PgSelect65
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda312 & Lambda317 --> PgSelect65
     PgSelect69[["PgSelect[69∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda322 & Lambda327 --> PgSelect69
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda327 & Lambda332 --> PgSelect69
     PgSelectSingle44 --> PgClassExpression47
     First52{{"First[52∈6] ➊"}}:::plan
     PgSelect48 --> First52
@@ -441,15 +461,15 @@ graph TD
     First71 --> PgSelectSingle72
     PgSelect81[["PgSelect[81∈7] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression80{{"PgClassExpression[80∈7] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda350 & Lambda355 --> PgSelect81
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda357 & Lambda362 --> PgSelect81
     PgSelect87[["PgSelect[87∈7] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda364 & Lambda369 --> PgSelect87
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda372 & Lambda377 --> PgSelect87
     PgSelect94[["PgSelect[94∈7] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda378 & Lambda383 --> PgSelect94
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda387 & Lambda392 --> PgSelect94
     PgSelect98[["PgSelect[98∈7] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda392 & Lambda397 --> PgSelect98
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda402 & Lambda407 --> PgSelect98
     PgSelect102[["PgSelect[102∈7] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda406 & Lambda411 --> PgSelect102
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda417 & Lambda422 --> PgSelect102
     PgSelectSingle77 --> PgClassExpression80
     First85{{"First[85∈7] ➊"}}:::plan
     PgSelect81 --> First85
@@ -479,15 +499,15 @@ graph TD
     First104 --> PgSelectSingle105
     PgSelect114[["PgSelect[114∈8] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression113{{"PgClassExpression[113∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda434 & Lambda439 --> PgSelect114
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda447 & Lambda452 --> PgSelect114
     PgSelect120[["PgSelect[120∈8] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda448 & Lambda453 --> PgSelect120
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda462 & Lambda467 --> PgSelect120
     PgSelect127[["PgSelect[127∈8] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda462 & Lambda467 --> PgSelect127
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda477 & Lambda482 --> PgSelect127
     PgSelect131[["PgSelect[131∈8] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda476 & Lambda481 --> PgSelect131
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda492 & Lambda497 --> PgSelect131
     PgSelect135[["PgSelect[135∈8] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda490 & Lambda495 --> PgSelect135
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda507 & Lambda512 --> PgSelect135
     PgSelectSingle110 --> PgClassExpression113
     First118{{"First[118∈8] ➊"}}:::plan
     PgSelect114 --> First118
@@ -518,7 +538,7 @@ graph TD
     PgInsertSingle150[["PgInsertSingle[150∈9] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object148{{"Object[148∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression149{{"PgClassExpression[149∈9] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object148 & PgClassExpression149 & Constant771 & Constant772 & Constant773 --> PgInsertSingle150
+    Object148 & PgClassExpression149 & Constant807 & Constant808 & Constant809 --> PgInsertSingle150
     PgInsertSingle145[["PgInsertSingle[145∈9] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object148 & Constant10 & Constant11 --> PgInsertSingle145
     Access146{{"Access[146∈9] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -530,64 +550,46 @@ graph TD
     PgClassExpression154{{"PgClassExpression[154∈9] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgInsertSingle150 --> PgClassExpression154
     PgSelect156[["PgSelect[156∈10] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda588{{"Lambda[588∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda593{{"Lambda[593∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object148 & Constant768 & Lambda258 & Lambda261 & Lambda588 & Lambda593 --> PgSelect156
+    Object148 & Constant804 & Lambda258 & Access262 & Lambda612 & Lambda617 --> PgSelect156
     PgSelect191[["PgSelect[191∈10] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda672{{"Lambda[672∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda677{{"Lambda[677∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object148 & Constant769 & Lambda258 & Lambda261 & Lambda672 & Lambda677 --> PgSelect191
+    Object148 & Constant805 & Lambda258 & Access262 & Lambda702 & Lambda707 --> PgSelect191
     PgSelect224[["PgSelect[224∈10] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda756{{"Lambda[756∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda761{{"Lambda[761∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object148 & Constant770 & Lambda258 & Lambda261 & Lambda756 & Lambda761 --> PgSelect224
-    Object587{{"Object[587∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant584 & Constant585 & Constant334 --> Object587
-    Object671{{"Object[671∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant668 & Constant669 & Constant334 --> Object671
-    Object755{{"Object[755∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant752 & Constant753 & Constant334 --> Object755
+    Object148 & Constant806 & Lambda258 & Access262 & Lambda792 & Lambda797 --> PgSelect224
+    PgPolymorphic163{{"PgPolymorphic[163∈10] ➊"}}:::plan
+    PgSelectSingle161{{"PgSelectSingle[161∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression162{{"PgClassExpression[162∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle161 & PgClassExpression162 --> PgPolymorphic163
+    PgPolymorphic196{{"PgPolymorphic[196∈10] ➊"}}:::plan
+    PgSelectSingle194{{"PgSelectSingle[194∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression195{{"PgClassExpression[195∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle194 & PgClassExpression195 --> PgPolymorphic196
+    PgPolymorphic229{{"PgPolymorphic[229∈10] ➊"}}:::plan
+    PgSelectSingle227{{"PgSelectSingle[227∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression228{{"PgClassExpression[228∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle227 & PgClassExpression228 --> PgPolymorphic229
     First160{{"First[160∈10] ➊"}}:::plan
     PgSelect156 --> First160
-    PgSelectSingle161{{"PgSelectSingle[161∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First160 --> PgSelectSingle161
+    PgSelectSingle161 --> PgClassExpression162
     First193{{"First[193∈10] ➊"}}:::plan
     PgSelect191 --> First193
-    PgSelectSingle194{{"PgSelectSingle[194∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First193 --> PgSelectSingle194
+    PgSelectSingle194 --> PgClassExpression195
     First226{{"First[226∈10] ➊"}}:::plan
     PgSelect224 --> First226
-    PgSelectSingle227{{"PgSelectSingle[227∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First226 --> PgSelectSingle227
-    Object587 --> Lambda588
-    Constant799 --> Lambda593
-    Object671 --> Lambda672
-    Constant805 --> Lambda677
-    Object755 --> Lambda756
-    Constant811 --> Lambda761
-    PgPolymorphic163{{"PgPolymorphic[163∈11] ➊"}}:::plan
-    PgClassExpression162{{"PgClassExpression[162∈11] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle161 & PgClassExpression162 --> PgPolymorphic163
-    PgPolymorphic196{{"PgPolymorphic[196∈11] ➊"}}:::plan
-    PgClassExpression195{{"PgClassExpression[195∈11] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle194 & PgClassExpression195 --> PgPolymorphic196
-    PgPolymorphic229{{"PgPolymorphic[229∈11] ➊"}}:::plan
-    PgClassExpression228{{"PgClassExpression[228∈11] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle227 & PgClassExpression228 --> PgPolymorphic229
-    PgSelectSingle161 --> PgClassExpression162
-    PgSelectSingle194 --> PgClassExpression195
     PgSelectSingle227 --> PgClassExpression228
     PgSelect165[["PgSelect[165∈12] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression164{{"PgClassExpression[164∈12] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda518 & Lambda523 --> PgSelect165
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda537 & Lambda542 --> PgSelect165
     PgSelect171[["PgSelect[171∈12] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda532 & Lambda537 --> PgSelect171
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda552 & Lambda557 --> PgSelect171
     PgSelect178[["PgSelect[178∈12] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda546 & Lambda551 --> PgSelect178
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda567 & Lambda572 --> PgSelect178
     PgSelect182[["PgSelect[182∈12] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda560 & Lambda565 --> PgSelect182
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda582 & Lambda587 --> PgSelect182
     PgSelect186[["PgSelect[186∈12] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda574 & Lambda579 --> PgSelect186
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda597 & Lambda602 --> PgSelect186
     PgSelectSingle161 --> PgClassExpression164
     First169{{"First[169∈12] ➊"}}:::plan
     PgSelect165 --> First169
@@ -617,15 +619,15 @@ graph TD
     First188 --> PgSelectSingle189
     PgSelect198[["PgSelect[198∈13] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression197{{"PgClassExpression[197∈13] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda602 & Lambda607 --> PgSelect198
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda627 & Lambda632 --> PgSelect198
     PgSelect204[["PgSelect[204∈13] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda616 & Lambda621 --> PgSelect204
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda642 & Lambda647 --> PgSelect204
     PgSelect211[["PgSelect[211∈13] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda630 & Lambda635 --> PgSelect211
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda657 & Lambda662 --> PgSelect211
     PgSelect215[["PgSelect[215∈13] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda644 & Lambda649 --> PgSelect215
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda672 & Lambda677 --> PgSelect215
     PgSelect219[["PgSelect[219∈13] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda658 & Lambda663 --> PgSelect219
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda687 & Lambda692 --> PgSelect219
     PgSelectSingle194 --> PgClassExpression197
     First202{{"First[202∈13] ➊"}}:::plan
     PgSelect198 --> First202
@@ -655,15 +657,15 @@ graph TD
     First221 --> PgSelectSingle222
     PgSelect231[["PgSelect[231∈14] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression230{{"PgClassExpression[230∈14] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda686 & Lambda691 --> PgSelect231
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda717 & Lambda722 --> PgSelect231
     PgSelect237[["PgSelect[237∈14] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda700 & Lambda705 --> PgSelect237
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda732 & Lambda737 --> PgSelect237
     PgSelect244[["PgSelect[244∈14] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda714 & Lambda719 --> PgSelect244
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda747 & Lambda752 --> PgSelect244
     PgSelect248[["PgSelect[248∈14] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda728 & Lambda733 --> PgSelect248
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda762 & Lambda767 --> PgSelect248
     PgSelect252[["PgSelect[252∈14] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda742 & Lambda747 --> PgSelect252
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda777 & Lambda782 --> PgSelect252
     PgSelectSingle227 --> PgClassExpression230
     First235{{"First[235∈14] ➊"}}:::plan
     PgSelect231 --> First235
@@ -697,47 +699,47 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-no-query"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda258,Lambda261,Constant262,Constant263,Constant264,Object265,Lambda266,Lambda271,Constant276,Constant277,Constant278,Object279,Lambda280,Lambda285,Constant290,Constant291,Constant292,Object293,Lambda294,Lambda299,Constant304,Constant305,Constant306,Object307,Lambda308,Lambda313,Constant318,Constant319,Constant320,Object321,Lambda322,Lambda327,Constant332,Constant333,Constant334,Constant346,Constant347,Object349,Lambda350,Lambda355,Constant360,Constant361,Object363,Lambda364,Lambda369,Constant374,Constant375,Object377,Lambda378,Lambda383,Constant388,Constant389,Object391,Lambda392,Lambda397,Constant402,Constant403,Object405,Lambda406,Lambda411,Constant416,Constant417,Constant430,Constant431,Object433,Lambda434,Lambda439,Constant444,Constant445,Object447,Lambda448,Lambda453,Constant458,Constant459,Object461,Lambda462,Lambda467,Constant472,Constant473,Object475,Lambda476,Lambda481,Constant486,Constant487,Object489,Lambda490,Lambda495,Constant500,Constant501,Constant514,Constant515,Object517,Lambda518,Lambda523,Constant528,Constant529,Object531,Lambda532,Lambda537,Constant542,Constant543,Object545,Lambda546,Lambda551,Constant556,Constant557,Object559,Lambda560,Lambda565,Constant570,Constant571,Object573,Lambda574,Lambda579,Constant584,Constant585,Constant598,Constant599,Object601,Lambda602,Lambda607,Constant612,Constant613,Object615,Lambda616,Lambda621,Constant626,Constant627,Object629,Lambda630,Lambda635,Constant640,Constant641,Object643,Lambda644,Lambda649,Constant654,Constant655,Object657,Lambda658,Lambda663,Constant668,Constant669,Constant682,Constant683,Object685,Lambda686,Lambda691,Constant696,Constant697,Object699,Lambda700,Lambda705,Constant710,Constant711,Object713,Lambda714,Lambda719,Constant724,Constant725,Object727,Lambda728,Lambda733,Constant738,Constant739,Object741,Lambda742,Lambda747,Constant752,Constant753,Constant762,Constant763,Constant764,Constant765,Constant766,Constant767,Constant768,Constant769,Constant770,Constant771,Constant772,Constant773,Constant774,Constant775,Constant776,Constant777,Constant778,Constant779,Constant780,Constant781,Constant782,Constant783,Constant784,Constant785,Constant786,Constant787,Constant788,Constant789,Constant790,Constant791,Constant792,Constant793,Constant794,Constant795,Constant796,Constant797,Constant798,Constant799,Constant800,Constant801,Constant802,Constant803,Constant804,Constant805,Constant806,Constant807,Constant808,Constant809,Constant810,Constant811 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 762, 763, 764<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda258,Lambda261,Access262,Constant263,Constant264,Constant265,Object266,Lambda267,Lambda272,Constant278,Constant279,Constant280,Object281,Lambda282,Lambda287,Constant293,Constant294,Constant295,Object296,Lambda297,Lambda302,Constant308,Constant309,Constant310,Object311,Lambda312,Lambda317,Constant323,Constant324,Constant325,Object326,Lambda327,Lambda332,Constant338,Constant339,Constant340,Object341,Lambda342,Lambda347,Constant353,Constant354,Object356,Lambda357,Lambda362,Constant368,Constant369,Object371,Lambda372,Lambda377,Constant383,Constant384,Object386,Lambda387,Lambda392,Constant398,Constant399,Object401,Lambda402,Lambda407,Constant413,Constant414,Object416,Lambda417,Lambda422,Constant428,Constant429,Object431,Lambda432,Lambda437,Constant443,Constant444,Object446,Lambda447,Lambda452,Constant458,Constant459,Object461,Lambda462,Lambda467,Constant473,Constant474,Object476,Lambda477,Lambda482,Constant488,Constant489,Object491,Lambda492,Lambda497,Constant503,Constant504,Object506,Lambda507,Lambda512,Constant518,Constant519,Object521,Lambda522,Lambda527,Constant533,Constant534,Object536,Lambda537,Lambda542,Constant548,Constant549,Object551,Lambda552,Lambda557,Constant563,Constant564,Object566,Lambda567,Lambda572,Constant578,Constant579,Object581,Lambda582,Lambda587,Constant593,Constant594,Object596,Lambda597,Lambda602,Constant608,Constant609,Object611,Lambda612,Lambda617,Constant623,Constant624,Object626,Lambda627,Lambda632,Constant638,Constant639,Object641,Lambda642,Lambda647,Constant653,Constant654,Object656,Lambda657,Lambda662,Constant668,Constant669,Object671,Lambda672,Lambda677,Constant683,Constant684,Object686,Lambda687,Lambda692,Constant698,Constant699,Object701,Lambda702,Lambda707,Constant713,Constant714,Object716,Lambda717,Lambda722,Constant728,Constant729,Object731,Lambda732,Lambda737,Constant743,Constant744,Object746,Lambda747,Lambda752,Constant758,Constant759,Object761,Lambda762,Lambda767,Constant773,Constant774,Object776,Lambda777,Lambda782,Constant788,Constant789,Object791,Lambda792,Lambda797,Constant798,Constant799,Constant800,Constant801,Constant802,Constant803,Constant804,Constant805,Constant806,Constant807,Constant808,Constant809,Constant810,Constant811,Constant812,Constant813,Constant814,Constant815,Constant816,Constant817,Constant818,Constant819,Constant820,Constant821,Constant822,Constant823,Constant824,Constant825,Constant826,Constant827,Constant828,Constant829,Constant830,Constant831,Constant832,Constant833,Constant834,Constant835,Constant836,Constant837,Constant838,Constant839,Constant840,Constant841,Constant842,Constant843,Constant844,Constant845,Constant846,Constant847 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 798, 799, 800<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (mutationField)<br />Deps: 10, 11, 2, 765, 766, 767, 768, 258, 261, 769, 770, 332, 333, 334, 781, 416, 417, 787, 500, 501, 793, 4, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgInsertSingle[28]<br />5: PgClassExpression[32]<br />6: PgInsertSingle[33]<br />7: <br />ᐳ: PgClassExpression[37]"):::bucket
+    Bucket3("Bucket 3 (mutationField)<br />Deps: 10, 11, 2, 801, 802, 803, 804, 258, 262, 342, 347, 805, 432, 437, 806, 522, 527, 4, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgInsertSingle[28]<br />5: PgClassExpression[32]<br />6: PgInsertSingle[33]<br />7: <br />ᐳ: PgClassExpression[37]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgInsertSingle28,Access29,Access30,Object31,PgClassExpression32,PgInsertSingle33,PgClassExpression37 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 768, 258, 261, 769, 770, 332, 333, 334, 781, 416, 417, 787, 500, 501, 793, 37, 4, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]<br />1: <br />ᐳ: 335, 341, 419, 425, 503, 509, 336, 420, 504<br />2: 39, 74, 107<br />ᐳ: 43, 44, 76, 77, 109, 110"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 804, 258, 262, 342, 347, 805, 432, 437, 806, 522, 527, 37, 4, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect39,First43,PgSelectSingle44,PgSelect74,First76,PgSelectSingle77,PgSelect107,First109,PgSelectSingle110,Object335,Lambda336,Lambda341,Object419,Lambda420,Lambda425,Object503,Lambda504,Lambda509 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 77, 110, 4, 31, 258, 261, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket4,PgSelect39,First43,PgSelectSingle44,PgClassExpression45,PgPolymorphic46,PgSelect74,First76,PgSelectSingle77,PgClassExpression78,PgPolymorphic79,PgSelect107,First109,PgSelectSingle110,PgClassExpression111,PgPolymorphic112 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 4, 44, 31, 258, 262, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 46, 77, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 79, 110, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512, 112<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression45,PgPolymorphic46,PgClassExpression78,PgPolymorphic79,PgClassExpression111,PgPolymorphic112 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 44, 31, 258, 261, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 46<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[47]<br />2: 48, 54, 61, 65, 69<br />ᐳ: 52, 53, 56, 57, 58, 59, 60, 63, 64, 67, 68, 71, 72"):::bucket
+    class Bucket5 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 44, 31, 258, 262, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 46<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[47]<br />2: 48, 54, 61, 65, 69<br />ᐳ: 52, 53, 56, 57, 58, 59, 60, 63, 64, 67, 68, 71, 72"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression47,PgSelect48,First52,PgSelectSingle53,PgSelect54,First56,PgSelectSingle57,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgSelect61,First63,PgSelectSingle64,PgSelect65,First67,PgSelectSingle68,PgSelect69,First71,PgSelectSingle72 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 77, 31, 258, 261, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 79<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[80]<br />2: 81, 87, 94, 98, 102<br />ᐳ: 85, 86, 89, 90, 91, 92, 93, 96, 97, 100, 101, 104, 105"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 77, 31, 258, 262, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 79<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[80]<br />2: 81, 87, 94, 98, 102<br />ᐳ: 85, 86, 89, 90, 91, 92, 93, 96, 97, 100, 101, 104, 105"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression80,PgSelect81,First85,PgSelectSingle86,PgSelect87,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgSelect94,First96,PgSelectSingle97,PgSelect98,First100,PgSelectSingle101,PgSelect102,First104,PgSelectSingle105 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 110, 31, 258, 261, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495, 112<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[113]<br />2: 114, 120, 127, 131, 135<br />ᐳ: 118, 119, 122, 123, 124, 125, 126, 129, 130, 133, 134, 137, 138"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 110, 31, 258, 262, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512, 112<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[113]<br />2: 114, 120, 127, 131, 135<br />ᐳ: 118, 119, 122, 123, 124, 125, 126, 129, 130, 133, 134, 137, 138"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression113,PgSelect114,First118,PgSelectSingle119,PgSelect120,First122,PgSelectSingle123,PgClassExpression124,PgClassExpression125,PgClassExpression126,PgSelect127,First129,PgSelectSingle130,PgSelect131,First133,PgSelectSingle134,PgSelect135,First137,PgSelectSingle138 bucket8
-    Bucket9("Bucket 9 (mutationField)<br />Deps: 10, 11, 2, 771, 772, 773, 768, 258, 261, 769, 770, 584, 585, 334, 799, 668, 669, 805, 752, 753, 811, 4, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747<br /><br />1: Access[146]<br />2: Access[147]<br />3: Object[148]<br />4: PgInsertSingle[145]<br />5: PgClassExpression[149]<br />6: PgInsertSingle[150]<br />7: <br />ᐳ: PgClassExpression[154]"):::bucket
+    Bucket9("Bucket 9 (mutationField)<br />Deps: 10, 11, 2, 807, 808, 809, 804, 258, 262, 612, 617, 805, 702, 707, 806, 792, 797, 4, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782<br /><br />1: Access[146]<br />2: Access[147]<br />3: Object[148]<br />4: PgInsertSingle[145]<br />5: PgClassExpression[149]<br />6: PgInsertSingle[150]<br />7: <br />ᐳ: PgClassExpression[154]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgInsertSingle145,Access146,Access147,Object148,PgClassExpression149,PgInsertSingle150,PgClassExpression154 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 148, 768, 258, 261, 769, 770, 584, 585, 334, 799, 668, 669, 805, 752, 753, 811, 154, 4, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[154]<br />1: <br />ᐳ: 587, 593, 671, 677, 755, 761, 588, 672, 756<br />2: 156, 191, 224<br />ᐳ: 160, 161, 193, 194, 226, 227"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 148, 804, 258, 262, 612, 617, 805, 702, 707, 806, 792, 797, 154, 4, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[154]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect156,First160,PgSelectSingle161,PgSelect191,First193,PgSelectSingle194,PgSelect224,First226,PgSelectSingle227,Object587,Lambda588,Lambda593,Object671,Lambda672,Lambda677,Object755,Lambda756,Lambda761 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 161, 194, 227, 4, 148, 258, 261, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket10,PgSelect156,First160,PgSelectSingle161,PgClassExpression162,PgPolymorphic163,PgSelect191,First193,PgSelectSingle194,PgClassExpression195,PgPolymorphic196,PgSelect224,First226,PgSelectSingle227,PgClassExpression228,PgPolymorphic229 bucket10
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 4, 161, 148, 258, 262, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 163, 194, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 196, 227, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782, 229<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression162,PgPolymorphic163,PgClassExpression195,PgPolymorphic196,PgClassExpression228,PgPolymorphic229 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 161, 148, 258, 261, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 163<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[164]<br />2: 165, 171, 178, 182, 186<br />ᐳ: 169, 170, 173, 174, 175, 176, 177, 180, 181, 184, 185, 188, 189"):::bucket
+    class Bucket11 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 161, 148, 258, 262, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 163<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[164]<br />2: 165, 171, 178, 182, 186<br />ᐳ: 169, 170, 173, 174, 175, 176, 177, 180, 181, 184, 185, 188, 189"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression164,PgSelect165,First169,PgSelectSingle170,PgSelect171,First173,PgSelectSingle174,PgClassExpression175,PgClassExpression176,PgClassExpression177,PgSelect178,First180,PgSelectSingle181,PgSelect182,First184,PgSelectSingle185,PgSelect186,First188,PgSelectSingle189 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 194, 148, 258, 261, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 196<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[197]<br />2: 198, 204, 211, 215, 219<br />ᐳ: 202, 203, 206, 207, 208, 209, 210, 213, 214, 217, 218, 221, 222"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 194, 148, 258, 262, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 196<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[197]<br />2: 198, 204, 211, 215, 219<br />ᐳ: 202, 203, 206, 207, 208, 209, 210, 213, 214, 217, 218, 221, 222"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression197,PgSelect198,First202,PgSelectSingle203,PgSelect204,First206,PgSelectSingle207,PgClassExpression208,PgClassExpression209,PgClassExpression210,PgSelect211,First213,PgSelectSingle214,PgSelect215,First217,PgSelectSingle218,PgSelect219,First221,PgSelectSingle222 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 227, 148, 258, 261, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747, 229<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[230]<br />2: 231, 237, 244, 248, 252<br />ᐳ: 235, 236, 239, 240, 241, 242, 243, 246, 247, 250, 251, 254, 255"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 227, 148, 258, 262, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782, 229<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[230]<br />2: 231, 237, 244, 248, 252<br />ᐳ: 235, 236, 239, 240, 241, 242, 243, 246, 247, 250, 251, 254, 255"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression230,PgSelect231,First235,PgSelectSingle236,PgSelect237,First239,PgSelectSingle240,PgClassExpression241,PgClassExpression242,PgClassExpression243,PgSelect244,First246,PgSelectSingle247,PgSelect248,First250,PgSelectSingle251,PgSelect252,First254,PgSelectSingle255 bucket14
     Bucket0 --> Bucket1 & Bucket3 & Bucket9

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.mermaid
@@ -9,132 +9,157 @@ graph TD
 
 
     %% plan dependencies
-    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object266{{"Object[266∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant264{{"Constant[264∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda258 & Constant262 & Constant263 & Constant264 --> Object265
-    Object279{{"Object[279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant276{{"Constant[276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant277{{"Constant[277∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant278{{"Constant[278∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda258 & Constant276 & Constant277 & Constant278 --> Object279
-    Object293{{"Object[293∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant290{{"Constant[290∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant291{{"Constant[291∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant292{{"Constant[292∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda258 & Constant290 & Constant291 & Constant292 --> Object293
-    Object307{{"Object[307∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant306{{"Constant[306∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda258 & Constant304 & Constant305 & Constant306 --> Object307
-    Object321{{"Object[321∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant318{{"Constant[318∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant319{{"Constant[319∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant320{{"Constant[320∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda258 & Constant318 & Constant319 & Constant320 --> Object321
-    Object349{{"Object[349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant346 & Constant347 & Constant264 --> Object349
-    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant360{{"Constant[360∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant360 & Constant361 & Constant278 --> Object363
-    Object377{{"Object[377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant374 & Constant375 & Constant292 --> Object377
-    Object391{{"Object[391∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant388 & Constant389 & Constant306 --> Object391
-    Object405{{"Object[405∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant402 & Constant403 & Constant320 --> Object405
-    Object433{{"Object[433∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant430 & Constant431 & Constant264 --> Object433
-    Object447{{"Object[447∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant444 & Constant445 & Constant278 --> Object447
+    Constant263{{"Constant[263∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant264{{"Constant[264∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant265{{"Constant[265∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda258 & Constant263 & Constant264 & Constant265 --> Object266
+    Object281{{"Object[281∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda258 & Constant278 & Constant279 & Constant280 --> Object281
+    Object296{{"Object[296∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant294{{"Constant[294∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant295{{"Constant[295∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda258 & Constant293 & Constant294 & Constant295 --> Object296
+    Object311{{"Object[311∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant308{{"Constant[308∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant309{{"Constant[309∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant310{{"Constant[310∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda258 & Constant308 & Constant309 & Constant310 --> Object311
+    Object326{{"Object[326∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant324{{"Constant[324∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant325{{"Constant[325∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda258 & Constant323 & Constant324 & Constant325 --> Object326
+    Object341{{"Object[341∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant338{{"Constant[338∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant339{{"Constant[339∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant340{{"Constant[340∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda258 & Constant338 & Constant339 & Constant340 --> Object341
+    Object356{{"Object[356∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant353{{"Constant[353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant354{{"Constant[354∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant353 & Constant354 & Constant265 --> Object356
+    Object371{{"Object[371∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant369{{"Constant[369∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant368 & Constant369 & Constant280 --> Object371
+    Object386{{"Object[386∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant384{{"Constant[384∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant383 & Constant384 & Constant295 --> Object386
+    Object401{{"Object[401∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant398 & Constant399 & Constant310 --> Object401
+    Object416{{"Object[416∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant414{{"Constant[414∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant413 & Constant414 & Constant325 --> Object416
+    Object431{{"Object[431∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant428{{"Constant[428∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant428 & Constant429 & Constant340 --> Object431
+    Object446{{"Object[446∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant443 & Constant444 & Constant265 --> Object446
     Object461{{"Object[461∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant458{{"Constant[458∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant459{{"Constant[459∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant458 & Constant459 & Constant292 --> Object461
-    Object475{{"Object[475∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant473{{"Constant[473∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant472 & Constant473 & Constant306 --> Object475
-    Object489{{"Object[489∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant487{{"Constant[487∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant486 & Constant487 & Constant320 --> Object489
-    Object517{{"Object[517∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant514{{"Constant[514∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant515{{"Constant[515∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant514 & Constant515 & Constant264 --> Object517
-    Object531{{"Object[531∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant528{{"Constant[528∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant529{{"Constant[529∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant528 & Constant529 & Constant278 --> Object531
-    Object545{{"Object[545∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant542{{"Constant[542∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant542 & Constant543 & Constant292 --> Object545
-    Object559{{"Object[559∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant556 & Constant557 & Constant306 --> Object559
-    Object573{{"Object[573∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant570{{"Constant[570∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant571{{"Constant[571∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant570 & Constant571 & Constant320 --> Object573
-    Object601{{"Object[601∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant598{{"Constant[598∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant599{{"Constant[599∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant598 & Constant599 & Constant264 --> Object601
-    Object615{{"Object[615∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant612{{"Constant[612∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant613{{"Constant[613∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant612 & Constant613 & Constant278 --> Object615
-    Object629{{"Object[629∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant626{{"Constant[626∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant627{{"Constant[627∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant626 & Constant627 & Constant292 --> Object629
-    Object643{{"Object[643∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant640{{"Constant[640∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant641{{"Constant[641∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant640 & Constant641 & Constant306 --> Object643
-    Object657{{"Object[657∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant654{{"Constant[654∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant655{{"Constant[655∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant654 & Constant655 & Constant320 --> Object657
-    Object685{{"Object[685∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant682{{"Constant[682∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant683{{"Constant[683∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda258 & Constant682 & Constant683 & Constant264 --> Object685
-    Object699{{"Object[699∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant696{{"Constant[696∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant697{{"Constant[697∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda258 & Constant696 & Constant697 & Constant278 --> Object699
-    Object713{{"Object[713∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant710{{"Constant[710∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant711{{"Constant[711∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda258 & Constant710 & Constant711 & Constant292 --> Object713
-    Object727{{"Object[727∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant724{{"Constant[724∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant725{{"Constant[725∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda258 & Constant724 & Constant725 & Constant306 --> Object727
-    Object741{{"Object[741∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant738{{"Constant[738∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant739{{"Constant[739∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda258 & Constant738 & Constant739 & Constant320 --> Object741
+    Constant459{{"Constant[459∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant458 & Constant459 & Constant280 --> Object461
+    Object476{{"Object[476∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant473 & Constant474 & Constant295 --> Object476
+    Object491{{"Object[491∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant488{{"Constant[488∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant489{{"Constant[489∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant488 & Constant489 & Constant310 --> Object491
+    Object506{{"Object[506∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant503{{"Constant[503∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant504{{"Constant[504∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant503 & Constant504 & Constant325 --> Object506
+    Object521{{"Object[521∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant518{{"Constant[518∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant519{{"Constant[519∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant518 & Constant519 & Constant340 --> Object521
+    Object536{{"Object[536∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant533{{"Constant[533∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant534{{"Constant[534∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant533 & Constant534 & Constant265 --> Object536
+    Object551{{"Object[551∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant548{{"Constant[548∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant549{{"Constant[549∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant548 & Constant549 & Constant280 --> Object551
+    Object566{{"Object[566∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant563{{"Constant[563∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant564{{"Constant[564∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant563 & Constant564 & Constant295 --> Object566
+    Object581{{"Object[581∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant579{{"Constant[579∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant578 & Constant579 & Constant310 --> Object581
+    Object596{{"Object[596∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant593{{"Constant[593∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant594{{"Constant[594∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant593 & Constant594 & Constant325 --> Object596
+    Object611{{"Object[611∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant608{{"Constant[608∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant609{{"Constant[609∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant608 & Constant609 & Constant340 --> Object611
+    Object626{{"Object[626∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant623 & Constant624 & Constant265 --> Object626
+    Object641{{"Object[641∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant638{{"Constant[638∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant639{{"Constant[639∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant638 & Constant639 & Constant280 --> Object641
+    Object656{{"Object[656∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant653{{"Constant[653∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant654{{"Constant[654∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant653 & Constant654 & Constant295 --> Object656
+    Object671{{"Object[671∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant668{{"Constant[668∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant669{{"Constant[669∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant668 & Constant669 & Constant310 --> Object671
+    Object686{{"Object[686∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant683{{"Constant[683∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant684{{"Constant[684∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant683 & Constant684 & Constant325 --> Object686
+    Object701{{"Object[701∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant698{{"Constant[698∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant699{{"Constant[699∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant698 & Constant699 & Constant340 --> Object701
+    Object716{{"Object[716∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant713{{"Constant[713∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant714{{"Constant[714∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda258 & Constant713 & Constant714 & Constant265 --> Object716
+    Object731{{"Object[731∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant728{{"Constant[728∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant729{{"Constant[729∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda258 & Constant728 & Constant729 & Constant280 --> Object731
+    Object746{{"Object[746∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant743{{"Constant[743∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant744{{"Constant[744∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda258 & Constant743 & Constant744 & Constant295 --> Object746
+    Object761{{"Object[761∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant758{{"Constant[758∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant759{{"Constant[759∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda258 & Constant758 & Constant759 & Constant310 --> Object761
+    Object776{{"Object[776∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant773{{"Constant[773∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant774{{"Constant[774∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda258 & Constant773 & Constant774 & Constant325 --> Object776
+    Object791{{"Object[791∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant788{{"Constant[788∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant789{{"Constant[789∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda258 & Constant788 & Constant789 & Constant340 --> Object791
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -142,198 +167,211 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Constant774{{"Constant[774∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant774 --> Lambda258
+    Constant810{{"Constant[810∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant810 --> Lambda258
     Lambda261{{"Lambda[261∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant775{{"Constant[775∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant775 --> Lambda261
-    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object265 --> Lambda266
-    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant776{{"Constant[776∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant776 --> Lambda271
-    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object279 --> Lambda280
-    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant777{{"Constant[777∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant777 --> Lambda285
-    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object293 --> Lambda294
-    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant778{{"Constant[778∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant778 --> Lambda299
-    Lambda308{{"Lambda[308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object307 --> Lambda308
-    Lambda313{{"Lambda[313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant779{{"Constant[779∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant779 --> Lambda313
-    Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object321 --> Lambda322
+    Constant811{{"Constant[811∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant811 --> Lambda261
+    Access262{{"Access[262∈0] ➊<br />ᐸ261.0ᐳ"}}:::plan
+    Lambda261 --> Access262
+    Lambda267{{"Lambda[267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object266 --> Lambda267
+    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant812{{"Constant[812∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant812 --> Lambda272
+    Lambda282{{"Lambda[282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object281 --> Lambda282
+    Lambda287{{"Lambda[287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant813{{"Constant[813∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant813 --> Lambda287
+    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object296 --> Lambda297
+    Lambda302{{"Lambda[302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant814{{"Constant[814∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant814 --> Lambda302
+    Lambda312{{"Lambda[312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object311 --> Lambda312
+    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant815{{"Constant[815∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant815 --> Lambda317
     Lambda327{{"Lambda[327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant780{{"Constant[780∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant780 --> Lambda327
-    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object349 --> Lambda350
-    Lambda355{{"Lambda[355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant782{{"Constant[782∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant782 --> Lambda355
-    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object363 --> Lambda364
-    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant783{{"Constant[783∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant783 --> Lambda369
-    Lambda378{{"Lambda[378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object377 --> Lambda378
-    Lambda383{{"Lambda[383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant784{{"Constant[784∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant784 --> Lambda383
+    Object326 --> Lambda327
+    Lambda332{{"Lambda[332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant816{{"Constant[816∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant816 --> Lambda332
+    Lambda342{{"Lambda[342∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object341 --> Lambda342
+    Lambda347{{"Lambda[347∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant817{{"Constant[817∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant817 --> Lambda347
+    Lambda357{{"Lambda[357∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object356 --> Lambda357
+    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant818{{"Constant[818∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant818 --> Lambda362
+    Lambda372{{"Lambda[372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object371 --> Lambda372
+    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant819{{"Constant[819∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant819 --> Lambda377
+    Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object386 --> Lambda387
     Lambda392{{"Lambda[392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object391 --> Lambda392
-    Lambda397{{"Lambda[397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant785{{"Constant[785∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant785 --> Lambda397
-    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object405 --> Lambda406
-    Lambda411{{"Lambda[411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant786{{"Constant[786∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant786 --> Lambda411
-    Lambda434{{"Lambda[434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object433 --> Lambda434
-    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant788{{"Constant[788∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant788 --> Lambda439
-    Lambda448{{"Lambda[448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object447 --> Lambda448
-    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant789{{"Constant[789∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant789 --> Lambda453
+    Constant820{{"Constant[820∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant820 --> Lambda392
+    Lambda402{{"Lambda[402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object401 --> Lambda402
+    Lambda407{{"Lambda[407∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant821{{"Constant[821∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant821 --> Lambda407
+    Lambda417{{"Lambda[417∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object416 --> Lambda417
+    Lambda422{{"Lambda[422∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant822{{"Constant[822∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant822 --> Lambda422
+    Lambda432{{"Lambda[432∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object431 --> Lambda432
+    Lambda437{{"Lambda[437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant823{{"Constant[823∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant823 --> Lambda437
+    Lambda447{{"Lambda[447∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object446 --> Lambda447
+    Lambda452{{"Lambda[452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant824{{"Constant[824∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant824 --> Lambda452
     Lambda462{{"Lambda[462∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object461 --> Lambda462
     Lambda467{{"Lambda[467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant790{{"Constant[790∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant790 --> Lambda467
-    Lambda476{{"Lambda[476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object475 --> Lambda476
-    Lambda481{{"Lambda[481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant791{{"Constant[791∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant791 --> Lambda481
-    Lambda490{{"Lambda[490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object489 --> Lambda490
-    Lambda495{{"Lambda[495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant792{{"Constant[792∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant792 --> Lambda495
-    Lambda518{{"Lambda[518∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object517 --> Lambda518
-    Lambda523{{"Lambda[523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant794{{"Constant[794∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant794 --> Lambda523
-    Lambda532{{"Lambda[532∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object531 --> Lambda532
+    Constant825{{"Constant[825∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant825 --> Lambda467
+    Lambda477{{"Lambda[477∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object476 --> Lambda477
+    Lambda482{{"Lambda[482∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant826{{"Constant[826∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant826 --> Lambda482
+    Lambda492{{"Lambda[492∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object491 --> Lambda492
+    Lambda497{{"Lambda[497∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant827{{"Constant[827∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant827 --> Lambda497
+    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object506 --> Lambda507
+    Lambda512{{"Lambda[512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant828{{"Constant[828∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant828 --> Lambda512
+    Lambda522{{"Lambda[522∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object521 --> Lambda522
+    Lambda527{{"Lambda[527∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant829{{"Constant[829∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant829 --> Lambda527
     Lambda537{{"Lambda[537∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant795{{"Constant[795∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant795 --> Lambda537
-    Lambda546{{"Lambda[546∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object545 --> Lambda546
-    Lambda551{{"Lambda[551∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant796{{"Constant[796∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant796 --> Lambda551
-    Lambda560{{"Lambda[560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object559 --> Lambda560
-    Lambda565{{"Lambda[565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant797{{"Constant[797∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant797 --> Lambda565
-    Lambda574{{"Lambda[574∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object573 --> Lambda574
-    Lambda579{{"Lambda[579∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant798{{"Constant[798∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant798 --> Lambda579
+    Object536 --> Lambda537
+    Lambda542{{"Lambda[542∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant830{{"Constant[830∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant830 --> Lambda542
+    Lambda552{{"Lambda[552∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object551 --> Lambda552
+    Lambda557{{"Lambda[557∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant831{{"Constant[831∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant831 --> Lambda557
+    Lambda567{{"Lambda[567∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object566 --> Lambda567
+    Lambda572{{"Lambda[572∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant832{{"Constant[832∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant832 --> Lambda572
+    Lambda582{{"Lambda[582∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object581 --> Lambda582
+    Lambda587{{"Lambda[587∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant833{{"Constant[833∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant833 --> Lambda587
+    Lambda597{{"Lambda[597∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object596 --> Lambda597
     Lambda602{{"Lambda[602∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object601 --> Lambda602
-    Lambda607{{"Lambda[607∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant800{{"Constant[800∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant800 --> Lambda607
-    Lambda616{{"Lambda[616∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object615 --> Lambda616
-    Lambda621{{"Lambda[621∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant801{{"Constant[801∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant801 --> Lambda621
-    Lambda630{{"Lambda[630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object629 --> Lambda630
-    Lambda635{{"Lambda[635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant802{{"Constant[802∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant802 --> Lambda635
-    Lambda644{{"Lambda[644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object643 --> Lambda644
-    Lambda649{{"Lambda[649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant803{{"Constant[803∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant803 --> Lambda649
-    Lambda658{{"Lambda[658∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object657 --> Lambda658
-    Lambda663{{"Lambda[663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant804{{"Constant[804∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant804 --> Lambda663
-    Lambda686{{"Lambda[686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object685 --> Lambda686
-    Lambda691{{"Lambda[691∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant806{{"Constant[806∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant806 --> Lambda691
-    Lambda700{{"Lambda[700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object699 --> Lambda700
-    Lambda705{{"Lambda[705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant807{{"Constant[807∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant807 --> Lambda705
-    Lambda714{{"Lambda[714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object713 --> Lambda714
-    Lambda719{{"Lambda[719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant808{{"Constant[808∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant808 --> Lambda719
-    Lambda728{{"Lambda[728∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object727 --> Lambda728
-    Lambda733{{"Lambda[733∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant809{{"Constant[809∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant809 --> Lambda733
-    Lambda742{{"Lambda[742∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object741 --> Lambda742
+    Constant834{{"Constant[834∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant834 --> Lambda602
+    Lambda612{{"Lambda[612∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object611 --> Lambda612
+    Lambda617{{"Lambda[617∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant835{{"Constant[835∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant835 --> Lambda617
+    Lambda627{{"Lambda[627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object626 --> Lambda627
+    Lambda632{{"Lambda[632∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant836{{"Constant[836∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant836 --> Lambda632
+    Lambda642{{"Lambda[642∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object641 --> Lambda642
+    Lambda647{{"Lambda[647∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant837{{"Constant[837∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant837 --> Lambda647
+    Lambda657{{"Lambda[657∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object656 --> Lambda657
+    Lambda662{{"Lambda[662∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant838{{"Constant[838∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant838 --> Lambda662
+    Lambda672{{"Lambda[672∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object671 --> Lambda672
+    Lambda677{{"Lambda[677∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant839{{"Constant[839∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant839 --> Lambda677
+    Lambda687{{"Lambda[687∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object686 --> Lambda687
+    Lambda692{{"Lambda[692∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant840{{"Constant[840∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant840 --> Lambda692
+    Lambda702{{"Lambda[702∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object701 --> Lambda702
+    Lambda707{{"Lambda[707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant841{{"Constant[841∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant841 --> Lambda707
+    Lambda717{{"Lambda[717∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object716 --> Lambda717
+    Lambda722{{"Lambda[722∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant842{{"Constant[842∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant842 --> Lambda722
+    Lambda732{{"Lambda[732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object731 --> Lambda732
+    Lambda737{{"Lambda[737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant843{{"Constant[843∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant843 --> Lambda737
     Lambda747{{"Lambda[747∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant810{{"Constant[810∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant810 --> Lambda747
+    Object746 --> Lambda747
+    Lambda752{{"Lambda[752∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant844{{"Constant[844∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant844 --> Lambda752
+    Lambda762{{"Lambda[762∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object761 --> Lambda762
+    Lambda767{{"Lambda[767∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant845{{"Constant[845∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant845 --> Lambda767
+    Lambda777{{"Lambda[777∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object776 --> Lambda777
+    Lambda782{{"Lambda[782∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant846{{"Constant[846∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant846 --> Lambda782
+    Lambda792{{"Lambda[792∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object791 --> Lambda792
+    Lambda797{{"Lambda[797∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant847{{"Constant[847∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant847 --> Lambda797
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant332{{"Constant[332∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant333{{"Constant[333∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant334{{"Constant[334∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant500{{"Constant[500∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant501{{"Constant[501∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant584{{"Constant[584∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant585{{"Constant[585∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant668{{"Constant[668∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant669{{"Constant[669∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant752{{"Constant[752∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant753{{"Constant[753∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant762{{"Constant[762∈0] ➊<br />ᐸ'My Relational Post 1'ᐳ"}}:::plan
-    Constant763{{"Constant[763∈0] ➊<br />ᐸ'A post, innit? 1'ᐳ"}}:::plan
-    Constant764{{"Constant[764∈0] ➊<br />ᐸ'Such a great post. 1'ᐳ"}}:::plan
-    Constant765{{"Constant[765∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
-    Constant766{{"Constant[766∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
-    Constant767{{"Constant[767∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
-    Constant768{{"Constant[768∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
-    Constant769{{"Constant[769∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
-    Constant770{{"Constant[770∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
-    Constant771{{"Constant[771∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
-    Constant772{{"Constant[772∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
-    Constant773{{"Constant[773∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
-    Constant781{{"Constant[781∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant787{{"Constant[787∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant793{{"Constant[793∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant805{{"Constant[805∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant811{{"Constant[811∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant798{{"Constant[798∈0] ➊<br />ᐸ'My Relational Post 1'ᐳ"}}:::plan
+    Constant799{{"Constant[799∈0] ➊<br />ᐸ'A post, innit? 1'ᐳ"}}:::plan
+    Constant800{{"Constant[800∈0] ➊<br />ᐸ'Such a great post. 1'ᐳ"}}:::plan
+    Constant801{{"Constant[801∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
+    Constant802{{"Constant[802∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
+    Constant803{{"Constant[803∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
+    Constant804{{"Constant[804∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
+    Constant805{{"Constant[805∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
+    Constant806{{"Constant[806∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
+    Constant807{{"Constant[807∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
+    Constant808{{"Constant[808∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
+    Constant809{{"Constant[809∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant762 & Constant763 & Constant764 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant798 & Constant799 & Constant800 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -342,7 +380,7 @@ graph TD
     PgInsertSingle33[["PgInsertSingle[33∈3] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object31{{"Object[31∈3] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression32{{"PgClassExpression[32∈3] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object31 & PgClassExpression32 & Constant765 & Constant766 & Constant767 --> PgInsertSingle33
+    Object31 & PgClassExpression32 & Constant801 & Constant802 & Constant803 --> PgInsertSingle33
     PgInsertSingle28[["PgInsertSingle[28∈3] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object31 & Constant10 & Constant11 --> PgInsertSingle28
     Access29{{"Access[29∈3] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -354,64 +392,46 @@ graph TD
     PgClassExpression37{{"PgClassExpression[37∈3] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgInsertSingle33 --> PgClassExpression37
     PgSelect39[["PgSelect[39∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda336{{"Lambda[336∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda341{{"Lambda[341∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object31 & Constant768 & Lambda258 & Lambda261 & Lambda336 & Lambda341 --> PgSelect39
+    Object31 & Constant804 & Lambda258 & Access262 & Lambda342 & Lambda347 --> PgSelect39
     PgSelect74[["PgSelect[74∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda420{{"Lambda[420∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda425{{"Lambda[425∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object31 & Constant769 & Lambda258 & Lambda261 & Lambda420 & Lambda425 --> PgSelect74
+    Object31 & Constant805 & Lambda258 & Access262 & Lambda432 & Lambda437 --> PgSelect74
     PgSelect107[["PgSelect[107∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda504{{"Lambda[504∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda509{{"Lambda[509∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object31 & Constant770 & Lambda258 & Lambda261 & Lambda504 & Lambda509 --> PgSelect107
-    Object335{{"Object[335∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant332 & Constant333 & Constant334 --> Object335
-    Object419{{"Object[419∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant416 & Constant417 & Constant334 --> Object419
-    Object503{{"Object[503∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant500 & Constant501 & Constant334 --> Object503
+    Object31 & Constant806 & Lambda258 & Access262 & Lambda522 & Lambda527 --> PgSelect107
+    PgPolymorphic46{{"PgPolymorphic[46∈4] ➊"}}:::plan
+    PgSelectSingle44{{"PgSelectSingle[44∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression45{{"PgClassExpression[45∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle44 & PgClassExpression45 --> PgPolymorphic46
+    PgPolymorphic79{{"PgPolymorphic[79∈4] ➊"}}:::plan
+    PgSelectSingle77{{"PgSelectSingle[77∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression78{{"PgClassExpression[78∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle77 & PgClassExpression78 --> PgPolymorphic79
+    PgPolymorphic112{{"PgPolymorphic[112∈4] ➊"}}:::plan
+    PgSelectSingle110{{"PgSelectSingle[110∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression111{{"PgClassExpression[111∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle110 & PgClassExpression111 --> PgPolymorphic112
     First43{{"First[43∈4] ➊"}}:::plan
     PgSelect39 --> First43
-    PgSelectSingle44{{"PgSelectSingle[44∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First43 --> PgSelectSingle44
+    PgSelectSingle44 --> PgClassExpression45
     First76{{"First[76∈4] ➊"}}:::plan
     PgSelect74 --> First76
-    PgSelectSingle77{{"PgSelectSingle[77∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First76 --> PgSelectSingle77
+    PgSelectSingle77 --> PgClassExpression78
     First109{{"First[109∈4] ➊"}}:::plan
     PgSelect107 --> First109
-    PgSelectSingle110{{"PgSelectSingle[110∈4] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First109 --> PgSelectSingle110
-    Object335 --> Lambda336
-    Constant781 --> Lambda341
-    Object419 --> Lambda420
-    Constant787 --> Lambda425
-    Object503 --> Lambda504
-    Constant793 --> Lambda509
-    PgPolymorphic46{{"PgPolymorphic[46∈5] ➊"}}:::plan
-    PgClassExpression45{{"PgClassExpression[45∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle44 & PgClassExpression45 --> PgPolymorphic46
-    PgPolymorphic79{{"PgPolymorphic[79∈5] ➊"}}:::plan
-    PgClassExpression78{{"PgClassExpression[78∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle77 & PgClassExpression78 --> PgPolymorphic79
-    PgPolymorphic112{{"PgPolymorphic[112∈5] ➊"}}:::plan
-    PgClassExpression111{{"PgClassExpression[111∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle110 & PgClassExpression111 --> PgPolymorphic112
-    PgSelectSingle44 --> PgClassExpression45
-    PgSelectSingle77 --> PgClassExpression78
     PgSelectSingle110 --> PgClassExpression111
     PgSelect48[["PgSelect[48∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression47{{"PgClassExpression[47∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda266 & Lambda271 --> PgSelect48
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda267 & Lambda272 --> PgSelect48
     PgSelect54[["PgSelect[54∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda280 & Lambda285 --> PgSelect54
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda282 & Lambda287 --> PgSelect54
     PgSelect61[["PgSelect[61∈6] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda294 & Lambda299 --> PgSelect61
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda297 & Lambda302 --> PgSelect61
     PgSelect65[["PgSelect[65∈6] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda308 & Lambda313 --> PgSelect65
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda312 & Lambda317 --> PgSelect65
     PgSelect69[["PgSelect[69∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object31 & PgClassExpression47 & Lambda258 & Lambda261 & Lambda322 & Lambda327 --> PgSelect69
+    Object31 & PgClassExpression47 & Lambda258 & Access262 & Lambda327 & Lambda332 --> PgSelect69
     PgSelectSingle44 --> PgClassExpression47
     First52{{"First[52∈6] ➊"}}:::plan
     PgSelect48 --> First52
@@ -441,15 +461,15 @@ graph TD
     First71 --> PgSelectSingle72
     PgSelect81[["PgSelect[81∈7] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression80{{"PgClassExpression[80∈7] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda350 & Lambda355 --> PgSelect81
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda357 & Lambda362 --> PgSelect81
     PgSelect87[["PgSelect[87∈7] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda364 & Lambda369 --> PgSelect87
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda372 & Lambda377 --> PgSelect87
     PgSelect94[["PgSelect[94∈7] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda378 & Lambda383 --> PgSelect94
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda387 & Lambda392 --> PgSelect94
     PgSelect98[["PgSelect[98∈7] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda392 & Lambda397 --> PgSelect98
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda402 & Lambda407 --> PgSelect98
     PgSelect102[["PgSelect[102∈7] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object31 & PgClassExpression80 & Lambda258 & Lambda261 & Lambda406 & Lambda411 --> PgSelect102
+    Object31 & PgClassExpression80 & Lambda258 & Access262 & Lambda417 & Lambda422 --> PgSelect102
     PgSelectSingle77 --> PgClassExpression80
     First85{{"First[85∈7] ➊"}}:::plan
     PgSelect81 --> First85
@@ -479,15 +499,15 @@ graph TD
     First104 --> PgSelectSingle105
     PgSelect114[["PgSelect[114∈8] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression113{{"PgClassExpression[113∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda434 & Lambda439 --> PgSelect114
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda447 & Lambda452 --> PgSelect114
     PgSelect120[["PgSelect[120∈8] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda448 & Lambda453 --> PgSelect120
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda462 & Lambda467 --> PgSelect120
     PgSelect127[["PgSelect[127∈8] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda462 & Lambda467 --> PgSelect127
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda477 & Lambda482 --> PgSelect127
     PgSelect131[["PgSelect[131∈8] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda476 & Lambda481 --> PgSelect131
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda492 & Lambda497 --> PgSelect131
     PgSelect135[["PgSelect[135∈8] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object31 & PgClassExpression113 & Lambda258 & Lambda261 & Lambda490 & Lambda495 --> PgSelect135
+    Object31 & PgClassExpression113 & Lambda258 & Access262 & Lambda507 & Lambda512 --> PgSelect135
     PgSelectSingle110 --> PgClassExpression113
     First118{{"First[118∈8] ➊"}}:::plan
     PgSelect114 --> First118
@@ -518,7 +538,7 @@ graph TD
     PgInsertSingle150[["PgInsertSingle[150∈9] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object148{{"Object[148∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression149{{"PgClassExpression[149∈9] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object148 & PgClassExpression149 & Constant771 & Constant772 & Constant773 --> PgInsertSingle150
+    Object148 & PgClassExpression149 & Constant807 & Constant808 & Constant809 --> PgInsertSingle150
     PgInsertSingle145[["PgInsertSingle[145∈9] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object148 & Constant10 & Constant11 --> PgInsertSingle145
     Access146{{"Access[146∈9] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -530,64 +550,46 @@ graph TD
     PgClassExpression154{{"PgClassExpression[154∈9] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgInsertSingle150 --> PgClassExpression154
     PgSelect156[["PgSelect[156∈10] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda588{{"Lambda[588∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda593{{"Lambda[593∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object148 & Constant768 & Lambda258 & Lambda261 & Lambda588 & Lambda593 --> PgSelect156
+    Object148 & Constant804 & Lambda258 & Access262 & Lambda612 & Lambda617 --> PgSelect156
     PgSelect191[["PgSelect[191∈10] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda672{{"Lambda[672∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda677{{"Lambda[677∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object148 & Constant769 & Lambda258 & Lambda261 & Lambda672 & Lambda677 --> PgSelect191
+    Object148 & Constant805 & Lambda258 & Access262 & Lambda702 & Lambda707 --> PgSelect191
     PgSelect224[["PgSelect[224∈10] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda756{{"Lambda[756∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda761{{"Lambda[761∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object148 & Constant770 & Lambda258 & Lambda261 & Lambda756 & Lambda761 --> PgSelect224
-    Object587{{"Object[587∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant584 & Constant585 & Constant334 --> Object587
-    Object671{{"Object[671∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant668 & Constant669 & Constant334 --> Object671
-    Object755{{"Object[755∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda258 & Constant752 & Constant753 & Constant334 --> Object755
+    Object148 & Constant806 & Lambda258 & Access262 & Lambda792 & Lambda797 --> PgSelect224
+    PgPolymorphic163{{"PgPolymorphic[163∈10] ➊"}}:::plan
+    PgSelectSingle161{{"PgSelectSingle[161∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression162{{"PgClassExpression[162∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle161 & PgClassExpression162 --> PgPolymorphic163
+    PgPolymorphic196{{"PgPolymorphic[196∈10] ➊"}}:::plan
+    PgSelectSingle194{{"PgSelectSingle[194∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression195{{"PgClassExpression[195∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle194 & PgClassExpression195 --> PgPolymorphic196
+    PgPolymorphic229{{"PgPolymorphic[229∈10] ➊"}}:::plan
+    PgSelectSingle227{{"PgSelectSingle[227∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression228{{"PgClassExpression[228∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle227 & PgClassExpression228 --> PgPolymorphic229
     First160{{"First[160∈10] ➊"}}:::plan
     PgSelect156 --> First160
-    PgSelectSingle161{{"PgSelectSingle[161∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First160 --> PgSelectSingle161
+    PgSelectSingle161 --> PgClassExpression162
     First193{{"First[193∈10] ➊"}}:::plan
     PgSelect191 --> First193
-    PgSelectSingle194{{"PgSelectSingle[194∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First193 --> PgSelectSingle194
+    PgSelectSingle194 --> PgClassExpression195
     First226{{"First[226∈10] ➊"}}:::plan
     PgSelect224 --> First226
-    PgSelectSingle227{{"PgSelectSingle[227∈10] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First226 --> PgSelectSingle227
-    Object587 --> Lambda588
-    Constant799 --> Lambda593
-    Object671 --> Lambda672
-    Constant805 --> Lambda677
-    Object755 --> Lambda756
-    Constant811 --> Lambda761
-    PgPolymorphic163{{"PgPolymorphic[163∈11] ➊"}}:::plan
-    PgClassExpression162{{"PgClassExpression[162∈11] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle161 & PgClassExpression162 --> PgPolymorphic163
-    PgPolymorphic196{{"PgPolymorphic[196∈11] ➊"}}:::plan
-    PgClassExpression195{{"PgClassExpression[195∈11] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle194 & PgClassExpression195 --> PgPolymorphic196
-    PgPolymorphic229{{"PgPolymorphic[229∈11] ➊"}}:::plan
-    PgClassExpression228{{"PgClassExpression[228∈11] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle227 & PgClassExpression228 --> PgPolymorphic229
-    PgSelectSingle161 --> PgClassExpression162
-    PgSelectSingle194 --> PgClassExpression195
     PgSelectSingle227 --> PgClassExpression228
     PgSelect165[["PgSelect[165∈12] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression164{{"PgClassExpression[164∈12] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda518 & Lambda523 --> PgSelect165
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda537 & Lambda542 --> PgSelect165
     PgSelect171[["PgSelect[171∈12] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda532 & Lambda537 --> PgSelect171
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda552 & Lambda557 --> PgSelect171
     PgSelect178[["PgSelect[178∈12] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda546 & Lambda551 --> PgSelect178
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda567 & Lambda572 --> PgSelect178
     PgSelect182[["PgSelect[182∈12] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda560 & Lambda565 --> PgSelect182
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda582 & Lambda587 --> PgSelect182
     PgSelect186[["PgSelect[186∈12] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object148 & PgClassExpression164 & Lambda258 & Lambda261 & Lambda574 & Lambda579 --> PgSelect186
+    Object148 & PgClassExpression164 & Lambda258 & Access262 & Lambda597 & Lambda602 --> PgSelect186
     PgSelectSingle161 --> PgClassExpression164
     First169{{"First[169∈12] ➊"}}:::plan
     PgSelect165 --> First169
@@ -617,15 +619,15 @@ graph TD
     First188 --> PgSelectSingle189
     PgSelect198[["PgSelect[198∈13] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression197{{"PgClassExpression[197∈13] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda602 & Lambda607 --> PgSelect198
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda627 & Lambda632 --> PgSelect198
     PgSelect204[["PgSelect[204∈13] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda616 & Lambda621 --> PgSelect204
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda642 & Lambda647 --> PgSelect204
     PgSelect211[["PgSelect[211∈13] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda630 & Lambda635 --> PgSelect211
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda657 & Lambda662 --> PgSelect211
     PgSelect215[["PgSelect[215∈13] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda644 & Lambda649 --> PgSelect215
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda672 & Lambda677 --> PgSelect215
     PgSelect219[["PgSelect[219∈13] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object148 & PgClassExpression197 & Lambda258 & Lambda261 & Lambda658 & Lambda663 --> PgSelect219
+    Object148 & PgClassExpression197 & Lambda258 & Access262 & Lambda687 & Lambda692 --> PgSelect219
     PgSelectSingle194 --> PgClassExpression197
     First202{{"First[202∈13] ➊"}}:::plan
     PgSelect198 --> First202
@@ -655,15 +657,15 @@ graph TD
     First221 --> PgSelectSingle222
     PgSelect231[["PgSelect[231∈14] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression230{{"PgClassExpression[230∈14] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda686 & Lambda691 --> PgSelect231
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda717 & Lambda722 --> PgSelect231
     PgSelect237[["PgSelect[237∈14] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda700 & Lambda705 --> PgSelect237
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda732 & Lambda737 --> PgSelect237
     PgSelect244[["PgSelect[244∈14] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda714 & Lambda719 --> PgSelect244
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda747 & Lambda752 --> PgSelect244
     PgSelect248[["PgSelect[248∈14] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda728 & Lambda733 --> PgSelect248
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda762 & Lambda767 --> PgSelect248
     PgSelect252[["PgSelect[252∈14] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object148 & PgClassExpression230 & Lambda258 & Lambda261 & Lambda742 & Lambda747 --> PgSelect252
+    Object148 & PgClassExpression230 & Lambda258 & Access262 & Lambda777 & Lambda782 --> PgSelect252
     PgSelectSingle227 --> PgClassExpression230
     First235{{"First[235∈14] ➊"}}:::plan
     PgSelect231 --> First235
@@ -697,47 +699,47 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-no-query"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda258,Lambda261,Constant262,Constant263,Constant264,Object265,Lambda266,Lambda271,Constant276,Constant277,Constant278,Object279,Lambda280,Lambda285,Constant290,Constant291,Constant292,Object293,Lambda294,Lambda299,Constant304,Constant305,Constant306,Object307,Lambda308,Lambda313,Constant318,Constant319,Constant320,Object321,Lambda322,Lambda327,Constant332,Constant333,Constant334,Constant346,Constant347,Object349,Lambda350,Lambda355,Constant360,Constant361,Object363,Lambda364,Lambda369,Constant374,Constant375,Object377,Lambda378,Lambda383,Constant388,Constant389,Object391,Lambda392,Lambda397,Constant402,Constant403,Object405,Lambda406,Lambda411,Constant416,Constant417,Constant430,Constant431,Object433,Lambda434,Lambda439,Constant444,Constant445,Object447,Lambda448,Lambda453,Constant458,Constant459,Object461,Lambda462,Lambda467,Constant472,Constant473,Object475,Lambda476,Lambda481,Constant486,Constant487,Object489,Lambda490,Lambda495,Constant500,Constant501,Constant514,Constant515,Object517,Lambda518,Lambda523,Constant528,Constant529,Object531,Lambda532,Lambda537,Constant542,Constant543,Object545,Lambda546,Lambda551,Constant556,Constant557,Object559,Lambda560,Lambda565,Constant570,Constant571,Object573,Lambda574,Lambda579,Constant584,Constant585,Constant598,Constant599,Object601,Lambda602,Lambda607,Constant612,Constant613,Object615,Lambda616,Lambda621,Constant626,Constant627,Object629,Lambda630,Lambda635,Constant640,Constant641,Object643,Lambda644,Lambda649,Constant654,Constant655,Object657,Lambda658,Lambda663,Constant668,Constant669,Constant682,Constant683,Object685,Lambda686,Lambda691,Constant696,Constant697,Object699,Lambda700,Lambda705,Constant710,Constant711,Object713,Lambda714,Lambda719,Constant724,Constant725,Object727,Lambda728,Lambda733,Constant738,Constant739,Object741,Lambda742,Lambda747,Constant752,Constant753,Constant762,Constant763,Constant764,Constant765,Constant766,Constant767,Constant768,Constant769,Constant770,Constant771,Constant772,Constant773,Constant774,Constant775,Constant776,Constant777,Constant778,Constant779,Constant780,Constant781,Constant782,Constant783,Constant784,Constant785,Constant786,Constant787,Constant788,Constant789,Constant790,Constant791,Constant792,Constant793,Constant794,Constant795,Constant796,Constant797,Constant798,Constant799,Constant800,Constant801,Constant802,Constant803,Constant804,Constant805,Constant806,Constant807,Constant808,Constant809,Constant810,Constant811 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 762, 763, 764<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda258,Lambda261,Access262,Constant263,Constant264,Constant265,Object266,Lambda267,Lambda272,Constant278,Constant279,Constant280,Object281,Lambda282,Lambda287,Constant293,Constant294,Constant295,Object296,Lambda297,Lambda302,Constant308,Constant309,Constant310,Object311,Lambda312,Lambda317,Constant323,Constant324,Constant325,Object326,Lambda327,Lambda332,Constant338,Constant339,Constant340,Object341,Lambda342,Lambda347,Constant353,Constant354,Object356,Lambda357,Lambda362,Constant368,Constant369,Object371,Lambda372,Lambda377,Constant383,Constant384,Object386,Lambda387,Lambda392,Constant398,Constant399,Object401,Lambda402,Lambda407,Constant413,Constant414,Object416,Lambda417,Lambda422,Constant428,Constant429,Object431,Lambda432,Lambda437,Constant443,Constant444,Object446,Lambda447,Lambda452,Constant458,Constant459,Object461,Lambda462,Lambda467,Constant473,Constant474,Object476,Lambda477,Lambda482,Constant488,Constant489,Object491,Lambda492,Lambda497,Constant503,Constant504,Object506,Lambda507,Lambda512,Constant518,Constant519,Object521,Lambda522,Lambda527,Constant533,Constant534,Object536,Lambda537,Lambda542,Constant548,Constant549,Object551,Lambda552,Lambda557,Constant563,Constant564,Object566,Lambda567,Lambda572,Constant578,Constant579,Object581,Lambda582,Lambda587,Constant593,Constant594,Object596,Lambda597,Lambda602,Constant608,Constant609,Object611,Lambda612,Lambda617,Constant623,Constant624,Object626,Lambda627,Lambda632,Constant638,Constant639,Object641,Lambda642,Lambda647,Constant653,Constant654,Object656,Lambda657,Lambda662,Constant668,Constant669,Object671,Lambda672,Lambda677,Constant683,Constant684,Object686,Lambda687,Lambda692,Constant698,Constant699,Object701,Lambda702,Lambda707,Constant713,Constant714,Object716,Lambda717,Lambda722,Constant728,Constant729,Object731,Lambda732,Lambda737,Constant743,Constant744,Object746,Lambda747,Lambda752,Constant758,Constant759,Object761,Lambda762,Lambda767,Constant773,Constant774,Object776,Lambda777,Lambda782,Constant788,Constant789,Object791,Lambda792,Lambda797,Constant798,Constant799,Constant800,Constant801,Constant802,Constant803,Constant804,Constant805,Constant806,Constant807,Constant808,Constant809,Constant810,Constant811,Constant812,Constant813,Constant814,Constant815,Constant816,Constant817,Constant818,Constant819,Constant820,Constant821,Constant822,Constant823,Constant824,Constant825,Constant826,Constant827,Constant828,Constant829,Constant830,Constant831,Constant832,Constant833,Constant834,Constant835,Constant836,Constant837,Constant838,Constant839,Constant840,Constant841,Constant842,Constant843,Constant844,Constant845,Constant846,Constant847 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 798, 799, 800<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (mutationField)<br />Deps: 10, 11, 2, 765, 766, 767, 768, 258, 261, 769, 770, 332, 333, 334, 781, 416, 417, 787, 500, 501, 793, 4, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgInsertSingle[28]<br />5: PgClassExpression[32]<br />6: PgInsertSingle[33]<br />7: <br />ᐳ: PgClassExpression[37]"):::bucket
+    Bucket3("Bucket 3 (mutationField)<br />Deps: 10, 11, 2, 801, 802, 803, 804, 258, 262, 342, 347, 805, 432, 437, 806, 522, 527, 4, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgInsertSingle[28]<br />5: PgClassExpression[32]<br />6: PgInsertSingle[33]<br />7: <br />ᐳ: PgClassExpression[37]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgInsertSingle28,Access29,Access30,Object31,PgClassExpression32,PgInsertSingle33,PgClassExpression37 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 768, 258, 261, 769, 770, 332, 333, 334, 781, 416, 417, 787, 500, 501, 793, 37, 4, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]<br />1: <br />ᐳ: 335, 341, 419, 425, 503, 509, 336, 420, 504<br />2: 39, 74, 107<br />ᐳ: 43, 44, 76, 77, 109, 110"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 804, 258, 262, 342, 347, 805, 432, 437, 806, 522, 527, 37, 4, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect39,First43,PgSelectSingle44,PgSelect74,First76,PgSelectSingle77,PgSelect107,First109,PgSelectSingle110,Object335,Lambda336,Lambda341,Object419,Lambda420,Lambda425,Object503,Lambda504,Lambda509 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 77, 110, 4, 31, 258, 261, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket4,PgSelect39,First43,PgSelectSingle44,PgClassExpression45,PgPolymorphic46,PgSelect74,First76,PgSelectSingle77,PgClassExpression78,PgPolymorphic79,PgSelect107,First109,PgSelectSingle110,PgClassExpression111,PgPolymorphic112 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 4, 44, 31, 258, 262, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 46, 77, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 79, 110, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512, 112<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression45,PgPolymorphic46,PgClassExpression78,PgPolymorphic79,PgClassExpression111,PgPolymorphic112 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 44, 31, 258, 261, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 46<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[47]<br />2: 48, 54, 61, 65, 69<br />ᐳ: 52, 53, 56, 57, 58, 59, 60, 63, 64, 67, 68, 71, 72"):::bucket
+    class Bucket5 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 44, 31, 258, 262, 267, 272, 282, 287, 297, 302, 312, 317, 327, 332, 46<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[47]<br />2: 48, 54, 61, 65, 69<br />ᐳ: 52, 53, 56, 57, 58, 59, 60, 63, 64, 67, 68, 71, 72"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression47,PgSelect48,First52,PgSelectSingle53,PgSelect54,First56,PgSelectSingle57,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgSelect61,First63,PgSelectSingle64,PgSelect65,First67,PgSelectSingle68,PgSelect69,First71,PgSelectSingle72 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 77, 31, 258, 261, 350, 355, 364, 369, 378, 383, 392, 397, 406, 411, 79<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[80]<br />2: 81, 87, 94, 98, 102<br />ᐳ: 85, 86, 89, 90, 91, 92, 93, 96, 97, 100, 101, 104, 105"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 77, 31, 258, 262, 357, 362, 372, 377, 387, 392, 402, 407, 417, 422, 79<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[80]<br />2: 81, 87, 94, 98, 102<br />ᐳ: 85, 86, 89, 90, 91, 92, 93, 96, 97, 100, 101, 104, 105"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression80,PgSelect81,First85,PgSelectSingle86,PgSelect87,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgSelect94,First96,PgSelectSingle97,PgSelect98,First100,PgSelectSingle101,PgSelect102,First104,PgSelectSingle105 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 110, 31, 258, 261, 434, 439, 448, 453, 462, 467, 476, 481, 490, 495, 112<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[113]<br />2: 114, 120, 127, 131, 135<br />ᐳ: 118, 119, 122, 123, 124, 125, 126, 129, 130, 133, 134, 137, 138"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 110, 31, 258, 262, 447, 452, 462, 467, 477, 482, 492, 497, 507, 512, 112<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[113]<br />2: 114, 120, 127, 131, 135<br />ᐳ: 118, 119, 122, 123, 124, 125, 126, 129, 130, 133, 134, 137, 138"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression113,PgSelect114,First118,PgSelectSingle119,PgSelect120,First122,PgSelectSingle123,PgClassExpression124,PgClassExpression125,PgClassExpression126,PgSelect127,First129,PgSelectSingle130,PgSelect131,First133,PgSelectSingle134,PgSelect135,First137,PgSelectSingle138 bucket8
-    Bucket9("Bucket 9 (mutationField)<br />Deps: 10, 11, 2, 771, 772, 773, 768, 258, 261, 769, 770, 584, 585, 334, 799, 668, 669, 805, 752, 753, 811, 4, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747<br /><br />1: Access[146]<br />2: Access[147]<br />3: Object[148]<br />4: PgInsertSingle[145]<br />5: PgClassExpression[149]<br />6: PgInsertSingle[150]<br />7: <br />ᐳ: PgClassExpression[154]"):::bucket
+    Bucket9("Bucket 9 (mutationField)<br />Deps: 10, 11, 2, 807, 808, 809, 804, 258, 262, 612, 617, 805, 702, 707, 806, 792, 797, 4, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782<br /><br />1: Access[146]<br />2: Access[147]<br />3: Object[148]<br />4: PgInsertSingle[145]<br />5: PgClassExpression[149]<br />6: PgInsertSingle[150]<br />7: <br />ᐳ: PgClassExpression[154]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgInsertSingle145,Access146,Access147,Object148,PgClassExpression149,PgInsertSingle150,PgClassExpression154 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 148, 768, 258, 261, 769, 770, 584, 585, 334, 799, 668, 669, 805, 752, 753, 811, 154, 4, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[154]<br />1: <br />ᐳ: 587, 593, 671, 677, 755, 761, 588, 672, 756<br />2: 156, 191, 224<br />ᐳ: 160, 161, 193, 194, 226, 227"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 148, 804, 258, 262, 612, 617, 805, 702, 707, 806, 792, 797, 154, 4, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[154]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect156,First160,PgSelectSingle161,PgSelect191,First193,PgSelectSingle194,PgSelect224,First226,PgSelectSingle227,Object587,Lambda588,Lambda593,Object671,Lambda672,Lambda677,Object755,Lambda756,Lambda761 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 161, 194, 227, 4, 148, 258, 261, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket10,PgSelect156,First160,PgSelectSingle161,PgClassExpression162,PgPolymorphic163,PgSelect191,First193,PgSelectSingle194,PgClassExpression195,PgPolymorphic196,PgSelect224,First226,PgSelectSingle227,PgClassExpression228,PgPolymorphic229 bucket10
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 4, 161, 148, 258, 262, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 163, 194, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 196, 227, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782, 229<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression162,PgPolymorphic163,PgClassExpression195,PgPolymorphic196,PgClassExpression228,PgPolymorphic229 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 161, 148, 258, 261, 518, 523, 532, 537, 546, 551, 560, 565, 574, 579, 163<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[164]<br />2: 165, 171, 178, 182, 186<br />ᐳ: 169, 170, 173, 174, 175, 176, 177, 180, 181, 184, 185, 188, 189"):::bucket
+    class Bucket11 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 161, 148, 258, 262, 537, 542, 552, 557, 567, 572, 582, 587, 597, 602, 163<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[164]<br />2: 165, 171, 178, 182, 186<br />ᐳ: 169, 170, 173, 174, 175, 176, 177, 180, 181, 184, 185, 188, 189"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression164,PgSelect165,First169,PgSelectSingle170,PgSelect171,First173,PgSelectSingle174,PgClassExpression175,PgClassExpression176,PgClassExpression177,PgSelect178,First180,PgSelectSingle181,PgSelect182,First184,PgSelectSingle185,PgSelect186,First188,PgSelectSingle189 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 194, 148, 258, 261, 602, 607, 616, 621, 630, 635, 644, 649, 658, 663, 196<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[197]<br />2: 198, 204, 211, 215, 219<br />ᐳ: 202, 203, 206, 207, 208, 209, 210, 213, 214, 217, 218, 221, 222"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 194, 148, 258, 262, 627, 632, 642, 647, 657, 662, 672, 677, 687, 692, 196<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[197]<br />2: 198, 204, 211, 215, 219<br />ᐳ: 202, 203, 206, 207, 208, 209, 210, 213, 214, 217, 218, 221, 222"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression197,PgSelect198,First202,PgSelectSingle203,PgSelect204,First206,PgSelectSingle207,PgClassExpression208,PgClassExpression209,PgClassExpression210,PgSelect211,First213,PgSelectSingle214,PgSelect215,First217,PgSelectSingle218,PgSelect219,First221,PgSelectSingle222 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 227, 148, 258, 261, 686, 691, 700, 705, 714, 719, 728, 733, 742, 747, 229<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[230]<br />2: 231, 237, 244, 248, 252<br />ᐳ: 235, 236, 239, 240, 241, 242, 243, 246, 247, 250, 251, 254, 255"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 227, 148, 258, 262, 717, 722, 732, 737, 747, 752, 762, 767, 777, 782, 229<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[230]<br />2: 231, 237, 244, 248, 252<br />ᐳ: 235, 236, 239, 240, 241, 242, 243, 246, 247, 250, 251, 254, 255"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression230,PgSelect231,First235,PgSelectSingle236,PgSelect237,First239,PgSelectSingle240,PgClassExpression241,PgClassExpression242,PgClassExpression243,PgSelect244,First246,PgSelectSingle247,PgSelect248,First250,PgSelectSingle251,PgSelect252,First254,PgSelectSingle255 bucket14
     Bucket0 --> Bucket1 & Bucket3 & Bucket9

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-null-description.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-null-description.deopt.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,21 +22,27 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant52 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant53 --> Lambda38
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda38 --> Access39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object43 --> Lambda44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant54 --> Lambda49
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Constant33{{"Constant[33∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant49 & Constant33 & Constant50 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant50 & Constant33 & Constant51 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -38,22 +50,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈2] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect23
-    Object42{{"Object[42∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
+    Object15 & PgClassExpression22 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Constant51 --> Lambda35
-    Constant52 --> Lambda38
-    Object42 --> Lambda43
-    Constant53 --> Lambda48
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -68,13 +70,13 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-null-description"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant33,Constant39,Constant40,Constant41,Constant49,Constant50,Constant51,Constant52,Constant53 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 49, 33, 50, 51, 52, 39, 40, 41, 53<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant33,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant50,Constant51,Constant52,Constant53,Constant54 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 50, 33, 51, 35, 39, 44, 49<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 51, 52, 39, 40, 41, 53, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 35, 38, 48, 42, 43<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 35, 39, 44, 49, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Lambda35,Lambda38,Object42,Lambda43,Lambda48 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-null-description.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-null-description.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,21 +22,27 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant52 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant53 --> Lambda38
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda38 --> Access39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object43 --> Lambda44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant54 --> Lambda49
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Constant33{{"Constant[33∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant49 & Constant33 & Constant50 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant50 & Constant33 & Constant51 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -38,22 +50,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈2] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect23
-    Object42{{"Object[42∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
+    Object15 & PgClassExpression22 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Constant51 --> Lambda35
-    Constant52 --> Lambda38
-    Object42 --> Lambda43
-    Constant53 --> Lambda48
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -68,13 +70,13 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-null-description"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant33,Constant39,Constant40,Constant41,Constant49,Constant50,Constant51,Constant52,Constant53 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 49, 33, 50, 51, 52, 39, 40, 41, 53<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant33,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant50,Constant51,Constant52,Constant53,Constant54 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 50, 33, 51, 35, 39, 44, 49<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 51, 52, 39, 40, 41, 53, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 35, 38, 48, 42, 43<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 35, 39, 44, 49, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Lambda35,Lambda38,Object42,Lambda43,Lambda48 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-x4.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-x4.deopt.mermaid
@@ -9,6 +9,24 @@ graph TD
 
 
     %% plan dependencies
+    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda116 & Constant121 & Constant122 & Constant123 --> Object124
+    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda116 & Constant136 & Constant137 & Constant123 --> Object139
+    Object154{{"Object[154∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda116 & Constant151 & Constant152 & Constant123 --> Object154
+    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda116 & Constant166 & Constant167 & Constant123 --> Object169
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,43 +34,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant184 --> Lambda116
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant188 --> Lambda116
     Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant185 --> Lambda119
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant189 --> Lambda119
+    Access120{{"Access[120∈0] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Lambda119 --> Access120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object124 --> Lambda125
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant190 --> Lambda130
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object139 --> Lambda140
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant191 --> Lambda145
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object154 --> Lambda155
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant192 --> Lambda160
+    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object169 --> Lambda170
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant193 --> Lambda175
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ'My Relational Post 4'ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ'A post, innit? 4'ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ'Such a great post. 4'ᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ'My Relational Post 4'ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ'A post, innit? 4'ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ'Such a great post. 4'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant172 & Constant173 & Constant174 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant176 & Constant177 & Constant178 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -60,18 +86,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda124{{"Lambda[124∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda129{{"Lambda[129∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda116 & Lambda119 & Lambda124 & Lambda129 --> PgSelect23
-    Object123{{"Object[123∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant120 & Constant121 & Constant122 --> Object123
+    Object15 & PgClassExpression22 & Lambda116 & Access120 & Lambda125 & Lambda130 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Object123 --> Lambda124
-    Constant186 --> Lambda129
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -83,7 +103,7 @@ graph TD
     PgInsertSingle44[["PgInsertSingle[44∈4] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object42{{"Object[42∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression43{{"PgClassExpression[43∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object42 & PgClassExpression43 & Constant175 & Constant176 & Constant177 --> PgInsertSingle44
+    Object42 & PgClassExpression43 & Constant179 & Constant180 & Constant181 --> PgInsertSingle44
     PgInsertSingle39[["PgInsertSingle[39∈4] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object42 & Constant10 & Constant11 --> PgInsertSingle39
     Access40{{"Access[40∈4] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -96,18 +116,12 @@ graph TD
     PgInsertSingle44 --> PgClassExpression48
     PgSelect50[["PgSelect[50∈5] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression49{{"PgClassExpression[49∈5] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda138{{"Lambda[138∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object42 & PgClassExpression49 & Lambda116 & Lambda119 & Lambda138 & Lambda143 --> PgSelect50
-    Object137{{"Object[137∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant134 & Constant135 & Constant122 --> Object137
+    Object42 & PgClassExpression49 & Lambda116 & Access120 & Lambda140 & Lambda145 --> PgSelect50
     PgInsertSingle44 --> PgClassExpression49
     First54{{"First[54∈5] ➊"}}:::plan
     PgSelect50 --> First54
     PgSelectSingle55{{"PgSelectSingle[55∈5] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First54 --> PgSelectSingle55
-    Object137 --> Lambda138
-    Constant187 --> Lambda143
     PgClassExpression56{{"PgClassExpression[56∈6] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle55 --> PgClassExpression56
     PgClassExpression57{{"PgClassExpression[57∈6] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -119,7 +133,7 @@ graph TD
     PgInsertSingle71[["PgInsertSingle[71∈7] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object69{{"Object[69∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression70{{"PgClassExpression[70∈7] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object69 & PgClassExpression70 & Constant178 & Constant179 & Constant180 --> PgInsertSingle71
+    Object69 & PgClassExpression70 & Constant182 & Constant183 & Constant184 --> PgInsertSingle71
     PgInsertSingle66[["PgInsertSingle[66∈7] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object69 & Constant10 & Constant11 --> PgInsertSingle66
     Access67{{"Access[67∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -132,18 +146,12 @@ graph TD
     PgInsertSingle71 --> PgClassExpression75
     PgSelect77[["PgSelect[77∈8] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression76{{"PgClassExpression[76∈8] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda152{{"Lambda[152∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda157{{"Lambda[157∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object69 & PgClassExpression76 & Lambda116 & Lambda119 & Lambda152 & Lambda157 --> PgSelect77
-    Object151{{"Object[151∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant148 & Constant149 & Constant122 --> Object151
+    Object69 & PgClassExpression76 & Lambda116 & Access120 & Lambda155 & Lambda160 --> PgSelect77
     PgInsertSingle71 --> PgClassExpression76
     First81{{"First[81∈8] ➊"}}:::plan
     PgSelect77 --> First81
     PgSelectSingle82{{"PgSelectSingle[82∈8] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First81 --> PgSelectSingle82
-    Object151 --> Lambda152
-    Constant188 --> Lambda157
     PgClassExpression83{{"PgClassExpression[83∈9] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle82 --> PgClassExpression83
     PgClassExpression84{{"PgClassExpression[84∈9] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -155,7 +163,7 @@ graph TD
     PgInsertSingle98[["PgInsertSingle[98∈10] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object96{{"Object[96∈10] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression97{{"PgClassExpression[97∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object96 & PgClassExpression97 & Constant181 & Constant182 & Constant183 --> PgInsertSingle98
+    Object96 & PgClassExpression97 & Constant185 & Constant186 & Constant187 --> PgInsertSingle98
     PgInsertSingle93[["PgInsertSingle[93∈10] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object96 & Constant10 & Constant11 --> PgInsertSingle93
     Access94{{"Access[94∈10] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -168,18 +176,12 @@ graph TD
     PgInsertSingle98 --> PgClassExpression102
     PgSelect104[["PgSelect[104∈11] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression103{{"PgClassExpression[103∈11] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda166{{"Lambda[166∈11] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda171{{"Lambda[171∈11] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object96 & PgClassExpression103 & Lambda116 & Lambda119 & Lambda166 & Lambda171 --> PgSelect104
-    Object165{{"Object[165∈11] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant162 & Constant163 & Constant122 --> Object165
+    Object96 & PgClassExpression103 & Lambda116 & Access120 & Lambda170 & Lambda175 --> PgSelect104
     PgInsertSingle98 --> PgClassExpression103
     First108{{"First[108∈11] ➊"}}:::plan
     PgSelect104 --> First108
     PgSelectSingle109{{"PgSelectSingle[109∈11] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First108 --> PgSelectSingle109
-    Object165 --> Lambda166
-    Constant189 --> Lambda171
     PgClassExpression110{{"PgClassExpression[110∈12] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle109 --> PgClassExpression110
     PgClassExpression111{{"PgClassExpression[111∈12] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -194,40 +196,40 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-x4"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda116,Lambda119,Constant120,Constant121,Constant122,Constant134,Constant135,Constant148,Constant149,Constant162,Constant163,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 172, 173, 174, 116, 119, 120, 121, 122, 186<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda116,Lambda119,Access120,Constant121,Constant122,Constant123,Object124,Lambda125,Lambda130,Constant136,Constant137,Object139,Lambda140,Lambda145,Constant151,Constant152,Object154,Lambda155,Lambda160,Constant166,Constant167,Object169,Lambda170,Lambda175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 176, 177, 178, 116, 120, 125, 130<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 116, 119, 120, 121, 122, 186, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 123, 129, 124<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 116, 120, 125, 130, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Object123,Lambda124,Lambda129 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket3
-    Bucket4("Bucket 4 (mutationField)<br />Deps: 10, 11, 2, 175, 176, 177, 116, 119, 134, 135, 122, 187<br /><br />1: Access[40]<br />2: Access[41]<br />3: Object[42]<br />4: PgInsertSingle[39]<br />5: PgClassExpression[43]<br />6: PgInsertSingle[44]<br />7: <br />ᐳ: PgClassExpression[48]"):::bucket
+    Bucket4("Bucket 4 (mutationField)<br />Deps: 10, 11, 2, 179, 180, 181, 116, 120, 140, 145<br /><br />1: Access[40]<br />2: Access[41]<br />3: Object[42]<br />4: PgInsertSingle[39]<br />5: PgClassExpression[43]<br />6: PgInsertSingle[44]<br />7: <br />ᐳ: PgClassExpression[48]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgInsertSingle39,Access40,Access41,Object42,PgClassExpression43,PgInsertSingle44,PgClassExpression48 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 42, 116, 119, 134, 135, 122, 187, 48<br /><br />ROOT PgClassExpression{4}ᐸ__relational_posts__ᐳ[48]<br />1: <br />ᐳ: 49, 137, 143, 138<br />2: PgSelect[50]<br />ᐳ: First[54], PgSelectSingle[55]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 42, 116, 120, 140, 145, 48<br /><br />ROOT PgClassExpression{4}ᐸ__relational_posts__ᐳ[48]<br />1: <br />ᐳ: PgClassExpression[49]<br />2: PgSelect[50]<br />ᐳ: First[54], PgSelectSingle[55]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression49,PgSelect50,First54,PgSelectSingle55,Object137,Lambda138,Lambda143 bucket5
+    class Bucket5,PgClassExpression49,PgSelect50,First54,PgSelectSingle55 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 55<br /><br />ROOT PgSelectSingle{5}ᐸrelational_postsᐳ[55]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgClassExpression59 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 10, 11, 2, 178, 179, 180, 116, 119, 148, 149, 122, 188<br /><br />1: Access[67]<br />2: Access[68]<br />3: Object[69]<br />4: PgInsertSingle[66]<br />5: PgClassExpression[70]<br />6: PgInsertSingle[71]<br />7: <br />ᐳ: PgClassExpression[75]"):::bucket
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 10, 11, 2, 182, 183, 184, 116, 120, 155, 160<br /><br />1: Access[67]<br />2: Access[68]<br />3: Object[69]<br />4: PgInsertSingle[66]<br />5: PgClassExpression[70]<br />6: PgInsertSingle[71]<br />7: <br />ᐳ: PgClassExpression[75]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgInsertSingle66,Access67,Access68,Object69,PgClassExpression70,PgInsertSingle71,PgClassExpression75 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 71, 69, 116, 119, 148, 149, 122, 188, 75<br /><br />ROOT PgClassExpression{7}ᐸ__relational_posts__ᐳ[75]<br />1: <br />ᐳ: 76, 151, 157, 152<br />2: PgSelect[77]<br />ᐳ: First[81], PgSelectSingle[82]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 71, 69, 116, 120, 155, 160, 75<br /><br />ROOT PgClassExpression{7}ᐸ__relational_posts__ᐳ[75]<br />1: <br />ᐳ: PgClassExpression[76]<br />2: PgSelect[77]<br />ᐳ: First[81], PgSelectSingle[82]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression76,PgSelect77,First81,PgSelectSingle82,Object151,Lambda152,Lambda157 bucket8
+    class Bucket8,PgClassExpression76,PgSelect77,First81,PgSelectSingle82 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 82<br /><br />ROOT PgSelectSingle{8}ᐸrelational_postsᐳ[82]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86 bucket9
-    Bucket10("Bucket 10 (mutationField)<br />Deps: 10, 11, 2, 181, 182, 183, 116, 119, 162, 163, 122, 189<br /><br />1: Access[94]<br />2: Access[95]<br />3: Object[96]<br />4: PgInsertSingle[93]<br />5: PgClassExpression[97]<br />6: PgInsertSingle[98]<br />7: <br />ᐳ: PgClassExpression[102]"):::bucket
+    Bucket10("Bucket 10 (mutationField)<br />Deps: 10, 11, 2, 185, 186, 187, 116, 120, 170, 175<br /><br />1: Access[94]<br />2: Access[95]<br />3: Object[96]<br />4: PgInsertSingle[93]<br />5: PgClassExpression[97]<br />6: PgInsertSingle[98]<br />7: <br />ᐳ: PgClassExpression[102]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgInsertSingle93,Access94,Access95,Object96,PgClassExpression97,PgInsertSingle98,PgClassExpression102 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 98, 96, 116, 119, 162, 163, 122, 189, 102<br /><br />ROOT PgClassExpression{10}ᐸ__relational_posts__ᐳ[102]<br />1: <br />ᐳ: 103, 165, 171, 166<br />2: PgSelect[104]<br />ᐳ: First[108], PgSelectSingle[109]"):::bucket
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 98, 96, 116, 120, 170, 175, 102<br /><br />ROOT PgClassExpression{10}ᐸ__relational_posts__ᐳ[102]<br />1: <br />ᐳ: PgClassExpression[103]<br />2: PgSelect[104]<br />ᐳ: First[108], PgSelectSingle[109]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression103,PgSelect104,First108,PgSelectSingle109,Object165,Lambda166,Lambda171 bucket11
+    class Bucket11,PgClassExpression103,PgSelect104,First108,PgSelectSingle109 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 109<br /><br />ROOT PgSelectSingle{11}ᐸrelational_postsᐳ[109]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression110,PgClassExpression111,PgClassExpression112,PgClassExpression113 bucket12

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-x4.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-x4.mermaid
@@ -9,6 +9,24 @@ graph TD
 
 
     %% plan dependencies
+    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda116 & Constant121 & Constant122 & Constant123 --> Object124
+    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda116 & Constant136 & Constant137 & Constant123 --> Object139
+    Object154{{"Object[154∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda116 & Constant151 & Constant152 & Constant123 --> Object154
+    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda116 & Constant166 & Constant167 & Constant123 --> Object169
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,43 +34,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant184 --> Lambda116
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant188 --> Lambda116
     Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant185 --> Lambda119
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant189 --> Lambda119
+    Access120{{"Access[120∈0] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Lambda119 --> Access120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object124 --> Lambda125
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant190 --> Lambda130
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object139 --> Lambda140
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant191 --> Lambda145
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object154 --> Lambda155
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant192 --> Lambda160
+    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object169 --> Lambda170
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant193 --> Lambda175
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ'My Relational Post 4'ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ'A post, innit? 4'ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ'Such a great post. 4'ᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ'My Relational Post 2'ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ'A post, innit? 2'ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ'Such a great post. 2'ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ'My Relational Post 3'ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ'A post, innit? 3'ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ'Such a great post. 3'ᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ'My Relational Post 4'ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ'A post, innit? 4'ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ'Such a great post. 4'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant172 & Constant173 & Constant174 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant176 & Constant177 & Constant178 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -60,18 +86,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda124{{"Lambda[124∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda129{{"Lambda[129∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda116 & Lambda119 & Lambda124 & Lambda129 --> PgSelect23
-    Object123{{"Object[123∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant120 & Constant121 & Constant122 --> Object123
+    Object15 & PgClassExpression22 & Lambda116 & Access120 & Lambda125 & Lambda130 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Object123 --> Lambda124
-    Constant186 --> Lambda129
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -83,7 +103,7 @@ graph TD
     PgInsertSingle44[["PgInsertSingle[44∈4] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object42{{"Object[42∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression43{{"PgClassExpression[43∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object42 & PgClassExpression43 & Constant175 & Constant176 & Constant177 --> PgInsertSingle44
+    Object42 & PgClassExpression43 & Constant179 & Constant180 & Constant181 --> PgInsertSingle44
     PgInsertSingle39[["PgInsertSingle[39∈4] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object42 & Constant10 & Constant11 --> PgInsertSingle39
     Access40{{"Access[40∈4] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -96,18 +116,12 @@ graph TD
     PgInsertSingle44 --> PgClassExpression48
     PgSelect50[["PgSelect[50∈5] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression49{{"PgClassExpression[49∈5] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda138{{"Lambda[138∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object42 & PgClassExpression49 & Lambda116 & Lambda119 & Lambda138 & Lambda143 --> PgSelect50
-    Object137{{"Object[137∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant134 & Constant135 & Constant122 --> Object137
+    Object42 & PgClassExpression49 & Lambda116 & Access120 & Lambda140 & Lambda145 --> PgSelect50
     PgInsertSingle44 --> PgClassExpression49
     First54{{"First[54∈5] ➊"}}:::plan
     PgSelect50 --> First54
     PgSelectSingle55{{"PgSelectSingle[55∈5] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First54 --> PgSelectSingle55
-    Object137 --> Lambda138
-    Constant187 --> Lambda143
     PgClassExpression56{{"PgClassExpression[56∈6] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle55 --> PgClassExpression56
     PgClassExpression57{{"PgClassExpression[57∈6] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -119,7 +133,7 @@ graph TD
     PgInsertSingle71[["PgInsertSingle[71∈7] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object69{{"Object[69∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression70{{"PgClassExpression[70∈7] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object69 & PgClassExpression70 & Constant178 & Constant179 & Constant180 --> PgInsertSingle71
+    Object69 & PgClassExpression70 & Constant182 & Constant183 & Constant184 --> PgInsertSingle71
     PgInsertSingle66[["PgInsertSingle[66∈7] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object69 & Constant10 & Constant11 --> PgInsertSingle66
     Access67{{"Access[67∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -132,18 +146,12 @@ graph TD
     PgInsertSingle71 --> PgClassExpression75
     PgSelect77[["PgSelect[77∈8] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression76{{"PgClassExpression[76∈8] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda152{{"Lambda[152∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda157{{"Lambda[157∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object69 & PgClassExpression76 & Lambda116 & Lambda119 & Lambda152 & Lambda157 --> PgSelect77
-    Object151{{"Object[151∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant148 & Constant149 & Constant122 --> Object151
+    Object69 & PgClassExpression76 & Lambda116 & Access120 & Lambda155 & Lambda160 --> PgSelect77
     PgInsertSingle71 --> PgClassExpression76
     First81{{"First[81∈8] ➊"}}:::plan
     PgSelect77 --> First81
     PgSelectSingle82{{"PgSelectSingle[82∈8] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First81 --> PgSelectSingle82
-    Object151 --> Lambda152
-    Constant188 --> Lambda157
     PgClassExpression83{{"PgClassExpression[83∈9] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle82 --> PgClassExpression83
     PgClassExpression84{{"PgClassExpression[84∈9] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -155,7 +163,7 @@ graph TD
     PgInsertSingle98[["PgInsertSingle[98∈10] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     Object96{{"Object[96∈10] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     PgClassExpression97{{"PgClassExpression[97∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object96 & PgClassExpression97 & Constant181 & Constant182 & Constant183 --> PgInsertSingle98
+    Object96 & PgClassExpression97 & Constant185 & Constant186 & Constant187 --> PgInsertSingle98
     PgInsertSingle93[["PgInsertSingle[93∈10] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object96 & Constant10 & Constant11 --> PgInsertSingle93
     Access94{{"Access[94∈10] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -168,18 +176,12 @@ graph TD
     PgInsertSingle98 --> PgClassExpression102
     PgSelect104[["PgSelect[104∈11] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression103{{"PgClassExpression[103∈11] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda166{{"Lambda[166∈11] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda171{{"Lambda[171∈11] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object96 & PgClassExpression103 & Lambda116 & Lambda119 & Lambda166 & Lambda171 --> PgSelect104
-    Object165{{"Object[165∈11] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116 & Constant162 & Constant163 & Constant122 --> Object165
+    Object96 & PgClassExpression103 & Lambda116 & Access120 & Lambda170 & Lambda175 --> PgSelect104
     PgInsertSingle98 --> PgClassExpression103
     First108{{"First[108∈11] ➊"}}:::plan
     PgSelect104 --> First108
     PgSelectSingle109{{"PgSelectSingle[109∈11] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First108 --> PgSelectSingle109
-    Object165 --> Lambda166
-    Constant189 --> Lambda171
     PgClassExpression110{{"PgClassExpression[110∈12] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle109 --> PgClassExpression110
     PgClassExpression111{{"PgClassExpression[111∈12] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -194,40 +196,40 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post-x4"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda116,Lambda119,Constant120,Constant121,Constant122,Constant134,Constant135,Constant148,Constant149,Constant162,Constant163,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 172, 173, 174, 116, 119, 120, 121, 122, 186<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda116,Lambda119,Access120,Constant121,Constant122,Constant123,Object124,Lambda125,Lambda130,Constant136,Constant137,Object139,Lambda140,Lambda145,Constant151,Constant152,Object154,Lambda155,Lambda160,Constant166,Constant167,Object169,Lambda170,Lambda175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 176, 177, 178, 116, 120, 125, 130<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 116, 119, 120, 121, 122, 186, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 123, 129, 124<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 116, 120, 125, 130, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Object123,Lambda124,Lambda129 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket3
-    Bucket4("Bucket 4 (mutationField)<br />Deps: 10, 11, 2, 175, 176, 177, 116, 119, 134, 135, 122, 187<br /><br />1: Access[40]<br />2: Access[41]<br />3: Object[42]<br />4: PgInsertSingle[39]<br />5: PgClassExpression[43]<br />6: PgInsertSingle[44]<br />7: <br />ᐳ: PgClassExpression[48]"):::bucket
+    Bucket4("Bucket 4 (mutationField)<br />Deps: 10, 11, 2, 179, 180, 181, 116, 120, 140, 145<br /><br />1: Access[40]<br />2: Access[41]<br />3: Object[42]<br />4: PgInsertSingle[39]<br />5: PgClassExpression[43]<br />6: PgInsertSingle[44]<br />7: <br />ᐳ: PgClassExpression[48]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgInsertSingle39,Access40,Access41,Object42,PgClassExpression43,PgInsertSingle44,PgClassExpression48 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 42, 116, 119, 134, 135, 122, 187, 48<br /><br />ROOT PgClassExpression{4}ᐸ__relational_posts__ᐳ[48]<br />1: <br />ᐳ: 49, 137, 143, 138<br />2: PgSelect[50]<br />ᐳ: First[54], PgSelectSingle[55]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 42, 116, 120, 140, 145, 48<br /><br />ROOT PgClassExpression{4}ᐸ__relational_posts__ᐳ[48]<br />1: <br />ᐳ: PgClassExpression[49]<br />2: PgSelect[50]<br />ᐳ: First[54], PgSelectSingle[55]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression49,PgSelect50,First54,PgSelectSingle55,Object137,Lambda138,Lambda143 bucket5
+    class Bucket5,PgClassExpression49,PgSelect50,First54,PgSelectSingle55 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 55<br /><br />ROOT PgSelectSingle{5}ᐸrelational_postsᐳ[55]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgClassExpression59 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 10, 11, 2, 178, 179, 180, 116, 119, 148, 149, 122, 188<br /><br />1: Access[67]<br />2: Access[68]<br />3: Object[69]<br />4: PgInsertSingle[66]<br />5: PgClassExpression[70]<br />6: PgInsertSingle[71]<br />7: <br />ᐳ: PgClassExpression[75]"):::bucket
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 10, 11, 2, 182, 183, 184, 116, 120, 155, 160<br /><br />1: Access[67]<br />2: Access[68]<br />3: Object[69]<br />4: PgInsertSingle[66]<br />5: PgClassExpression[70]<br />6: PgInsertSingle[71]<br />7: <br />ᐳ: PgClassExpression[75]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgInsertSingle66,Access67,Access68,Object69,PgClassExpression70,PgInsertSingle71,PgClassExpression75 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 71, 69, 116, 119, 148, 149, 122, 188, 75<br /><br />ROOT PgClassExpression{7}ᐸ__relational_posts__ᐳ[75]<br />1: <br />ᐳ: 76, 151, 157, 152<br />2: PgSelect[77]<br />ᐳ: First[81], PgSelectSingle[82]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 71, 69, 116, 120, 155, 160, 75<br /><br />ROOT PgClassExpression{7}ᐸ__relational_posts__ᐳ[75]<br />1: <br />ᐳ: PgClassExpression[76]<br />2: PgSelect[77]<br />ᐳ: First[81], PgSelectSingle[82]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression76,PgSelect77,First81,PgSelectSingle82,Object151,Lambda152,Lambda157 bucket8
+    class Bucket8,PgClassExpression76,PgSelect77,First81,PgSelectSingle82 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 82<br /><br />ROOT PgSelectSingle{8}ᐸrelational_postsᐳ[82]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86 bucket9
-    Bucket10("Bucket 10 (mutationField)<br />Deps: 10, 11, 2, 181, 182, 183, 116, 119, 162, 163, 122, 189<br /><br />1: Access[94]<br />2: Access[95]<br />3: Object[96]<br />4: PgInsertSingle[93]<br />5: PgClassExpression[97]<br />6: PgInsertSingle[98]<br />7: <br />ᐳ: PgClassExpression[102]"):::bucket
+    Bucket10("Bucket 10 (mutationField)<br />Deps: 10, 11, 2, 185, 186, 187, 116, 120, 170, 175<br /><br />1: Access[94]<br />2: Access[95]<br />3: Object[96]<br />4: PgInsertSingle[93]<br />5: PgClassExpression[97]<br />6: PgInsertSingle[98]<br />7: <br />ᐳ: PgClassExpression[102]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgInsertSingle93,Access94,Access95,Object96,PgClassExpression97,PgInsertSingle98,PgClassExpression102 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 98, 96, 116, 119, 162, 163, 122, 189, 102<br /><br />ROOT PgClassExpression{10}ᐸ__relational_posts__ᐳ[102]<br />1: <br />ᐳ: 103, 165, 171, 166<br />2: PgSelect[104]<br />ᐳ: First[108], PgSelectSingle[109]"):::bucket
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 98, 96, 116, 120, 170, 175, 102<br /><br />ROOT PgClassExpression{10}ᐸ__relational_posts__ᐳ[102]<br />1: <br />ᐳ: PgClassExpression[103]<br />2: PgSelect[104]<br />ᐳ: First[108], PgSelectSingle[109]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression103,PgSelect104,First108,PgSelectSingle109,Object165,Lambda166,Lambda171 bucket11
+    class Bucket11,PgClassExpression103,PgSelect104,First108,PgSelectSingle109 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 109<br /><br />ROOT PgSelectSingle{11}ᐸrelational_postsᐳ[109]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression110,PgClassExpression111,PgClassExpression112,PgClassExpression113 bucket12

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post.deopt.mermaid
@@ -9,6 +9,27 @@ graph TD
 
 
     %% plan dependencies
+    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda59 & Constant64 & Constant65 & Constant66 --> Object67
+    Object82{{"Object[82∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda59 & Constant79 & Constant80 & Constant81 --> Object82
+    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda59 & Constant96 & Constant97 & Constant98 --> Object99
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda59 & Constant113 & Constant114 & Constant115 --> Object116
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,37 +37,42 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant122 --> Lambda59
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant126 --> Lambda59
     Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant123 --> Lambda62
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant127 --> Lambda62
+    Access63{{"Access[63∈0] ➊<br />ᐸ62.0ᐳ"}}:::plan
+    Lambda62 --> Access63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object67 --> Lambda68
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant128 --> Lambda73
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object82 --> Lambda83
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant129 --> Lambda88
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object99 --> Lambda100
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant130 --> Lambda105
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object116 --> Lambda117
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant131 --> Lambda122
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant119 & Constant120 & Constant121 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant123 & Constant124 & Constant125 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -54,39 +80,15 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda97{{"Lambda[97∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda102{{"Lambda[102∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda118{{"Lambda[118∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda62 & Lambda81 & Lambda86 & Lambda62 & Lambda97 & Lambda102 & Lambda59 & Lambda62 & Lambda113 & Lambda118 --> PgSelect23
-    Object66{{"Object[66∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant63 & Constant64 & Constant65 --> Object66
-    Object80{{"Object[80∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant77 & Constant78 & Constant79 --> Object80
-    Object96{{"Object[96∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant93 & Constant94 & Constant95 --> Object96
-    Object112{{"Object[112∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant109 & Constant110 & Constant111 --> Object112
+    Object15 & PgClassExpression22 & Access63 & Lambda83 & Lambda88 & Access63 & Lambda100 & Lambda105 & Lambda59 & Access63 & Lambda117 & Lambda122 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Lambda67{{"Lambda[67∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object66 --> Lambda67
-    Lambda72{{"Lambda[72∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant124 --> Lambda72
-    Object80 --> Lambda81
-    Constant125 --> Lambda86
-    Object96 --> Lambda97
-    Constant126 --> Lambda102
-    Object112 --> Lambda113
-    Constant127 --> Lambda118
     PgSelect51[["PgSelect[51∈3] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression50{{"PgClassExpression[50∈3] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object15 & PgClassExpression50 & Lambda59 & Lambda62 & Lambda67 & Lambda72 --> PgSelect51
+    Object15 & PgClassExpression50 & Lambda59 & Access63 & Lambda68 & Lambda73 --> PgSelect51
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -96,8 +98,8 @@ graph TD
     PgClassExpression32{{"PgClassExpression[32∈3] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression32
     PgSelectSingle39{{"PgSelectSingle[39∈3] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys103{{"RemapKeys[103∈3] ➊<br />ᐸ28:{”0”:6}ᐳ"}}:::plan
-    RemapKeys103 --> PgSelectSingle39
+    RemapKeys106{{"RemapKeys[106∈3] ➊<br />ᐸ28:{”0”:6}ᐳ"}}:::plan
+    RemapKeys106 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
     PgSelectSingle44{{"PgSelectSingle[44∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -109,7 +111,7 @@ graph TD
     PgSelect51 --> First53
     PgSelectSingle54{{"PgSelectSingle[54∈3] ➊<br />ᐸpeopleᐳ"}}:::plan
     First53 --> PgSelectSingle54
-    PgSelectSingle28 --> RemapKeys103
+    PgSelectSingle28 --> RemapKeys106
     PgClassExpression55{{"PgClassExpression[55∈4] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle54 --> PgClassExpression55
     PgClassExpression56{{"PgClassExpression[56∈4] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -120,16 +122,16 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda59,Lambda62,Constant63,Constant64,Constant65,Constant77,Constant78,Constant79,Constant93,Constant94,Constant95,Constant109,Constant110,Constant111,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125,Constant126,Constant127 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 119, 120, 121, 62, 59, 63, 64, 65, 124, 77, 78, 79, 125, 93, 94, 95, 126, 109, 110, 111, 127<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda59,Lambda62,Access63,Constant64,Constant65,Constant66,Object67,Lambda68,Lambda73,Constant79,Constant80,Constant81,Object82,Lambda83,Lambda88,Constant96,Constant97,Constant98,Object99,Lambda100,Lambda105,Constant113,Constant114,Constant115,Object116,Lambda117,Lambda122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 123, 124, 125, 63, 83, 88, 100, 105, 59, 117, 122, 68, 73<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 62, 59, 63, 64, 65, 124, 77, 78, 79, 125, 93, 94, 95, 126, 109, 110, 111, 127, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 66, 72, 80, 86, 96, 102, 112, 118, 67, 81, 97, 113<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 63, 83, 88, 100, 105, 59, 117, 122, 21, 68, 73<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Object66,Lambda67,Lambda72,Object80,Lambda81,Lambda86,Object96,Lambda97,Lambda102,Object112,Lambda113,Lambda118 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 15, 59, 62, 67, 72<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]<br />1: <br />ᐳ: 29, 30, 31, 32, 44, 103, 39, 40, 45, 50<br />2: PgSelect[51]<br />ᐳ: First[53], PgSelectSingle[54]"):::bucket
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 15, 59, 63, 68, 73<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]<br />1: <br />ᐳ: 29, 30, 31, 32, 44, 106, 39, 40, 45, 50<br />2: PgSelect[51]<br />ᐳ: First[53], PgSelectSingle[54]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgSelectSingle39,PgClassExpression40,PgSelectSingle44,PgClassExpression45,PgClassExpression50,PgSelect51,First53,PgSelectSingle54,RemapKeys103 bucket3
+    class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgSelectSingle39,PgClassExpression40,PgSelectSingle44,PgClassExpression45,PgClassExpression50,PgSelect51,First53,PgSelectSingle54,RemapKeys106 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 54<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[54]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression55,PgClassExpression56 bucket4

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post.mermaid
@@ -9,6 +9,27 @@ graph TD
 
 
     %% plan dependencies
+    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda59 & Constant64 & Constant65 & Constant66 --> Object67
+    Object84{{"Object[84∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda59 & Constant81 & Constant82 & Constant83 --> Object84
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda59 & Constant98 & Constant99 & Constant100 --> Object101
+    Object118{{"Object[118∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda59 & Constant115 & Constant116 & Constant117 --> Object118
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,33 +37,42 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant128 --> Lambda59
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant129 --> Lambda62
+    Access63{{"Access[63∈0] ➊<br />ᐸ62.0ᐳ"}}:::plan
+    Lambda62 --> Access63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object67 --> Lambda68
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant130 --> Lambda73
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object84 --> Lambda85
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant131 --> Lambda90
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object101 --> Lambda102
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant132 --> Lambda107
+    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object118 --> Lambda119
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant133 --> Lambda124
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant10{{"Constant[10∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant11{{"Constant[11∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ'My Relational Post'ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ'A post, innit?'ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ'Such a great post.'ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    Object15 & PgClassExpression16 & Constant121 & Constant122 & Constant123 --> PgInsertSingle17
+    Object15 & PgClassExpression16 & Constant125 & Constant126 & Constant127 --> PgInsertSingle17
     PgInsertSingle12[["PgInsertSingle[12∈1] ➊<br />ᐸrelational_items(type,author_id)ᐳ"]]:::sideeffectplan
     Object15 & Constant10 & Constant11 --> PgInsertSingle12
     PgInsertSingle12 --> PgClassExpression16
@@ -50,40 +80,12 @@ graph TD
     PgInsertSingle17 --> PgClassExpression21
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ(__relatio...ts__).”id”ᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda99{{"Lambda[99∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈2] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda115{{"Lambda[115∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda120{{"Lambda[120∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & PgClassExpression22 & Lambda62 & Lambda67 & Lambda72 & Lambda62 & Lambda83 & Lambda88 & Lambda62 & Lambda99 & Lambda104 & Lambda59 & Lambda62 & Lambda115 & Lambda120 --> PgSelect23
-    Object66{{"Object[66∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant63 & Constant64 & Constant65 --> Object66
-    Object82{{"Object[82∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant79 & Constant80 & Constant81 --> Object82
-    Object98{{"Object[98∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant95 & Constant96 & Constant97 --> Object98
-    Object114{{"Object[114∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant111 & Constant112 & Constant113 --> Object114
+    Object15 & PgClassExpression22 & Access63 & Lambda68 & Lambda73 & Access63 & Lambda85 & Lambda90 & Access63 & Lambda102 & Lambda107 & Lambda59 & Access63 & Lambda119 & Lambda124 --> PgSelect23
     PgInsertSingle17 --> PgClassExpression22
     First27{{"First[27∈2] ➊"}}:::plan
     PgSelect23 --> First27
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First27 --> PgSelectSingle28
-    Constant124 --> Lambda59
-    Constant125 --> Lambda62
-    Object66 --> Lambda67
-    Constant126 --> Lambda72
-    Object82 --> Lambda83
-    Constant127 --> Lambda88
-    Object98 --> Lambda99
-    Constant128 --> Lambda104
-    Object114 --> Lambda115
-    Constant129 --> Lambda120
     PgClassExpression29{{"PgClassExpression[29∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -93,8 +95,8 @@ graph TD
     PgClassExpression32{{"PgClassExpression[32∈3] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression32
     PgSelectSingle39{{"PgSelectSingle[39∈3] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys105{{"RemapKeys[105∈3] ➊<br />ᐸ28:{”0”:7}ᐳ"}}:::plan
-    RemapKeys105 --> PgSelectSingle39
+    RemapKeys108{{"RemapKeys[108∈3] ➊<br />ᐸ28:{”0”:7}ᐳ"}}:::plan
+    RemapKeys108 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
     PgSelectSingle44{{"PgSelectSingle[44∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -102,10 +104,10 @@ graph TD
     PgClassExpression45{{"PgClassExpression[45∈3] ➊<br />ᐸ__relation..._archived”ᐳ"}}:::plan
     PgSelectSingle44 --> PgClassExpression45
     PgSelectSingle54{{"PgSelectSingle[54∈3] ➊<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys73{{"RemapKeys[73∈3] ➊<br />ᐸ44:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys73 --> PgSelectSingle54
-    PgSelectSingle44 --> RemapKeys73
-    PgSelectSingle28 --> RemapKeys105
+    RemapKeys74{{"RemapKeys[74∈3] ➊<br />ᐸ44:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys74 --> PgSelectSingle54
+    PgSelectSingle44 --> RemapKeys74
+    PgSelectSingle28 --> RemapKeys108
     PgClassExpression55{{"PgClassExpression[55∈4] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle54 --> PgClassExpression55
     PgClassExpression56{{"PgClassExpression[56∈4] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -116,16 +118,16 @@ graph TD
     subgraph "Buckets for mutations/basics/create-relational-post"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Constant63,Constant64,Constant65,Constant79,Constant80,Constant81,Constant95,Constant96,Constant97,Constant111,Constant112,Constant113,Constant121,Constant122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 121, 122, 123, 124, 125, 63, 64, 65, 126, 79, 80, 81, 127, 95, 96, 97, 128, 111, 112, 113, 129<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant10,Constant11,Access13,Access14,Object15,Lambda59,Lambda62,Access63,Constant64,Constant65,Constant66,Object67,Lambda68,Lambda73,Constant81,Constant82,Constant83,Object84,Lambda85,Lambda90,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant115,Constant116,Constant117,Object118,Lambda119,Lambda124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 11, 125, 126, 127, 63, 68, 73, 85, 90, 102, 107, 59, 119, 124<br /><br />1: PgInsertSingle[12]<br />2: PgClassExpression[16]<br />3: PgInsertSingle[17]<br />4: <br />ᐳ: PgClassExpression[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle12,PgClassExpression16,PgInsertSingle17,PgClassExpression21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 124, 125, 63, 64, 65, 126, 79, 80, 81, 127, 95, 96, 97, 128, 111, 112, 113, 129, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: 22, 59, 62, 72, 88, 104, 120, 66, 67, 82, 83, 98, 99, 114, 115<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 15, 63, 68, 73, 85, 90, 102, 107, 59, 119, 124, 21<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[21]<br />1: <br />ᐳ: PgClassExpression[22]<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,Lambda59,Lambda62,Object66,Lambda67,Lambda72,Object82,Lambda83,Lambda88,Object98,Lambda99,Lambda104,Object114,Lambda115,Lambda120 bucket2
+    class Bucket2,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgSelectSingle39,PgClassExpression40,PgSelectSingle44,PgClassExpression45,PgSelectSingle54,RemapKeys73,RemapKeys105 bucket3
+    class Bucket3,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgSelectSingle39,PgClassExpression40,PgSelectSingle44,PgClassExpression45,PgSelectSingle54,RemapKeys74,RemapKeys108 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 54<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[54]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression55,PgClassExpression56 bucket4

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.deopt.mermaid
@@ -9,84 +9,97 @@ graph TD
 
 
     %% plan dependencies
-    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object138{{"Object[138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda130 & Constant134 & Constant135 & Constant136 --> Object137
-    Object151{{"Object[151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant148 & Constant149 & Constant136 --> Object151
-    Object165{{"Object[165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant162 & Constant163 & Constant136 --> Object165
-    Object179{{"Object[179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda130 & Constant176 & Constant177 & Constant178 --> Object179
-    Object193{{"Object[193∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant190 & Constant191 & Constant136 --> Object193
-    Object207{{"Object[207∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant205{{"Constant[205∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda130 & Constant204 & Constant205 & Constant206 --> Object207
-    Object221{{"Object[221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant219{{"Constant[219∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda130 & Constant218 & Constant219 & Constant220 --> Object221
-    Object235{{"Object[235∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant232{{"Constant[232∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant233{{"Constant[233∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda130 & Constant232 & Constant233 & Constant234 --> Object235
-    Object263{{"Object[263∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant261{{"Constant[261∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda130 & Constant260 & Constant261 & Constant178 --> Object263
-    Object277{{"Object[277∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant274{{"Constant[274∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant275{{"Constant[275∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant274 & Constant275 & Constant136 --> Object277
-    Object291{{"Object[291∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant288{{"Constant[288∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant289{{"Constant[289∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda130 & Constant288 & Constant289 & Constant206 --> Object291
-    Object305{{"Object[305∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant302{{"Constant[302∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant303{{"Constant[303∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda130 & Constant302 & Constant303 & Constant220 --> Object305
-    Object319{{"Object[319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant317{{"Constant[317∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda130 & Constant316 & Constant317 & Constant234 --> Object319
-    Object347{{"Object[347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda130 & Constant344 & Constant345 & Constant178 --> Object347
-    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant358 & Constant359 & Constant136 --> Object361
-    Object375{{"Object[375∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda130 & Constant372 & Constant373 & Constant206 --> Object375
-    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda130 & Constant386 & Constant387 & Constant220 --> Object389
-    Object403{{"Object[403∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda130 & Constant400 & Constant401 & Constant234 --> Object403
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda130 & Constant135 & Constant136 & Constant137 --> Object138
+    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant150 & Constant151 & Constant137 --> Object153
+    Object168{{"Object[168∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant165 & Constant166 & Constant137 --> Object168
+    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda130 & Constant180 & Constant181 & Constant182 --> Object183
+    Object198{{"Object[198∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant196{{"Constant[196∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant195 & Constant196 & Constant137 --> Object198
+    Object213{{"Object[213∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant212{{"Constant[212∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda130 & Constant210 & Constant211 & Constant212 --> Object213
+    Object228{{"Object[228∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant226{{"Constant[226∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda130 & Constant225 & Constant226 & Constant227 --> Object228
+    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda130 & Constant240 & Constant241 & Constant242 --> Object243
+    Object258{{"Object[258∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant256{{"Constant[256∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant257{{"Constant[257∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda130 & Constant255 & Constant256 & Constant257 --> Object258
+    Object273{{"Object[273∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant270{{"Constant[270∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant271{{"Constant[271∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda130 & Constant270 & Constant271 & Constant182 --> Object273
+    Object288{{"Object[288∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant285 & Constant286 & Constant137 --> Object288
+    Object303{{"Object[303∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant300{{"Constant[300∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant301{{"Constant[301∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda130 & Constant300 & Constant301 & Constant212 --> Object303
+    Object318{{"Object[318∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant315{{"Constant[315∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant316{{"Constant[316∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda130 & Constant315 & Constant316 & Constant227 --> Object318
+    Object333{{"Object[333∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant330{{"Constant[330∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant331{{"Constant[331∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda130 & Constant330 & Constant331 & Constant242 --> Object333
+    Object348{{"Object[348∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda130 & Constant345 & Constant346 & Constant257 --> Object348
+    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda130 & Constant360 & Constant361 & Constant182 --> Object363
+    Object378{{"Object[378∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant375 & Constant376 & Constant137 --> Object378
+    Object393{{"Object[393∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda130 & Constant390 & Constant391 & Constant212 --> Object393
+    Object408{{"Object[408∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda130 & Constant405 & Constant406 & Constant227 --> Object408
+    Object423{{"Object[423∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda130 & Constant420 & Constant421 & Constant242 --> Object423
+    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda130 & Constant435 & Constant436 & Constant257 --> Object438
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -94,125 +107,132 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant427{{"Constant[427∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant427 --> Lambda130
+    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant448 --> Lambda130
     Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant428 --> Lambda133
-    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object137 --> Lambda138
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant429 --> Lambda143
-    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object151 --> Lambda152
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant430 --> Lambda157
-    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object165 --> Lambda166
-    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant431 --> Lambda171
-    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object179 --> Lambda180
-    Lambda185{{"Lambda[185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant432{{"Constant[432∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant432 --> Lambda185
-    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object193 --> Lambda194
+    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant449 --> Lambda133
+    Access134{{"Access[134∈0] ➊<br />ᐸ133.0ᐳ"}}:::plan
+    Lambda133 --> Access134
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object138 --> Lambda139
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant450 --> Lambda144
+    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object153 --> Lambda154
+    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant451 --> Lambda159
+    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object168 --> Lambda169
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant452 --> Lambda174
+    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object183 --> Lambda184
+    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant453 --> Lambda189
     Lambda199{{"Lambda[199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant433{{"Constant[433∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant433 --> Lambda199
-    Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object207 --> Lambda208
-    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant434 --> Lambda213
-    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object221 --> Lambda222
-    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant435 --> Lambda227
-    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object235 --> Lambda236
-    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant436 --> Lambda241
+    Object198 --> Lambda199
+    Lambda204{{"Lambda[204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant454{{"Constant[454∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant454 --> Lambda204
+    Lambda214{{"Lambda[214∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object213 --> Lambda214
+    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant455{{"Constant[455∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant455 --> Lambda219
+    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object228 --> Lambda229
+    Lambda234{{"Lambda[234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant456{{"Constant[456∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant456 --> Lambda234
+    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object243 --> Lambda244
+    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant457{{"Constant[457∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant457 --> Lambda249
+    Lambda259{{"Lambda[259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object258 --> Lambda259
     Lambda264{{"Lambda[264∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object263 --> Lambda264
-    Lambda269{{"Lambda[269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant438 --> Lambda269
-    Lambda278{{"Lambda[278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object277 --> Lambda278
-    Lambda283{{"Lambda[283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant439 --> Lambda283
-    Lambda292{{"Lambda[292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object291 --> Lambda292
-    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant440 --> Lambda297
-    Lambda306{{"Lambda[306∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object305 --> Lambda306
-    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant441 --> Lambda311
-    Lambda320{{"Lambda[320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object319 --> Lambda320
-    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant442 --> Lambda325
-    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object347 --> Lambda348
-    Lambda353{{"Lambda[353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant444 --> Lambda353
-    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object361 --> Lambda362
-    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant445 --> Lambda367
-    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object375 --> Lambda376
-    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant446{{"Constant[446∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant446 --> Lambda381
-    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object389 --> Lambda390
-    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant447{{"Constant[447∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant447 --> Lambda395
-    Lambda404{{"Lambda[404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object403 --> Lambda404
+    Constant458{{"Constant[458∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant458 --> Lambda264
+    Lambda274{{"Lambda[274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object273 --> Lambda274
+    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant459 --> Lambda279
+    Lambda289{{"Lambda[289∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object288 --> Lambda289
+    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant460 --> Lambda294
+    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object303 --> Lambda304
+    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant461 --> Lambda309
+    Lambda319{{"Lambda[319∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object318 --> Lambda319
+    Lambda324{{"Lambda[324∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant462 --> Lambda324
+    Lambda334{{"Lambda[334∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object333 --> Lambda334
+    Lambda339{{"Lambda[339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant463 --> Lambda339
+    Lambda349{{"Lambda[349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object348 --> Lambda349
+    Lambda354{{"Lambda[354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant464 --> Lambda354
+    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object363 --> Lambda364
+    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant465 --> Lambda369
+    Lambda379{{"Lambda[379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object378 --> Lambda379
+    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant466 --> Lambda384
+    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object393 --> Lambda394
+    Lambda399{{"Lambda[399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant467{{"Constant[467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant467 --> Lambda399
     Lambda409{{"Lambda[409∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant448 --> Lambda409
+    Object408 --> Lambda409
+    Lambda414{{"Lambda[414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant468{{"Constant[468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant468 --> Lambda414
+    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object423 --> Lambda424
+    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant469 --> Lambda429
+    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object438 --> Lambda439
+    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant470 --> Lambda444
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'Computed post ꖛ1'ᐳ"}}:::plan
     Constant13{{"Constant[13∈0] ➊<br />ᐸ'Computed post ꖛ2'ᐳ"}}:::plan
     Constant19{{"Constant[19∈0] ➊<br />ᐸ'Computed post ꖛ3'ᐳ"}}:::plan
-    Constant246{{"Constant[246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant247{{"Constant[247∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant330{{"Constant[330∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant331{{"Constant[331∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant445{{"Constant[445∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
     PgSelect8[["PgSelect[8∈1] ➊<br />ᐸrelational_posts(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Constant6 & Constant7 & Lambda130 & Lambda133 & Lambda138 & Lambda143 --> PgSelect8
+    Object11 & Constant6 & Constant7 & Lambda130 & Access134 & Lambda139 & Lambda144 --> PgSelect8
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸrelational_posts(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Constant6 & Constant13 & Lambda130 & Lambda133 & Lambda152 & Lambda157 --> PgSelect14
+    Object11 & Constant6 & Constant13 & Lambda130 & Access134 & Lambda154 & Lambda159 --> PgSelect14
     PgSelect20[["PgSelect[20∈1] ➊<br />ᐸrelational_posts(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Constant6 & Constant19 & Lambda130 & Lambda133 & Lambda166 & Lambda171 --> PgSelect20
+    Object11 & Constant6 & Constant19 & Lambda130 & Access134 & Lambda169 & Lambda174 --> PgSelect20
     First24{{"First[24∈1] ➊"}}:::plan
     PgSelect20 --> First24
     PgSelectSingle25{{"PgSelectSingle[25∈1] ➊<br />ᐸrelational_postsᐳ"}}:::plan
@@ -220,64 +240,46 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈1] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelect28[["PgSelect[28∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda250{{"Lambda[250∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda255{{"Lambda[255∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant424 & Lambda130 & Lambda133 & Lambda250 & Lambda255 --> PgSelect28
+    Object11 & Constant445 & Lambda130 & Access134 & Lambda259 & Lambda264 --> PgSelect28
     PgSelect63[["PgSelect[63∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda334{{"Lambda[334∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda339{{"Lambda[339∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant425 & Lambda130 & Lambda133 & Lambda334 & Lambda339 --> PgSelect63
+    Object11 & Constant446 & Lambda130 & Access134 & Lambda349 & Lambda354 --> PgSelect63
     PgSelect96[["PgSelect[96∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda418{{"Lambda[418∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda423{{"Lambda[423∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant426 & Lambda130 & Lambda133 & Lambda418 & Lambda423 --> PgSelect96
-    Object249{{"Object[249∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda130 & Constant246 & Constant247 & Constant248 --> Object249
-    Object333{{"Object[333∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda130 & Constant330 & Constant331 & Constant248 --> Object333
-    Object417{{"Object[417∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda130 & Constant414 & Constant415 & Constant248 --> Object417
+    Object11 & Constant447 & Lambda130 & Access134 & Lambda439 & Lambda444 --> PgSelect96
+    PgPolymorphic35{{"PgPolymorphic[35∈2] ➊"}}:::plan
+    PgSelectSingle33{{"PgSelectSingle[33∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle33 & PgClassExpression34 --> PgPolymorphic35
+    PgPolymorphic68{{"PgPolymorphic[68∈2] ➊"}}:::plan
+    PgSelectSingle66{{"PgSelectSingle[66∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression67{{"PgClassExpression[67∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle66 & PgClassExpression67 --> PgPolymorphic68
+    PgPolymorphic101{{"PgPolymorphic[101∈2] ➊"}}:::plan
+    PgSelectSingle99{{"PgSelectSingle[99∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression100{{"PgClassExpression[100∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle99 & PgClassExpression100 --> PgPolymorphic101
     First32{{"First[32∈2] ➊"}}:::plan
     PgSelect28 --> First32
-    PgSelectSingle33{{"PgSelectSingle[33∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First32 --> PgSelectSingle33
+    PgSelectSingle33 --> PgClassExpression34
     First65{{"First[65∈2] ➊"}}:::plan
     PgSelect63 --> First65
-    PgSelectSingle66{{"PgSelectSingle[66∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First65 --> PgSelectSingle66
+    PgSelectSingle66 --> PgClassExpression67
     First98{{"First[98∈2] ➊"}}:::plan
     PgSelect96 --> First98
-    PgSelectSingle99{{"PgSelectSingle[99∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First98 --> PgSelectSingle99
-    Object249 --> Lambda250
-    Constant437 --> Lambda255
-    Object333 --> Lambda334
-    Constant443 --> Lambda339
-    Object417 --> Lambda418
-    Constant449 --> Lambda423
-    PgPolymorphic35{{"PgPolymorphic[35∈3] ➊"}}:::plan
-    PgClassExpression34{{"PgClassExpression[34∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle33 & PgClassExpression34 --> PgPolymorphic35
-    PgPolymorphic68{{"PgPolymorphic[68∈3] ➊"}}:::plan
-    PgClassExpression67{{"PgClassExpression[67∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle66 & PgClassExpression67 --> PgPolymorphic68
-    PgPolymorphic101{{"PgPolymorphic[101∈3] ➊"}}:::plan
-    PgClassExpression100{{"PgClassExpression[100∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle99 & PgClassExpression100 --> PgPolymorphic101
-    PgSelectSingle33 --> PgClassExpression34
-    PgSelectSingle66 --> PgClassExpression67
     PgSelectSingle99 --> PgClassExpression100
     PgSelect37[["PgSelect[37∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda180 & Lambda185 --> PgSelect37
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda184 & Lambda189 --> PgSelect37
     PgSelect43[["PgSelect[43∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda194 & Lambda199 --> PgSelect43
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda199 & Lambda204 --> PgSelect43
     PgSelect50[["PgSelect[50∈4] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda208 & Lambda213 --> PgSelect50
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda214 & Lambda219 --> PgSelect50
     PgSelect54[["PgSelect[54∈4] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda222 & Lambda227 --> PgSelect54
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda229 & Lambda234 --> PgSelect54
     PgSelect58[["PgSelect[58∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda236 & Lambda241 --> PgSelect58
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda244 & Lambda249 --> PgSelect58
     PgSelectSingle33 --> PgClassExpression36
     First41{{"First[41∈4] ➊"}}:::plan
     PgSelect37 --> First41
@@ -307,15 +309,15 @@ graph TD
     First60 --> PgSelectSingle61
     PgSelect70[["PgSelect[70∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression69{{"PgClassExpression[69∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda264 & Lambda269 --> PgSelect70
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda274 & Lambda279 --> PgSelect70
     PgSelect76[["PgSelect[76∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda278 & Lambda283 --> PgSelect76
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda289 & Lambda294 --> PgSelect76
     PgSelect83[["PgSelect[83∈5] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda292 & Lambda297 --> PgSelect83
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda304 & Lambda309 --> PgSelect83
     PgSelect87[["PgSelect[87∈5] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda306 & Lambda311 --> PgSelect87
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda319 & Lambda324 --> PgSelect87
     PgSelect91[["PgSelect[91∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda320 & Lambda325 --> PgSelect91
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda334 & Lambda339 --> PgSelect91
     PgSelectSingle66 --> PgClassExpression69
     First74{{"First[74∈5] ➊"}}:::plan
     PgSelect70 --> First74
@@ -345,15 +347,15 @@ graph TD
     First93 --> PgSelectSingle94
     PgSelect103[["PgSelect[103∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression102{{"PgClassExpression[102∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda348 & Lambda353 --> PgSelect103
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda364 & Lambda369 --> PgSelect103
     PgSelect109[["PgSelect[109∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda362 & Lambda367 --> PgSelect109
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda379 & Lambda384 --> PgSelect109
     PgSelect116[["PgSelect[116∈6] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda376 & Lambda381 --> PgSelect116
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda394 & Lambda399 --> PgSelect116
     PgSelect120[["PgSelect[120∈6] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda390 & Lambda395 --> PgSelect120
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda409 & Lambda414 --> PgSelect120
     PgSelect124[["PgSelect[124∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda404 & Lambda409 --> PgSelect124
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda424 & Lambda429 --> PgSelect124
     PgSelectSingle99 --> PgClassExpression102
     First107{{"First[107∈6] ➊"}}:::plan
     PgSelect103 --> First107
@@ -391,23 +393,23 @@ graph TD
     subgraph "Buckets for mutations/basics/create-three-relational-posts-computed"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant19,Lambda130,Lambda133,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Constant148,Constant149,Object151,Lambda152,Lambda157,Constant162,Constant163,Object165,Lambda166,Lambda171,Constant176,Constant177,Constant178,Object179,Lambda180,Lambda185,Constant190,Constant191,Object193,Lambda194,Lambda199,Constant204,Constant205,Constant206,Object207,Lambda208,Lambda213,Constant218,Constant219,Constant220,Object221,Lambda222,Lambda227,Constant232,Constant233,Constant234,Object235,Lambda236,Lambda241,Constant246,Constant247,Constant248,Constant260,Constant261,Object263,Lambda264,Lambda269,Constant274,Constant275,Object277,Lambda278,Lambda283,Constant288,Constant289,Object291,Lambda292,Lambda297,Constant302,Constant303,Object305,Lambda306,Lambda311,Constant316,Constant317,Object319,Lambda320,Lambda325,Constant330,Constant331,Constant344,Constant345,Object347,Lambda348,Lambda353,Constant358,Constant359,Object361,Lambda362,Lambda367,Constant372,Constant373,Object375,Lambda376,Lambda381,Constant386,Constant387,Object389,Lambda390,Lambda395,Constant400,Constant401,Object403,Lambda404,Lambda409,Constant414,Constant415,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 130, 133, 138, 143, 13, 152, 157, 19, 166, 171, 424, 425, 426, 246, 247, 248, 437, 330, 331, 443, 414, 415, 449, 4, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409<br /><br />1: PgSelect[8]<br />2: PgSelect[14]<br />3: PgSelect[20]<br />4: <br />ᐳ: 24, 25, 26"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant19,Lambda130,Lambda133,Access134,Constant135,Constant136,Constant137,Object138,Lambda139,Lambda144,Constant150,Constant151,Object153,Lambda154,Lambda159,Constant165,Constant166,Object168,Lambda169,Lambda174,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant195,Constant196,Object198,Lambda199,Lambda204,Constant210,Constant211,Constant212,Object213,Lambda214,Lambda219,Constant225,Constant226,Constant227,Object228,Lambda229,Lambda234,Constant240,Constant241,Constant242,Object243,Lambda244,Lambda249,Constant255,Constant256,Constant257,Object258,Lambda259,Lambda264,Constant270,Constant271,Object273,Lambda274,Lambda279,Constant285,Constant286,Object288,Lambda289,Lambda294,Constant300,Constant301,Object303,Lambda304,Lambda309,Constant315,Constant316,Object318,Lambda319,Lambda324,Constant330,Constant331,Object333,Lambda334,Lambda339,Constant345,Constant346,Object348,Lambda349,Lambda354,Constant360,Constant361,Object363,Lambda364,Lambda369,Constant375,Constant376,Object378,Lambda379,Lambda384,Constant390,Constant391,Object393,Lambda394,Lambda399,Constant405,Constant406,Object408,Lambda409,Lambda414,Constant420,Constant421,Object423,Lambda424,Lambda429,Constant435,Constant436,Object438,Lambda439,Lambda444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450,Constant451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 130, 134, 139, 144, 13, 154, 159, 19, 169, 174, 445, 259, 264, 446, 349, 354, 447, 439, 444, 4, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429<br /><br />1: PgSelect[8]<br />2: PgSelect[14]<br />3: PgSelect[20]<br />4: <br />ᐳ: 24, 25, 26"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect8,PgSelect14,PgSelect20,First24,PgSelectSingle25,PgClassExpression26 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 424, 130, 133, 425, 426, 246, 247, 248, 437, 330, 331, 443, 414, 415, 449, 26, 4, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[26]<br />1: <br />ᐳ: 249, 255, 333, 339, 417, 423, 250, 334, 418<br />2: 28, 63, 96<br />ᐳ: 32, 33, 65, 66, 98, 99"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 445, 130, 134, 259, 264, 446, 349, 354, 447, 439, 444, 26, 4, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[26]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect28,First32,PgSelectSingle33,PgSelect63,First65,PgSelectSingle66,PgSelect96,First98,PgSelectSingle99,Object249,Lambda250,Lambda255,Object333,Lambda334,Lambda339,Object417,Lambda418,Lambda423 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 33, 66, 99, 4, 11, 130, 133, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect28,First32,PgSelectSingle33,PgClassExpression34,PgPolymorphic35,PgSelect63,First65,PgSelectSingle66,PgClassExpression67,PgPolymorphic68,PgSelect96,First98,PgSelectSingle99,PgClassExpression100,PgPolymorphic101 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 33, 11, 130, 134, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 35, 66, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 68, 99, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 101<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression34,PgPolymorphic35,PgClassExpression67,PgPolymorphic68,PgClassExpression100,PgPolymorphic101 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 33, 11, 130, 133, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 35<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[36]<br />2: 37, 43, 50, 54, 58<br />ᐳ: 41, 42, 45, 46, 47, 48, 49, 52, 53, 56, 57, 60, 61"):::bucket
+    class Bucket3 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 33, 11, 130, 134, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 35<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[36]<br />2: 37, 43, 50, 54, 58<br />ᐳ: 41, 42, 45, 46, 47, 48, 49, 52, 53, 56, 57, 60, 61"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression36,PgSelect37,First41,PgSelectSingle42,PgSelect43,First45,PgSelectSingle46,PgClassExpression47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectSingle53,PgSelect54,First56,PgSelectSingle57,PgSelect58,First60,PgSelectSingle61 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 66, 11, 130, 133, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 68<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[69]<br />2: 70, 76, 83, 87, 91<br />ᐳ: 74, 75, 78, 79, 80, 81, 82, 85, 86, 89, 90, 93, 94"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 66, 11, 130, 134, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 68<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[69]<br />2: 70, 76, 83, 87, 91<br />ᐳ: 74, 75, 78, 79, 80, 81, 82, 85, 86, 89, 90, 93, 94"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression69,PgSelect70,First74,PgSelectSingle75,PgSelect76,First78,PgSelectSingle79,PgClassExpression80,PgClassExpression81,PgClassExpression82,PgSelect83,First85,PgSelectSingle86,PgSelect87,First89,PgSelectSingle90,PgSelect91,First93,PgSelectSingle94 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 99, 11, 130, 133, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409, 101<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[102]<br />2: 103, 109, 116, 120, 124<br />ᐳ: 107, 108, 111, 112, 113, 114, 115, 118, 119, 122, 123, 126, 127"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 99, 11, 130, 134, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 101<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[102]<br />2: 103, 109, 116, 120, 124<br />ᐳ: 107, 108, 111, 112, 113, 114, 115, 118, 119, 122, 123, 126, 127"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression102,PgSelect103,First107,PgSelectSingle108,PgSelect109,First111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115,PgSelect116,First118,PgSelectSingle119,PgSelect120,First122,PgSelectSingle123,PgSelect124,First126,PgSelectSingle127 bucket6
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.mermaid
@@ -9,84 +9,97 @@ graph TD
 
 
     %% plan dependencies
-    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object138{{"Object[138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda130 & Constant134 & Constant135 & Constant136 --> Object137
-    Object151{{"Object[151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant148 & Constant149 & Constant136 --> Object151
-    Object165{{"Object[165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant162 & Constant163 & Constant136 --> Object165
-    Object179{{"Object[179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda130 & Constant176 & Constant177 & Constant178 --> Object179
-    Object193{{"Object[193∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant190 & Constant191 & Constant136 --> Object193
-    Object207{{"Object[207∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant205{{"Constant[205∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda130 & Constant204 & Constant205 & Constant206 --> Object207
-    Object221{{"Object[221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant219{{"Constant[219∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda130 & Constant218 & Constant219 & Constant220 --> Object221
-    Object235{{"Object[235∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant232{{"Constant[232∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant233{{"Constant[233∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda130 & Constant232 & Constant233 & Constant234 --> Object235
-    Object263{{"Object[263∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant261{{"Constant[261∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda130 & Constant260 & Constant261 & Constant178 --> Object263
-    Object277{{"Object[277∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant274{{"Constant[274∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant275{{"Constant[275∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant274 & Constant275 & Constant136 --> Object277
-    Object291{{"Object[291∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant288{{"Constant[288∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant289{{"Constant[289∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda130 & Constant288 & Constant289 & Constant206 --> Object291
-    Object305{{"Object[305∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant302{{"Constant[302∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant303{{"Constant[303∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda130 & Constant302 & Constant303 & Constant220 --> Object305
-    Object319{{"Object[319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant317{{"Constant[317∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda130 & Constant316 & Constant317 & Constant234 --> Object319
-    Object347{{"Object[347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda130 & Constant344 & Constant345 & Constant178 --> Object347
-    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda130 & Constant358 & Constant359 & Constant136 --> Object361
-    Object375{{"Object[375∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda130 & Constant372 & Constant373 & Constant206 --> Object375
-    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda130 & Constant386 & Constant387 & Constant220 --> Object389
-    Object403{{"Object[403∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda130 & Constant400 & Constant401 & Constant234 --> Object403
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda130 & Constant135 & Constant136 & Constant137 --> Object138
+    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant150 & Constant151 & Constant137 --> Object153
+    Object168{{"Object[168∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant165 & Constant166 & Constant137 --> Object168
+    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda130 & Constant180 & Constant181 & Constant182 --> Object183
+    Object198{{"Object[198∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant196{{"Constant[196∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant195 & Constant196 & Constant137 --> Object198
+    Object213{{"Object[213∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant212{{"Constant[212∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda130 & Constant210 & Constant211 & Constant212 --> Object213
+    Object228{{"Object[228∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant226{{"Constant[226∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda130 & Constant225 & Constant226 & Constant227 --> Object228
+    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda130 & Constant240 & Constant241 & Constant242 --> Object243
+    Object258{{"Object[258∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant256{{"Constant[256∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant257{{"Constant[257∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda130 & Constant255 & Constant256 & Constant257 --> Object258
+    Object273{{"Object[273∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant270{{"Constant[270∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant271{{"Constant[271∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda130 & Constant270 & Constant271 & Constant182 --> Object273
+    Object288{{"Object[288∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant285 & Constant286 & Constant137 --> Object288
+    Object303{{"Object[303∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant300{{"Constant[300∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant301{{"Constant[301∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda130 & Constant300 & Constant301 & Constant212 --> Object303
+    Object318{{"Object[318∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant315{{"Constant[315∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant316{{"Constant[316∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda130 & Constant315 & Constant316 & Constant227 --> Object318
+    Object333{{"Object[333∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant330{{"Constant[330∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant331{{"Constant[331∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda130 & Constant330 & Constant331 & Constant242 --> Object333
+    Object348{{"Object[348∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda130 & Constant345 & Constant346 & Constant257 --> Object348
+    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda130 & Constant360 & Constant361 & Constant182 --> Object363
+    Object378{{"Object[378∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda130 & Constant375 & Constant376 & Constant137 --> Object378
+    Object393{{"Object[393∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda130 & Constant390 & Constant391 & Constant212 --> Object393
+    Object408{{"Object[408∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda130 & Constant405 & Constant406 & Constant227 --> Object408
+    Object423{{"Object[423∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda130 & Constant420 & Constant421 & Constant242 --> Object423
+    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda130 & Constant435 & Constant436 & Constant257 --> Object438
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -94,125 +107,132 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant427{{"Constant[427∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant427 --> Lambda130
+    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant448 --> Lambda130
     Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant428 --> Lambda133
-    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object137 --> Lambda138
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant429 --> Lambda143
-    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object151 --> Lambda152
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant430 --> Lambda157
-    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object165 --> Lambda166
-    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant431 --> Lambda171
-    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object179 --> Lambda180
-    Lambda185{{"Lambda[185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant432{{"Constant[432∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant432 --> Lambda185
-    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object193 --> Lambda194
+    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant449 --> Lambda133
+    Access134{{"Access[134∈0] ➊<br />ᐸ133.0ᐳ"}}:::plan
+    Lambda133 --> Access134
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object138 --> Lambda139
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant450 --> Lambda144
+    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object153 --> Lambda154
+    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant451 --> Lambda159
+    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object168 --> Lambda169
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant452 --> Lambda174
+    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object183 --> Lambda184
+    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant453 --> Lambda189
     Lambda199{{"Lambda[199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant433{{"Constant[433∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant433 --> Lambda199
-    Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object207 --> Lambda208
-    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant434 --> Lambda213
-    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object221 --> Lambda222
-    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant435 --> Lambda227
-    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object235 --> Lambda236
-    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant436 --> Lambda241
+    Object198 --> Lambda199
+    Lambda204{{"Lambda[204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant454{{"Constant[454∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant454 --> Lambda204
+    Lambda214{{"Lambda[214∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object213 --> Lambda214
+    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant455{{"Constant[455∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant455 --> Lambda219
+    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object228 --> Lambda229
+    Lambda234{{"Lambda[234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant456{{"Constant[456∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant456 --> Lambda234
+    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object243 --> Lambda244
+    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant457{{"Constant[457∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant457 --> Lambda249
+    Lambda259{{"Lambda[259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object258 --> Lambda259
     Lambda264{{"Lambda[264∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object263 --> Lambda264
-    Lambda269{{"Lambda[269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant438 --> Lambda269
-    Lambda278{{"Lambda[278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object277 --> Lambda278
-    Lambda283{{"Lambda[283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant439 --> Lambda283
-    Lambda292{{"Lambda[292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object291 --> Lambda292
-    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant440 --> Lambda297
-    Lambda306{{"Lambda[306∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object305 --> Lambda306
-    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant441 --> Lambda311
-    Lambda320{{"Lambda[320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object319 --> Lambda320
-    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant442 --> Lambda325
-    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object347 --> Lambda348
-    Lambda353{{"Lambda[353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant444 --> Lambda353
-    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object361 --> Lambda362
-    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant445 --> Lambda367
-    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object375 --> Lambda376
-    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant446{{"Constant[446∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant446 --> Lambda381
-    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object389 --> Lambda390
-    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant447{{"Constant[447∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant447 --> Lambda395
-    Lambda404{{"Lambda[404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object403 --> Lambda404
+    Constant458{{"Constant[458∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant458 --> Lambda264
+    Lambda274{{"Lambda[274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object273 --> Lambda274
+    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant459 --> Lambda279
+    Lambda289{{"Lambda[289∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object288 --> Lambda289
+    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant460 --> Lambda294
+    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object303 --> Lambda304
+    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant461 --> Lambda309
+    Lambda319{{"Lambda[319∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object318 --> Lambda319
+    Lambda324{{"Lambda[324∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant462 --> Lambda324
+    Lambda334{{"Lambda[334∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object333 --> Lambda334
+    Lambda339{{"Lambda[339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant463 --> Lambda339
+    Lambda349{{"Lambda[349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object348 --> Lambda349
+    Lambda354{{"Lambda[354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant464 --> Lambda354
+    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object363 --> Lambda364
+    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant465 --> Lambda369
+    Lambda379{{"Lambda[379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object378 --> Lambda379
+    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant466 --> Lambda384
+    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object393 --> Lambda394
+    Lambda399{{"Lambda[399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant467{{"Constant[467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant467 --> Lambda399
     Lambda409{{"Lambda[409∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant448 --> Lambda409
+    Object408 --> Lambda409
+    Lambda414{{"Lambda[414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant468{{"Constant[468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant468 --> Lambda414
+    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object423 --> Lambda424
+    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant469 --> Lambda429
+    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object438 --> Lambda439
+    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant470 --> Lambda444
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'Computed post ꖛ1'ᐳ"}}:::plan
     Constant13{{"Constant[13∈0] ➊<br />ᐸ'Computed post ꖛ2'ᐳ"}}:::plan
     Constant19{{"Constant[19∈0] ➊<br />ᐸ'Computed post ꖛ3'ᐳ"}}:::plan
-    Constant246{{"Constant[246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant247{{"Constant[247∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant330{{"Constant[330∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant331{{"Constant[331∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant445{{"Constant[445∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
     PgSelect8[["PgSelect[8∈1] ➊<br />ᐸrelational_posts(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Constant6 & Constant7 & Lambda130 & Lambda133 & Lambda138 & Lambda143 --> PgSelect8
+    Object11 & Constant6 & Constant7 & Lambda130 & Access134 & Lambda139 & Lambda144 --> PgSelect8
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸrelational_posts(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Constant6 & Constant13 & Lambda130 & Lambda133 & Lambda152 & Lambda157 --> PgSelect14
+    Object11 & Constant6 & Constant13 & Lambda130 & Access134 & Lambda154 & Lambda159 --> PgSelect14
     PgSelect20[["PgSelect[20∈1] ➊<br />ᐸrelational_posts(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Constant6 & Constant19 & Lambda130 & Lambda133 & Lambda166 & Lambda171 --> PgSelect20
+    Object11 & Constant6 & Constant19 & Lambda130 & Access134 & Lambda169 & Lambda174 --> PgSelect20
     First24{{"First[24∈1] ➊"}}:::plan
     PgSelect20 --> First24
     PgSelectSingle25{{"PgSelectSingle[25∈1] ➊<br />ᐸrelational_postsᐳ"}}:::plan
@@ -220,64 +240,46 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈1] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelect28[["PgSelect[28∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda250{{"Lambda[250∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda255{{"Lambda[255∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant424 & Lambda130 & Lambda133 & Lambda250 & Lambda255 --> PgSelect28
+    Object11 & Constant445 & Lambda130 & Access134 & Lambda259 & Lambda264 --> PgSelect28
     PgSelect63[["PgSelect[63∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda334{{"Lambda[334∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda339{{"Lambda[339∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant425 & Lambda130 & Lambda133 & Lambda334 & Lambda339 --> PgSelect63
+    Object11 & Constant446 & Lambda130 & Access134 & Lambda349 & Lambda354 --> PgSelect63
     PgSelect96[["PgSelect[96∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda418{{"Lambda[418∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda423{{"Lambda[423∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant426 & Lambda130 & Lambda133 & Lambda418 & Lambda423 --> PgSelect96
-    Object249{{"Object[249∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda130 & Constant246 & Constant247 & Constant248 --> Object249
-    Object333{{"Object[333∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda130 & Constant330 & Constant331 & Constant248 --> Object333
-    Object417{{"Object[417∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda130 & Constant414 & Constant415 & Constant248 --> Object417
+    Object11 & Constant447 & Lambda130 & Access134 & Lambda439 & Lambda444 --> PgSelect96
+    PgPolymorphic35{{"PgPolymorphic[35∈2] ➊"}}:::plan
+    PgSelectSingle33{{"PgSelectSingle[33∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle33 & PgClassExpression34 --> PgPolymorphic35
+    PgPolymorphic68{{"PgPolymorphic[68∈2] ➊"}}:::plan
+    PgSelectSingle66{{"PgSelectSingle[66∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression67{{"PgClassExpression[67∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle66 & PgClassExpression67 --> PgPolymorphic68
+    PgPolymorphic101{{"PgPolymorphic[101∈2] ➊"}}:::plan
+    PgSelectSingle99{{"PgSelectSingle[99∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression100{{"PgClassExpression[100∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle99 & PgClassExpression100 --> PgPolymorphic101
     First32{{"First[32∈2] ➊"}}:::plan
     PgSelect28 --> First32
-    PgSelectSingle33{{"PgSelectSingle[33∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First32 --> PgSelectSingle33
+    PgSelectSingle33 --> PgClassExpression34
     First65{{"First[65∈2] ➊"}}:::plan
     PgSelect63 --> First65
-    PgSelectSingle66{{"PgSelectSingle[66∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First65 --> PgSelectSingle66
+    PgSelectSingle66 --> PgClassExpression67
     First98{{"First[98∈2] ➊"}}:::plan
     PgSelect96 --> First98
-    PgSelectSingle99{{"PgSelectSingle[99∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First98 --> PgSelectSingle99
-    Object249 --> Lambda250
-    Constant437 --> Lambda255
-    Object333 --> Lambda334
-    Constant443 --> Lambda339
-    Object417 --> Lambda418
-    Constant449 --> Lambda423
-    PgPolymorphic35{{"PgPolymorphic[35∈3] ➊"}}:::plan
-    PgClassExpression34{{"PgClassExpression[34∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle33 & PgClassExpression34 --> PgPolymorphic35
-    PgPolymorphic68{{"PgPolymorphic[68∈3] ➊"}}:::plan
-    PgClassExpression67{{"PgClassExpression[67∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle66 & PgClassExpression67 --> PgPolymorphic68
-    PgPolymorphic101{{"PgPolymorphic[101∈3] ➊"}}:::plan
-    PgClassExpression100{{"PgClassExpression[100∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle99 & PgClassExpression100 --> PgPolymorphic101
-    PgSelectSingle33 --> PgClassExpression34
-    PgSelectSingle66 --> PgClassExpression67
     PgSelectSingle99 --> PgClassExpression100
     PgSelect37[["PgSelect[37∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda180 & Lambda185 --> PgSelect37
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda184 & Lambda189 --> PgSelect37
     PgSelect43[["PgSelect[43∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda194 & Lambda199 --> PgSelect43
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda199 & Lambda204 --> PgSelect43
     PgSelect50[["PgSelect[50∈4] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda208 & Lambda213 --> PgSelect50
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda214 & Lambda219 --> PgSelect50
     PgSelect54[["PgSelect[54∈4] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda222 & Lambda227 --> PgSelect54
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda229 & Lambda234 --> PgSelect54
     PgSelect58[["PgSelect[58∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression36 & Lambda130 & Lambda133 & Lambda236 & Lambda241 --> PgSelect58
+    Object11 & PgClassExpression36 & Lambda130 & Access134 & Lambda244 & Lambda249 --> PgSelect58
     PgSelectSingle33 --> PgClassExpression36
     First41{{"First[41∈4] ➊"}}:::plan
     PgSelect37 --> First41
@@ -307,15 +309,15 @@ graph TD
     First60 --> PgSelectSingle61
     PgSelect70[["PgSelect[70∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression69{{"PgClassExpression[69∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda264 & Lambda269 --> PgSelect70
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda274 & Lambda279 --> PgSelect70
     PgSelect76[["PgSelect[76∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda278 & Lambda283 --> PgSelect76
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda289 & Lambda294 --> PgSelect76
     PgSelect83[["PgSelect[83∈5] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda292 & Lambda297 --> PgSelect83
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda304 & Lambda309 --> PgSelect83
     PgSelect87[["PgSelect[87∈5] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda306 & Lambda311 --> PgSelect87
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda319 & Lambda324 --> PgSelect87
     PgSelect91[["PgSelect[91∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression69 & Lambda130 & Lambda133 & Lambda320 & Lambda325 --> PgSelect91
+    Object11 & PgClassExpression69 & Lambda130 & Access134 & Lambda334 & Lambda339 --> PgSelect91
     PgSelectSingle66 --> PgClassExpression69
     First74{{"First[74∈5] ➊"}}:::plan
     PgSelect70 --> First74
@@ -345,15 +347,15 @@ graph TD
     First93 --> PgSelectSingle94
     PgSelect103[["PgSelect[103∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression102{{"PgClassExpression[102∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda348 & Lambda353 --> PgSelect103
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda364 & Lambda369 --> PgSelect103
     PgSelect109[["PgSelect[109∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda362 & Lambda367 --> PgSelect109
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda379 & Lambda384 --> PgSelect109
     PgSelect116[["PgSelect[116∈6] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda376 & Lambda381 --> PgSelect116
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda394 & Lambda399 --> PgSelect116
     PgSelect120[["PgSelect[120∈6] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda390 & Lambda395 --> PgSelect120
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda409 & Lambda414 --> PgSelect120
     PgSelect124[["PgSelect[124∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression102 & Lambda130 & Lambda133 & Lambda404 & Lambda409 --> PgSelect124
+    Object11 & PgClassExpression102 & Lambda130 & Access134 & Lambda424 & Lambda429 --> PgSelect124
     PgSelectSingle99 --> PgClassExpression102
     First107{{"First[107∈6] ➊"}}:::plan
     PgSelect103 --> First107
@@ -391,23 +393,23 @@ graph TD
     subgraph "Buckets for mutations/basics/create-three-relational-posts-computed"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant19,Lambda130,Lambda133,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Constant148,Constant149,Object151,Lambda152,Lambda157,Constant162,Constant163,Object165,Lambda166,Lambda171,Constant176,Constant177,Constant178,Object179,Lambda180,Lambda185,Constant190,Constant191,Object193,Lambda194,Lambda199,Constant204,Constant205,Constant206,Object207,Lambda208,Lambda213,Constant218,Constant219,Constant220,Object221,Lambda222,Lambda227,Constant232,Constant233,Constant234,Object235,Lambda236,Lambda241,Constant246,Constant247,Constant248,Constant260,Constant261,Object263,Lambda264,Lambda269,Constant274,Constant275,Object277,Lambda278,Lambda283,Constant288,Constant289,Object291,Lambda292,Lambda297,Constant302,Constant303,Object305,Lambda306,Lambda311,Constant316,Constant317,Object319,Lambda320,Lambda325,Constant330,Constant331,Constant344,Constant345,Object347,Lambda348,Lambda353,Constant358,Constant359,Object361,Lambda362,Lambda367,Constant372,Constant373,Object375,Lambda376,Lambda381,Constant386,Constant387,Object389,Lambda390,Lambda395,Constant400,Constant401,Object403,Lambda404,Lambda409,Constant414,Constant415,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 130, 133, 138, 143, 13, 152, 157, 19, 166, 171, 424, 425, 426, 246, 247, 248, 437, 330, 331, 443, 414, 415, 449, 4, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409<br /><br />1: PgSelect[8]<br />2: PgSelect[14]<br />3: PgSelect[20]<br />4: <br />ᐳ: 24, 25, 26"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant19,Lambda130,Lambda133,Access134,Constant135,Constant136,Constant137,Object138,Lambda139,Lambda144,Constant150,Constant151,Object153,Lambda154,Lambda159,Constant165,Constant166,Object168,Lambda169,Lambda174,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant195,Constant196,Object198,Lambda199,Lambda204,Constant210,Constant211,Constant212,Object213,Lambda214,Lambda219,Constant225,Constant226,Constant227,Object228,Lambda229,Lambda234,Constant240,Constant241,Constant242,Object243,Lambda244,Lambda249,Constant255,Constant256,Constant257,Object258,Lambda259,Lambda264,Constant270,Constant271,Object273,Lambda274,Lambda279,Constant285,Constant286,Object288,Lambda289,Lambda294,Constant300,Constant301,Object303,Lambda304,Lambda309,Constant315,Constant316,Object318,Lambda319,Lambda324,Constant330,Constant331,Object333,Lambda334,Lambda339,Constant345,Constant346,Object348,Lambda349,Lambda354,Constant360,Constant361,Object363,Lambda364,Lambda369,Constant375,Constant376,Object378,Lambda379,Lambda384,Constant390,Constant391,Object393,Lambda394,Lambda399,Constant405,Constant406,Object408,Lambda409,Lambda414,Constant420,Constant421,Object423,Lambda424,Lambda429,Constant435,Constant436,Object438,Lambda439,Lambda444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450,Constant451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 130, 134, 139, 144, 13, 154, 159, 19, 169, 174, 445, 259, 264, 446, 349, 354, 447, 439, 444, 4, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429<br /><br />1: PgSelect[8]<br />2: PgSelect[14]<br />3: PgSelect[20]<br />4: <br />ᐳ: 24, 25, 26"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect8,PgSelect14,PgSelect20,First24,PgSelectSingle25,PgClassExpression26 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 424, 130, 133, 425, 426, 246, 247, 248, 437, 330, 331, 443, 414, 415, 449, 26, 4, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[26]<br />1: <br />ᐳ: 249, 255, 333, 339, 417, 423, 250, 334, 418<br />2: 28, 63, 96<br />ᐳ: 32, 33, 65, 66, 98, 99"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 445, 130, 134, 259, 264, 446, 349, 354, 447, 439, 444, 26, 4, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[26]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect28,First32,PgSelectSingle33,PgSelect63,First65,PgSelectSingle66,PgSelect96,First98,PgSelectSingle99,Object249,Lambda250,Lambda255,Object333,Lambda334,Lambda339,Object417,Lambda418,Lambda423 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 33, 66, 99, 4, 11, 130, 133, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect28,First32,PgSelectSingle33,PgClassExpression34,PgPolymorphic35,PgSelect63,First65,PgSelectSingle66,PgClassExpression67,PgPolymorphic68,PgSelect96,First98,PgSelectSingle99,PgClassExpression100,PgPolymorphic101 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 33, 11, 130, 134, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 35, 66, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 68, 99, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 101<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression34,PgPolymorphic35,PgClassExpression67,PgPolymorphic68,PgClassExpression100,PgPolymorphic101 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 33, 11, 130, 133, 180, 185, 194, 199, 208, 213, 222, 227, 236, 241, 35<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[36]<br />2: 37, 43, 50, 54, 58<br />ᐳ: 41, 42, 45, 46, 47, 48, 49, 52, 53, 56, 57, 60, 61"):::bucket
+    class Bucket3 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 33, 11, 130, 134, 184, 189, 199, 204, 214, 219, 229, 234, 244, 249, 35<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[36]<br />2: 37, 43, 50, 54, 58<br />ᐳ: 41, 42, 45, 46, 47, 48, 49, 52, 53, 56, 57, 60, 61"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression36,PgSelect37,First41,PgSelectSingle42,PgSelect43,First45,PgSelectSingle46,PgClassExpression47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectSingle53,PgSelect54,First56,PgSelectSingle57,PgSelect58,First60,PgSelectSingle61 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 66, 11, 130, 133, 264, 269, 278, 283, 292, 297, 306, 311, 320, 325, 68<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[69]<br />2: 70, 76, 83, 87, 91<br />ᐳ: 74, 75, 78, 79, 80, 81, 82, 85, 86, 89, 90, 93, 94"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 66, 11, 130, 134, 274, 279, 289, 294, 304, 309, 319, 324, 334, 339, 68<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[69]<br />2: 70, 76, 83, 87, 91<br />ᐳ: 74, 75, 78, 79, 80, 81, 82, 85, 86, 89, 90, 93, 94"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression69,PgSelect70,First74,PgSelectSingle75,PgSelect76,First78,PgSelectSingle79,PgClassExpression80,PgClassExpression81,PgClassExpression82,PgSelect83,First85,PgSelectSingle86,PgSelect87,First89,PgSelectSingle90,PgSelect91,First93,PgSelectSingle94 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 99, 11, 130, 133, 348, 353, 362, 367, 376, 381, 390, 395, 404, 409, 101<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[102]<br />2: 103, 109, 116, 120, 124<br />ᐳ: 107, 108, 111, 112, 113, 114, 115, 118, 119, 122, 123, 126, 127"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 99, 11, 130, 134, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 101<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[102]<br />2: 103, 109, 116, 120, 124<br />ᐳ: 107, 108, 111, 112, 113, 114, 115, 118, 119, 122, 123, 126, 127"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression102,PgSelect103,First107,PgSelectSingle108,PgSelect109,First111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115,PgSelect116,First118,PgSelectSingle119,PgSelect120,First122,PgSelectSingle123,PgSelect124,First126,PgSelectSingle127 bucket6
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.deopt.mermaid
@@ -9,72 +9,85 @@ graph TD
 
 
     %% plan dependencies
-    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda152 & Constant156 & Constant157 & Constant158 --> Object159
-    Object173{{"Object[173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda152 & Constant170 & Constant171 & Constant172 --> Object173
-    Object187{{"Object[187∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda152 & Constant184 & Constant185 & Constant186 --> Object187
-    Object201{{"Object[201∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant199{{"Constant[199∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda152 & Constant198 & Constant199 & Constant200 --> Object201
-    Object215{{"Object[215∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda152 & Constant212 & Constant213 & Constant214 --> Object215
-    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda152 & Constant240 & Constant241 & Constant158 --> Object243
-    Object257{{"Object[257∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant254{{"Constant[254∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant255{{"Constant[255∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda152 & Constant254 & Constant255 & Constant172 --> Object257
-    Object271{{"Object[271∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda152 & Constant268 & Constant269 & Constant186 --> Object271
-    Object285{{"Object[285∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant283{{"Constant[283∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda152 & Constant282 & Constant283 & Constant200 --> Object285
-    Object299{{"Object[299∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant296{{"Constant[296∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant297{{"Constant[297∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda152 & Constant296 & Constant297 & Constant214 --> Object299
-    Object327{{"Object[327∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant324{{"Constant[324∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant325{{"Constant[325∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda152 & Constant324 & Constant325 & Constant158 --> Object327
-    Object341{{"Object[341∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant338{{"Constant[338∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant339{{"Constant[339∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda152 & Constant338 & Constant339 & Constant172 --> Object341
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda152 & Constant157 & Constant158 & Constant159 --> Object160
+    Object175{{"Object[175∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda152 & Constant172 & Constant173 & Constant174 --> Object175
+    Object190{{"Object[190∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda152 & Constant187 & Constant188 & Constant189 --> Object190
+    Object205{{"Object[205∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda152 & Constant202 & Constant203 & Constant204 --> Object205
+    Object220{{"Object[220∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda152 & Constant217 & Constant218 & Constant219 --> Object220
+    Object235{{"Object[235∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant233{{"Constant[233∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda152 & Constant232 & Constant233 & Constant234 --> Object235
+    Object250{{"Object[250∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant248{{"Constant[248∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda152 & Constant247 & Constant248 & Constant159 --> Object250
+    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda152 & Constant262 & Constant263 & Constant174 --> Object265
+    Object280{{"Object[280∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant278{{"Constant[278∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda152 & Constant277 & Constant278 & Constant189 --> Object280
+    Object295{{"Object[295∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant292{{"Constant[292∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda152 & Constant292 & Constant293 & Constant204 --> Object295
+    Object310{{"Object[310∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant307{{"Constant[307∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant308{{"Constant[308∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda152 & Constant307 & Constant308 & Constant219 --> Object310
+    Object325{{"Object[325∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant322{{"Constant[322∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda152 & Constant322 & Constant323 & Constant234 --> Object325
+    Object340{{"Object[340∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant337{{"Constant[337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant338{{"Constant[338∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda152 & Constant337 & Constant338 & Constant159 --> Object340
     Object355{{"Object[355∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant352{{"Constant[352∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant353{{"Constant[353∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda152 & Constant352 & Constant353 & Constant186 --> Object355
-    Object369{{"Object[369∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant366{{"Constant[366∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda152 & Constant366 & Constant367 & Constant200 --> Object369
-    Object383{{"Object[383∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda152 & Constant380 & Constant381 & Constant214 --> Object383
+    Constant353{{"Constant[353∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda152 & Constant352 & Constant353 & Constant174 --> Object355
+    Object370{{"Object[370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant367{{"Constant[367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda152 & Constant367 & Constant368 & Constant189 --> Object370
+    Object385{{"Object[385∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant382{{"Constant[382∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda152 & Constant382 & Constant383 & Constant204 --> Object385
+    Object400{{"Object[400∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda152 & Constant397 & Constant398 & Constant219 --> Object400
+    Object415{{"Object[415∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant412{{"Constant[412∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda152 & Constant412 & Constant413 & Constant234 --> Object415
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -82,86 +95,103 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant404{{"Constant[404∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant404 --> Lambda152
+    Constant422{{"Constant[422∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant422 --> Lambda152
     Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant405{{"Constant[405∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant405 --> Lambda155
-    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object159 --> Lambda160
-    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant409{{"Constant[409∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant409 --> Lambda165
-    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object173 --> Lambda174
-    Lambda179{{"Lambda[179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant410 --> Lambda179
-    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object187 --> Lambda188
-    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant411 --> Lambda193
-    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object201 --> Lambda202
-    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant412{{"Constant[412∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant412 --> Lambda207
-    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object215 --> Lambda216
+    Constant423{{"Constant[423∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant423 --> Lambda155
+    Access156{{"Access[156∈0] ➊<br />ᐸ155.0ᐳ"}}:::plan
+    Lambda155 --> Access156
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object160 --> Lambda161
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant427{{"Constant[427∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant427 --> Lambda166
+    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object175 --> Lambda176
+    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant428{{"Constant[428∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant428 --> Lambda181
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object190 --> Lambda191
+    Lambda196{{"Lambda[196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant429 --> Lambda196
+    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object205 --> Lambda206
+    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant430{{"Constant[430∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant430 --> Lambda211
     Lambda221{{"Lambda[221∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant413{{"Constant[413∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant413 --> Lambda221
-    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object243 --> Lambda244
-    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant415 --> Lambda249
-    Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object257 --> Lambda258
-    Lambda263{{"Lambda[263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant416 --> Lambda263
-    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object271 --> Lambda272
-    Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant417 --> Lambda277
+    Object220 --> Lambda221
+    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant431 --> Lambda226
+    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object235 --> Lambda236
+    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant432 --> Lambda241
+    Lambda251{{"Lambda[251∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object250 --> Lambda251
+    Lambda256{{"Lambda[256∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant433 --> Lambda256
+    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object265 --> Lambda266
+    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant434 --> Lambda271
+    Lambda281{{"Lambda[281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object280 --> Lambda281
     Lambda286{{"Lambda[286∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object285 --> Lambda286
-    Lambda291{{"Lambda[291∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant418{{"Constant[418∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant418 --> Lambda291
-    Lambda300{{"Lambda[300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object299 --> Lambda300
-    Lambda305{{"Lambda[305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant419{{"Constant[419∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant419 --> Lambda305
-    Lambda328{{"Lambda[328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object327 --> Lambda328
-    Lambda333{{"Lambda[333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant421{{"Constant[421∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant421 --> Lambda333
-    Lambda342{{"Lambda[342∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object341 --> Lambda342
-    Lambda347{{"Lambda[347∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant422 --> Lambda347
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant435 --> Lambda286
+    Lambda296{{"Lambda[296∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object295 --> Lambda296
+    Lambda301{{"Lambda[301∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant436 --> Lambda301
+    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object310 --> Lambda311
+    Lambda316{{"Lambda[316∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant437{{"Constant[437∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant437 --> Lambda316
+    Lambda326{{"Lambda[326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object325 --> Lambda326
+    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant438{{"Constant[438∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant438 --> Lambda331
+    Lambda341{{"Lambda[341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object340 --> Lambda341
+    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant439{{"Constant[439∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant439 --> Lambda346
     Lambda356{{"Lambda[356∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object355 --> Lambda356
     Lambda361{{"Lambda[361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant423{{"Constant[423∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant423 --> Lambda361
-    Lambda370{{"Lambda[370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object369 --> Lambda370
-    Lambda375{{"Lambda[375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant424 --> Lambda375
-    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object383 --> Lambda384
-    Lambda389{{"Lambda[389∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant425 --> Lambda389
+    Constant440{{"Constant[440∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant440 --> Lambda361
+    Lambda371{{"Lambda[371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object370 --> Lambda371
+    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant441{{"Constant[441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant441 --> Lambda376
+    Lambda386{{"Lambda[386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object385 --> Lambda386
+    Lambda391{{"Lambda[391∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant442{{"Constant[442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant442 --> Lambda391
+    Lambda401{{"Lambda[401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object400 --> Lambda401
+    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant443 --> Lambda406
+    Lambda416{{"Lambda[416∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object415 --> Lambda416
+    Lambda421{{"Lambda[421∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant444 --> Lambda421
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ2ᐳ"}}:::plan
@@ -172,19 +202,9 @@ graph TD
     Constant28{{"Constant[28∈0] ➊<br />ᐸ'Desc 2'ᐳ"}}:::plan
     Constant41{{"Constant[41∈0] ➊<br />ᐸ'Post ꖛ3'ᐳ"}}:::plan
     Constant42{{"Constant[42∈0] ➊<br />ᐸ'Desc 3'ᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant311{{"Constant[311∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
-    Constant408{{"Constant[408∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant420{{"Constant[420∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant424{{"Constant[424∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
+    Constant425{{"Constant[425∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
+    Constant426{{"Constant[426∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
     PgInsertSingle16[["PgInsertSingle[16∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
     Object11 & PgClassExpression12 & Constant13 & Constant14 & Constant15 --> PgInsertSingle16
@@ -206,64 +226,46 @@ graph TD
     PgClassExpression48{{"PgClassExpression[48∈1] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgInsertSingle44 --> PgClassExpression48
     PgSelect50[["PgSelect[50∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda230{{"Lambda[230∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda235{{"Lambda[235∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant406 & Lambda152 & Lambda155 & Lambda230 & Lambda235 --> PgSelect50
+    Object11 & Constant424 & Lambda152 & Access156 & Lambda236 & Lambda241 --> PgSelect50
     PgSelect85[["PgSelect[85∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda314{{"Lambda[314∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda319{{"Lambda[319∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant407 & Lambda152 & Lambda155 & Lambda314 & Lambda319 --> PgSelect85
+    Object11 & Constant425 & Lambda152 & Access156 & Lambda326 & Lambda331 --> PgSelect85
     PgSelect118[["PgSelect[118∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda398{{"Lambda[398∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda403{{"Lambda[403∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant408 & Lambda152 & Lambda155 & Lambda398 & Lambda403 --> PgSelect118
-    Object229{{"Object[229∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda152 & Constant226 & Constant227 & Constant228 --> Object229
-    Object313{{"Object[313∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda152 & Constant310 & Constant311 & Constant228 --> Object313
-    Object397{{"Object[397∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda152 & Constant394 & Constant395 & Constant228 --> Object397
+    Object11 & Constant426 & Lambda152 & Access156 & Lambda416 & Lambda421 --> PgSelect118
+    PgPolymorphic57{{"PgPolymorphic[57∈2] ➊"}}:::plan
+    PgSelectSingle55{{"PgSelectSingle[55∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression56{{"PgClassExpression[56∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle55 & PgClassExpression56 --> PgPolymorphic57
+    PgPolymorphic90{{"PgPolymorphic[90∈2] ➊"}}:::plan
+    PgSelectSingle88{{"PgSelectSingle[88∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression89{{"PgClassExpression[89∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle88 & PgClassExpression89 --> PgPolymorphic90
+    PgPolymorphic123{{"PgPolymorphic[123∈2] ➊"}}:::plan
+    PgSelectSingle121{{"PgSelectSingle[121∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression122{{"PgClassExpression[122∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle121 & PgClassExpression122 --> PgPolymorphic123
     First54{{"First[54∈2] ➊"}}:::plan
     PgSelect50 --> First54
-    PgSelectSingle55{{"PgSelectSingle[55∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First54 --> PgSelectSingle55
+    PgSelectSingle55 --> PgClassExpression56
     First87{{"First[87∈2] ➊"}}:::plan
     PgSelect85 --> First87
-    PgSelectSingle88{{"PgSelectSingle[88∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First87 --> PgSelectSingle88
+    PgSelectSingle88 --> PgClassExpression89
     First120{{"First[120∈2] ➊"}}:::plan
     PgSelect118 --> First120
-    PgSelectSingle121{{"PgSelectSingle[121∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First120 --> PgSelectSingle121
-    Object229 --> Lambda230
-    Constant414 --> Lambda235
-    Object313 --> Lambda314
-    Constant420 --> Lambda319
-    Object397 --> Lambda398
-    Constant426 --> Lambda403
-    PgPolymorphic57{{"PgPolymorphic[57∈3] ➊"}}:::plan
-    PgClassExpression56{{"PgClassExpression[56∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle55 & PgClassExpression56 --> PgPolymorphic57
-    PgPolymorphic90{{"PgPolymorphic[90∈3] ➊"}}:::plan
-    PgClassExpression89{{"PgClassExpression[89∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle88 & PgClassExpression89 --> PgPolymorphic90
-    PgPolymorphic123{{"PgPolymorphic[123∈3] ➊"}}:::plan
-    PgClassExpression122{{"PgClassExpression[122∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle121 & PgClassExpression122 --> PgPolymorphic123
-    PgSelectSingle55 --> PgClassExpression56
-    PgSelectSingle88 --> PgClassExpression89
     PgSelectSingle121 --> PgClassExpression122
     PgSelect59[["PgSelect[59∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression58{{"PgClassExpression[58∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda160 & Lambda165 --> PgSelect59
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda161 & Lambda166 --> PgSelect59
     PgSelect65[["PgSelect[65∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda174 & Lambda179 --> PgSelect65
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda176 & Lambda181 --> PgSelect65
     PgSelect72[["PgSelect[72∈4] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda188 & Lambda193 --> PgSelect72
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda191 & Lambda196 --> PgSelect72
     PgSelect76[["PgSelect[76∈4] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda202 & Lambda207 --> PgSelect76
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda206 & Lambda211 --> PgSelect76
     PgSelect80[["PgSelect[80∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda216 & Lambda221 --> PgSelect80
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda221 & Lambda226 --> PgSelect80
     PgSelectSingle55 --> PgClassExpression58
     First63{{"First[63∈4] ➊"}}:::plan
     PgSelect59 --> First63
@@ -293,15 +295,15 @@ graph TD
     First82 --> PgSelectSingle83
     PgSelect92[["PgSelect[92∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression91{{"PgClassExpression[91∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda244 & Lambda249 --> PgSelect92
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda251 & Lambda256 --> PgSelect92
     PgSelect98[["PgSelect[98∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda258 & Lambda263 --> PgSelect98
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda266 & Lambda271 --> PgSelect98
     PgSelect105[["PgSelect[105∈5] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda272 & Lambda277 --> PgSelect105
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda281 & Lambda286 --> PgSelect105
     PgSelect109[["PgSelect[109∈5] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda286 & Lambda291 --> PgSelect109
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda296 & Lambda301 --> PgSelect109
     PgSelect113[["PgSelect[113∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda300 & Lambda305 --> PgSelect113
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda311 & Lambda316 --> PgSelect113
     PgSelectSingle88 --> PgClassExpression91
     First96{{"First[96∈5] ➊"}}:::plan
     PgSelect92 --> First96
@@ -331,15 +333,15 @@ graph TD
     First115 --> PgSelectSingle116
     PgSelect125[["PgSelect[125∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression124{{"PgClassExpression[124∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda328 & Lambda333 --> PgSelect125
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda341 & Lambda346 --> PgSelect125
     PgSelect131[["PgSelect[131∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda342 & Lambda347 --> PgSelect131
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda356 & Lambda361 --> PgSelect131
     PgSelect138[["PgSelect[138∈6] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda356 & Lambda361 --> PgSelect138
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda371 & Lambda376 --> PgSelect138
     PgSelect142[["PgSelect[142∈6] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda370 & Lambda375 --> PgSelect142
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda386 & Lambda391 --> PgSelect142
     PgSelect146[["PgSelect[146∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda384 & Lambda389 --> PgSelect146
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda401 & Lambda406 --> PgSelect146
     PgSelectSingle121 --> PgClassExpression124
     First129{{"First[129∈6] ➊"}}:::plan
     PgSelect125 --> First129
@@ -377,23 +379,23 @@ graph TD
     subgraph "Buckets for mutations/basics/create-three-relational-posts"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant14,Constant15,Constant27,Constant28,Constant41,Constant42,Lambda152,Lambda155,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant170,Constant171,Constant172,Object173,Lambda174,Lambda179,Constant184,Constant185,Constant186,Object187,Lambda188,Lambda193,Constant198,Constant199,Constant200,Object201,Lambda202,Lambda207,Constant212,Constant213,Constant214,Object215,Lambda216,Lambda221,Constant226,Constant227,Constant228,Constant240,Constant241,Object243,Lambda244,Lambda249,Constant254,Constant255,Object257,Lambda258,Lambda263,Constant268,Constant269,Object271,Lambda272,Lambda277,Constant282,Constant283,Object285,Lambda286,Lambda291,Constant296,Constant297,Object299,Lambda300,Lambda305,Constant310,Constant311,Constant324,Constant325,Object327,Lambda328,Lambda333,Constant338,Constant339,Object341,Lambda342,Lambda347,Constant352,Constant353,Object355,Lambda356,Lambda361,Constant366,Constant367,Object369,Lambda370,Lambda375,Constant380,Constant381,Object383,Lambda384,Lambda389,Constant394,Constant395,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422,Constant423,Constant424,Constant425,Constant426 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 14, 15, 27, 28, 41, 42, 406, 152, 155, 407, 408, 226, 227, 228, 414, 310, 311, 420, 394, 395, 426, 4, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389<br /><br />1: PgInsertSingle[8]<br />2: PgClassExpression[12]<br />3: PgInsertSingle[16]<br />4: PgInsertSingle[22]<br />5: PgClassExpression[26]<br />6: PgInsertSingle[30]<br />7: PgInsertSingle[36]<br />8: PgClassExpression[40]<br />9: PgInsertSingle[44]<br />10: <br />ᐳ: PgClassExpression[48]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant14,Constant15,Constant27,Constant28,Constant41,Constant42,Lambda152,Lambda155,Access156,Constant157,Constant158,Constant159,Object160,Lambda161,Lambda166,Constant172,Constant173,Constant174,Object175,Lambda176,Lambda181,Constant187,Constant188,Constant189,Object190,Lambda191,Lambda196,Constant202,Constant203,Constant204,Object205,Lambda206,Lambda211,Constant217,Constant218,Constant219,Object220,Lambda221,Lambda226,Constant232,Constant233,Constant234,Object235,Lambda236,Lambda241,Constant247,Constant248,Object250,Lambda251,Lambda256,Constant262,Constant263,Object265,Lambda266,Lambda271,Constant277,Constant278,Object280,Lambda281,Lambda286,Constant292,Constant293,Object295,Lambda296,Lambda301,Constant307,Constant308,Object310,Lambda311,Lambda316,Constant322,Constant323,Object325,Lambda326,Lambda331,Constant337,Constant338,Object340,Lambda341,Lambda346,Constant352,Constant353,Object355,Lambda356,Lambda361,Constant367,Constant368,Object370,Lambda371,Lambda376,Constant382,Constant383,Object385,Lambda386,Lambda391,Constant397,Constant398,Object400,Lambda401,Lambda406,Constant412,Constant413,Object415,Lambda416,Lambda421,Constant422,Constant423,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 14, 15, 27, 28, 41, 42, 424, 152, 156, 236, 241, 425, 326, 331, 426, 416, 421, 4, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406<br /><br />1: PgInsertSingle[8]<br />2: PgClassExpression[12]<br />3: PgInsertSingle[16]<br />4: PgInsertSingle[22]<br />5: PgClassExpression[26]<br />6: PgInsertSingle[30]<br />7: PgInsertSingle[36]<br />8: PgClassExpression[40]<br />9: PgInsertSingle[44]<br />10: <br />ᐳ: PgClassExpression[48]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle8,PgClassExpression12,PgInsertSingle16,PgInsertSingle22,PgClassExpression26,PgInsertSingle30,PgInsertSingle36,PgClassExpression40,PgInsertSingle44,PgClassExpression48 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 406, 152, 155, 407, 408, 226, 227, 228, 414, 310, 311, 420, 394, 395, 426, 48, 4, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]<br />1: <br />ᐳ: 229, 235, 313, 319, 397, 403, 230, 314, 398<br />2: 50, 85, 118<br />ᐳ: 54, 55, 87, 88, 120, 121"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 424, 152, 156, 236, 241, 425, 326, 331, 426, 416, 421, 48, 4, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect50,First54,PgSelectSingle55,PgSelect85,First87,PgSelectSingle88,PgSelect118,First120,PgSelectSingle121,Object229,Lambda230,Lambda235,Object313,Lambda314,Lambda319,Object397,Lambda398,Lambda403 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 55, 88, 121, 4, 11, 152, 155, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect50,First54,PgSelectSingle55,PgClassExpression56,PgPolymorphic57,PgSelect85,First87,PgSelectSingle88,PgClassExpression89,PgPolymorphic90,PgSelect118,First120,PgSelectSingle121,PgClassExpression122,PgPolymorphic123 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 55, 11, 152, 156, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 57, 88, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 90, 121, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406, 123<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression56,PgPolymorphic57,PgClassExpression89,PgPolymorphic90,PgClassExpression122,PgPolymorphic123 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 55, 11, 152, 155, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 57<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[58]<br />2: 59, 65, 72, 76, 80<br />ᐳ: 63, 64, 67, 68, 69, 70, 71, 74, 75, 78, 79, 82, 83"):::bucket
+    class Bucket3 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 55, 11, 152, 156, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 57<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[58]<br />2: 59, 65, 72, 76, 80<br />ᐳ: 63, 64, 67, 68, 69, 70, 71, 74, 75, 78, 79, 82, 83"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression58,PgSelect59,First63,PgSelectSingle64,PgSelect65,First67,PgSelectSingle68,PgClassExpression69,PgClassExpression70,PgClassExpression71,PgSelect72,First74,PgSelectSingle75,PgSelect76,First78,PgSelectSingle79,PgSelect80,First82,PgSelectSingle83 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 88, 11, 152, 155, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 90<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[91]<br />2: 92, 98, 105, 109, 113<br />ᐳ: 96, 97, 100, 101, 102, 103, 104, 107, 108, 111, 112, 115, 116"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 88, 11, 152, 156, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 90<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[91]<br />2: 92, 98, 105, 109, 113<br />ᐳ: 96, 97, 100, 101, 102, 103, 104, 107, 108, 111, 112, 115, 116"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression91,PgSelect92,First96,PgSelectSingle97,PgSelect98,First100,PgSelectSingle101,PgClassExpression102,PgClassExpression103,PgClassExpression104,PgSelect105,First107,PgSelectSingle108,PgSelect109,First111,PgSelectSingle112,PgSelect113,First115,PgSelectSingle116 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 121, 11, 152, 155, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389, 123<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[124]<br />2: 125, 131, 138, 142, 146<br />ᐳ: 129, 130, 133, 134, 135, 136, 137, 140, 141, 144, 145, 148, 149"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 121, 11, 152, 156, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406, 123<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[124]<br />2: 125, 131, 138, 142, 146<br />ᐳ: 129, 130, 133, 134, 135, 136, 137, 140, 141, 144, 145, 148, 149"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression124,PgSelect125,First129,PgSelectSingle130,PgSelect131,First133,PgSelectSingle134,PgClassExpression135,PgClassExpression136,PgClassExpression137,PgSelect138,First140,PgSelectSingle141,PgSelect142,First144,PgSelectSingle145,PgSelect146,First148,PgSelectSingle149 bucket6
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.mermaid
@@ -9,72 +9,85 @@ graph TD
 
 
     %% plan dependencies
-    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda152 & Constant156 & Constant157 & Constant158 --> Object159
-    Object173{{"Object[173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda152 & Constant170 & Constant171 & Constant172 --> Object173
-    Object187{{"Object[187∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda152 & Constant184 & Constant185 & Constant186 --> Object187
-    Object201{{"Object[201∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant199{{"Constant[199∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda152 & Constant198 & Constant199 & Constant200 --> Object201
-    Object215{{"Object[215∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda152 & Constant212 & Constant213 & Constant214 --> Object215
-    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda152 & Constant240 & Constant241 & Constant158 --> Object243
-    Object257{{"Object[257∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant254{{"Constant[254∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant255{{"Constant[255∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda152 & Constant254 & Constant255 & Constant172 --> Object257
-    Object271{{"Object[271∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda152 & Constant268 & Constant269 & Constant186 --> Object271
-    Object285{{"Object[285∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant283{{"Constant[283∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda152 & Constant282 & Constant283 & Constant200 --> Object285
-    Object299{{"Object[299∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant296{{"Constant[296∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant297{{"Constant[297∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda152 & Constant296 & Constant297 & Constant214 --> Object299
-    Object327{{"Object[327∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant324{{"Constant[324∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant325{{"Constant[325∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda152 & Constant324 & Constant325 & Constant158 --> Object327
-    Object341{{"Object[341∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant338{{"Constant[338∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant339{{"Constant[339∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda152 & Constant338 & Constant339 & Constant172 --> Object341
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda152 & Constant157 & Constant158 & Constant159 --> Object160
+    Object175{{"Object[175∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda152 & Constant172 & Constant173 & Constant174 --> Object175
+    Object190{{"Object[190∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda152 & Constant187 & Constant188 & Constant189 --> Object190
+    Object205{{"Object[205∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda152 & Constant202 & Constant203 & Constant204 --> Object205
+    Object220{{"Object[220∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda152 & Constant217 & Constant218 & Constant219 --> Object220
+    Object235{{"Object[235∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant233{{"Constant[233∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda152 & Constant232 & Constant233 & Constant234 --> Object235
+    Object250{{"Object[250∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant248{{"Constant[248∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda152 & Constant247 & Constant248 & Constant159 --> Object250
+    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda152 & Constant262 & Constant263 & Constant174 --> Object265
+    Object280{{"Object[280∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant278{{"Constant[278∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda152 & Constant277 & Constant278 & Constant189 --> Object280
+    Object295{{"Object[295∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant292{{"Constant[292∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda152 & Constant292 & Constant293 & Constant204 --> Object295
+    Object310{{"Object[310∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant307{{"Constant[307∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant308{{"Constant[308∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda152 & Constant307 & Constant308 & Constant219 --> Object310
+    Object325{{"Object[325∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant322{{"Constant[322∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda152 & Constant322 & Constant323 & Constant234 --> Object325
+    Object340{{"Object[340∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant337{{"Constant[337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant338{{"Constant[338∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda152 & Constant337 & Constant338 & Constant159 --> Object340
     Object355{{"Object[355∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant352{{"Constant[352∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant353{{"Constant[353∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda152 & Constant352 & Constant353 & Constant186 --> Object355
-    Object369{{"Object[369∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant366{{"Constant[366∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda152 & Constant366 & Constant367 & Constant200 --> Object369
-    Object383{{"Object[383∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda152 & Constant380 & Constant381 & Constant214 --> Object383
+    Constant353{{"Constant[353∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda152 & Constant352 & Constant353 & Constant174 --> Object355
+    Object370{{"Object[370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant367{{"Constant[367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda152 & Constant367 & Constant368 & Constant189 --> Object370
+    Object385{{"Object[385∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant382{{"Constant[382∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda152 & Constant382 & Constant383 & Constant204 --> Object385
+    Object400{{"Object[400∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda152 & Constant397 & Constant398 & Constant219 --> Object400
+    Object415{{"Object[415∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant412{{"Constant[412∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda152 & Constant412 & Constant413 & Constant234 --> Object415
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -82,86 +95,103 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant404{{"Constant[404∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant404 --> Lambda152
+    Constant422{{"Constant[422∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant422 --> Lambda152
     Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant405{{"Constant[405∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant405 --> Lambda155
-    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object159 --> Lambda160
-    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant409{{"Constant[409∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant409 --> Lambda165
-    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object173 --> Lambda174
-    Lambda179{{"Lambda[179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant410 --> Lambda179
-    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object187 --> Lambda188
-    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant411 --> Lambda193
-    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object201 --> Lambda202
-    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant412{{"Constant[412∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant412 --> Lambda207
-    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object215 --> Lambda216
+    Constant423{{"Constant[423∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant423 --> Lambda155
+    Access156{{"Access[156∈0] ➊<br />ᐸ155.0ᐳ"}}:::plan
+    Lambda155 --> Access156
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object160 --> Lambda161
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant427{{"Constant[427∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant427 --> Lambda166
+    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object175 --> Lambda176
+    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant428{{"Constant[428∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant428 --> Lambda181
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object190 --> Lambda191
+    Lambda196{{"Lambda[196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant429 --> Lambda196
+    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object205 --> Lambda206
+    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant430{{"Constant[430∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant430 --> Lambda211
     Lambda221{{"Lambda[221∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant413{{"Constant[413∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant413 --> Lambda221
-    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object243 --> Lambda244
-    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant415 --> Lambda249
-    Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object257 --> Lambda258
-    Lambda263{{"Lambda[263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant416 --> Lambda263
-    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object271 --> Lambda272
-    Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant417 --> Lambda277
+    Object220 --> Lambda221
+    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant431 --> Lambda226
+    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object235 --> Lambda236
+    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant432 --> Lambda241
+    Lambda251{{"Lambda[251∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object250 --> Lambda251
+    Lambda256{{"Lambda[256∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant433 --> Lambda256
+    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object265 --> Lambda266
+    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant434 --> Lambda271
+    Lambda281{{"Lambda[281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object280 --> Lambda281
     Lambda286{{"Lambda[286∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object285 --> Lambda286
-    Lambda291{{"Lambda[291∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant418{{"Constant[418∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant418 --> Lambda291
-    Lambda300{{"Lambda[300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object299 --> Lambda300
-    Lambda305{{"Lambda[305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant419{{"Constant[419∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant419 --> Lambda305
-    Lambda328{{"Lambda[328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object327 --> Lambda328
-    Lambda333{{"Lambda[333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant421{{"Constant[421∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant421 --> Lambda333
-    Lambda342{{"Lambda[342∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object341 --> Lambda342
-    Lambda347{{"Lambda[347∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant422 --> Lambda347
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant435 --> Lambda286
+    Lambda296{{"Lambda[296∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object295 --> Lambda296
+    Lambda301{{"Lambda[301∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant436 --> Lambda301
+    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object310 --> Lambda311
+    Lambda316{{"Lambda[316∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant437{{"Constant[437∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant437 --> Lambda316
+    Lambda326{{"Lambda[326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object325 --> Lambda326
+    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant438{{"Constant[438∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant438 --> Lambda331
+    Lambda341{{"Lambda[341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object340 --> Lambda341
+    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant439{{"Constant[439∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant439 --> Lambda346
     Lambda356{{"Lambda[356∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object355 --> Lambda356
     Lambda361{{"Lambda[361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant423{{"Constant[423∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant423 --> Lambda361
-    Lambda370{{"Lambda[370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object369 --> Lambda370
-    Lambda375{{"Lambda[375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant424 --> Lambda375
-    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object383 --> Lambda384
-    Lambda389{{"Lambda[389∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant425 --> Lambda389
+    Constant440{{"Constant[440∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant440 --> Lambda361
+    Lambda371{{"Lambda[371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object370 --> Lambda371
+    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant441{{"Constant[441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant441 --> Lambda376
+    Lambda386{{"Lambda[386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object385 --> Lambda386
+    Lambda391{{"Lambda[391∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant442{{"Constant[442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant442 --> Lambda391
+    Lambda401{{"Lambda[401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object400 --> Lambda401
+    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant443 --> Lambda406
+    Lambda416{{"Lambda[416∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object415 --> Lambda416
+    Lambda421{{"Lambda[421∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant444 --> Lambda421
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸ'POST'ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ2ᐳ"}}:::plan
@@ -172,19 +202,9 @@ graph TD
     Constant28{{"Constant[28∈0] ➊<br />ᐸ'Desc 2'ᐳ"}}:::plan
     Constant41{{"Constant[41∈0] ➊<br />ᐸ'Post ꖛ3'ᐳ"}}:::plan
     Constant42{{"Constant[42∈0] ➊<br />ᐸ'Desc 3'ᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant311{{"Constant[311∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
-    Constant408{{"Constant[408∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant420{{"Constant[420∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant424{{"Constant[424∈0] ➊<br />ᐸ1000000ᐳ"}}:::plan
+    Constant425{{"Constant[425∈0] ➊<br />ᐸ1000001ᐳ"}}:::plan
+    Constant426{{"Constant[426∈0] ➊<br />ᐸ1000002ᐳ"}}:::plan
     PgInsertSingle16[["PgInsertSingle[16∈1] ➊<br />ᐸrelational_posts(id,title,description,note)ᐳ"]]:::sideeffectplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
     Object11 & PgClassExpression12 & Constant13 & Constant14 & Constant15 --> PgInsertSingle16
@@ -206,64 +226,46 @@ graph TD
     PgClassExpression48{{"PgClassExpression[48∈1] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
     PgInsertSingle44 --> PgClassExpression48
     PgSelect50[["PgSelect[50∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda230{{"Lambda[230∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda235{{"Lambda[235∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant406 & Lambda152 & Lambda155 & Lambda230 & Lambda235 --> PgSelect50
+    Object11 & Constant424 & Lambda152 & Access156 & Lambda236 & Lambda241 --> PgSelect50
     PgSelect85[["PgSelect[85∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda314{{"Lambda[314∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda319{{"Lambda[319∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant407 & Lambda152 & Lambda155 & Lambda314 & Lambda319 --> PgSelect85
+    Object11 & Constant425 & Lambda152 & Access156 & Lambda326 & Lambda331 --> PgSelect85
     PgSelect118[["PgSelect[118∈2] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda398{{"Lambda[398∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda403{{"Lambda[403∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant408 & Lambda152 & Lambda155 & Lambda398 & Lambda403 --> PgSelect118
-    Object229{{"Object[229∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda152 & Constant226 & Constant227 & Constant228 --> Object229
-    Object313{{"Object[313∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda152 & Constant310 & Constant311 & Constant228 --> Object313
-    Object397{{"Object[397∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda152 & Constant394 & Constant395 & Constant228 --> Object397
+    Object11 & Constant426 & Lambda152 & Access156 & Lambda416 & Lambda421 --> PgSelect118
+    PgPolymorphic57{{"PgPolymorphic[57∈2] ➊"}}:::plan
+    PgSelectSingle55{{"PgSelectSingle[55∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression56{{"PgClassExpression[56∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle55 & PgClassExpression56 --> PgPolymorphic57
+    PgPolymorphic90{{"PgPolymorphic[90∈2] ➊"}}:::plan
+    PgSelectSingle88{{"PgSelectSingle[88∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression89{{"PgClassExpression[89∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle88 & PgClassExpression89 --> PgPolymorphic90
+    PgPolymorphic123{{"PgPolymorphic[123∈2] ➊"}}:::plan
+    PgSelectSingle121{{"PgSelectSingle[121∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
+    PgClassExpression122{{"PgClassExpression[122∈2] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle121 & PgClassExpression122 --> PgPolymorphic123
     First54{{"First[54∈2] ➊"}}:::plan
     PgSelect50 --> First54
-    PgSelectSingle55{{"PgSelectSingle[55∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First54 --> PgSelectSingle55
+    PgSelectSingle55 --> PgClassExpression56
     First87{{"First[87∈2] ➊"}}:::plan
     PgSelect85 --> First87
-    PgSelectSingle88{{"PgSelectSingle[88∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First87 --> PgSelectSingle88
+    PgSelectSingle88 --> PgClassExpression89
     First120{{"First[120∈2] ➊"}}:::plan
     PgSelect118 --> First120
-    PgSelectSingle121{{"PgSelectSingle[121∈2] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First120 --> PgSelectSingle121
-    Object229 --> Lambda230
-    Constant414 --> Lambda235
-    Object313 --> Lambda314
-    Constant420 --> Lambda319
-    Object397 --> Lambda398
-    Constant426 --> Lambda403
-    PgPolymorphic57{{"PgPolymorphic[57∈3] ➊"}}:::plan
-    PgClassExpression56{{"PgClassExpression[56∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle55 & PgClassExpression56 --> PgPolymorphic57
-    PgPolymorphic90{{"PgPolymorphic[90∈3] ➊"}}:::plan
-    PgClassExpression89{{"PgClassExpression[89∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle88 & PgClassExpression89 --> PgPolymorphic90
-    PgPolymorphic123{{"PgPolymorphic[123∈3] ➊"}}:::plan
-    PgClassExpression122{{"PgClassExpression[122∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle121 & PgClassExpression122 --> PgPolymorphic123
-    PgSelectSingle55 --> PgClassExpression56
-    PgSelectSingle88 --> PgClassExpression89
     PgSelectSingle121 --> PgClassExpression122
     PgSelect59[["PgSelect[59∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression58{{"PgClassExpression[58∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda160 & Lambda165 --> PgSelect59
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda161 & Lambda166 --> PgSelect59
     PgSelect65[["PgSelect[65∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda174 & Lambda179 --> PgSelect65
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda176 & Lambda181 --> PgSelect65
     PgSelect72[["PgSelect[72∈4] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda188 & Lambda193 --> PgSelect72
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda191 & Lambda196 --> PgSelect72
     PgSelect76[["PgSelect[76∈4] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda202 & Lambda207 --> PgSelect76
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda206 & Lambda211 --> PgSelect76
     PgSelect80[["PgSelect[80∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression58 & Lambda152 & Lambda155 & Lambda216 & Lambda221 --> PgSelect80
+    Object11 & PgClassExpression58 & Lambda152 & Access156 & Lambda221 & Lambda226 --> PgSelect80
     PgSelectSingle55 --> PgClassExpression58
     First63{{"First[63∈4] ➊"}}:::plan
     PgSelect59 --> First63
@@ -293,15 +295,15 @@ graph TD
     First82 --> PgSelectSingle83
     PgSelect92[["PgSelect[92∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression91{{"PgClassExpression[91∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda244 & Lambda249 --> PgSelect92
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda251 & Lambda256 --> PgSelect92
     PgSelect98[["PgSelect[98∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda258 & Lambda263 --> PgSelect98
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda266 & Lambda271 --> PgSelect98
     PgSelect105[["PgSelect[105∈5] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda272 & Lambda277 --> PgSelect105
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda281 & Lambda286 --> PgSelect105
     PgSelect109[["PgSelect[109∈5] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda286 & Lambda291 --> PgSelect109
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda296 & Lambda301 --> PgSelect109
     PgSelect113[["PgSelect[113∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression91 & Lambda152 & Lambda155 & Lambda300 & Lambda305 --> PgSelect113
+    Object11 & PgClassExpression91 & Lambda152 & Access156 & Lambda311 & Lambda316 --> PgSelect113
     PgSelectSingle88 --> PgClassExpression91
     First96{{"First[96∈5] ➊"}}:::plan
     PgSelect92 --> First96
@@ -331,15 +333,15 @@ graph TD
     First115 --> PgSelectSingle116
     PgSelect125[["PgSelect[125∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression124{{"PgClassExpression[124∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda328 & Lambda333 --> PgSelect125
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda341 & Lambda346 --> PgSelect125
     PgSelect131[["PgSelect[131∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda342 & Lambda347 --> PgSelect131
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda356 & Lambda361 --> PgSelect131
     PgSelect138[["PgSelect[138∈6] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda356 & Lambda361 --> PgSelect138
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda371 & Lambda376 --> PgSelect138
     PgSelect142[["PgSelect[142∈6] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda370 & Lambda375 --> PgSelect142
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda386 & Lambda391 --> PgSelect142
     PgSelect146[["PgSelect[146∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object11 & PgClassExpression124 & Lambda152 & Lambda155 & Lambda384 & Lambda389 --> PgSelect146
+    Object11 & PgClassExpression124 & Lambda152 & Access156 & Lambda401 & Lambda406 --> PgSelect146
     PgSelectSingle121 --> PgClassExpression124
     First129{{"First[129∈6] ➊"}}:::plan
     PgSelect125 --> First129
@@ -377,23 +379,23 @@ graph TD
     subgraph "Buckets for mutations/basics/create-three-relational-posts"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant14,Constant15,Constant27,Constant28,Constant41,Constant42,Lambda152,Lambda155,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant170,Constant171,Constant172,Object173,Lambda174,Lambda179,Constant184,Constant185,Constant186,Object187,Lambda188,Lambda193,Constant198,Constant199,Constant200,Object201,Lambda202,Lambda207,Constant212,Constant213,Constant214,Object215,Lambda216,Lambda221,Constant226,Constant227,Constant228,Constant240,Constant241,Object243,Lambda244,Lambda249,Constant254,Constant255,Object257,Lambda258,Lambda263,Constant268,Constant269,Object271,Lambda272,Lambda277,Constant282,Constant283,Object285,Lambda286,Lambda291,Constant296,Constant297,Object299,Lambda300,Lambda305,Constant310,Constant311,Constant324,Constant325,Object327,Lambda328,Lambda333,Constant338,Constant339,Object341,Lambda342,Lambda347,Constant352,Constant353,Object355,Lambda356,Lambda361,Constant366,Constant367,Object369,Lambda370,Lambda375,Constant380,Constant381,Object383,Lambda384,Lambda389,Constant394,Constant395,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422,Constant423,Constant424,Constant425,Constant426 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 14, 15, 27, 28, 41, 42, 406, 152, 155, 407, 408, 226, 227, 228, 414, 310, 311, 420, 394, 395, 426, 4, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389<br /><br />1: PgInsertSingle[8]<br />2: PgClassExpression[12]<br />3: PgInsertSingle[16]<br />4: PgInsertSingle[22]<br />5: PgClassExpression[26]<br />6: PgInsertSingle[30]<br />7: PgInsertSingle[36]<br />8: PgClassExpression[40]<br />9: PgInsertSingle[44]<br />10: <br />ᐳ: PgClassExpression[48]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Constant7,Access9,Access10,Object11,Constant13,Constant14,Constant15,Constant27,Constant28,Constant41,Constant42,Lambda152,Lambda155,Access156,Constant157,Constant158,Constant159,Object160,Lambda161,Lambda166,Constant172,Constant173,Constant174,Object175,Lambda176,Lambda181,Constant187,Constant188,Constant189,Object190,Lambda191,Lambda196,Constant202,Constant203,Constant204,Object205,Lambda206,Lambda211,Constant217,Constant218,Constant219,Object220,Lambda221,Lambda226,Constant232,Constant233,Constant234,Object235,Lambda236,Lambda241,Constant247,Constant248,Object250,Lambda251,Lambda256,Constant262,Constant263,Object265,Lambda266,Lambda271,Constant277,Constant278,Object280,Lambda281,Lambda286,Constant292,Constant293,Object295,Lambda296,Lambda301,Constant307,Constant308,Object310,Lambda311,Lambda316,Constant322,Constant323,Object325,Lambda326,Lambda331,Constant337,Constant338,Object340,Lambda341,Lambda346,Constant352,Constant353,Object355,Lambda356,Lambda361,Constant367,Constant368,Object370,Lambda371,Lambda376,Constant382,Constant383,Object385,Lambda386,Lambda391,Constant397,Constant398,Object400,Lambda401,Lambda406,Constant412,Constant413,Object415,Lambda416,Lambda421,Constant422,Constant423,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 14, 15, 27, 28, 41, 42, 424, 152, 156, 236, 241, 425, 326, 331, 426, 416, 421, 4, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406<br /><br />1: PgInsertSingle[8]<br />2: PgClassExpression[12]<br />3: PgInsertSingle[16]<br />4: PgInsertSingle[22]<br />5: PgClassExpression[26]<br />6: PgInsertSingle[30]<br />7: PgInsertSingle[36]<br />8: PgClassExpression[40]<br />9: PgInsertSingle[44]<br />10: <br />ᐳ: PgClassExpression[48]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle8,PgClassExpression12,PgInsertSingle16,PgInsertSingle22,PgClassExpression26,PgInsertSingle30,PgInsertSingle36,PgClassExpression40,PgInsertSingle44,PgClassExpression48 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 406, 152, 155, 407, 408, 226, 227, 228, 414, 310, 311, 420, 394, 395, 426, 48, 4, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]<br />1: <br />ᐳ: 229, 235, 313, 319, 397, 403, 230, 314, 398<br />2: 50, 85, 118<br />ᐳ: 54, 55, 87, 88, 120, 121"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 424, 152, 156, 236, 241, 425, 326, 331, 426, 416, 421, 48, 4, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect50,First54,PgSelectSingle55,PgSelect85,First87,PgSelectSingle88,PgSelect118,First120,PgSelectSingle121,Object229,Lambda230,Lambda235,Object313,Lambda314,Lambda319,Object397,Lambda398,Lambda403 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 55, 88, 121, 4, 11, 152, 155, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect50,First54,PgSelectSingle55,PgClassExpression56,PgPolymorphic57,PgSelect85,First87,PgSelectSingle88,PgClassExpression89,PgPolymorphic90,PgSelect118,First120,PgSelectSingle121,PgClassExpression122,PgPolymorphic123 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 55, 11, 152, 156, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 57, 88, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 90, 121, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406, 123<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression56,PgPolymorphic57,PgClassExpression89,PgPolymorphic90,PgClassExpression122,PgPolymorphic123 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 55, 11, 152, 155, 160, 165, 174, 179, 188, 193, 202, 207, 216, 221, 57<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[58]<br />2: 59, 65, 72, 76, 80<br />ᐳ: 63, 64, 67, 68, 69, 70, 71, 74, 75, 78, 79, 82, 83"):::bucket
+    class Bucket3 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 55, 11, 152, 156, 161, 166, 176, 181, 191, 196, 206, 211, 221, 226, 57<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[58]<br />2: 59, 65, 72, 76, 80<br />ᐳ: 63, 64, 67, 68, 69, 70, 71, 74, 75, 78, 79, 82, 83"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression58,PgSelect59,First63,PgSelectSingle64,PgSelect65,First67,PgSelectSingle68,PgClassExpression69,PgClassExpression70,PgClassExpression71,PgSelect72,First74,PgSelectSingle75,PgSelect76,First78,PgSelectSingle79,PgSelect80,First82,PgSelectSingle83 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 88, 11, 152, 155, 244, 249, 258, 263, 272, 277, 286, 291, 300, 305, 90<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[91]<br />2: 92, 98, 105, 109, 113<br />ᐳ: 96, 97, 100, 101, 102, 103, 104, 107, 108, 111, 112, 115, 116"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 88, 11, 152, 156, 251, 256, 266, 271, 281, 286, 296, 301, 311, 316, 90<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[91]<br />2: 92, 98, 105, 109, 113<br />ᐳ: 96, 97, 100, 101, 102, 103, 104, 107, 108, 111, 112, 115, 116"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression91,PgSelect92,First96,PgSelectSingle97,PgSelect98,First100,PgSelectSingle101,PgClassExpression102,PgClassExpression103,PgClassExpression104,PgSelect105,First107,PgSelectSingle108,PgSelect109,First111,PgSelectSingle112,PgSelect113,First115,PgSelectSingle116 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 121, 11, 152, 155, 328, 333, 342, 347, 356, 361, 370, 375, 384, 389, 123<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[124]<br />2: 125, 131, 138, 142, 146<br />ᐳ: 129, 130, 133, 134, 135, 136, 137, 140, 141, 144, 145, 148, 149"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 121, 11, 152, 156, 341, 346, 356, 361, 371, 376, 386, 391, 401, 406, 123<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[124]<br />2: 125, 131, 138, 142, 146<br />ᐳ: 129, 130, 133, 134, 135, 136, 137, 140, 141, 144, 145, 148, 149"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression124,PgSelect125,First129,PgSelectSingle130,PgSelect131,First133,PgSelectSingle134,PgClassExpression135,PgClassExpression136,PgClassExpression137,PgSelect138,First140,PgSelectSingle141,PgSelect142,First144,PgSelectSingle145,PgSelect146,First148,PgSelectSingle149 bucket6
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/mutations/basics/delete-relational-post.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/delete-relational-post.deopt.mermaid
@@ -9,6 +9,43 @@ graph TD
 
 
     %% plan dependencies
+    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda82 & Constant87 & Constant88 & Constant89 --> Object90
+    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda82 & Constant102 & Constant103 & Constant104 --> Object105
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda82 & Constant119 & Constant120 & Constant121 --> Object122
+    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda82 & Constant136 & Constant137 & Constant138 --> Object139
+    Object154{{"Object[154∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda82 & Constant151 & Constant152 & Constant89 --> Object154
+    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda82 & Constant166 & Constant167 & Constant104 --> Object169
+    Object186{{"Object[186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda82 & Constant183 & Constant184 & Constant121 --> Object186
+    Object203{{"Object[203∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant200{{"Constant[200∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda82 & Constant200 & Constant201 & Constant138 --> Object203
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,62 +53,61 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant204 --> Lambda82
+    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant212 --> Lambda82
     Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant205 --> Lambda85
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant213 --> Lambda85
+    Access86{{"Access[86∈0] ➊<br />ᐸ85.0ᐳ"}}:::plan
+    Lambda85 --> Access86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object90 --> Lambda91
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant214 --> Lambda96
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object105 --> Lambda106
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant215 --> Lambda111
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant216 --> Lambda128
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object139 --> Lambda140
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant217 --> Lambda145
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object154 --> Lambda155
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant218 --> Lambda160
+    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object169 --> Lambda170
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant219 --> Lambda175
+    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object186 --> Lambda187
+    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant220 --> Lambda192
+    Lambda204{{"Lambda[204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object203 --> Lambda204
+    Lambda209{{"Lambda[209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant221 --> Lambda209
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant202{{"Constant[202∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant203{{"Constant[203∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
     PgDeleteSingle8[["PgDeleteSingle[8∈1] ➊<br />ᐸrelational_posts(id)ᐳ"]]:::sideeffectplan
-    Object11 & Constant202 --> PgDeleteSingle8
+    Object11 & Constant210 --> PgDeleteSingle8
     PgSelect14[["PgSelect[14∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda120{{"Lambda[120∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda125{{"Lambda[125∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda136{{"Lambda[136∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda141{{"Lambda[141∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & PgClassExpression13 & Lambda85 & Lambda104 & Lambda109 & Lambda85 & Lambda120 & Lambda125 & Lambda82 & Lambda85 & Lambda136 & Lambda141 --> PgSelect14
-    Object89{{"Object[89∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant86 & Constant87 & Constant88 --> Object89
-    Object103{{"Object[103∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant100 & Constant101 & Constant102 --> Object103
-    Object119{{"Object[119∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant116 & Constant117 & Constant118 --> Object119
-    Object135{{"Object[135∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant132 & Constant133 & Constant134 --> Object135
+    Object11 & PgClassExpression13 & Access86 & Lambda106 & Lambda111 & Access86 & Lambda123 & Lambda128 & Lambda82 & Access86 & Lambda140 & Lambda145 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgDeleteSingle8 --> PgClassExpression12
     PgDeleteSingle8 --> PgClassExpression13
@@ -79,19 +115,9 @@ graph TD
     PgSelect14 --> First18
     PgSelectSingle19{{"PgSelectSingle[19∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First18 --> PgSelectSingle19
-    Lambda90{{"Lambda[90∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object89 --> Lambda90
-    Lambda95{{"Lambda[95∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant206 --> Lambda95
-    Object103 --> Lambda104
-    Constant207 --> Lambda109
-    Object119 --> Lambda120
-    Constant208 --> Lambda125
-    Object135 --> Lambda136
-    Constant209 --> Lambda141
     PgSelect37[["PgSelect[37∈3] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈3] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression36 & Lambda82 & Lambda85 & Lambda90 & Lambda95 --> PgSelect37
+    Object11 & PgClassExpression36 & Lambda82 & Access86 & Lambda91 & Lambda96 --> PgSelect37
     PgClassExpression20{{"PgClassExpression[20∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression20
     PgClassExpression21{{"PgClassExpression[21∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -101,8 +127,8 @@ graph TD
     PgClassExpression23{{"PgClassExpression[23∈3] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression23
     PgSelectSingle30{{"PgSelectSingle[30∈3] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys126{{"RemapKeys[126∈3] ➊<br />ᐸ19:{”0”:5}ᐳ"}}:::plan
-    RemapKeys126 --> PgSelectSingle30
+    RemapKeys129{{"RemapKeys[129∈3] ➊<br />ᐸ19:{”0”:5}ᐳ"}}:::plan
+    RemapKeys129 --> PgSelectSingle30
     PgClassExpression31{{"PgClassExpression[31∈3] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle30 --> PgClassExpression31
     PgSelectSingle35{{"PgSelectSingle[35∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -112,14 +138,14 @@ graph TD
     PgSelect37 --> First39
     PgSelectSingle40{{"PgSelectSingle[40∈3] ➊<br />ᐸpeopleᐳ"}}:::plan
     First39 --> PgSelectSingle40
-    PgSelectSingle19 --> RemapKeys126
+    PgSelectSingle19 --> RemapKeys129
     PgClassExpression41{{"PgClassExpression[41∈4] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈4] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression42
     PgDeleteSingle45[["PgDeleteSingle[45∈5] ➊<br />ᐸrelational_posts(id)ᐳ"]]:::sideeffectplan
     Object48{{"Object[48∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object48 & Constant203 --> PgDeleteSingle45
+    Object48 & Constant211 --> PgDeleteSingle45
     Access46{{"Access[46∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access47{{"Access[47∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access46 & Access47 --> Object48
@@ -127,21 +153,7 @@ graph TD
     __Value2 --> Access47
     PgSelect51[["PgSelect[51∈6] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression50{{"PgClassExpression[50∈6] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
-    Lambda164{{"Lambda[164∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda169{{"Lambda[169∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda180{{"Lambda[180∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda185{{"Lambda[185∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda196{{"Lambda[196∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda201{{"Lambda[201∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object48 & PgClassExpression50 & Lambda85 & Lambda164 & Lambda169 & Lambda85 & Lambda180 & Lambda185 & Lambda82 & Lambda85 & Lambda196 & Lambda201 --> PgSelect51
-    Object149{{"Object[149∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant146 & Constant147 & Constant88 --> Object149
-    Object163{{"Object[163∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant160 & Constant161 & Constant102 --> Object163
-    Object179{{"Object[179∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant176 & Constant177 & Constant118 --> Object179
-    Object195{{"Object[195∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant192 & Constant193 & Constant134 --> Object195
+    Object48 & PgClassExpression50 & Access86 & Lambda170 & Lambda175 & Access86 & Lambda187 & Lambda192 & Lambda82 & Access86 & Lambda204 & Lambda209 --> PgSelect51
     PgClassExpression49{{"PgClassExpression[49∈6] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgDeleteSingle45 --> PgClassExpression49
     PgDeleteSingle45 --> PgClassExpression50
@@ -149,19 +161,9 @@ graph TD
     PgSelect51 --> First55
     PgSelectSingle56{{"PgSelectSingle[56∈6] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First55 --> PgSelectSingle56
-    Lambda150{{"Lambda[150∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object149 --> Lambda150
-    Lambda155{{"Lambda[155∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant210 --> Lambda155
-    Object163 --> Lambda164
-    Constant211 --> Lambda169
-    Object179 --> Lambda180
-    Constant212 --> Lambda185
-    Object195 --> Lambda196
-    Constant213 --> Lambda201
     PgSelect74[["PgSelect[74∈7] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression73{{"PgClassExpression[73∈7] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object48 & PgClassExpression73 & Lambda82 & Lambda85 & Lambda150 & Lambda155 --> PgSelect74
+    Object48 & PgClassExpression73 & Lambda82 & Access86 & Lambda155 & Lambda160 --> PgSelect74
     PgClassExpression57{{"PgClassExpression[57∈7] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle56 --> PgClassExpression57
     PgClassExpression58{{"PgClassExpression[58∈7] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -171,8 +173,8 @@ graph TD
     PgClassExpression60{{"PgClassExpression[60∈7] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle56 --> PgClassExpression60
     PgSelectSingle67{{"PgSelectSingle[67∈7] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys186{{"RemapKeys[186∈7] ➊<br />ᐸ56:{”0”:5}ᐳ"}}:::plan
-    RemapKeys186 --> PgSelectSingle67
+    RemapKeys193{{"RemapKeys[193∈7] ➊<br />ᐸ56:{”0”:5}ᐳ"}}:::plan
+    RemapKeys193 --> PgSelectSingle67
     PgClassExpression68{{"PgClassExpression[68∈7] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression68
     PgSelectSingle72{{"PgSelectSingle[72∈7] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -182,7 +184,7 @@ graph TD
     PgSelect74 --> First76
     PgSelectSingle77{{"PgSelectSingle[77∈7] ➊<br />ᐸpeopleᐳ"}}:::plan
     First76 --> PgSelectSingle77
-    PgSelectSingle56 --> RemapKeys186
+    PgSelectSingle56 --> RemapKeys193
     PgClassExpression78{{"PgClassExpression[78∈8] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle77 --> PgClassExpression78
     PgClassExpression79{{"PgClassExpression[79∈8] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -193,28 +195,28 @@ graph TD
     subgraph "Buckets for mutations/basics/delete-relational-post"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Lambda82,Lambda85,Constant86,Constant87,Constant88,Constant100,Constant101,Constant102,Constant116,Constant117,Constant118,Constant132,Constant133,Constant134,Constant146,Constant147,Constant160,Constant161,Constant176,Constant177,Constant192,Constant193,Constant202,Constant203,Constant204,Constant205,Constant206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212,Constant213 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 202, 85, 82, 86, 87, 88, 206, 100, 101, 102, 207, 116, 117, 118, 208, 132, 133, 134, 209"):::bucket
+    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Lambda82,Lambda85,Access86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant102,Constant103,Constant104,Object105,Lambda106,Lambda111,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant136,Constant137,Constant138,Object139,Lambda140,Lambda145,Constant151,Constant152,Object154,Lambda155,Lambda160,Constant166,Constant167,Object169,Lambda170,Lambda175,Constant183,Constant184,Object186,Lambda187,Lambda192,Constant200,Constant201,Object203,Lambda204,Lambda209,Constant210,Constant211,Constant212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 210, 86, 106, 111, 123, 128, 82, 140, 145, 91, 96"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgDeleteSingle8 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 8, 11, 85, 82, 86, 87, 88, 206, 100, 101, 102, 207, 116, 117, 118, 208, 132, 133, 134, 209<br /><br />ROOT PgDeleteSingle{1}ᐸrelational_posts(id)ᐳ[8]<br />1: <br />ᐳ: 12, 13, 89, 95, 103, 109, 119, 125, 135, 141, 90, 104, 120, 136<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 8, 11, 86, 106, 111, 123, 128, 82, 140, 145, 91, 96<br /><br />ROOT PgDeleteSingle{1}ᐸrelational_posts(id)ᐳ[8]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,First18,PgSelectSingle19,Object89,Lambda90,Lambda95,Object103,Lambda104,Lambda109,Object119,Lambda120,Lambda125,Object135,Lambda136,Lambda141 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 11, 82, 85, 90, 95<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[19]<br />1: <br />ᐳ: 20, 21, 22, 23, 35, 126, 30, 31, 36<br />2: PgSelect[37]<br />ᐳ: First[39], PgSelectSingle[40]"):::bucket
+    class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,First18,PgSelectSingle19 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 11, 82, 86, 91, 96<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[19]<br />1: <br />ᐳ: 20, 21, 22, 23, 35, 129, 30, 31, 36<br />2: PgSelect[37]<br />ᐳ: First[39], PgSelectSingle[40]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgSelectSingle30,PgClassExpression31,PgSelectSingle35,PgClassExpression36,PgSelect37,First39,PgSelectSingle40,RemapKeys126 bucket3
+    class Bucket3,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgSelectSingle30,PgClassExpression31,PgSelectSingle35,PgClassExpression36,PgSelect37,First39,PgSelectSingle40,RemapKeys129 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 40<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[40]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression41,PgClassExpression42 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 203, 2, 85, 82, 146, 147, 88, 210, 160, 161, 102, 211, 176, 177, 118, 212, 192, 193, 134, 213<br /><br />1: Access[46]<br />2: Access[47]<br />3: Object[48]<br />4: PgDeleteSingle[45]"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 211, 2, 86, 170, 175, 187, 192, 82, 204, 209, 155, 160<br /><br />1: Access[46]<br />2: Access[47]<br />3: Object[48]<br />4: PgDeleteSingle[45]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgDeleteSingle45,Access46,Access47,Object48 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 45, 48, 85, 82, 146, 147, 88, 210, 160, 161, 102, 211, 176, 177, 118, 212, 192, 193, 134, 213<br /><br />ROOT PgDeleteSingle{5}ᐸrelational_posts(id)ᐳ[45]<br />1: <br />ᐳ: 49, 50, 149, 155, 163, 169, 179, 185, 195, 201, 150, 164, 180, 196<br />2: PgSelect[51]<br />ᐳ: First[55], PgSelectSingle[56]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 45, 48, 86, 170, 175, 187, 192, 82, 204, 209, 155, 160<br /><br />ROOT PgDeleteSingle{5}ᐸrelational_posts(id)ᐳ[45]<br />1: <br />ᐳ: 49, 50<br />2: PgSelect[51]<br />ᐳ: First[55], PgSelectSingle[56]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression49,PgClassExpression50,PgSelect51,First55,PgSelectSingle56,Object149,Lambda150,Lambda155,Object163,Lambda164,Lambda169,Object179,Lambda180,Lambda185,Object195,Lambda196,Lambda201 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 56, 48, 82, 85, 150, 155<br /><br />ROOT PgSelectSingle{6}ᐸrelational_postsᐳ[56]<br />1: <br />ᐳ: 57, 58, 59, 60, 72, 186, 67, 68, 73<br />2: PgSelect[74]<br />ᐳ: First[76], PgSelectSingle[77]"):::bucket
+    class Bucket6,PgClassExpression49,PgClassExpression50,PgSelect51,First55,PgSelectSingle56 bucket6
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 56, 48, 82, 86, 155, 160<br /><br />ROOT PgSelectSingle{6}ᐸrelational_postsᐳ[56]<br />1: <br />ᐳ: 57, 58, 59, 60, 72, 193, 67, 68, 73<br />2: PgSelect[74]<br />ᐳ: First[76], PgSelectSingle[77]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgSelectSingle67,PgClassExpression68,PgSelectSingle72,PgClassExpression73,PgSelect74,First76,PgSelectSingle77,RemapKeys186 bucket7
+    class Bucket7,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgSelectSingle67,PgClassExpression68,PgSelectSingle72,PgClassExpression73,PgSelect74,First76,PgSelectSingle77,RemapKeys193 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 77<br /><br />ROOT PgSelectSingle{7}ᐸpeopleᐳ[77]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression78,PgClassExpression79 bucket8

--- a/grafast/dataplan-pg/__tests__/mutations/basics/delete-relational-post.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/delete-relational-post.mermaid
@@ -9,6 +9,43 @@ graph TD
 
 
     %% plan dependencies
+    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda82 & Constant87 & Constant88 & Constant89 --> Object90
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda82 & Constant104 & Constant105 & Constant106 --> Object107
+    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda82 & Constant121 & Constant122 & Constant123 --> Object124
+    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda82 & Constant138 & Constant139 & Constant140 --> Object141
+    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda82 & Constant153 & Constant154 & Constant89 --> Object156
+    Object173{{"Object[173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda82 & Constant170 & Constant171 & Constant106 --> Object173
+    Object190{{"Object[190∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda82 & Constant187 & Constant188 & Constant123 --> Object190
+    Object207{{"Object[207∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda82 & Constant204 & Constant205 & Constant140 --> Object207
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,64 +53,61 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant208 --> Lambda82
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant216 --> Lambda82
     Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant209 --> Lambda85
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant217 --> Lambda85
+    Access86{{"Access[86∈0] ➊<br />ᐸ85.0ᐳ"}}:::plan
+    Lambda85 --> Access86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object90 --> Lambda91
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant218 --> Lambda96
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant219 --> Lambda113
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object124 --> Lambda125
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant220 --> Lambda130
+    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object141 --> Lambda142
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant221 --> Lambda147
+    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object156 --> Lambda157
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant222 --> Lambda162
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object173 --> Lambda174
+    Lambda179{{"Lambda[179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant223 --> Lambda179
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object190 --> Lambda191
+    Lambda196{{"Lambda[196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant224 --> Lambda196
+    Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object207 --> Lambda208
+    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant225 --> Lambda213
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant215{{"Constant[215∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
     PgDeleteSingle8[["PgDeleteSingle[8∈1] ➊<br />ᐸrelational_posts(id)ᐳ"]]:::sideeffectplan
-    Object11 & Constant206 --> PgDeleteSingle8
+    Object11 & Constant214 --> PgDeleteSingle8
     PgSelect14[["PgSelect[14∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
-    Lambda90{{"Lambda[90∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda95{{"Lambda[95∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda111{{"Lambda[111∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda127{{"Lambda[127∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda138{{"Lambda[138∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & PgClassExpression13 & Lambda85 & Lambda90 & Lambda95 & Lambda85 & Lambda106 & Lambda111 & Lambda85 & Lambda122 & Lambda127 & Lambda82 & Lambda85 & Lambda138 & Lambda143 --> PgSelect14
-    Object89{{"Object[89∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant86 & Constant87 & Constant88 --> Object89
-    Object105{{"Object[105∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant102 & Constant103 & Constant104 --> Object105
-    Object121{{"Object[121∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant118 & Constant119 & Constant120 --> Object121
-    Object137{{"Object[137∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant134 & Constant135 & Constant136 --> Object137
+    Object11 & PgClassExpression13 & Access86 & Lambda91 & Lambda96 & Access86 & Lambda108 & Lambda113 & Access86 & Lambda125 & Lambda130 & Lambda82 & Access86 & Lambda142 & Lambda147 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgDeleteSingle8 --> PgClassExpression12
     PgDeleteSingle8 --> PgClassExpression13
@@ -81,14 +115,6 @@ graph TD
     PgSelect14 --> First18
     PgSelectSingle19{{"PgSelectSingle[19∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First18 --> PgSelectSingle19
-    Object89 --> Lambda90
-    Constant210 --> Lambda95
-    Object105 --> Lambda106
-    Constant211 --> Lambda111
-    Object121 --> Lambda122
-    Constant212 --> Lambda127
-    Object137 --> Lambda138
-    Constant213 --> Lambda143
     PgClassExpression20{{"PgClassExpression[20∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression20
     PgClassExpression21{{"PgClassExpression[21∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -98,22 +124,22 @@ graph TD
     PgClassExpression23{{"PgClassExpression[23∈3] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression23
     PgSelectSingle30{{"PgSelectSingle[30∈3] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys128{{"RemapKeys[128∈3] ➊<br />ᐸ19:{”0”:7}ᐳ"}}:::plan
-    RemapKeys128 --> PgSelectSingle30
+    RemapKeys131{{"RemapKeys[131∈3] ➊<br />ᐸ19:{”0”:7}ᐳ"}}:::plan
+    RemapKeys131 --> PgSelectSingle30
     PgClassExpression31{{"PgClassExpression[31∈3] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle30 --> PgClassExpression31
     PgSelectSingle35{{"PgSelectSingle[35∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     PgSelectSingle19 --> PgSelectSingle35
     PgSelectSingle40{{"PgSelectSingle[40∈3] ➊<br />ᐸpeopleᐳ"}}:::plan
     PgSelectSingle35 --> PgSelectSingle40
-    PgSelectSingle19 --> RemapKeys128
+    PgSelectSingle19 --> RemapKeys131
     PgClassExpression41{{"PgClassExpression[41∈4] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈4] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression42
     PgDeleteSingle45[["PgDeleteSingle[45∈5] ➊<br />ᐸrelational_posts(id)ᐳ"]]:::sideeffectplan
     Object48{{"Object[48∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object48 & Constant207 --> PgDeleteSingle45
+    Object48 & Constant215 --> PgDeleteSingle45
     Access46{{"Access[46∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access47{{"Access[47∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access46 & Access47 --> Object48
@@ -121,23 +147,7 @@ graph TD
     __Value2 --> Access47
     PgSelect51[["PgSelect[51∈6] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression50{{"PgClassExpression[50∈6] ➊<br />ᐸ__relational_posts__ᐳ"}}:::plan
-    Lambda152{{"Lambda[152∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda157{{"Lambda[157∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda168{{"Lambda[168∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda173{{"Lambda[173∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda184{{"Lambda[184∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda189{{"Lambda[189∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda200{{"Lambda[200∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda205{{"Lambda[205∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object48 & PgClassExpression50 & Lambda85 & Lambda152 & Lambda157 & Lambda85 & Lambda168 & Lambda173 & Lambda85 & Lambda184 & Lambda189 & Lambda82 & Lambda85 & Lambda200 & Lambda205 --> PgSelect51
-    Object151{{"Object[151∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant148 & Constant149 & Constant88 --> Object151
-    Object167{{"Object[167∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant164 & Constant165 & Constant104 --> Object167
-    Object183{{"Object[183∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant180 & Constant181 & Constant120 --> Object183
-    Object199{{"Object[199∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant196 & Constant197 & Constant136 --> Object199
+    Object48 & PgClassExpression50 & Access86 & Lambda157 & Lambda162 & Access86 & Lambda174 & Lambda179 & Access86 & Lambda191 & Lambda196 & Lambda82 & Access86 & Lambda208 & Lambda213 --> PgSelect51
     PgClassExpression49{{"PgClassExpression[49∈6] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgDeleteSingle45 --> PgClassExpression49
     PgDeleteSingle45 --> PgClassExpression50
@@ -145,14 +155,6 @@ graph TD
     PgSelect51 --> First55
     PgSelectSingle56{{"PgSelectSingle[56∈6] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First55 --> PgSelectSingle56
-    Object151 --> Lambda152
-    Constant214 --> Lambda157
-    Object167 --> Lambda168
-    Constant215 --> Lambda173
-    Object183 --> Lambda184
-    Constant216 --> Lambda189
-    Object199 --> Lambda200
-    Constant217 --> Lambda205
     PgClassExpression57{{"PgClassExpression[57∈7] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle56 --> PgClassExpression57
     PgClassExpression58{{"PgClassExpression[58∈7] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -162,15 +164,15 @@ graph TD
     PgClassExpression60{{"PgClassExpression[60∈7] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle56 --> PgClassExpression60
     PgSelectSingle67{{"PgSelectSingle[67∈7] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys190{{"RemapKeys[190∈7] ➊<br />ᐸ56:{”0”:7}ᐳ"}}:::plan
-    RemapKeys190 --> PgSelectSingle67
+    RemapKeys197{{"RemapKeys[197∈7] ➊<br />ᐸ56:{”0”:7}ᐳ"}}:::plan
+    RemapKeys197 --> PgSelectSingle67
     PgClassExpression68{{"PgClassExpression[68∈7] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression68
     PgSelectSingle72{{"PgSelectSingle[72∈7] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     PgSelectSingle56 --> PgSelectSingle72
     PgSelectSingle77{{"PgSelectSingle[77∈7] ➊<br />ᐸpeopleᐳ"}}:::plan
     PgSelectSingle72 --> PgSelectSingle77
-    PgSelectSingle56 --> RemapKeys190
+    PgSelectSingle56 --> RemapKeys197
     PgClassExpression78{{"PgClassExpression[78∈8] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle77 --> PgClassExpression78
     PgClassExpression79{{"PgClassExpression[79∈8] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -181,28 +183,28 @@ graph TD
     subgraph "Buckets for mutations/basics/delete-relational-post"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Lambda82,Lambda85,Constant86,Constant87,Constant88,Constant102,Constant103,Constant104,Constant118,Constant119,Constant120,Constant134,Constant135,Constant136,Constant148,Constant149,Constant164,Constant165,Constant180,Constant181,Constant196,Constant197,Constant206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212,Constant213,Constant214,Constant215,Constant216,Constant217 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 206, 85, 82, 86, 87, 88, 210, 102, 103, 104, 211, 118, 119, 120, 212, 134, 135, 136, 213"):::bucket
+    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Lambda82,Lambda85,Access86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant121,Constant122,Constant123,Object124,Lambda125,Lambda130,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant170,Constant171,Object173,Lambda174,Lambda179,Constant187,Constant188,Object190,Lambda191,Lambda196,Constant204,Constant205,Object207,Lambda208,Lambda213,Constant214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222,Constant223,Constant224,Constant225 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 214, 86, 91, 96, 108, 113, 125, 130, 82, 142, 147"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgDeleteSingle8 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 8, 11, 85, 82, 86, 87, 88, 210, 102, 103, 104, 211, 118, 119, 120, 212, 134, 135, 136, 213<br /><br />ROOT PgDeleteSingle{1}ᐸrelational_posts(id)ᐳ[8]<br />1: <br />ᐳ: 12, 13, 89, 95, 105, 111, 121, 127, 137, 143, 90, 106, 122, 138<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 8, 11, 86, 91, 96, 108, 113, 125, 130, 82, 142, 147<br /><br />ROOT PgDeleteSingle{1}ᐸrelational_posts(id)ᐳ[8]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,First18,PgSelectSingle19,Object89,Lambda90,Lambda95,Object105,Lambda106,Lambda111,Object121,Lambda122,Lambda127,Object137,Lambda138,Lambda143 bucket2
+    class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,First18,PgSelectSingle19 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[19]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgSelectSingle30,PgClassExpression31,PgSelectSingle35,PgSelectSingle40,RemapKeys128 bucket3
+    class Bucket3,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgSelectSingle30,PgClassExpression31,PgSelectSingle35,PgSelectSingle40,RemapKeys131 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 40<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[40]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression41,PgClassExpression42 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 207, 2, 85, 82, 148, 149, 88, 214, 164, 165, 104, 215, 180, 181, 120, 216, 196, 197, 136, 217<br /><br />1: Access[46]<br />2: Access[47]<br />3: Object[48]<br />4: PgDeleteSingle[45]"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 215, 2, 86, 157, 162, 174, 179, 191, 196, 82, 208, 213<br /><br />1: Access[46]<br />2: Access[47]<br />3: Object[48]<br />4: PgDeleteSingle[45]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgDeleteSingle45,Access46,Access47,Object48 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 45, 48, 85, 82, 148, 149, 88, 214, 164, 165, 104, 215, 180, 181, 120, 216, 196, 197, 136, 217<br /><br />ROOT PgDeleteSingle{5}ᐸrelational_posts(id)ᐳ[45]<br />1: <br />ᐳ: 49, 50, 151, 157, 167, 173, 183, 189, 199, 205, 152, 168, 184, 200<br />2: PgSelect[51]<br />ᐳ: First[55], PgSelectSingle[56]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 45, 48, 86, 157, 162, 174, 179, 191, 196, 82, 208, 213<br /><br />ROOT PgDeleteSingle{5}ᐸrelational_posts(id)ᐳ[45]<br />1: <br />ᐳ: 49, 50<br />2: PgSelect[51]<br />ᐳ: First[55], PgSelectSingle[56]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression49,PgClassExpression50,PgSelect51,First55,PgSelectSingle56,Object151,Lambda152,Lambda157,Object167,Lambda168,Lambda173,Object183,Lambda184,Lambda189,Object199,Lambda200,Lambda205 bucket6
+    class Bucket6,PgClassExpression49,PgClassExpression50,PgSelect51,First55,PgSelectSingle56 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 56<br /><br />ROOT PgSelectSingle{6}ᐸrelational_postsᐳ[56]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgSelectSingle67,PgClassExpression68,PgSelectSingle72,PgSelectSingle77,RemapKeys190 bucket7
+    class Bucket7,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgSelectSingle67,PgClassExpression68,PgSelectSingle72,PgSelectSingle77,RemapKeys197 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 77<br /><br />ROOT PgSelectSingle{7}ᐸpeopleᐳ[77]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression78,PgClassExpression79 bucket8

--- a/grafast/dataplan-pg/__tests__/mutations/basics/update-relational-post.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/update-relational-post.deopt.mermaid
@@ -9,6 +9,75 @@ graph TD
 
 
     %% plan dependencies
+    Object196{{"Object[196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda188 & Constant193 & Constant194 & Constant195 --> Object196
+    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda188 & Constant208 & Constant209 & Constant210 --> Object211
+    Object228{{"Object[228∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant226{{"Constant[226∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda188 & Constant225 & Constant226 & Constant227 --> Object228
+    Object245{{"Object[245∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda188 & Constant242 & Constant243 & Constant244 --> Object245
+    Object260{{"Object[260∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant257{{"Constant[257∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant258{{"Constant[258∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda188 & Constant257 & Constant258 & Constant195 --> Object260
+    Object275{{"Object[275∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant272{{"Constant[272∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant273{{"Constant[273∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant272 & Constant273 & Constant210 --> Object275
+    Object292{{"Object[292∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda188 & Constant289 & Constant290 & Constant227 --> Object292
+    Object309{{"Object[309∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant306{{"Constant[306∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant307{{"Constant[307∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant306 & Constant307 & Constant244 --> Object309
+    Object324{{"Object[324∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant321{{"Constant[321∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant322{{"Constant[322∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda188 & Constant321 & Constant322 & Constant195 --> Object324
+    Object339{{"Object[339∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant336{{"Constant[336∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant337{{"Constant[337∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant336 & Constant337 & Constant210 --> Object339
+    Object356{{"Object[356∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant353{{"Constant[353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant354{{"Constant[354∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda188 & Constant353 & Constant354 & Constant227 --> Object356
+    Object373{{"Object[373∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant370{{"Constant[370∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant371{{"Constant[371∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant370 & Constant371 & Constant244 --> Object373
+    Object388{{"Object[388∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant385{{"Constant[385∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda188 & Constant385 & Constant386 & Constant195 --> Object388
+    Object403{{"Object[403∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant400{{"Constant[400∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant401{{"Constant[401∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant400 & Constant401 & Constant210 --> Object403
+    Object420{{"Object[420∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda188 & Constant417 & Constant418 & Constant227 --> Object420
+    Object437{{"Object[437∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant434 & Constant435 & Constant244 --> Object437
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,107 +85,112 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant432{{"Constant[432∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant432 --> Lambda188
+    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant448 --> Lambda188
     Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant433{{"Constant[433∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant433 --> Lambda191
+    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant449 --> Lambda191
+    Access192{{"Access[192∈0] ➊<br />ᐸ191.0ᐳ"}}:::plan
+    Lambda191 --> Access192
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object196 --> Lambda197
+    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant450 --> Lambda202
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object211 --> Lambda212
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant451 --> Lambda217
+    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object228 --> Lambda229
+    Lambda234{{"Lambda[234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant452 --> Lambda234
+    Lambda246{{"Lambda[246∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object245 --> Lambda246
+    Lambda251{{"Lambda[251∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant453 --> Lambda251
+    Lambda261{{"Lambda[261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object260 --> Lambda261
+    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant454{{"Constant[454∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant454 --> Lambda266
+    Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object275 --> Lambda276
+    Lambda281{{"Lambda[281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant455{{"Constant[455∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant455 --> Lambda281
+    Lambda293{{"Lambda[293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object292 --> Lambda293
+    Lambda298{{"Lambda[298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant456{{"Constant[456∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant456 --> Lambda298
+    Lambda310{{"Lambda[310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object309 --> Lambda310
+    Lambda315{{"Lambda[315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant457{{"Constant[457∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant457 --> Lambda315
+    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object324 --> Lambda325
+    Lambda330{{"Lambda[330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant458{{"Constant[458∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant458 --> Lambda330
+    Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object339 --> Lambda340
+    Lambda345{{"Lambda[345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant459 --> Lambda345
+    Lambda357{{"Lambda[357∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object356 --> Lambda357
+    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant460 --> Lambda362
+    Lambda374{{"Lambda[374∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object373 --> Lambda374
+    Lambda379{{"Lambda[379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant461 --> Lambda379
+    Lambda389{{"Lambda[389∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object388 --> Lambda389
+    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant462 --> Lambda394
+    Lambda404{{"Lambda[404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object403 --> Lambda404
+    Lambda409{{"Lambda[409∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant463 --> Lambda409
+    Lambda421{{"Lambda[421∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object420 --> Lambda421
+    Lambda426{{"Lambda[426∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant464 --> Lambda426
+    Lambda438{{"Lambda[438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object437 --> Lambda438
+    Lambda443{{"Lambda[443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant465 --> Lambda443
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant186{{"Constant[186∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Constant238{{"Constant[238∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant239{{"Constant[239∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant252{{"Constant[252∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant253{{"Constant[253∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant283{{"Constant[283∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant298{{"Constant[298∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant299{{"Constant[299∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant312{{"Constant[312∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant313{{"Constant[313∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant326{{"Constant[326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant327{{"Constant[327∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant342{{"Constant[342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant343{{"Constant[343∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant418{{"Constant[418∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant419{{"Constant[419∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸ'A description'ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ'A note'ᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant446{{"Constant[446∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant447{{"Constant[447∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant445{{"Constant[445∈0] ➊<br />ᐸ'A description'ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ'A note'ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
     PgUpdateSingle11[["PgUpdateSingle[11∈1] ➊<br />ᐸrelational_posts(id;description)ᐳ"]]:::sideeffectplan
-    Object14 & Constant428 & Constant429 --> PgUpdateSingle11
+    Object14 & Constant444 & Constant445 --> PgUpdateSingle11
     PgSelect17[["PgSelect[17∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈2] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda210{{"Lambda[210∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda215{{"Lambda[215∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda226{{"Lambda[226∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda231{{"Lambda[231∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda242{{"Lambda[242∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda247{{"Lambda[247∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & PgClassExpression15 & Lambda191 & Lambda210 & Lambda215 & Lambda191 & Lambda226 & Lambda231 & Lambda188 & Lambda191 & Lambda242 & Lambda247 --> PgSelect17
-    Object195{{"Object[195∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant192 & Constant193 & Constant194 --> Object195
-    Object209{{"Object[209∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant206 & Constant207 & Constant208 --> Object209
-    Object225{{"Object[225∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant222 & Constant223 & Constant224 --> Object225
-    Object241{{"Object[241∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant238 & Constant239 & Constant240 --> Object241
+    Object14 & PgClassExpression15 & Access192 & Lambda212 & Lambda217 & Access192 & Lambda229 & Lambda234 & Lambda188 & Access192 & Lambda246 & Lambda251 --> PgSelect17
     PgUpdateSingle11 --> PgClassExpression15
     First21{{"First[21∈2] ➊"}}:::plan
     PgSelect17 --> First21
     PgSelectSingle22{{"PgSelectSingle[22∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First21 --> PgSelectSingle22
-    Lambda196{{"Lambda[196∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object195 --> Lambda196
-    Lambda201{{"Lambda[201∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant434 --> Lambda201
-    Object209 --> Lambda210
-    Constant435 --> Lambda215
-    Object225 --> Lambda226
-    Constant436 --> Lambda231
-    Object241 --> Lambda242
-    Constant437 --> Lambda247
     PgSelect45[["PgSelect[45∈3] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression44{{"PgClassExpression[44∈3] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object14 & PgClassExpression44 & Lambda188 & Lambda191 & Lambda196 & Lambda201 --> PgSelect45
+    Object14 & PgClassExpression44 & Lambda188 & Access192 & Lambda197 & Lambda202 --> PgSelect45
     PgClassExpression23{{"PgClassExpression[23∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -126,8 +200,8 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈3] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈3] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys232{{"RemapKeys[232∈3] ➊<br />ᐸ22:{”0”:6}ᐳ"}}:::plan
-    RemapKeys232 --> PgSelectSingle33
+    RemapKeys235{{"RemapKeys[235∈3] ➊<br />ᐸ22:{”0”:6}ᐳ"}}:::plan
+    RemapKeys235 --> PgSelectSingle33
     PgClassExpression34{{"PgClassExpression[34∈3] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgSelectSingle38{{"PgSelectSingle[38∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -139,14 +213,14 @@ graph TD
     PgSelect45 --> First47
     PgSelectSingle48{{"PgSelectSingle[48∈3] ➊<br />ᐸpeopleᐳ"}}:::plan
     First47 --> PgSelectSingle48
-    PgSelectSingle22 --> RemapKeys232
+    PgSelectSingle22 --> RemapKeys235
     PgClassExpression49{{"PgClassExpression[49∈4] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈4] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression50
     PgUpdateSingle56[["PgUpdateSingle[56∈5] ➊<br />ᐸrelational_posts(id;note)ᐳ"]]:::sideeffectplan
     Object59{{"Object[59∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object59 & Constant428 & Constant430 --> PgUpdateSingle56
+    Object59 & Constant444 & Constant446 --> PgUpdateSingle56
     Access57{{"Access[57∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access58{{"Access[58∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access57 & Access58 --> Object59
@@ -154,39 +228,15 @@ graph TD
     __Value2 --> Access58
     PgSelect62[["PgSelect[62∈6] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression60{{"PgClassExpression[60∈6] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda270{{"Lambda[270∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda275{{"Lambda[275∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda286{{"Lambda[286∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda291{{"Lambda[291∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda302{{"Lambda[302∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda307{{"Lambda[307∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object59 & PgClassExpression60 & Lambda191 & Lambda270 & Lambda275 & Lambda191 & Lambda286 & Lambda291 & Lambda188 & Lambda191 & Lambda302 & Lambda307 --> PgSelect62
-    Object255{{"Object[255∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant252 & Constant253 & Constant194 --> Object255
-    Object269{{"Object[269∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant266 & Constant267 & Constant208 --> Object269
-    Object285{{"Object[285∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant282 & Constant283 & Constant224 --> Object285
-    Object301{{"Object[301∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant298 & Constant299 & Constant240 --> Object301
+    Object59 & PgClassExpression60 & Access192 & Lambda276 & Lambda281 & Access192 & Lambda293 & Lambda298 & Lambda188 & Access192 & Lambda310 & Lambda315 --> PgSelect62
     PgUpdateSingle56 --> PgClassExpression60
     First66{{"First[66∈6] ➊"}}:::plan
     PgSelect62 --> First66
     PgSelectSingle67{{"PgSelectSingle[67∈6] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First66 --> PgSelectSingle67
-    Lambda256{{"Lambda[256∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object255 --> Lambda256
-    Lambda261{{"Lambda[261∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant438 --> Lambda261
-    Object269 --> Lambda270
-    Constant439 --> Lambda275
-    Object285 --> Lambda286
-    Constant440 --> Lambda291
-    Object301 --> Lambda302
-    Constant441 --> Lambda307
     PgSelect90[["PgSelect[90∈7] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression89{{"PgClassExpression[89∈7] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object59 & PgClassExpression89 & Lambda188 & Lambda191 & Lambda256 & Lambda261 --> PgSelect90
+    Object59 & PgClassExpression89 & Lambda188 & Access192 & Lambda261 & Lambda266 --> PgSelect90
     PgClassExpression68{{"PgClassExpression[68∈7] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression68
     PgClassExpression69{{"PgClassExpression[69∈7] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -196,8 +246,8 @@ graph TD
     PgClassExpression71{{"PgClassExpression[71∈7] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression71
     PgSelectSingle78{{"PgSelectSingle[78∈7] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys292{{"RemapKeys[292∈7] ➊<br />ᐸ67:{”0”:6}ᐳ"}}:::plan
-    RemapKeys292 --> PgSelectSingle78
+    RemapKeys299{{"RemapKeys[299∈7] ➊<br />ᐸ67:{”0”:6}ᐳ"}}:::plan
+    RemapKeys299 --> PgSelectSingle78
     PgClassExpression79{{"PgClassExpression[79∈7] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle78 --> PgClassExpression79
     PgSelectSingle83{{"PgSelectSingle[83∈7] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -209,14 +259,14 @@ graph TD
     PgSelect90 --> First92
     PgSelectSingle93{{"PgSelectSingle[93∈7] ➊<br />ᐸpeopleᐳ"}}:::plan
     First92 --> PgSelectSingle93
-    PgSelectSingle67 --> RemapKeys292
+    PgSelectSingle67 --> RemapKeys299
     PgClassExpression94{{"PgClassExpression[94∈8] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle93 --> PgClassExpression94
     PgClassExpression95{{"PgClassExpression[95∈8] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle93 --> PgClassExpression95
     PgUpdateSingle101[["PgUpdateSingle[101∈9] ➊<br />ᐸrelational_posts(id;description)ᐳ"]]:::sideeffectplan
     Object104{{"Object[104∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object104 & Constant428 & Constant186 --> PgUpdateSingle101
+    Object104 & Constant444 & Constant186 --> PgUpdateSingle101
     Access102{{"Access[102∈9] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access103{{"Access[103∈9] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access102 & Access103 --> Object104
@@ -224,39 +274,15 @@ graph TD
     __Value2 --> Access103
     PgSelect107[["PgSelect[107∈10] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression105{{"PgClassExpression[105∈10] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda330{{"Lambda[330∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda335{{"Lambda[335∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda346{{"Lambda[346∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda351{{"Lambda[351∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda362{{"Lambda[362∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda367{{"Lambda[367∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 & PgClassExpression105 & Lambda191 & Lambda330 & Lambda335 & Lambda191 & Lambda346 & Lambda351 & Lambda188 & Lambda191 & Lambda362 & Lambda367 --> PgSelect107
-    Object315{{"Object[315∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant312 & Constant313 & Constant194 --> Object315
-    Object329{{"Object[329∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant326 & Constant327 & Constant208 --> Object329
-    Object345{{"Object[345∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant342 & Constant343 & Constant224 --> Object345
-    Object361{{"Object[361∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant358 & Constant359 & Constant240 --> Object361
+    Object104 & PgClassExpression105 & Access192 & Lambda340 & Lambda345 & Access192 & Lambda357 & Lambda362 & Lambda188 & Access192 & Lambda374 & Lambda379 --> PgSelect107
     PgUpdateSingle101 --> PgClassExpression105
     First111{{"First[111∈10] ➊"}}:::plan
     PgSelect107 --> First111
     PgSelectSingle112{{"PgSelectSingle[112∈10] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First111 --> PgSelectSingle112
-    Lambda316{{"Lambda[316∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object315 --> Lambda316
-    Lambda321{{"Lambda[321∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant442 --> Lambda321
-    Object329 --> Lambda330
-    Constant443 --> Lambda335
-    Object345 --> Lambda346
-    Constant444 --> Lambda351
-    Object361 --> Lambda362
-    Constant445 --> Lambda367
     PgSelect135[["PgSelect[135∈11] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression134{{"PgClassExpression[134∈11] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object104 & PgClassExpression134 & Lambda188 & Lambda191 & Lambda316 & Lambda321 --> PgSelect135
+    Object104 & PgClassExpression134 & Lambda188 & Access192 & Lambda325 & Lambda330 --> PgSelect135
     PgClassExpression113{{"PgClassExpression[113∈11] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle112 --> PgClassExpression113
     PgClassExpression114{{"PgClassExpression[114∈11] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -266,8 +292,8 @@ graph TD
     PgClassExpression116{{"PgClassExpression[116∈11] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle112 --> PgClassExpression116
     PgSelectSingle123{{"PgSelectSingle[123∈11] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys352{{"RemapKeys[352∈11] ➊<br />ᐸ112:{”0”:6}ᐳ"}}:::plan
-    RemapKeys352 --> PgSelectSingle123
+    RemapKeys363{{"RemapKeys[363∈11] ➊<br />ᐸ112:{”0”:6}ᐳ"}}:::plan
+    RemapKeys363 --> PgSelectSingle123
     PgClassExpression124{{"PgClassExpression[124∈11] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle123 --> PgClassExpression124
     PgSelectSingle128{{"PgSelectSingle[128∈11] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -279,14 +305,14 @@ graph TD
     PgSelect135 --> First137
     PgSelectSingle138{{"PgSelectSingle[138∈11] ➊<br />ᐸpeopleᐳ"}}:::plan
     First137 --> PgSelectSingle138
-    PgSelectSingle112 --> RemapKeys352
+    PgSelectSingle112 --> RemapKeys363
     PgClassExpression139{{"PgClassExpression[139∈12] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle138 --> PgClassExpression139
     PgClassExpression140{{"PgClassExpression[140∈12] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle138 --> PgClassExpression140
     PgUpdateSingle146[["PgUpdateSingle[146∈13] ➊<br />ᐸrelational_posts(id;description)ᐳ"]]:::sideeffectplan
     Object149{{"Object[149∈13] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object149 & Constant431 & Constant186 --> PgUpdateSingle146
+    Object149 & Constant447 & Constant186 --> PgUpdateSingle146
     Access147{{"Access[147∈13] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access148{{"Access[148∈13] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access147 & Access148 --> Object149
@@ -294,39 +320,15 @@ graph TD
     __Value2 --> Access148
     PgSelect152[["PgSelect[152∈14] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression150{{"PgClassExpression[150∈14] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda390{{"Lambda[390∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda395{{"Lambda[395∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda406{{"Lambda[406∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda411{{"Lambda[411∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda422{{"Lambda[422∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda427{{"Lambda[427∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object149 & PgClassExpression150 & Lambda191 & Lambda390 & Lambda395 & Lambda191 & Lambda406 & Lambda411 & Lambda188 & Lambda191 & Lambda422 & Lambda427 --> PgSelect152
-    Object375{{"Object[375∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant372 & Constant373 & Constant194 --> Object375
-    Object389{{"Object[389∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant386 & Constant387 & Constant208 --> Object389
-    Object405{{"Object[405∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant402 & Constant403 & Constant224 --> Object405
-    Object421{{"Object[421∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant418 & Constant419 & Constant240 --> Object421
+    Object149 & PgClassExpression150 & Access192 & Lambda404 & Lambda409 & Access192 & Lambda421 & Lambda426 & Lambda188 & Access192 & Lambda438 & Lambda443 --> PgSelect152
     PgUpdateSingle146 --> PgClassExpression150
     First156{{"First[156∈14] ➊"}}:::plan
     PgSelect152 --> First156
     PgSelectSingle157{{"PgSelectSingle[157∈14] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First156 --> PgSelectSingle157
-    Lambda376{{"Lambda[376∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object375 --> Lambda376
-    Lambda381{{"Lambda[381∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant446 --> Lambda381
-    Object389 --> Lambda390
-    Constant447 --> Lambda395
-    Object405 --> Lambda406
-    Constant448 --> Lambda411
-    Object421 --> Lambda422
-    Constant449 --> Lambda427
     PgSelect180[["PgSelect[180∈15] ➊<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression179{{"PgClassExpression[179∈15] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
-    Object149 & PgClassExpression179 & Lambda188 & Lambda191 & Lambda376 & Lambda381 --> PgSelect180
+    Object149 & PgClassExpression179 & Lambda188 & Access192 & Lambda389 & Lambda394 --> PgSelect180
     PgClassExpression158{{"PgClassExpression[158∈15] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression158
     PgClassExpression159{{"PgClassExpression[159∈15] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -336,8 +338,8 @@ graph TD
     PgClassExpression161{{"PgClassExpression[161∈15] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression161
     PgSelectSingle168{{"PgSelectSingle[168∈15] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys412{{"RemapKeys[412∈15] ➊<br />ᐸ157:{”0”:6}ᐳ"}}:::plan
-    RemapKeys412 --> PgSelectSingle168
+    RemapKeys427{{"RemapKeys[427∈15] ➊<br />ᐸ157:{”0”:6}ᐳ"}}:::plan
+    RemapKeys427 --> PgSelectSingle168
     PgClassExpression169{{"PgClassExpression[169∈15] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle168 --> PgClassExpression169
     PgSelectSingle173{{"PgSelectSingle[173∈15] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -349,7 +351,7 @@ graph TD
     PgSelect180 --> First182
     PgSelectSingle183{{"PgSelectSingle[183∈15] ➊<br />ᐸpeopleᐳ"}}:::plan
     First182 --> PgSelectSingle183
-    PgSelectSingle157 --> RemapKeys412
+    PgSelectSingle157 --> RemapKeys427
     PgClassExpression184{{"PgClassExpression[184∈16] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle183 --> PgClassExpression184
     PgClassExpression185{{"PgClassExpression[185∈16] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -360,52 +362,52 @@ graph TD
     subgraph "Buckets for mutations/basics/update-relational-post"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Constant186,Lambda188,Lambda191,Constant192,Constant193,Constant194,Constant206,Constant207,Constant208,Constant222,Constant223,Constant224,Constant238,Constant239,Constant240,Constant252,Constant253,Constant266,Constant267,Constant282,Constant283,Constant298,Constant299,Constant312,Constant313,Constant326,Constant327,Constant342,Constant343,Constant358,Constant359,Constant372,Constant373,Constant386,Constant387,Constant402,Constant403,Constant418,Constant419,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 428, 429, 191, 188, 192, 193, 194, 434, 206, 207, 208, 435, 222, 223, 224, 436, 238, 239, 240, 437"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Constant186,Lambda188,Lambda191,Access192,Constant193,Constant194,Constant195,Object196,Lambda197,Lambda202,Constant208,Constant209,Constant210,Object211,Lambda212,Lambda217,Constant225,Constant226,Constant227,Object228,Lambda229,Lambda234,Constant242,Constant243,Constant244,Object245,Lambda246,Lambda251,Constant257,Constant258,Object260,Lambda261,Lambda266,Constant272,Constant273,Object275,Lambda276,Lambda281,Constant289,Constant290,Object292,Lambda293,Lambda298,Constant306,Constant307,Object309,Lambda310,Lambda315,Constant321,Constant322,Object324,Lambda325,Lambda330,Constant336,Constant337,Object339,Lambda340,Lambda345,Constant353,Constant354,Object356,Lambda357,Lambda362,Constant370,Constant371,Object373,Lambda374,Lambda379,Constant385,Constant386,Object388,Lambda389,Lambda394,Constant400,Constant401,Object403,Lambda404,Lambda409,Constant417,Constant418,Object420,Lambda421,Lambda426,Constant434,Constant435,Object437,Lambda438,Lambda443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450,Constant451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 444, 445, 192, 212, 217, 229, 234, 188, 246, 251, 197, 202"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 14, 191, 188, 192, 193, 194, 434, 206, 207, 208, 435, 222, 223, 224, 436, 238, 239, 240, 437<br /><br />ROOT PgUpdateSingle{1}ᐸrelational_posts(id;description)ᐳ[11]<br />1: <br />ᐳ: 15, 195, 201, 209, 215, 225, 231, 241, 247, 196, 210, 226, 242<br />2: PgSelect[17]<br />ᐳ: First[21], PgSelectSingle[22]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 14, 192, 212, 217, 229, 234, 188, 246, 251, 197, 202<br /><br />ROOT PgUpdateSingle{1}ᐸrelational_posts(id;description)ᐳ[11]<br />1: <br />ᐳ: PgClassExpression[15]<br />2: PgSelect[17]<br />ᐳ: First[21], PgSelectSingle[22]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression15,PgSelect17,First21,PgSelectSingle22,Object195,Lambda196,Lambda201,Object209,Lambda210,Lambda215,Object225,Lambda226,Lambda231,Object241,Lambda242,Lambda247 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 14, 188, 191, 196, 201<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[22]<br />1: <br />ᐳ: 23, 24, 25, 26, 38, 232, 33, 34, 39, 44<br />2: PgSelect[45]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    class Bucket2,PgClassExpression15,PgSelect17,First21,PgSelectSingle22 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 14, 188, 192, 197, 202<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[22]<br />1: <br />ᐳ: 23, 24, 25, 26, 38, 235, 33, 34, 39, 44<br />2: PgSelect[45]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgSelectSingle33,PgClassExpression34,PgSelectSingle38,PgClassExpression39,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,RemapKeys232 bucket3
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgSelectSingle33,PgClassExpression34,PgSelectSingle38,PgClassExpression39,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,RemapKeys235 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[48]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression49,PgClassExpression50 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 428, 430, 2, 191, 188, 252, 253, 194, 438, 266, 267, 208, 439, 282, 283, 224, 440, 298, 299, 240, 441<br /><br />1: Access[57]<br />2: Access[58]<br />3: Object[59]<br />4: PgUpdateSingle[56]"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 444, 446, 2, 192, 276, 281, 293, 298, 188, 310, 315, 261, 266<br /><br />1: Access[57]<br />2: Access[58]<br />3: Object[59]<br />4: PgUpdateSingle[56]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgUpdateSingle56,Access57,Access58,Object59 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 56, 59, 191, 188, 252, 253, 194, 438, 266, 267, 208, 439, 282, 283, 224, 440, 298, 299, 240, 441<br /><br />ROOT PgUpdateSingle{5}ᐸrelational_posts(id;note)ᐳ[56]<br />1: <br />ᐳ: 60, 255, 261, 269, 275, 285, 291, 301, 307, 256, 270, 286, 302<br />2: PgSelect[62]<br />ᐳ: First[66], PgSelectSingle[67]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 56, 59, 192, 276, 281, 293, 298, 188, 310, 315, 261, 266<br /><br />ROOT PgUpdateSingle{5}ᐸrelational_posts(id;note)ᐳ[56]<br />1: <br />ᐳ: PgClassExpression[60]<br />2: PgSelect[62]<br />ᐳ: First[66], PgSelectSingle[67]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression60,PgSelect62,First66,PgSelectSingle67,Object255,Lambda256,Lambda261,Object269,Lambda270,Lambda275,Object285,Lambda286,Lambda291,Object301,Lambda302,Lambda307 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 67, 59, 188, 191, 256, 261<br /><br />ROOT PgSelectSingle{6}ᐸrelational_postsᐳ[67]<br />1: <br />ᐳ: 68, 69, 70, 71, 83, 292, 78, 79, 84, 89<br />2: PgSelect[90]<br />ᐳ: First[92], PgSelectSingle[93]"):::bucket
+    class Bucket6,PgClassExpression60,PgSelect62,First66,PgSelectSingle67 bucket6
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 67, 59, 188, 192, 261, 266<br /><br />ROOT PgSelectSingle{6}ᐸrelational_postsᐳ[67]<br />1: <br />ᐳ: 68, 69, 70, 71, 83, 299, 78, 79, 84, 89<br />2: PgSelect[90]<br />ᐳ: First[92], PgSelectSingle[93]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgClassExpression71,PgSelectSingle78,PgClassExpression79,PgSelectSingle83,PgClassExpression84,PgClassExpression89,PgSelect90,First92,PgSelectSingle93,RemapKeys292 bucket7
+    class Bucket7,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgClassExpression71,PgSelectSingle78,PgClassExpression79,PgSelectSingle83,PgClassExpression84,PgClassExpression89,PgSelect90,First92,PgSelectSingle93,RemapKeys299 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 93<br /><br />ROOT PgSelectSingle{7}ᐸpeopleᐳ[93]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression94,PgClassExpression95 bucket8
-    Bucket9("Bucket 9 (mutationField)<br />Deps: 428, 186, 2, 191, 188, 312, 313, 194, 442, 326, 327, 208, 443, 342, 343, 224, 444, 358, 359, 240, 445<br /><br />1: Access[102]<br />2: Access[103]<br />3: Object[104]<br />4: PgUpdateSingle[101]"):::bucket
+    Bucket9("Bucket 9 (mutationField)<br />Deps: 444, 186, 2, 192, 340, 345, 357, 362, 188, 374, 379, 325, 330<br /><br />1: Access[102]<br />2: Access[103]<br />3: Object[104]<br />4: PgUpdateSingle[101]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgUpdateSingle101,Access102,Access103,Object104 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 101, 104, 191, 188, 312, 313, 194, 442, 326, 327, 208, 443, 342, 343, 224, 444, 358, 359, 240, 445<br /><br />ROOT PgUpdateSingle{9}ᐸrelational_posts(id;description)ᐳ[101]<br />1: <br />ᐳ: 105, 315, 321, 329, 335, 345, 351, 361, 367, 316, 330, 346, 362<br />2: PgSelect[107]<br />ᐳ: First[111], PgSelectSingle[112]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 101, 104, 192, 340, 345, 357, 362, 188, 374, 379, 325, 330<br /><br />ROOT PgUpdateSingle{9}ᐸrelational_posts(id;description)ᐳ[101]<br />1: <br />ᐳ: PgClassExpression[105]<br />2: PgSelect[107]<br />ᐳ: First[111], PgSelectSingle[112]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression105,PgSelect107,First111,PgSelectSingle112,Object315,Lambda316,Lambda321,Object329,Lambda330,Lambda335,Object345,Lambda346,Lambda351,Object361,Lambda362,Lambda367 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 112, 104, 188, 191, 316, 321<br /><br />ROOT PgSelectSingle{10}ᐸrelational_postsᐳ[112]<br />1: <br />ᐳ: 113, 114, 115, 116, 128, 352, 123, 124, 129, 134<br />2: PgSelect[135]<br />ᐳ: First[137], PgSelectSingle[138]"):::bucket
+    class Bucket10,PgClassExpression105,PgSelect107,First111,PgSelectSingle112 bucket10
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 112, 104, 188, 192, 325, 330<br /><br />ROOT PgSelectSingle{10}ᐸrelational_postsᐳ[112]<br />1: <br />ᐳ: 113, 114, 115, 116, 128, 363, 123, 124, 129, 134<br />2: PgSelect[135]<br />ᐳ: First[137], PgSelectSingle[138]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression113,PgClassExpression114,PgClassExpression115,PgClassExpression116,PgSelectSingle123,PgClassExpression124,PgSelectSingle128,PgClassExpression129,PgClassExpression134,PgSelect135,First137,PgSelectSingle138,RemapKeys352 bucket11
+    class Bucket11,PgClassExpression113,PgClassExpression114,PgClassExpression115,PgClassExpression116,PgSelectSingle123,PgClassExpression124,PgSelectSingle128,PgClassExpression129,PgClassExpression134,PgSelect135,First137,PgSelectSingle138,RemapKeys363 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 138<br /><br />ROOT PgSelectSingle{11}ᐸpeopleᐳ[138]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression139,PgClassExpression140 bucket12
-    Bucket13("Bucket 13 (mutationField)<br />Deps: 431, 186, 2, 191, 188, 372, 373, 194, 446, 386, 387, 208, 447, 402, 403, 224, 448, 418, 419, 240, 449<br /><br />1: Access[147]<br />2: Access[148]<br />3: Object[149]<br />4: PgUpdateSingle[146]"):::bucket
+    Bucket13("Bucket 13 (mutationField)<br />Deps: 447, 186, 2, 192, 404, 409, 421, 426, 188, 438, 443, 389, 394<br /><br />1: Access[147]<br />2: Access[148]<br />3: Object[149]<br />4: PgUpdateSingle[146]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgUpdateSingle146,Access147,Access148,Object149 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 146, 149, 191, 188, 372, 373, 194, 446, 386, 387, 208, 447, 402, 403, 224, 448, 418, 419, 240, 449<br /><br />ROOT PgUpdateSingle{13}ᐸrelational_posts(id;description)ᐳ[146]<br />1: <br />ᐳ: 150, 375, 381, 389, 395, 405, 411, 421, 427, 376, 390, 406, 422<br />2: PgSelect[152]<br />ᐳ: First[156], PgSelectSingle[157]"):::bucket
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 146, 149, 192, 404, 409, 421, 426, 188, 438, 443, 389, 394<br /><br />ROOT PgUpdateSingle{13}ᐸrelational_posts(id;description)ᐳ[146]<br />1: <br />ᐳ: PgClassExpression[150]<br />2: PgSelect[152]<br />ᐳ: First[156], PgSelectSingle[157]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression150,PgSelect152,First156,PgSelectSingle157,Object375,Lambda376,Lambda381,Object389,Lambda390,Lambda395,Object405,Lambda406,Lambda411,Object421,Lambda422,Lambda427 bucket14
-    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 157, 149, 188, 191, 376, 381<br /><br />ROOT PgSelectSingle{14}ᐸrelational_postsᐳ[157]<br />1: <br />ᐳ: 158, 159, 160, 161, 173, 412, 168, 169, 174, 179<br />2: PgSelect[180]<br />ᐳ: First[182], PgSelectSingle[183]"):::bucket
+    class Bucket14,PgClassExpression150,PgSelect152,First156,PgSelectSingle157 bucket14
+    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 157, 149, 188, 192, 389, 394<br /><br />ROOT PgSelectSingle{14}ᐸrelational_postsᐳ[157]<br />1: <br />ᐳ: 158, 159, 160, 161, 173, 427, 168, 169, 174, 179<br />2: PgSelect[180]<br />ᐳ: First[182], PgSelectSingle[183]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression158,PgClassExpression159,PgClassExpression160,PgClassExpression161,PgSelectSingle168,PgClassExpression169,PgSelectSingle173,PgClassExpression174,PgClassExpression179,PgSelect180,First182,PgSelectSingle183,RemapKeys412 bucket15
+    class Bucket15,PgClassExpression158,PgClassExpression159,PgClassExpression160,PgClassExpression161,PgSelectSingle168,PgClassExpression169,PgSelectSingle173,PgClassExpression174,PgClassExpression179,PgSelect180,First182,PgSelectSingle183,RemapKeys427 bucket15
     Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 183<br /><br />ROOT PgSelectSingle{15}ᐸpeopleᐳ[183]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,PgClassExpression184,PgClassExpression185 bucket16

--- a/grafast/dataplan-pg/__tests__/mutations/basics/update-relational-post.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/update-relational-post.mermaid
@@ -9,6 +9,75 @@ graph TD
 
 
     %% plan dependencies
+    Object196{{"Object[196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda188 & Constant193 & Constant194 & Constant195 --> Object196
+    Object213{{"Object[213∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant212{{"Constant[212∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda188 & Constant210 & Constant211 & Constant212 --> Object213
+    Object230{{"Object[230∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda188 & Constant227 & Constant228 & Constant229 --> Object230
+    Object247{{"Object[247∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant245{{"Constant[245∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda188 & Constant244 & Constant245 & Constant246 --> Object247
+    Object262{{"Object[262∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant259{{"Constant[259∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant260{{"Constant[260∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda188 & Constant259 & Constant260 & Constant195 --> Object262
+    Object279{{"Object[279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant276{{"Constant[276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant276 & Constant277 & Constant212 --> Object279
+    Object296{{"Object[296∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant294{{"Constant[294∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda188 & Constant293 & Constant294 & Constant229 --> Object296
+    Object313{{"Object[313∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant310{{"Constant[310∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant311{{"Constant[311∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant310 & Constant311 & Constant246 --> Object313
+    Object328{{"Object[328∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant325{{"Constant[325∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant326{{"Constant[326∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda188 & Constant325 & Constant326 & Constant195 --> Object328
+    Object345{{"Object[345∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant342{{"Constant[342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant342 & Constant343 & Constant212 --> Object345
+    Object362{{"Object[362∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda188 & Constant359 & Constant360 & Constant229 --> Object362
+    Object379{{"Object[379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant377{{"Constant[377∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant376 & Constant377 & Constant246 --> Object379
+    Object394{{"Object[394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda188 & Constant391 & Constant392 & Constant195 --> Object394
+    Object411{{"Object[411∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant408{{"Constant[408∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant409{{"Constant[409∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant408 & Constant409 & Constant212 --> Object411
+    Object428{{"Object[428∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant425{{"Constant[425∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant426{{"Constant[426∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
+    Lambda188 & Constant425 & Constant426 & Constant229 --> Object428
+    Object445{{"Object[445∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant442{{"Constant[442∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant442 & Constant443 & Constant246 --> Object445
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,104 +85,109 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant440 --> Lambda188
+    Constant456{{"Constant[456∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant456 --> Lambda188
     Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant441 --> Lambda191
+    Constant457{{"Constant[457∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant457 --> Lambda191
+    Access192{{"Access[192∈0] ➊<br />ᐸ191.0ᐳ"}}:::plan
+    Lambda191 --> Access192
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object196 --> Lambda197
+    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant458{{"Constant[458∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant458 --> Lambda202
+    Lambda214{{"Lambda[214∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object213 --> Lambda214
+    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant459 --> Lambda219
+    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object230 --> Lambda231
+    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant460 --> Lambda236
+    Lambda248{{"Lambda[248∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object247 --> Lambda248
+    Lambda253{{"Lambda[253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant461 --> Lambda253
+    Lambda263{{"Lambda[263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object262 --> Lambda263
+    Lambda268{{"Lambda[268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant462 --> Lambda268
+    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object279 --> Lambda280
+    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant463 --> Lambda285
+    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object296 --> Lambda297
+    Lambda302{{"Lambda[302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant464 --> Lambda302
+    Lambda314{{"Lambda[314∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object313 --> Lambda314
+    Lambda319{{"Lambda[319∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant465 --> Lambda319
+    Lambda329{{"Lambda[329∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object328 --> Lambda329
+    Lambda334{{"Lambda[334∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant466 --> Lambda334
+    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object345 --> Lambda346
+    Lambda351{{"Lambda[351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant467{{"Constant[467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant467 --> Lambda351
+    Lambda363{{"Lambda[363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object362 --> Lambda363
+    Lambda368{{"Lambda[368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant468{{"Constant[468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant468 --> Lambda368
+    Lambda380{{"Lambda[380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object379 --> Lambda380
+    Lambda385{{"Lambda[385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant469 --> Lambda385
+    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object394 --> Lambda395
+    Lambda400{{"Lambda[400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant470 --> Lambda400
+    Lambda412{{"Lambda[412∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object411 --> Lambda412
+    Lambda417{{"Lambda[417∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant471{{"Constant[471∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant471 --> Lambda417
+    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object428 --> Lambda429
+    Lambda434{{"Lambda[434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant472{{"Constant[472∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant472 --> Lambda434
+    Lambda446{{"Lambda[446∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object445 --> Lambda446
+    Lambda451{{"Lambda[451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant473 --> Lambda451
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant186{{"Constant[186∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant225{{"Constant[225∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant242{{"Constant[242∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Constant254{{"Constant[254∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant255{{"Constant[255∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant302{{"Constant[302∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant303{{"Constant[303∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant317{{"Constant[317∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant332{{"Constant[332∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant333{{"Constant[333∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant348{{"Constant[348∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant349{{"Constant[349∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant364{{"Constant[364∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸsql.identifier(”relational_posts_title_lower”)ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant427{{"Constant[427∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸ'A description'ᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ'A note'ᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant446{{"Constant[446∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant447{{"Constant[447∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant451{{"Constant[451∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant452{{"Constant[452∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant453{{"Constant[453∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant454{{"Constant[454∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant455{{"Constant[455∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant456{{"Constant[456∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant457{{"Constant[457∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸ'A description'ᐳ"}}:::plan
+    Constant454{{"Constant[454∈0] ➊<br />ᐸ'A note'ᐳ"}}:::plan
+    Constant455{{"Constant[455∈0] ➊<br />ᐸ3141592ᐳ"}}:::plan
     PgUpdateSingle11[["PgUpdateSingle[11∈1] ➊<br />ᐸrelational_posts(id;description)ᐳ"]]:::sideeffectplan
-    Object14 & Constant436 & Constant437 --> PgUpdateSingle11
+    Object14 & Constant452 & Constant453 --> PgUpdateSingle11
     PgSelect17[["PgSelect[17∈2] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈2] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda196{{"Lambda[196∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda201{{"Lambda[201∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda212{{"Lambda[212∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda217{{"Lambda[217∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda228{{"Lambda[228∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda233{{"Lambda[233∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda244{{"Lambda[244∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda249{{"Lambda[249∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & PgClassExpression15 & Lambda191 & Lambda196 & Lambda201 & Lambda191 & Lambda212 & Lambda217 & Lambda191 & Lambda228 & Lambda233 & Lambda188 & Lambda191 & Lambda244 & Lambda249 --> PgSelect17
-    Object195{{"Object[195∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant192 & Constant193 & Constant194 --> Object195
-    Object211{{"Object[211∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant208 & Constant209 & Constant210 --> Object211
-    Object227{{"Object[227∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant224 & Constant225 & Constant226 --> Object227
-    Object243{{"Object[243∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant240 & Constant241 & Constant242 --> Object243
+    Object14 & PgClassExpression15 & Access192 & Lambda197 & Lambda202 & Access192 & Lambda214 & Lambda219 & Access192 & Lambda231 & Lambda236 & Lambda188 & Access192 & Lambda248 & Lambda253 --> PgSelect17
     PgUpdateSingle11 --> PgClassExpression15
     First21{{"First[21∈2] ➊"}}:::plan
     PgSelect17 --> First21
     PgSelectSingle22{{"PgSelectSingle[22∈2] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First21 --> PgSelectSingle22
-    Object195 --> Lambda196
-    Constant442 --> Lambda201
-    Object211 --> Lambda212
-    Constant443 --> Lambda217
-    Object227 --> Lambda228
-    Constant444 --> Lambda233
-    Object243 --> Lambda244
-    Constant445 --> Lambda249
     PgClassExpression23{{"PgClassExpression[23∈3] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -123,8 +197,8 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈3] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈3] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys234{{"RemapKeys[234∈3] ➊<br />ᐸ22:{”0”:7}ᐳ"}}:::plan
-    RemapKeys234 --> PgSelectSingle33
+    RemapKeys237{{"RemapKeys[237∈3] ➊<br />ᐸ22:{”0”:7}ᐳ"}}:::plan
+    RemapKeys237 --> PgSelectSingle33
     PgClassExpression34{{"PgClassExpression[34∈3] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgSelectSingle38{{"PgSelectSingle[38∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -132,17 +206,17 @@ graph TD
     PgClassExpression39{{"PgClassExpression[39∈3] ➊<br />ᐸ__relation..._archived”ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
     PgSelectSingle48{{"PgSelectSingle[48∈3] ➊<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys202{{"RemapKeys[202∈3] ➊<br />ᐸ38:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys202 --> PgSelectSingle48
-    PgSelectSingle38 --> RemapKeys202
-    PgSelectSingle22 --> RemapKeys234
+    RemapKeys203{{"RemapKeys[203∈3] ➊<br />ᐸ38:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys203 --> PgSelectSingle48
+    PgSelectSingle38 --> RemapKeys203
+    PgSelectSingle22 --> RemapKeys237
     PgClassExpression49{{"PgClassExpression[49∈4] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈4] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression50
     PgUpdateSingle56[["PgUpdateSingle[56∈5] ➊<br />ᐸrelational_posts(id;note)ᐳ"]]:::sideeffectplan
     Object59{{"Object[59∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object59 & Constant436 & Constant438 --> PgUpdateSingle56
+    Object59 & Constant452 & Constant454 --> PgUpdateSingle56
     Access57{{"Access[57∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access58{{"Access[58∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access57 & Access58 --> Object59
@@ -150,36 +224,12 @@ graph TD
     __Value2 --> Access58
     PgSelect62[["PgSelect[62∈6] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression60{{"PgClassExpression[60∈6] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda258{{"Lambda[258∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda263{{"Lambda[263∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda274{{"Lambda[274∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda279{{"Lambda[279∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda290{{"Lambda[290∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda295{{"Lambda[295∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda306{{"Lambda[306∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda311{{"Lambda[311∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object59 & PgClassExpression60 & Lambda191 & Lambda258 & Lambda263 & Lambda191 & Lambda274 & Lambda279 & Lambda191 & Lambda290 & Lambda295 & Lambda188 & Lambda191 & Lambda306 & Lambda311 --> PgSelect62
-    Object257{{"Object[257∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant254 & Constant255 & Constant194 --> Object257
-    Object273{{"Object[273∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant270 & Constant271 & Constant210 --> Object273
-    Object289{{"Object[289∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant286 & Constant287 & Constant226 --> Object289
-    Object305{{"Object[305∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant302 & Constant303 & Constant242 --> Object305
+    Object59 & PgClassExpression60 & Access192 & Lambda263 & Lambda268 & Access192 & Lambda280 & Lambda285 & Access192 & Lambda297 & Lambda302 & Lambda188 & Access192 & Lambda314 & Lambda319 --> PgSelect62
     PgUpdateSingle56 --> PgClassExpression60
     First66{{"First[66∈6] ➊"}}:::plan
     PgSelect62 --> First66
     PgSelectSingle67{{"PgSelectSingle[67∈6] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First66 --> PgSelectSingle67
-    Object257 --> Lambda258
-    Constant446 --> Lambda263
-    Object273 --> Lambda274
-    Constant447 --> Lambda279
-    Object289 --> Lambda290
-    Constant448 --> Lambda295
-    Object305 --> Lambda306
-    Constant449 --> Lambda311
     PgClassExpression68{{"PgClassExpression[68∈7] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression68
     PgClassExpression69{{"PgClassExpression[69∈7] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -189,8 +239,8 @@ graph TD
     PgClassExpression71{{"PgClassExpression[71∈7] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression71
     PgSelectSingle78{{"PgSelectSingle[78∈7] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys296{{"RemapKeys[296∈7] ➊<br />ᐸ67:{”0”:7}ᐳ"}}:::plan
-    RemapKeys296 --> PgSelectSingle78
+    RemapKeys303{{"RemapKeys[303∈7] ➊<br />ᐸ67:{”0”:7}ᐳ"}}:::plan
+    RemapKeys303 --> PgSelectSingle78
     PgClassExpression79{{"PgClassExpression[79∈7] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle78 --> PgClassExpression79
     PgSelectSingle83{{"PgSelectSingle[83∈7] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -198,17 +248,17 @@ graph TD
     PgClassExpression84{{"PgClassExpression[84∈7] ➊<br />ᐸ__relation..._archived”ᐳ"}}:::plan
     PgSelectSingle83 --> PgClassExpression84
     PgSelectSingle93{{"PgSelectSingle[93∈7] ➊<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys264{{"RemapKeys[264∈7] ➊<br />ᐸ83:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys264 --> PgSelectSingle93
-    PgSelectSingle83 --> RemapKeys264
-    PgSelectSingle67 --> RemapKeys296
+    RemapKeys269{{"RemapKeys[269∈7] ➊<br />ᐸ83:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys269 --> PgSelectSingle93
+    PgSelectSingle83 --> RemapKeys269
+    PgSelectSingle67 --> RemapKeys303
     PgClassExpression94{{"PgClassExpression[94∈8] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle93 --> PgClassExpression94
     PgClassExpression95{{"PgClassExpression[95∈8] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle93 --> PgClassExpression95
     PgUpdateSingle101[["PgUpdateSingle[101∈9] ➊<br />ᐸrelational_posts(id;description)ᐳ"]]:::sideeffectplan
     Object104{{"Object[104∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object104 & Constant436 & Constant186 --> PgUpdateSingle101
+    Object104 & Constant452 & Constant186 --> PgUpdateSingle101
     Access102{{"Access[102∈9] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access103{{"Access[103∈9] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access102 & Access103 --> Object104
@@ -216,36 +266,12 @@ graph TD
     __Value2 --> Access103
     PgSelect107[["PgSelect[107∈10] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression105{{"PgClassExpression[105∈10] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda320{{"Lambda[320∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda325{{"Lambda[325∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda336{{"Lambda[336∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda341{{"Lambda[341∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda352{{"Lambda[352∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda357{{"Lambda[357∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda368{{"Lambda[368∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda373{{"Lambda[373∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 & PgClassExpression105 & Lambda191 & Lambda320 & Lambda325 & Lambda191 & Lambda336 & Lambda341 & Lambda191 & Lambda352 & Lambda357 & Lambda188 & Lambda191 & Lambda368 & Lambda373 --> PgSelect107
-    Object319{{"Object[319∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant316 & Constant317 & Constant194 --> Object319
-    Object335{{"Object[335∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant332 & Constant333 & Constant210 --> Object335
-    Object351{{"Object[351∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant348 & Constant349 & Constant226 --> Object351
-    Object367{{"Object[367∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant364 & Constant365 & Constant242 --> Object367
+    Object104 & PgClassExpression105 & Access192 & Lambda329 & Lambda334 & Access192 & Lambda346 & Lambda351 & Access192 & Lambda363 & Lambda368 & Lambda188 & Access192 & Lambda380 & Lambda385 --> PgSelect107
     PgUpdateSingle101 --> PgClassExpression105
     First111{{"First[111∈10] ➊"}}:::plan
     PgSelect107 --> First111
     PgSelectSingle112{{"PgSelectSingle[112∈10] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First111 --> PgSelectSingle112
-    Object319 --> Lambda320
-    Constant450 --> Lambda325
-    Object335 --> Lambda336
-    Constant451 --> Lambda341
-    Object351 --> Lambda352
-    Constant452 --> Lambda357
-    Object367 --> Lambda368
-    Constant453 --> Lambda373
     PgClassExpression113{{"PgClassExpression[113∈11] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle112 --> PgClassExpression113
     PgClassExpression114{{"PgClassExpression[114∈11] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -255,8 +281,8 @@ graph TD
     PgClassExpression116{{"PgClassExpression[116∈11] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle112 --> PgClassExpression116
     PgSelectSingle123{{"PgSelectSingle[123∈11] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys358{{"RemapKeys[358∈11] ➊<br />ᐸ112:{”0”:7}ᐳ"}}:::plan
-    RemapKeys358 --> PgSelectSingle123
+    RemapKeys369{{"RemapKeys[369∈11] ➊<br />ᐸ112:{”0”:7}ᐳ"}}:::plan
+    RemapKeys369 --> PgSelectSingle123
     PgClassExpression124{{"PgClassExpression[124∈11] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle123 --> PgClassExpression124
     PgSelectSingle128{{"PgSelectSingle[128∈11] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -264,17 +290,17 @@ graph TD
     PgClassExpression129{{"PgClassExpression[129∈11] ➊<br />ᐸ__relation..._archived”ᐳ"}}:::plan
     PgSelectSingle128 --> PgClassExpression129
     PgSelectSingle138{{"PgSelectSingle[138∈11] ➊<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys326{{"RemapKeys[326∈11] ➊<br />ᐸ128:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys326 --> PgSelectSingle138
-    PgSelectSingle128 --> RemapKeys326
-    PgSelectSingle112 --> RemapKeys358
+    RemapKeys335{{"RemapKeys[335∈11] ➊<br />ᐸ128:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys335 --> PgSelectSingle138
+    PgSelectSingle128 --> RemapKeys335
+    PgSelectSingle112 --> RemapKeys369
     PgClassExpression139{{"PgClassExpression[139∈12] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle138 --> PgClassExpression139
     PgClassExpression140{{"PgClassExpression[140∈12] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle138 --> PgClassExpression140
     PgUpdateSingle146[["PgUpdateSingle[146∈13] ➊<br />ᐸrelational_posts(id;description)ᐳ"]]:::sideeffectplan
     Object149{{"Object[149∈13] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object149 & Constant439 & Constant186 --> PgUpdateSingle146
+    Object149 & Constant455 & Constant186 --> PgUpdateSingle146
     Access147{{"Access[147∈13] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access148{{"Access[148∈13] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access147 & Access148 --> Object149
@@ -282,36 +308,12 @@ graph TD
     __Value2 --> Access148
     PgSelect152[["PgSelect[152∈14] ➊<br />ᐸrelational_postsᐳ"]]:::plan
     PgClassExpression150{{"PgClassExpression[150∈14] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
-    Lambda382{{"Lambda[382∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda387{{"Lambda[387∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda398{{"Lambda[398∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda403{{"Lambda[403∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda414{{"Lambda[414∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda419{{"Lambda[419∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda430{{"Lambda[430∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda435{{"Lambda[435∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object149 & PgClassExpression150 & Lambda191 & Lambda382 & Lambda387 & Lambda191 & Lambda398 & Lambda403 & Lambda191 & Lambda414 & Lambda419 & Lambda188 & Lambda191 & Lambda430 & Lambda435 --> PgSelect152
-    Object381{{"Object[381∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant378 & Constant379 & Constant194 --> Object381
-    Object397{{"Object[397∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant394 & Constant395 & Constant210 --> Object397
-    Object413{{"Object[413∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant410 & Constant411 & Constant226 --> Object413
-    Object429{{"Object[429∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant426 & Constant427 & Constant242 --> Object429
+    Object149 & PgClassExpression150 & Access192 & Lambda395 & Lambda400 & Access192 & Lambda412 & Lambda417 & Access192 & Lambda429 & Lambda434 & Lambda188 & Access192 & Lambda446 & Lambda451 --> PgSelect152
     PgUpdateSingle146 --> PgClassExpression150
     First156{{"First[156∈14] ➊"}}:::plan
     PgSelect152 --> First156
     PgSelectSingle157{{"PgSelectSingle[157∈14] ➊<br />ᐸrelational_postsᐳ"}}:::plan
     First156 --> PgSelectSingle157
-    Object381 --> Lambda382
-    Constant454 --> Lambda387
-    Object397 --> Lambda398
-    Constant455 --> Lambda403
-    Object413 --> Lambda414
-    Constant456 --> Lambda419
-    Object429 --> Lambda430
-    Constant457 --> Lambda435
     PgClassExpression158{{"PgClassExpression[158∈15] ➊<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression158
     PgClassExpression159{{"PgClassExpression[159∈15] ➊<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
@@ -321,8 +323,8 @@ graph TD
     PgClassExpression161{{"PgClassExpression[161∈15] ➊<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression161
     PgSelectSingle168{{"PgSelectSingle[168∈15] ➊<br />ᐸtextᐳ"}}:::plan
-    RemapKeys420{{"RemapKeys[420∈15] ➊<br />ᐸ157:{”0”:7}ᐳ"}}:::plan
-    RemapKeys420 --> PgSelectSingle168
+    RemapKeys435{{"RemapKeys[435∈15] ➊<br />ᐸ157:{”0”:7}ᐳ"}}:::plan
+    RemapKeys435 --> PgSelectSingle168
     PgClassExpression169{{"PgClassExpression[169∈15] ➊<br />ᐸ__relation..._lower__.vᐳ"}}:::plan
     PgSelectSingle168 --> PgClassExpression169
     PgSelectSingle173{{"PgSelectSingle[173∈15] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -330,10 +332,10 @@ graph TD
     PgClassExpression174{{"PgClassExpression[174∈15] ➊<br />ᐸ__relation..._archived”ᐳ"}}:::plan
     PgSelectSingle173 --> PgClassExpression174
     PgSelectSingle183{{"PgSelectSingle[183∈15] ➊<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys388{{"RemapKeys[388∈15] ➊<br />ᐸ173:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys388 --> PgSelectSingle183
-    PgSelectSingle173 --> RemapKeys388
-    PgSelectSingle157 --> RemapKeys420
+    RemapKeys401{{"RemapKeys[401∈15] ➊<br />ᐸ173:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys401 --> PgSelectSingle183
+    PgSelectSingle173 --> RemapKeys401
+    PgSelectSingle157 --> RemapKeys435
     PgClassExpression184{{"PgClassExpression[184∈16] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle183 --> PgClassExpression184
     PgClassExpression185{{"PgClassExpression[185∈16] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -344,52 +346,52 @@ graph TD
     subgraph "Buckets for mutations/basics/update-relational-post"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Constant186,Lambda188,Lambda191,Constant192,Constant193,Constant194,Constant208,Constant209,Constant210,Constant224,Constant225,Constant226,Constant240,Constant241,Constant242,Constant254,Constant255,Constant270,Constant271,Constant286,Constant287,Constant302,Constant303,Constant316,Constant317,Constant332,Constant333,Constant348,Constant349,Constant364,Constant365,Constant378,Constant379,Constant394,Constant395,Constant410,Constant411,Constant426,Constant427,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450,Constant451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 436, 437, 191, 188, 192, 193, 194, 442, 208, 209, 210, 443, 224, 225, 226, 444, 240, 241, 242, 445"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Constant186,Lambda188,Lambda191,Access192,Constant193,Constant194,Constant195,Object196,Lambda197,Lambda202,Constant210,Constant211,Constant212,Object213,Lambda214,Lambda219,Constant227,Constant228,Constant229,Object230,Lambda231,Lambda236,Constant244,Constant245,Constant246,Object247,Lambda248,Lambda253,Constant259,Constant260,Object262,Lambda263,Lambda268,Constant276,Constant277,Object279,Lambda280,Lambda285,Constant293,Constant294,Object296,Lambda297,Lambda302,Constant310,Constant311,Object313,Lambda314,Lambda319,Constant325,Constant326,Object328,Lambda329,Lambda334,Constant342,Constant343,Object345,Lambda346,Lambda351,Constant359,Constant360,Object362,Lambda363,Lambda368,Constant376,Constant377,Object379,Lambda380,Lambda385,Constant391,Constant392,Object394,Lambda395,Lambda400,Constant408,Constant409,Object411,Lambda412,Lambda417,Constant425,Constant426,Object428,Lambda429,Lambda434,Constant442,Constant443,Object445,Lambda446,Lambda451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 452, 453, 192, 197, 202, 214, 219, 231, 236, 188, 248, 253"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 14, 191, 188, 192, 193, 194, 442, 208, 209, 210, 443, 224, 225, 226, 444, 240, 241, 242, 445<br /><br />ROOT PgUpdateSingle{1}ᐸrelational_posts(id;description)ᐳ[11]<br />1: <br />ᐳ: 15, 195, 201, 211, 217, 227, 233, 243, 249, 196, 212, 228, 244<br />2: PgSelect[17]<br />ᐳ: First[21], PgSelectSingle[22]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 14, 192, 197, 202, 214, 219, 231, 236, 188, 248, 253<br /><br />ROOT PgUpdateSingle{1}ᐸrelational_posts(id;description)ᐳ[11]<br />1: <br />ᐳ: PgClassExpression[15]<br />2: PgSelect[17]<br />ᐳ: First[21], PgSelectSingle[22]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression15,PgSelect17,First21,PgSelectSingle22,Object195,Lambda196,Lambda201,Object211,Lambda212,Lambda217,Object227,Lambda228,Lambda233,Object243,Lambda244,Lambda249 bucket2
+    class Bucket2,PgClassExpression15,PgSelect17,First21,PgSelectSingle22 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22<br /><br />ROOT PgSelectSingle{2}ᐸrelational_postsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgSelectSingle33,PgClassExpression34,PgSelectSingle38,PgClassExpression39,PgSelectSingle48,RemapKeys202,RemapKeys234 bucket3
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgSelectSingle33,PgClassExpression34,PgSelectSingle38,PgClassExpression39,PgSelectSingle48,RemapKeys203,RemapKeys237 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[48]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression49,PgClassExpression50 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 436, 438, 2, 191, 188, 254, 255, 194, 446, 270, 271, 210, 447, 286, 287, 226, 448, 302, 303, 242, 449<br /><br />1: Access[57]<br />2: Access[58]<br />3: Object[59]<br />4: PgUpdateSingle[56]"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 452, 454, 2, 192, 263, 268, 280, 285, 297, 302, 188, 314, 319<br /><br />1: Access[57]<br />2: Access[58]<br />3: Object[59]<br />4: PgUpdateSingle[56]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgUpdateSingle56,Access57,Access58,Object59 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 56, 59, 191, 188, 254, 255, 194, 446, 270, 271, 210, 447, 286, 287, 226, 448, 302, 303, 242, 449<br /><br />ROOT PgUpdateSingle{5}ᐸrelational_posts(id;note)ᐳ[56]<br />1: <br />ᐳ: 60, 257, 263, 273, 279, 289, 295, 305, 311, 258, 274, 290, 306<br />2: PgSelect[62]<br />ᐳ: First[66], PgSelectSingle[67]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 56, 59, 192, 263, 268, 280, 285, 297, 302, 188, 314, 319<br /><br />ROOT PgUpdateSingle{5}ᐸrelational_posts(id;note)ᐳ[56]<br />1: <br />ᐳ: PgClassExpression[60]<br />2: PgSelect[62]<br />ᐳ: First[66], PgSelectSingle[67]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression60,PgSelect62,First66,PgSelectSingle67,Object257,Lambda258,Lambda263,Object273,Lambda274,Lambda279,Object289,Lambda290,Lambda295,Object305,Lambda306,Lambda311 bucket6
+    class Bucket6,PgClassExpression60,PgSelect62,First66,PgSelectSingle67 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 67<br /><br />ROOT PgSelectSingle{6}ᐸrelational_postsᐳ[67]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgClassExpression71,PgSelectSingle78,PgClassExpression79,PgSelectSingle83,PgClassExpression84,PgSelectSingle93,RemapKeys264,RemapKeys296 bucket7
+    class Bucket7,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgClassExpression71,PgSelectSingle78,PgClassExpression79,PgSelectSingle83,PgClassExpression84,PgSelectSingle93,RemapKeys269,RemapKeys303 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 93<br /><br />ROOT PgSelectSingle{7}ᐸpeopleᐳ[93]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression94,PgClassExpression95 bucket8
-    Bucket9("Bucket 9 (mutationField)<br />Deps: 436, 186, 2, 191, 188, 316, 317, 194, 450, 332, 333, 210, 451, 348, 349, 226, 452, 364, 365, 242, 453<br /><br />1: Access[102]<br />2: Access[103]<br />3: Object[104]<br />4: PgUpdateSingle[101]"):::bucket
+    Bucket9("Bucket 9 (mutationField)<br />Deps: 452, 186, 2, 192, 329, 334, 346, 351, 363, 368, 188, 380, 385<br /><br />1: Access[102]<br />2: Access[103]<br />3: Object[104]<br />4: PgUpdateSingle[101]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgUpdateSingle101,Access102,Access103,Object104 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 101, 104, 191, 188, 316, 317, 194, 450, 332, 333, 210, 451, 348, 349, 226, 452, 364, 365, 242, 453<br /><br />ROOT PgUpdateSingle{9}ᐸrelational_posts(id;description)ᐳ[101]<br />1: <br />ᐳ: 105, 319, 325, 335, 341, 351, 357, 367, 373, 320, 336, 352, 368<br />2: PgSelect[107]<br />ᐳ: First[111], PgSelectSingle[112]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 101, 104, 192, 329, 334, 346, 351, 363, 368, 188, 380, 385<br /><br />ROOT PgUpdateSingle{9}ᐸrelational_posts(id;description)ᐳ[101]<br />1: <br />ᐳ: PgClassExpression[105]<br />2: PgSelect[107]<br />ᐳ: First[111], PgSelectSingle[112]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression105,PgSelect107,First111,PgSelectSingle112,Object319,Lambda320,Lambda325,Object335,Lambda336,Lambda341,Object351,Lambda352,Lambda357,Object367,Lambda368,Lambda373 bucket10
+    class Bucket10,PgClassExpression105,PgSelect107,First111,PgSelectSingle112 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 112<br /><br />ROOT PgSelectSingle{10}ᐸrelational_postsᐳ[112]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression113,PgClassExpression114,PgClassExpression115,PgClassExpression116,PgSelectSingle123,PgClassExpression124,PgSelectSingle128,PgClassExpression129,PgSelectSingle138,RemapKeys326,RemapKeys358 bucket11
+    class Bucket11,PgClassExpression113,PgClassExpression114,PgClassExpression115,PgClassExpression116,PgSelectSingle123,PgClassExpression124,PgSelectSingle128,PgClassExpression129,PgSelectSingle138,RemapKeys335,RemapKeys369 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 138<br /><br />ROOT PgSelectSingle{11}ᐸpeopleᐳ[138]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression139,PgClassExpression140 bucket12
-    Bucket13("Bucket 13 (mutationField)<br />Deps: 439, 186, 2, 191, 188, 378, 379, 194, 454, 394, 395, 210, 455, 410, 411, 226, 456, 426, 427, 242, 457<br /><br />1: Access[147]<br />2: Access[148]<br />3: Object[149]<br />4: PgUpdateSingle[146]"):::bucket
+    Bucket13("Bucket 13 (mutationField)<br />Deps: 455, 186, 2, 192, 395, 400, 412, 417, 429, 434, 188, 446, 451<br /><br />1: Access[147]<br />2: Access[148]<br />3: Object[149]<br />4: PgUpdateSingle[146]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgUpdateSingle146,Access147,Access148,Object149 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 146, 149, 191, 188, 378, 379, 194, 454, 394, 395, 210, 455, 410, 411, 226, 456, 426, 427, 242, 457<br /><br />ROOT PgUpdateSingle{13}ᐸrelational_posts(id;description)ᐳ[146]<br />1: <br />ᐳ: 150, 381, 387, 397, 403, 413, 419, 429, 435, 382, 398, 414, 430<br />2: PgSelect[152]<br />ᐳ: First[156], PgSelectSingle[157]"):::bucket
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 146, 149, 192, 395, 400, 412, 417, 429, 434, 188, 446, 451<br /><br />ROOT PgUpdateSingle{13}ᐸrelational_posts(id;description)ᐳ[146]<br />1: <br />ᐳ: PgClassExpression[150]<br />2: PgSelect[152]<br />ᐳ: First[156], PgSelectSingle[157]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression150,PgSelect152,First156,PgSelectSingle157,Object381,Lambda382,Lambda387,Object397,Lambda398,Lambda403,Object413,Lambda414,Lambda419,Object429,Lambda430,Lambda435 bucket14
+    class Bucket14,PgClassExpression150,PgSelect152,First156,PgSelectSingle157 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 157<br /><br />ROOT PgSelectSingle{14}ᐸrelational_postsᐳ[157]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression158,PgClassExpression159,PgClassExpression160,PgClassExpression161,PgSelectSingle168,PgClassExpression169,PgSelectSingle173,PgClassExpression174,PgSelectSingle183,RemapKeys388,RemapKeys420 bucket15
+    class Bucket15,PgClassExpression158,PgClassExpression159,PgClassExpression160,PgClassExpression161,PgSelectSingle168,PgClassExpression169,PgSelectSingle173,PgClassExpression174,PgSelectSingle183,RemapKeys401,RemapKeys435 bucket15
     Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 183<br /><br />ROOT PgSelectSingle{15}ᐸpeopleᐳ[183]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,PgClassExpression184,PgClassExpression185 bucket16

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-1.deopt.mermaid
@@ -12,63 +12,65 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda103 & Lambda108 --> PgSelect8
-    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant99 & Constant100 & Constant101 --> Object102
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda107 & Lambda112 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109 --> Lambda53
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant110 --> Lambda56
-    Object102 --> Lambda103
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant114 --> Lambda108
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant114 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant115 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant116 --> Lambda82
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant117 --> Lambda97
+    Object106 --> Lambda107
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant118 --> Lambda112
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant85 & Constant86 & Constant87 --> Object88
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant111 --> Lambda66
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object74 --> Lambda75
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant112 --> Lambda80
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant113 --> Lambda94
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -76,14 +78,14 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Lambda56 & Lambda89 & Lambda94 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Access57 & Lambda92 & Lambda97 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -97,7 +99,7 @@ graph TD
     PgSelectSingle33 --> PgClassExpression35
     PgSelect43[["PgSelect[43∈8]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈8]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect43
     PgCursor38{{"PgCursor[38∈8]"}}:::plan
     List40{{"List[40∈8]<br />ᐸ39ᐳ"}}:::plan
     List40 --> PgCursor38
@@ -119,31 +121,31 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 71, 72, 85, 86, 87, 99, 100, 101, 109, 110, 111, 112, 113, 114, 11, 53, 56, 102, 103, 108<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 73, 74, 88, 89, 90, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 57, 61, 62, 67, 76, 77, 82, 91, 92, 97, 106, 107, 112<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant71,Constant72,Constant85,Constant86,Constant87,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 111, 71, 72, 112, 85, 86, 87, 113, 11, 21, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object74,Lambda75,Lambda80,Object88,Lambda89,Lambda94 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80"):::bucket
+    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 56, 61, 66, 75, 80<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 57, 62, 67, 77, 82<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item24,PgSelectSingle25 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-1.mermaid
@@ -12,63 +12,65 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda107 & Lambda112 --> PgSelect8
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda111 & Lambda116 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant75 & Constant76 & Constant60 --> Object78
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant92 & Constant93 & Constant94 --> Object95
+    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant107 & Constant108 & Constant109 --> Object110
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda53
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda56
-    Object106 --> Lambda107
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant118 --> Lambda112
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant119 --> Lambda67
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object78 --> Lambda79
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda84
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object95 --> Lambda96
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda101
+    Object110 --> Lambda111
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant122 --> Lambda116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object76{{"Object[76∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant73 & Constant74 & Constant59 --> Object76
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant89 & Constant90 & Constant91 --> Object92
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda66
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant116 --> Lambda82
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object92 --> Lambda93
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant117 --> Lambda98
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda56 & Lambda61 & Lambda66 & Lambda56 & Lambda77 & Lambda82 & Lambda53 & Lambda56 & Lambda93 & Lambda98 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access57 & Lambda62 & Lambda67 & Access57 & Lambda79 & Lambda84 & Lambda53 & Access57 & Lambda96 & Lambda101 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
@@ -84,9 +86,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈6]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys67{{"RemapKeys[67∈6]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys67 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys67
+    RemapKeys68{{"RemapKeys[68∈6]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys68 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys68
     PgClassExpression34{{"PgClassExpression[34∈7]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈7]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -100,9 +102,9 @@ graph TD
     PgClassExpression41{{"PgClassExpression[41∈8]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression41
     PgSelectSingle48{{"PgSelectSingle[48∈8]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys83{{"RemapKeys[83∈8]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys83 --> PgSelectSingle48
-    PgSelectSingle25 --> RemapKeys83
+    RemapKeys85{{"RemapKeys[85∈8]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys85 --> PgSelectSingle48
+    PgSelectSingle25 --> RemapKeys85
     PgClassExpression49{{"PgClassExpression[49∈9]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈9]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -111,19 +113,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 73, 74, 89, 90, 91, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 106, 107, 112<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 75, 76, 92, 93, 94, 107, 108, 109, 117, 118, 119, 120, 121, 122, 11, 53, 56, 57, 61, 62, 67, 78, 79, 84, 95, 96, 101, 110, 111, 116<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 115, 73, 74, 116, 89, 90, 91, 117, 11, 21, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant75,Constant76,Object78,Lambda79,Lambda84,Constant92,Constant93,Constant94,Object95,Lambda96,Lambda101,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 57, 62, 67, 79, 84, 53, 96, 101<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object76,Lambda77,Lambda82,Object92,Lambda93,Lambda98 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 56, 61, 66, 77, 82, 53, 93, 98<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 57, 62, 67, 79, 84, 53, 96, 101<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 56, 61, 66, 77, 82, 53, 93, 98"):::bucket
+    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 57, 62, 67, 79, 84, 53, 96, 101"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 56, 61, 66, 77, 82, 53, 93, 98<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 57, 62, 67, 79, 84, 53, 96, 101<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
@@ -131,13 +133,13 @@ graph TD
     class Bucket5,__Item24,PgSelectSingle25 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression26,PgSelectSingle33,RemapKeys67 bucket6
+    class Bucket6,PgClassExpression26,PgSelectSingle33,RemapKeys68 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys83 bucket8
+    class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys85 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[48]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression49,PgClassExpression50 bucket9

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.deopt.mermaid
@@ -12,63 +12,65 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda103 & Lambda108 --> PgSelect8
-    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant99 & Constant100 & Constant101 --> Object102
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda107 & Lambda112 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109 --> Lambda53
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant110 --> Lambda56
-    Object102 --> Lambda103
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant114 --> Lambda108
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant114 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant115 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant116 --> Lambda82
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant117 --> Lambda97
+    Object106 --> Lambda107
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant118 --> Lambda112
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant85 & Constant86 & Constant87 --> Object88
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant111 --> Lambda66
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object74 --> Lambda75
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant112 --> Lambda80
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant113 --> Lambda94
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -76,14 +78,14 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Lambda56 & Lambda89 & Lambda94 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Access57 & Lambda92 & Lambda97 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -97,7 +99,7 @@ graph TD
     PgSelectSingle33 --> PgClassExpression35
     PgSelect43[["PgSelect[43∈8]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈8]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect43
     PgCursor38{{"PgCursor[38∈8]"}}:::plan
     List40{{"List[40∈8]<br />ᐸ39ᐳ"}}:::plan
     List40 --> PgCursor38
@@ -119,31 +121,31 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-2"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 71, 72, 85, 86, 87, 99, 100, 101, 109, 110, 111, 112, 113, 114, 11, 53, 56, 102, 103, 108<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 73, 74, 88, 89, 90, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 57, 61, 62, 67, 76, 77, 82, 91, 92, 97, 106, 107, 112<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant71,Constant72,Constant85,Constant86,Constant87,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 111, 71, 72, 112, 85, 86, 87, 113, 21, 11, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 11, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object74,Lambda75,Lambda80,Object88,Lambda89,Lambda94 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 21, 11, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 21, 11, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 53, 56, 89, 94, 61, 66, 75, 80"):::bucket
+    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 53, 57, 92, 97, 62, 67, 77, 82"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 56, 61, 66, 75, 80<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 57, 62, 67, 77, 82<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item24,PgSelectSingle25 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-2.mermaid
@@ -12,63 +12,65 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda107 & Lambda112 --> PgSelect8
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda111 & Lambda116 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant75 & Constant76 & Constant60 --> Object78
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant92 & Constant93 & Constant94 --> Object95
+    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant107 & Constant108 & Constant109 --> Object110
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda53
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda56
-    Object106 --> Lambda107
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant118 --> Lambda112
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant119 --> Lambda67
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object78 --> Lambda79
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda84
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object95 --> Lambda96
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda101
+    Object110 --> Lambda111
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant122 --> Lambda116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object76{{"Object[76∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant73 & Constant74 & Constant59 --> Object76
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant89 & Constant90 & Constant91 --> Object92
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda66
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant116 --> Lambda82
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object92 --> Lambda93
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant117 --> Lambda98
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda56 & Lambda61 & Lambda66 & Lambda56 & Lambda77 & Lambda82 & Lambda53 & Lambda56 & Lambda93 & Lambda98 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access57 & Lambda62 & Lambda67 & Access57 & Lambda79 & Lambda84 & Lambda53 & Access57 & Lambda96 & Lambda101 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
@@ -84,9 +86,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈6]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys67{{"RemapKeys[67∈6]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys67 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys67
+    RemapKeys68{{"RemapKeys[68∈6]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys68 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys68
     PgClassExpression34{{"PgClassExpression[34∈7]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈7]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -100,9 +102,9 @@ graph TD
     PgClassExpression41{{"PgClassExpression[41∈8]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression41
     PgSelectSingle48{{"PgSelectSingle[48∈8]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys83{{"RemapKeys[83∈8]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys83 --> PgSelectSingle48
-    PgSelectSingle25 --> RemapKeys83
+    RemapKeys85{{"RemapKeys[85∈8]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys85 --> PgSelectSingle48
+    PgSelectSingle25 --> RemapKeys85
     PgClassExpression49{{"PgClassExpression[49∈9]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈9]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -111,19 +113,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-2"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 73, 74, 89, 90, 91, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 106, 107, 112<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 75, 76, 92, 93, 94, 107, 108, 109, 117, 118, 119, 120, 121, 122, 11, 53, 56, 57, 61, 62, 67, 78, 79, 84, 95, 96, 101, 110, 111, 116<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 115, 73, 74, 116, 89, 90, 91, 117, 21, 11, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant75,Constant76,Object78,Lambda79,Lambda84,Constant92,Constant93,Constant94,Object95,Lambda96,Lambda101,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 11, 57, 62, 67, 79, 84, 53, 96, 101<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object76,Lambda77,Lambda82,Object92,Lambda93,Lambda98 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 56, 61, 66, 77, 82, 53, 93, 98<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 57, 62, 67, 79, 84, 53, 96, 101<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 21, 11, 56, 61, 66, 77, 82, 53, 93, 98<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 21, 11, 57, 62, 67, 79, 84, 53, 96, 101<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 56, 61, 66, 77, 82, 53, 93, 98"):::bucket
+    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 57, 62, 67, 79, 84, 53, 96, 101"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
@@ -131,13 +133,13 @@ graph TD
     class Bucket5,__Item24,PgSelectSingle25 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression26,PgSelectSingle33,RemapKeys67 bucket6
+    class Bucket6,PgClassExpression26,PgSelectSingle33,RemapKeys68 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys83 bucket8
+    class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys85 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[48]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression49,PgClassExpression50 bucket9

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.deopt.mermaid
@@ -12,71 +12,73 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
     Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda54 & Lambda57 & Lambda118 & Lambda123 --> PgSelect8
-    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda54 & Constant114 & Constant115 & Constant116 --> Object117
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda54 & Access58 & Lambda123 & Lambda128 --> PgSelect8
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda54 & Constant89 & Constant90 & Constant61 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda54 & Constant104 & Constant75 & Constant76 --> Object107
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda54 & Constant119 & Constant120 & Constant121 --> Object122
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant124 --> Lambda54
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant125 --> Lambda57
-    Object117 --> Lambda118
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant130 --> Lambda123
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant129 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant130 --> Lambda57
+    Lambda57 --> Access58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant131 --> Lambda68
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant132 --> Lambda83
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant133 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant134 --> Lambda113
+    Object122 --> Lambda123
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant135 --> Lambda128
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object61{{"Object[61∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant72 & Constant73 & Constant74 --> Object75
-    Object89{{"Object[89∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant86 & Constant87 & Constant60 --> Object89
-    Object103{{"Object[103∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant100 & Constant73 & Constant74 --> Object103
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant126 --> Lambda67
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant127 --> Lambda81
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object89 --> Lambda90
-    Lambda95{{"Lambda[95∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant128 --> Lambda95
-    Lambda104{{"Lambda[104∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object103 --> Lambda104
-    Lambda109{{"Lambda[109∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant129 --> Lambda109
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -84,14 +86,14 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda54 & Lambda57 & Lambda76 & Lambda81 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda54 & Access58 & Lambda78 & Lambda83 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda54 & Lambda57 & Lambda62 & Lambda67 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda54 & Access58 & Lambda63 & Lambda68 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -104,14 +106,14 @@ graph TD
     PgClassExpression35{{"PgClassExpression[35∈7]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression35
     PgSelect36[["PgSelect[36∈8]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda54 & Lambda57 & Lambda104 & Lambda109 --> PgSelect36
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda54 & Access58 & Lambda108 & Lambda113 --> PgSelect36
     __Item37[/"__Item[37∈9]<br />ᐸ36ᐳ"\]:::itemplan
     PgSelect36 ==> __Item37
     PgSelectSingle38{{"PgSelectSingle[38∈9]<br />ᐸmessagesᐳ"}}:::plan
     __Item37 --> PgSelectSingle38
     PgSelect44[["PgSelect[44∈10]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression43{{"PgClassExpression[43∈10]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression43 & Lambda54 & Lambda57 & Lambda90 & Lambda95 --> PgSelect44
+    Object11 & PgClassExpression43 & Lambda54 & Access58 & Lambda93 & Lambda98 --> PgSelect44
     PgCursor39{{"PgCursor[39∈10]"}}:::plan
     List41{{"List[41∈10]<br />ᐸ40ᐳ"}}:::plan
     List41 --> PgCursor39
@@ -133,37 +135,37 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-3"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 72, 73, 74, 86, 87, 100, 114, 115, 116, 124, 125, 126, 127, 128, 129, 130, 11, 54, 57, 117, 118, 123<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 59, 60, 61, 74, 75, 76, 89, 90, 104, 119, 120, 121, 129, 130, 131, 132, 133, 134, 135, 11, 54, 57, 58, 62, 63, 68, 77, 78, 83, 92, 93, 98, 107, 108, 113, 122, 123, 128<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda54,Lambda57,Constant58,Constant59,Constant60,Constant72,Constant73,Constant74,Constant86,Constant87,Constant100,Constant114,Constant115,Constant116,Object117,Lambda118,Lambda123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 54, 58, 59, 60, 126, 72, 73, 74, 127, 86, 87, 128, 100, 129, 21, 11, 57<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant89,Constant90,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant129,Constant130,Constant131,Constant132,Constant133,Constant134,Constant135 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 11, 54, 58, 78, 83, 63, 68, 108, 113, 93, 98<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object61,Lambda62,Lambda67,Object75,Lambda76,Lambda81,Object89,Lambda90,Lambda95,Object103,Lambda104,Lambda109 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 54, 57, 76, 81, 62, 67, 104, 109, 90, 95<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 54, 58, 78, 83, 63, 68, 108, 113, 93, 98<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression16,PgClassExpression22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 11, 16, 22, 54, 57, 76, 81, 62, 67, 104, 109, 90, 95<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 11, 16, 22, 54, 58, 78, 83, 63, 68, 108, 113, 93, 98<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 54, 57, 76, 81, 62, 67"):::bucket
+    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 54, 58, 78, 83, 63, 68"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 54, 57, 62, 67<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 54, 58, 63, 68<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item24,PgSelectSingle25 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 54, 57, 62, 67<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 54, 58, 63, 68<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (defer)<br />Deps: 11, 16, 22, 21, 54, 57, 104, 109, 90, 95"):::bucket
+    Bucket8("Bucket 8 (defer)<br />Deps: 11, 16, 22, 21, 54, 58, 108, 113, 93, 98"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgSelect36 bucket8
-    Bucket9("Bucket 9 (listItem)<br />Deps: 11, 54, 57, 90, 95<br /><br />ROOT __Item{9}ᐸ36ᐳ[37]"):::bucket
+    Bucket9("Bucket 9 (listItem)<br />Deps: 11, 54, 58, 93, 98<br /><br />ROOT __Item{9}ᐸ36ᐳ[37]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,__Item37,PgSelectSingle38 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 38, 11, 54, 57, 90, 95<br /><br />ROOT PgSelectSingle{9}ᐸmessagesᐳ[38]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 38, 11, 54, 58, 93, 98<br /><br />ROOT PgSelectSingle{9}ᐸmessagesᐳ[38]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgClassExpression43,PgSelect44,First48,PgSelectSingle49 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{10}ᐸusersᐳ[49]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-3.mermaid
@@ -12,71 +12,73 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
     Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda54 & Lambda57 & Lambda122 & Lambda127 --> PgSelect8
-    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda54 & Constant118 & Constant119 & Constant120 --> Object121
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda54 & Access58 & Lambda127 & Lambda132 --> PgSelect8
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda54 & Constant91 & Constant92 & Constant61 --> Object94
+    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda54 & Constant108 & Constant77 & Constant78 --> Object111
+    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda54 & Constant123 & Constant124 & Constant125 --> Object126
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant128 --> Lambda54
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant129 --> Lambda57
-    Object121 --> Lambda122
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant134 --> Lambda127
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant133 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant134 --> Lambda57
+    Lambda57 --> Access58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant135 --> Lambda68
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object79 --> Lambda80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant136 --> Lambda85
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant137 --> Lambda100
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object111 --> Lambda112
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant138 --> Lambda117
+    Object126 --> Lambda127
+    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant139 --> Lambda132
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object61{{"Object[61∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
-    Object91{{"Object[91∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant88 & Constant89 & Constant60 --> Object91
-    Object107{{"Object[107∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant104 & Constant75 & Constant76 --> Object107
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant130 --> Lambda67
-    Lambda78{{"Lambda[78∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object77 --> Lambda78
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant131 --> Lambda83
-    Lambda92{{"Lambda[92∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object91 --> Lambda92
-    Lambda97{{"Lambda[97∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant132 --> Lambda97
-    Lambda108{{"Lambda[108∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object107 --> Lambda108
-    Lambda113{{"Lambda[113∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant133 --> Lambda113
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
@@ -92,15 +94,15 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈6]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys68{{"RemapKeys[68∈6]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys68 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys68
+    RemapKeys69{{"RemapKeys[69∈6]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys69 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys69
     PgClassExpression34{{"PgClassExpression[34∈7]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈7]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression35
     PgSelect36[["PgSelect[36∈8]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda57 & Lambda92 & Lambda97 & Lambda54 & Lambda57 & Lambda108 & Lambda113 --> PgSelect36
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access58 & Lambda95 & Lambda100 & Lambda54 & Access58 & Lambda112 & Lambda117 --> PgSelect36
     __Item37[/"__Item[37∈9]<br />ᐸ36ᐳ"\]:::itemplan
     PgSelect36 ==> __Item37
     PgSelectSingle38{{"PgSelectSingle[38∈9]<br />ᐸmessagesᐳ"}}:::plan
@@ -114,9 +116,9 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈10]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression42
     PgSelectSingle49{{"PgSelectSingle[49∈10]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys98{{"RemapKeys[98∈10]<br />ᐸ38:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys98 --> PgSelectSingle49
-    PgSelectSingle38 --> RemapKeys98
+    RemapKeys101{{"RemapKeys[101∈10]<br />ᐸ38:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys101 --> PgSelectSingle49
+    PgSelectSingle38 --> RemapKeys101
     PgClassExpression50{{"PgClassExpression[50∈11]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression51{{"PgClassExpression[51∈11]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -125,19 +127,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-3"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 74, 75, 76, 88, 89, 104, 118, 119, 120, 128, 129, 130, 131, 132, 133, 134, 11, 54, 57, 121, 122, 127<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 59, 60, 61, 76, 77, 78, 91, 92, 108, 123, 124, 125, 133, 134, 135, 136, 137, 138, 139, 11, 54, 57, 58, 62, 63, 68, 79, 80, 85, 94, 95, 100, 111, 112, 117, 126, 127, 132<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda54,Lambda57,Constant58,Constant59,Constant60,Constant74,Constant75,Constant76,Constant88,Constant89,Constant104,Constant118,Constant119,Constant120,Object121,Lambda122,Lambda127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133,Constant134 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 54, 58, 59, 60, 130, 74, 75, 76, 131, 88, 89, 132, 104, 133, 21, 11, 57<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant91,Constant92,Object94,Lambda95,Lambda100,Constant108,Object111,Lambda112,Lambda117,Constant123,Constant124,Constant125,Object126,Lambda127,Lambda132,Constant133,Constant134,Constant135,Constant136,Constant137,Constant138,Constant139 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 11, 58, 63, 68, 54, 80, 85, 95, 100, 112, 117<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object61,Lambda62,Lambda67,Object77,Lambda78,Lambda83,Object91,Lambda92,Lambda97,Object107,Lambda108,Lambda113 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 57, 62, 67, 54, 78, 83, 92, 97, 108, 113<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 11, 58, 63, 68, 54, 80, 85, 95, 100, 112, 117<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression16,PgClassExpression22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 11, 16, 22, 57, 62, 67, 54, 78, 83, 92, 97, 108, 113<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 11, 16, 22, 58, 63, 68, 54, 80, 85, 95, 100, 112, 117<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 57, 62, 67, 54, 78, 83"):::bucket
+    Bucket4("Bucket 4 (defer)<br />Deps: 11, 16, 22, 21, 58, 63, 68, 54, 80, 85"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
@@ -145,11 +147,11 @@ graph TD
     class Bucket5,__Item24,PgSelectSingle25 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression26,PgSelectSingle33,RemapKeys68 bucket6
+    class Bucket6,PgClassExpression26,PgSelectSingle33,RemapKeys69 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (defer)<br />Deps: 11, 16, 22, 21, 57, 92, 97, 54, 108, 113"):::bucket
+    Bucket8("Bucket 8 (defer)<br />Deps: 11, 16, 22, 21, 58, 95, 100, 54, 112, 117"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgSelect36 bucket8
     Bucket9("Bucket 9 (listItem)<br /><br />ROOT __Item{9}ᐸ36ᐳ[37]"):::bucket
@@ -157,7 +159,7 @@ graph TD
     class Bucket9,__Item37,PgSelectSingle38 bucket9
     Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 38<br /><br />ROOT PgSelectSingle{9}ᐸmessagesᐳ[38]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys98 bucket10
+    class Bucket10,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys101 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{10}ᐸusersᐳ[49]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression50,PgClassExpression51 bucket11

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.deopt.mermaid
@@ -12,83 +12,87 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access84{{"Access[84∈0] ➊<br />ᐸ83.0ᐳ"}}:::plan
     Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda80 & Lambda83 & Lambda145 & Lambda150 --> PgSelect8
-    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda80 & Constant141 & Constant142 & Constant143 --> Object144
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda80 & Access84 & Lambda150 & Lambda155 --> PgSelect8
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda80 & Constant85 & Constant86 & Constant87 --> Object88
+    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda80 & Constant100 & Constant101 & Constant87 --> Object103
+    Object119{{"Object[119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda80 & Constant116 & Constant117 & Constant118 --> Object119
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda80 & Constant131 & Constant117 & Constant118 --> Object134
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda80 & Constant146 & Constant147 & Constant148 --> Object149
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant151 --> Lambda80
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant152 --> Lambda83
-    Object144 --> Lambda145
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant158 --> Lambda150
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant156 --> Lambda80
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant157 --> Lambda83
+    Lambda83 --> Access84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object88 --> Lambda89
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant159 --> Lambda94
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object103 --> Lambda104
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant160 --> Lambda109
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda114
+    Access115{{"Access[115∈0] ➊<br />ᐸ114.0ᐳ"}}:::plan
+    Lambda114 --> Access115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object119 --> Lambda120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant161 --> Lambda125
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object134 --> Lambda135
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant162 --> Lambda140
+    Object149 --> Lambda150
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant163 --> Lambda155
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object87{{"Object[87∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant84 & Constant85 & Constant86 --> Object87
-    Object101{{"Object[101∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant98 & Constant99 & Constant86 --> Object101
-    Object116{{"Object[116∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant113 & Constant114 & Constant115 --> Object116
-    Object130{{"Object[130∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant127 & Constant114 & Constant115 --> Object130
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object87 --> Lambda88
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant154 --> Lambda93
-    Lambda102{{"Lambda[102∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object101 --> Lambda102
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant155 --> Lambda107
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant153 --> Lambda112
-    Lambda117{{"Lambda[117∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object116 --> Lambda117
-    Lambda122{{"Lambda[122∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant156 --> Lambda122
-    Lambda131{{"Lambda[131∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object130 --> Lambda131
-    Lambda136{{"Lambda[136∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157 --> Lambda136
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Lambda112 & Lambda117 & Lambda122 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Access115 & Lambda120 & Lambda125 --> PgSelect23
     PgSelect74[["PgSelect[74∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Lambda83 & Lambda131 & Lambda136 --> PgSelect74
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Access84 & Lambda135 & Lambda140 --> PgSelect74
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access55{{"Access[55∈3]<br />ᐸ23.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
@@ -135,7 +139,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda80 & Lambda83 & Lambda88 & Lambda93 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda80 & Access84 & Lambda89 & Lambda94 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -149,7 +153,7 @@ graph TD
     PgSelectSingle33 --> PgClassExpression35
     PgSelect43[["PgSelect[43∈8]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈8]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda80 & Lambda83 & Lambda102 & Lambda107 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda80 & Access84 & Lambda104 & Lambda109 --> PgSelect43
     PgCursor38{{"PgCursor[38∈8]"}}:::plan
     List40{{"List[40∈8]<br />ᐸ39ᐳ"}}:::plan
     List40 --> PgCursor38
@@ -171,31 +175,31 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-4"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 84, 85, 86, 98, 99, 113, 114, 115, 127, 141, 142, 143, 151, 152, 153, 154, 155, 156, 157, 158, 11, 80, 83, 144, 145, 150<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 85, 86, 87, 100, 101, 116, 117, 118, 131, 146, 147, 148, 156, 157, 158, 159, 160, 161, 162, 163, 11, 80, 83, 84, 88, 89, 94, 103, 104, 109, 114, 115, 119, 120, 125, 134, 135, 140, 149, 150, 155<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda80,Lambda83,Constant84,Constant85,Constant86,Constant98,Constant99,Constant113,Constant114,Constant115,Constant127,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 80, 84, 85, 86, 154, 98, 99, 155, 153, 113, 114, 115, 156, 127, 157, 11, 21, 6, 83<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda80,Lambda83,Access84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant100,Constant101,Object103,Lambda104,Lambda109,Lambda114,Access115,Constant116,Constant117,Constant118,Object119,Lambda120,Lambda125,Constant131,Object134,Lambda135,Lambda140,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 80, 115, 120, 125, 6, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object87,Lambda88,Lambda93,Object101,Lambda102,Lambda107,Lambda112,Object116,Lambda117,Lambda122,Object130,Lambda131,Lambda136 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 112, 117, 122, 6, 83, 131, 136, 88, 93, 102, 107<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 115, 120, 125, 6, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 112, 117, 122, 6, 83, 131, 136, 88, 93, 102, 107<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 52<br />2: PgSelect[23], PgSelect[74]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 65, 71"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 115, 120, 125, 6, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 52<br />2: PgSelect[23], PgSelect[74]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 65, 71"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,PgSelect74,First75,PgSelectSingle76,PgClassExpression77 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 83, 88, 93, 102, 107<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 84, 89, 94, 104, 109<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 88, 93<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 89, 94<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5 bucket5
-    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 80, 83, 88, 93<br /><br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 80, 84, 89, 94<br /><br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 102, 107<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 104, 109<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.mermaid
@@ -11,102 +11,106 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access84{{"Access[84∈0] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access117{{"Access[117∈0] ➊<br />ᐸ116.0ᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda83 & Lambda102 & Lambda107 & Lambda114 & Lambda119 & Lambda124 & Lambda83 & Lambda138 & Lambda143 & Lambda80 & Lambda83 & Lambda156 & Lambda161 --> PgSelect8
-    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda80 & Constant98 & Constant99 & Constant86 --> Object101
-    Object118{{"Object[118∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda80 & Constant115 & Constant116 & Constant117 --> Object118
-    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda80 & Constant134 & Constant116 & Constant117 --> Object137
-    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda80 & Constant152 & Constant153 & Constant154 --> Object155
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access84 & Lambda104 & Lambda109 & Access117 & Lambda122 & Lambda127 & Access84 & Lambda142 & Lambda147 & Lambda80 & Access84 & Lambda161 & Lambda166 --> PgSelect8
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda80 & Constant85 & Constant86 & Constant87 --> Object88
+    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda80 & Constant100 & Constant101 & Constant87 --> Object103
+    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda80 & Constant118 & Constant119 & Constant120 --> Object121
+    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda80 & Constant138 & Constant119 & Constant120 --> Object141
+    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda80 & Constant157 & Constant158 & Constant159 --> Object160
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant162 --> Lambda80
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant163 --> Lambda83
-    Object101 --> Lambda102
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant166 --> Lambda107
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant164 --> Lambda114
-    Object118 --> Lambda119
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant167 --> Lambda124
-    Object137 --> Lambda138
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant168 --> Lambda143
-    Object155 --> Lambda156
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant169 --> Lambda161
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant167 --> Lambda80
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant168 --> Lambda83
+    Lambda83 --> Access84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object88 --> Lambda89
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant170 --> Lambda94
+    Object103 --> Lambda104
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant171 --> Lambda109
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant169 --> Lambda116
+    Lambda116 --> Access117
+    Object121 --> Lambda122
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant172 --> Lambda127
+    Object141 --> Lambda142
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant173 --> Lambda147
+    Object160 --> Lambda161
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant174 --> Lambda166
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
     Constant78{{"Constant[78∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant81{{"Constant[81∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Object87{{"Object[87∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant84 & Constant85 & Constant86 --> Object87
+    Constant114{{"Constant[114∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object87 --> Lambda88
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant165 --> Lambda93
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object128{{"Object[128∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access126{{"Access[126∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access126 & Constant78 & Constant78 & Lambda80 & Constant112 --> Object128
-    Object146{{"Object[146∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access144{{"Access[144∈3]<br />ᐸ12.2ᐳ"}}:::plan
-    Access144 & Constant78 & Constant78 & Lambda80 & Constant81 --> Object146
+    Object131{{"Object[131∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access129{{"Access[129∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access129 & Constant78 & Constant78 & Lambda80 & Constant114 --> Object131
+    Object150{{"Object[150∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access148{{"Access[148∈3]<br />ᐸ12.2ᐳ"}}:::plan
+    Access148 & Constant78 & Constant78 & Lambda80 & Constant81 --> Object150
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access55{{"Access[55∈3]<br />ᐸ129.hasMoreᐳ"}}:::plan
+    Access55{{"Access[55∈3]<br />ᐸ132.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
     Object56{{"Object[56∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access55 --> Object56
     PgPageInfo52{{"PgPageInfo[52∈3] ➊"}}:::plan
     Connection21 --> PgPageInfo52
-    Lambda129{{"Lambda[129∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda129 --> Access55
+    Lambda132{{"Lambda[132∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda132 --> Access55
     Lambda57{{"Lambda[57∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object56 --> Lambda57
     Lambda61{{"Lambda[61∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object60 --> Lambda61
     First63{{"First[63∈3]"}}:::plan
-    Lambda129 --> First63
+    Lambda132 --> First63
     PgSelectSingle64{{"PgSelectSingle[64∈3]<br />ᐸmessagesᐳ"}}:::plan
     First63 --> PgSelectSingle64
     PgCursor65{{"PgCursor[65∈3]"}}:::plan
@@ -116,7 +120,7 @@ graph TD
     PgSelectSingle64 --> PgClassExpression66
     PgClassExpression66 --> List67
     Last69{{"Last[69∈3]"}}:::plan
-    Lambda129 --> Last69
+    Lambda132 --> Last69
     PgSelectSingle70{{"PgSelectSingle[70∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last69 --> PgSelectSingle70
     PgCursor71{{"PgCursor[71∈3]"}}:::plan
@@ -126,23 +130,23 @@ graph TD
     PgSelectSingle70 --> PgClassExpression72
     PgClassExpression72 --> List73
     First75{{"First[75∈3]"}}:::plan
-    Lambda147{{"Lambda[147∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda147 --> First75
+    Lambda151{{"Lambda[151∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda151 --> First75
     PgSelectSingle76{{"PgSelectSingle[76∈3]<br />ᐸmessagesᐳ"}}:::plan
     First75 --> PgSelectSingle76
     PgClassExpression77{{"PgClassExpression[77∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle76 --> PgClassExpression77
-    __Item12 --> Access126
-    Object128 --> Lambda129
-    __Item12 --> Access144
-    Object146 --> Lambda147
-    __Item24[/"__Item[24∈4]<br />ᐸ129ᐳ"\]:::itemplan
-    Lambda129 ==> __Item24
+    __Item12 --> Access129
+    Object131 --> Lambda132
+    __Item12 --> Access148
+    Object150 --> Lambda151
+    __Item24[/"__Item[24∈4]<br />ᐸ132ᐳ"\]:::itemplan
+    Lambda132 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda80 & Lambda83 & Lambda88 & Lambda93 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda80 & Access84 & Lambda89 & Lambda94 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈6]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -163,9 +167,9 @@ graph TD
     PgClassExpression41{{"PgClassExpression[41∈8]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression41
     PgSelectSingle48{{"PgSelectSingle[48∈8]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys108{{"RemapKeys[108∈8]<br />ᐸ25:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys108 --> PgSelectSingle48
-    PgSelectSingle25 --> RemapKeys108
+    RemapKeys110{{"RemapKeys[110∈8]<br />ᐸ25:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys110 --> PgSelectSingle48
+    PgSelectSingle25 --> RemapKeys110
     PgClassExpression49{{"PgClassExpression[49∈9]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈9]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -174,25 +178,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-4"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 78, 81, 84, 85, 86, 98, 99, 112, 115, 116, 117, 134, 152, 153, 154, 162, 163, 164, 165, 166, 167, 168, 169, 11, 80, 83, 101, 102, 107, 114, 118, 119, 124, 137, 138, 143, 155, 156, 161<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 78, 81, 85, 86, 87, 100, 101, 114, 118, 119, 120, 138, 157, 158, 159, 167, 168, 169, 170, 171, 172, 173, 174, 11, 80, 83, 84, 88, 89, 94, 103, 104, 109, 116, 117, 121, 122, 127, 141, 142, 147, 160, 161, 166<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant78,Lambda80,Constant81,Lambda83,Constant84,Constant85,Constant86,Constant98,Constant99,Object101,Lambda102,Lambda107,Constant112,Lambda114,Constant115,Constant116,Constant117,Object118,Lambda119,Lambda124,Constant134,Object137,Lambda138,Lambda143,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 80, 84, 85, 86, 165, 21, 6, 78, 112, 81, 11, 83<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant78,Lambda80,Constant81,Lambda83,Access84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant100,Constant101,Object103,Lambda104,Lambda109,Constant114,Lambda116,Access117,Constant118,Constant119,Constant120,Object121,Lambda122,Lambda127,Constant138,Object141,Lambda142,Lambda147,Constant157,Constant158,Constant159,Object160,Lambda161,Lambda166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 6, 78, 80, 114, 81, 11, 84, 89, 94<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object87,Lambda88,Lambda93 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 6, 12, 78, 80, 112, 81, 11, 83, 88, 93<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 6, 12, 78, 80, 114, 81, 11, 84, 89, 94<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 78, 80, 112, 81, 11, 83, 88, 93<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 78, 80, 114, 81, 11, 84, 89, 94<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,First75,PgSelectSingle76,PgClassExpression77,Access126,Object128,Lambda129,Access144,Object146,Lambda147 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 83, 88, 93<br /><br />ROOT __Item{4}ᐸ129ᐳ[24]"):::bucket
+    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,First75,PgSelectSingle76,PgClassExpression77,Access129,Object131,Lambda132,Access148,Object150,Lambda151 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 84, 89, 94<br /><br />ROOT __Item{4}ᐸ132ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 88, 93<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 89, 94<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5 bucket5
-    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 80, 83, 88, 93<br /><br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 80, 84, 89, 94<br /><br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
@@ -200,7 +204,7 @@ graph TD
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys108 bucket8
+    class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys110 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[48]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression49,PgClassExpression50 bucket9

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.deopt.mermaid
@@ -12,83 +12,87 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
     Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda68 & Lambda71 & Lambda133 & Lambda138 --> PgSelect8
-    Object132{{"Object[132∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda68 & Constant129 & Constant130 & Constant131 --> Object132
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda68 & Access72 & Lambda138 & Lambda143 --> PgSelect8
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda68 & Constant88 & Constant89 & Constant75 --> Object91
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant105 & Constant106 --> Object107
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant119 & Constant105 & Constant106 --> Object122
+    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda68 & Constant134 & Constant135 & Constant136 --> Object137
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant139 --> Lambda68
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant140 --> Lambda71
-    Object132 --> Lambda133
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant146 --> Lambda138
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant144 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant145 --> Lambda71
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant147 --> Lambda82
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant148 --> Lambda97
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant146 --> Lambda102
+    Access103{{"Access[103∈0] ➊<br />ᐸ102.0ᐳ"}}:::plan
+    Lambda102 --> Access103
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant149 --> Lambda113
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant150 --> Lambda128
+    Object137 --> Lambda138
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant151 --> Lambda143
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object89{{"Object[89∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant86 & Constant87 & Constant74 --> Object89
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant102 & Constant103 --> Object104
-    Object118{{"Object[118∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant115 & Constant102 & Constant103 --> Object118
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant142 --> Lambda81
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object89 --> Lambda90
-    Lambda95{{"Lambda[95∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant143 --> Lambda95
-    Lambda100{{"Lambda[100∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant141 --> Lambda100
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 --> Lambda105
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant144 --> Lambda110
-    Lambda119{{"Lambda[119∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object118 --> Lambda119
-    Lambda124{{"Lambda[124∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant145 --> Lambda124
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda68 & Lambda100 & Lambda105 & Lambda110 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda68 & Access103 & Lambda108 & Lambda113 --> PgSelect23
     PgSelect62[["PgSelect[62∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda68 & Lambda71 & Lambda119 & Lambda124 --> PgSelect62
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda68 & Access72 & Lambda123 & Lambda128 --> PgSelect62
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access55{{"Access[55∈3]<br />ᐸ23.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
@@ -115,7 +119,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -129,7 +133,7 @@ graph TD
     PgSelectSingle33 --> PgClassExpression35
     PgSelect40[["PgSelect[40∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression39 & Lambda68 & Lambda71 & Lambda90 & Lambda95 --> PgSelect40
+    Object11 & PgClassExpression39 & Lambda68 & Access72 & Lambda92 & Lambda97 --> PgSelect40
     PgClassExpression38{{"PgClassExpression[38∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression38
     PgSelectSingle25 --> PgClassExpression39
@@ -151,28 +155,28 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-5"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 72, 73, 74, 86, 87, 101, 102, 103, 115, 129, 130, 131, 139, 140, 141, 142, 143, 144, 145, 146, 11, 68, 71, 132, 133, 138<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 73, 74, 75, 88, 89, 104, 105, 106, 119, 134, 135, 136, 144, 145, 146, 147, 148, 149, 150, 151, 11, 68, 71, 72, 76, 77, 82, 91, 92, 97, 102, 103, 107, 108, 113, 122, 123, 128, 137, 138, 143<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant86,Constant87,Constant101,Constant102,Constant103,Constant115,Constant129,Constant130,Constant131,Object132,Lambda133,Lambda138,Constant139,Constant140,Constant141,Constant142,Constant143,Constant144,Constant145,Constant146 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 68, 72, 73, 74, 142, 86, 87, 143, 141, 101, 102, 103, 144, 115, 145, 11, 21, 6, 71<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant88,Constant89,Object91,Lambda92,Lambda97,Lambda102,Access103,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant119,Object122,Lambda123,Lambda128,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Constant144,Constant145,Constant146,Constant147,Constant148,Constant149,Constant150,Constant151 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 68, 103, 108, 113, 6, 72, 123, 128, 77, 82, 92, 97<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object75,Lambda76,Lambda81,Object89,Lambda90,Lambda95,Lambda100,Object104,Lambda105,Lambda110,Object118,Lambda119,Lambda124 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 68, 100, 105, 110, 6, 71, 119, 124, 76, 81, 90, 95<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 68, 103, 108, 113, 6, 72, 123, 128, 77, 82, 92, 97<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 68, 100, 105, 110, 6, 71, 119, 124, 76, 81, 90, 95<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 52<br />2: PgSelect[23], PgSelect[62]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 65"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 68, 103, 108, 113, 6, 72, 123, 128, 77, 82, 92, 97<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 52<br />2: PgSelect[23], PgSelect[62]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 65"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 68, 71, 76, 81, 90, 95<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 68, 72, 77, 82, 92, 97<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25, 11, 68, 71, 90, 95<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 38, 39<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25, 11, 68, 72, 92, 97<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 38, 39<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression38,PgClassExpression39,PgSelect40,First44,PgSelectSingle45 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[45]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.mermaid
@@ -11,121 +11,125 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access107{{"Access[107∈0] ➊<br />ᐸ106.0ᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda71 & Lambda76 & Lambda81 & Lambda92 & Lambda97 & Lambda104 & Lambda109 & Lambda114 & Lambda71 & Lambda128 & Lambda133 & Lambda68 & Lambda71 & Lambda146 & Lambda151 --> PgSelect8
-    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Lambda68 & Constant88 & Constant89 & Constant74 --> Object91
-    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda68 & Constant105 & Constant106 & Constant107 --> Object108
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda68 & Constant124 & Constant106 & Constant107 --> Object127
-    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda68 & Constant142 & Constant143 & Constant144 --> Object145
+    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access72 & Lambda77 & Lambda82 & Lambda94 & Lambda99 & Access107 & Lambda112 & Lambda117 & Access72 & Lambda132 & Lambda137 & Lambda68 & Access72 & Lambda151 & Lambda156 --> PgSelect8
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object93{{"Object[93∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda68 & Constant90 & Constant91 & Constant75 --> Object93
+    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda68 & Constant108 & Constant109 & Constant110 --> Object111
+    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant128 & Constant109 & Constant110 --> Object131
+    Object150{{"Object[150∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda68 & Constant147 & Constant148 & Constant149 --> Object150
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant152 --> Lambda68
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant153 --> Lambda71
-    Object75 --> Lambda76
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant155 --> Lambda81
-    Object91 --> Lambda92
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant156 --> Lambda97
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant154 --> Lambda104
-    Object108 --> Lambda109
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant157 --> Lambda114
-    Object127 --> Lambda128
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant158 --> Lambda133
-    Object145 --> Lambda146
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant159 --> Lambda151
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant157 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda71
+    Lambda71 --> Access72
+    Object76 --> Lambda77
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant160 --> Lambda82
+    Object93 --> Lambda94
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant161 --> Lambda99
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant159 --> Lambda106
+    Lambda106 --> Access107
+    Object111 --> Lambda112
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant162 --> Lambda117
+    Object131 --> Lambda132
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant163 --> Lambda137
+    Object150 --> Lambda151
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant164 --> Lambda156
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
     Constant66{{"Constant[66∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant69{{"Constant[69∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object118{{"Object[118∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access116{{"Access[116∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access116 & Constant66 & Constant66 & Lambda68 & Constant102 --> Object118
-    Object136{{"Object[136∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access134{{"Access[134∈3]<br />ᐸ12.2ᐳ"}}:::plan
-    Access134 & Constant66 & Constant66 & Lambda68 & Constant69 --> Object136
+    Object121{{"Object[121∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access119{{"Access[119∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access119 & Constant66 & Constant66 & Lambda68 & Constant104 --> Object121
+    Object140{{"Object[140∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access138{{"Access[138∈3]<br />ᐸ12.2ᐳ"}}:::plan
+    Access138 & Constant66 & Constant66 & Lambda68 & Constant69 --> Object140
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access55{{"Access[55∈3]<br />ᐸ119.hasMoreᐳ"}}:::plan
+    Access55{{"Access[55∈3]<br />ᐸ122.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
     Object56{{"Object[56∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access55 --> Object56
     PgPageInfo52{{"PgPageInfo[52∈3] ➊"}}:::plan
     Connection21 --> PgPageInfo52
-    Lambda119{{"Lambda[119∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda119 --> Access55
+    Lambda122{{"Lambda[122∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda122 --> Access55
     Lambda57{{"Lambda[57∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object56 --> Lambda57
     Lambda61{{"Lambda[61∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object60 --> Lambda61
     First63{{"First[63∈3]"}}:::plan
-    Lambda137{{"Lambda[137∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda137 --> First63
+    Lambda141{{"Lambda[141∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda141 --> First63
     PgSelectSingle64{{"PgSelectSingle[64∈3]<br />ᐸmessagesᐳ"}}:::plan
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    __Item12 --> Access116
-    Object118 --> Lambda119
-    __Item12 --> Access134
-    Object136 --> Lambda137
-    __Item24[/"__Item[24∈4]<br />ᐸ119ᐳ"\]:::itemplan
-    Lambda119 ==> __Item24
+    __Item12 --> Access119
+    Object121 --> Lambda122
+    __Item12 --> Access138
+    Object140 --> Lambda141
+    __Item24[/"__Item[24∈4]<br />ᐸ122ᐳ"\]:::itemplan
+    Lambda122 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys83
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -133,9 +137,9 @@ graph TD
     PgClassExpression38{{"PgClassExpression[38∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression38
     PgSelectSingle45{{"PgSelectSingle[45∈7]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys98{{"RemapKeys[98∈7]<br />ᐸ25:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys98 --> PgSelectSingle45
-    PgSelectSingle25 --> RemapKeys98
+    RemapKeys100{{"RemapKeys[100∈7]<br />ᐸ25:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys100 --> PgSelectSingle45
+    PgSelectSingle25 --> RemapKeys100
     PgClassExpression46{{"PgClassExpression[46∈8]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle45 --> PgClassExpression46
     PgClassExpression47{{"PgClassExpression[47∈8]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -150,30 +154,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-5"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 66, 69, 72, 73, 74, 88, 89, 102, 105, 106, 107, 124, 142, 143, 144, 152, 153, 154, 155, 156, 157, 158, 159, 11, 68, 71, 75, 76, 81, 91, 92, 97, 104, 108, 109, 114, 127, 128, 133, 145, 146, 151<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 66, 69, 73, 74, 75, 90, 91, 104, 108, 109, 110, 128, 147, 148, 149, 157, 158, 159, 160, 161, 162, 163, 164, 11, 68, 71, 72, 76, 77, 82, 93, 94, 99, 106, 107, 111, 112, 117, 131, 132, 137, 150, 151, 156<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant66,Lambda68,Constant69,Lambda71,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant88,Constant89,Object91,Lambda92,Lambda97,Constant102,Lambda104,Constant105,Constant106,Constant107,Object108,Lambda109,Lambda114,Constant124,Object127,Lambda128,Lambda133,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158,Constant159 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 6, 66, 68, 102, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant66,Lambda68,Constant69,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant90,Constant91,Object93,Lambda94,Lambda99,Constant104,Lambda106,Access107,Constant108,Constant109,Constant110,Object111,Lambda112,Lambda117,Constant128,Object131,Lambda132,Lambda137,Constant147,Constant148,Constant149,Object150,Lambda151,Lambda156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163,Constant164 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 6, 66, 68, 104, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 6, 12, 66, 68, 102, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 6, 12, 66, 68, 104, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 66, 68, 102, 69<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 66, 68, 104, 69<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgClassExpression65,Access116,Object118,Lambda119,Access134,Object136,Lambda137 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ119ᐳ[24]"):::bucket
+    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgClassExpression65,Access119,Object121,Lambda122,Access138,Object140,Lambda141 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ122ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys82 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys83 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression38,PgSelectSingle45,RemapKeys98 bucket7
+    class Bucket7,PgClassExpression38,PgSelectSingle45,RemapKeys100 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[45]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression46,PgClassExpression47 bucket8

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.deopt.mermaid
@@ -12,69 +12,71 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda103 & Lambda108 --> PgSelect8
-    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant99 & Constant100 & Constant101 --> Object102
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda107 & Lambda112 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109 --> Lambda53
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant110 --> Lambda56
-    Object102 --> Lambda103
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant114 --> Lambda108
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant114 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant115 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant116 --> Lambda82
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant117 --> Lambda97
+    Object106 --> Lambda107
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant118 --> Lambda112
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant85 & Constant86 & Constant87 --> Object88
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant111 --> Lambda66
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object74 --> Lambda75
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant112 --> Lambda80
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant113 --> Lambda94
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Lambda56 & Lambda89 & Lambda94 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Access57 & Lambda92 & Lambda97 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -85,7 +87,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression26
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect28
     PgSelectSingle25 --> PgClassExpression27
     First32{{"First[32∈6]"}}:::plan
     PgSelect28 --> First32
@@ -105,7 +107,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression41
     PgSelect43[["PgSelect[43∈9]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈9]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect43
     PgSelectSingle25 --> PgClassExpression42
     First47{{"First[47∈9]"}}:::plan
     PgSelect43 --> First47
@@ -119,34 +121,34 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-6"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 71, 72, 85, 86, 87, 99, 100, 101, 109, 110, 111, 112, 113, 114, 11, 53, 56, 102, 103, 108<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 73, 74, 88, 89, 90, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 57, 61, 62, 67, 76, 77, 82, 91, 92, 97, 106, 107, 112<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant71,Constant72,Constant85,Constant86,Constant87,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 111, 71, 72, 112, 85, 86, 87, 113, 11, 21, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object74,Lambda75,Lambda80,Object88,Lambda89,Lambda94 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 53, 56, 61, 66, 75, 80<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 53, 57, 62, 67, 77, 82<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26 bucket5
-    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41 bucket8
-    Bucket9("Bucket 9 (defer)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket9("Bucket 9 (defer)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket9
     Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{9}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-6.mermaid
@@ -11,83 +11,85 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda56 & Lambda89 & Lambda94 & Lambda53 & Lambda56 & Lambda108 & Lambda113 --> PgSelect8
-    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda53 & Constant85 & Constant86 & Constant87 --> Object88
-    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant104 & Constant105 & Constant106 --> Object107
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access57 & Lambda92 & Lambda97 & Lambda53 & Access57 & Lambda112 & Lambda117 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant88 & Constant89 & Constant90 --> Object91
+    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant108 & Constant109 & Constant110 --> Object111
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda53
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant115 --> Lambda56
-    Object88 --> Lambda89
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant118 --> Lambda94
-    Object107 --> Lambda108
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant119 --> Lambda113
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant119 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant121 --> Lambda82
+    Object91 --> Lambda92
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant122 --> Lambda97
+    Object111 --> Lambda112
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant123 --> Lambda117
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
     Constant51{{"Constant[51∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant54{{"Constant[54∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant116 --> Lambda66
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object74 --> Lambda75
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant117 --> Lambda80
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object98{{"Object[98∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access96{{"Access[96∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access96 & Constant51 & Constant51 & Lambda53 & Constant54 --> Object98
-    __Item12 --> Access96
-    Lambda99{{"Lambda[99∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object98 --> Lambda99
-    __Item24[/"__Item[24∈4]<br />ᐸ99ᐳ"\]:::itemplan
-    Lambda99 ==> __Item24
+    Object101{{"Object[101∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access99{{"Access[99∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access99 & Constant51 & Constant51 & Lambda53 & Constant54 --> Object101
+    __Item12 --> Access99
+    Lambda102{{"Lambda[102∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object101 --> Lambda102
+    __Item24[/"__Item[24∈4]<br />ᐸ102ᐳ"\]:::itemplan
+    Lambda102 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelect28[["PgSelect[28∈6]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈6]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect28
     PgSelectSingle25 --> PgClassExpression27
     First32{{"First[32∈6]"}}:::plan
     PgSelect28 --> First32
@@ -107,7 +109,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression41
     PgSelect43[["PgSelect[43∈9]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈9]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect43
     PgSelectSingle25 --> PgClassExpression42
     First47{{"First[47∈9]"}}:::plan
     PgSelect43 --> First47
@@ -121,34 +123,34 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-6"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 51, 54, 57, 58, 59, 71, 72, 85, 86, 87, 104, 105, 106, 114, 115, 116, 117, 118, 119, 11, 53, 56, 88, 89, 94, 107, 108, 113<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 51, 54, 58, 59, 60, 73, 74, 88, 89, 90, 108, 109, 110, 118, 119, 120, 121, 122, 123, 11, 53, 56, 57, 61, 62, 67, 76, 77, 82, 91, 92, 97, 111, 112, 117<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Constant51,Lambda53,Constant54,Lambda56,Constant57,Constant58,Constant59,Constant71,Constant72,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 116, 71, 72, 117, 51, 54, 21, 11, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Constant51,Lambda53,Constant54,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant108,Constant109,Constant110,Object111,Lambda112,Lambda117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 51, 53, 54, 21, 11, 57, 62, 67, 77, 82<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object74,Lambda75,Lambda80 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 12, 51, 53, 54, 21, 11, 56, 61, 66, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 12, 51, 53, 54, 21, 11, 57, 62, 67, 77, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 12, 51, 53, 54, 21, 11, 56, 61, 66, 75, 80<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 12, 51, 53, 54, 21, 11, 57, 62, 67, 77, 82<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Access96,Object98,Lambda99 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 53, 56, 61, 66, 75, 80<br /><br />ROOT __Item{4}ᐸ99ᐳ[24]"):::bucket
+    class Bucket3,Access99,Object101,Lambda102 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 53, 57, 62, 67, 77, 82<br /><br />ROOT __Item{4}ᐸ102ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26 bucket5
-    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor38,PgClassExpression39,List40,PgClassExpression41 bucket8
-    Bucket9("Bucket 9 (defer)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket9("Bucket 9 (defer)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket9
     Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{9}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.deopt.mermaid
@@ -12,63 +12,65 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda103 & Lambda108 --> PgSelect8
-    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant99 & Constant100 & Constant101 --> Object102
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda107 & Lambda112 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109 --> Lambda53
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant110 --> Lambda56
-    Object102 --> Lambda103
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant114 --> Lambda108
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant114 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant115 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant116 --> Lambda82
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant117 --> Lambda97
+    Object106 --> Lambda107
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant118 --> Lambda112
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant85 & Constant86 & Constant87 --> Object88
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant111 --> Lambda66
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object74 --> Lambda75
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant112 --> Lambda80
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant113 --> Lambda94
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Lambda56 & Lambda89 & Lambda94 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Access57 & Lambda92 & Lambda97 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
@@ -85,7 +87,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression26
     PgSelect28[["PgSelect[28∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect28
     PgSelectSingle25 --> PgClassExpression27
     First32{{"First[32∈7]"}}:::plan
     PgSelect28 --> First32
@@ -105,7 +107,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression41
     PgSelect43[["PgSelect[43∈10]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈10]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect43
     PgSelectSingle25 --> PgClassExpression42
     First47{{"First[47∈10]"}}:::plan
     PgSelect43 --> First47
@@ -119,37 +121,37 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-7"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 71, 72, 85, 86, 87, 99, 100, 101, 109, 110, 111, 112, 113, 114, 11, 53, 56, 102, 103, 108<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 73, 74, 88, 89, 90, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 57, 61, 62, 67, 76, 77, 82, 91, 92, 97, 106, 107, 112<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant71,Constant72,Constant85,Constant86,Constant87,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 111, 71, 72, 112, 85, 86, 87, 113, 11, 21, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object74,Lambda75,Lambda80,Object88,Lambda89,Lambda94 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80"):::bucket
+    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 56, 61, 66, 75, 80<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 57, 62, 67, 77, 82<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item24,PgSelectSingle25 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26 bucket6
-    Bucket7("Bucket 7 (defer)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket7("Bucket 7 (defer)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[33]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression34,PgClassExpression35 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgCursor38,PgClassExpression39,List40,PgClassExpression41 bucket9
-    Bucket10("Bucket 10 (defer)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket10("Bucket 10 (defer)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{10}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-7.mermaid
@@ -12,63 +12,65 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda53 & Lambda56 & Lambda103 & Lambda108 --> PgSelect8
-    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda53 & Constant99 & Constant100 & Constant101 --> Object102
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda53 & Access57 & Lambda107 & Lambda112 --> PgSelect8
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant103 & Constant104 & Constant105 --> Object106
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109 --> Lambda53
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant110 --> Lambda56
-    Object102 --> Lambda103
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant114 --> Lambda108
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda53
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant114 --> Lambda56
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant115 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant116 --> Lambda82
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant117 --> Lambda97
+    Object106 --> Lambda107
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant118 --> Lambda112
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant85 & Constant86 & Constant87 --> Object88
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant111 --> Lambda66
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object74 --> Lambda75
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant112 --> Lambda80
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant113 --> Lambda94
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈4]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Lambda56 & Lambda89 & Lambda94 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda53 & Access57 & Lambda92 & Lambda97 --> PgSelect23
     __Item24[/"__Item[24∈5]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈5]<br />ᐸmessagesᐳ"}}:::plan
@@ -85,7 +87,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression26
     PgSelect28[["PgSelect[28∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect28
     PgSelectSingle25 --> PgClassExpression27
     First32{{"First[32∈7]"}}:::plan
     PgSelect28 --> First32
@@ -105,7 +107,7 @@ graph TD
     PgSelectSingle25 --> PgClassExpression41
     PgSelect43[["PgSelect[43∈10]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈10]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect43
     PgSelectSingle25 --> PgClassExpression42
     First47{{"First[47∈10]"}}:::plan
     PgSelect43 --> First47
@@ -119,37 +121,37 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.defer-7"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 57, 58, 59, 71, 72, 85, 86, 87, 99, 100, 101, 109, 110, 111, 112, 113, 114, 11, 53, 56, 102, 103, 108<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 58, 59, 60, 73, 74, 88, 89, 90, 103, 104, 105, 113, 114, 115, 116, 117, 118, 11, 53, 56, 57, 61, 62, 67, 76, 77, 82, 91, 92, 97, 106, 107, 112<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Constant57,Constant58,Constant59,Constant71,Constant72,Constant85,Constant86,Constant87,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 53, 57, 58, 59, 111, 71, 72, 112, 85, 86, 87, 113, 11, 21, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object60,Lambda61,Lambda66,Object74,Lambda75,Lambda80,Object88,Lambda89,Lambda94 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 53, 56, 89, 94, 61, 66, 75, 80"):::bucket
+    Bucket3("Bucket 3 (defer)<br />Deps: 13, 11, 21, 53, 57, 92, 97, 62, 67, 77, 82"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 53, 56, 89, 94, 61, 66, 75, 80<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 53, 57, 92, 97, 62, 67, 77, 82<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect23 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 56, 61, 66, 75, 80<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 53, 57, 62, 67, 77, 82<br /><br />ROOT __Item{5}ᐸ23ᐳ[24]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item24,PgSelectSingle25 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression26 bucket6
-    Bucket7("Bucket 7 (defer)<br />Deps: 25, 11, 53, 56, 61, 66<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket7("Bucket 7 (defer)<br />Deps: 25, 11, 53, 57, 62, 67<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[33]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression34,PgClassExpression35 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgCursor38,PgClassExpression39,List40,PgClassExpression41 bucket9
-    Bucket10("Bucket 10 (defer)<br />Deps: 25, 11, 53, 56, 75, 80<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket10("Bucket 10 (defer)<br />Deps: 25, 11, 53, 57, 77, 82<br /><br />1: <br />ᐳ: PgClassExpression[42]<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{10}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.deopt.mermaid
@@ -12,83 +12,87 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access84{{"Access[84∈0] ➊<br />ᐸ83.0ᐳ"}}:::plan
     Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda80 & Lambda83 & Lambda145 & Lambda150 --> PgSelect8
-    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda80 & Constant141 & Constant142 & Constant143 --> Object144
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda80 & Access84 & Lambda150 & Lambda155 --> PgSelect8
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda80 & Constant85 & Constant86 & Constant87 --> Object88
+    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda80 & Constant100 & Constant101 & Constant87 --> Object103
+    Object119{{"Object[119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda80 & Constant116 & Constant117 & Constant118 --> Object119
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda80 & Constant131 & Constant117 & Constant118 --> Object134
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda80 & Constant146 & Constant147 & Constant148 --> Object149
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant151 --> Lambda80
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant152 --> Lambda83
-    Object144 --> Lambda145
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant158 --> Lambda150
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant156 --> Lambda80
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant157 --> Lambda83
+    Lambda83 --> Access84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object88 --> Lambda89
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant159 --> Lambda94
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object103 --> Lambda104
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant160 --> Lambda109
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda114
+    Access115{{"Access[115∈0] ➊<br />ᐸ114.0ᐳ"}}:::plan
+    Lambda114 --> Access115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object119 --> Lambda120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant161 --> Lambda125
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object134 --> Lambda135
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant162 --> Lambda140
+    Object149 --> Lambda150
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant163 --> Lambda155
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object87{{"Object[87∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant84 & Constant85 & Constant86 --> Object87
-    Object101{{"Object[101∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant98 & Constant99 & Constant86 --> Object101
-    Object116{{"Object[116∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant113 & Constant114 & Constant115 --> Object116
-    Object130{{"Object[130∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant127 & Constant114 & Constant115 --> Object130
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object87 --> Lambda88
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant154 --> Lambda93
-    Lambda102{{"Lambda[102∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object101 --> Lambda102
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant155 --> Lambda107
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant153 --> Lambda112
-    Lambda117{{"Lambda[117∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object116 --> Lambda117
-    Lambda122{{"Lambda[122∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant156 --> Lambda122
-    Lambda131{{"Lambda[131∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object130 --> Lambda131
-    Lambda136{{"Lambda[136∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157 --> Lambda136
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Lambda112 & Lambda117 & Lambda122 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Access115 & Lambda120 & Lambda125 --> PgSelect23
     PgSelect74[["PgSelect[74∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Lambda83 & Lambda131 & Lambda136 --> PgSelect74
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda80 & Access84 & Lambda135 & Lambda140 --> PgSelect74
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access55{{"Access[55∈3]<br />ᐸ23.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
@@ -135,7 +139,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda80 & Lambda83 & Lambda88 & Lambda93 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda80 & Access84 & Lambda89 & Lambda94 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -149,7 +153,7 @@ graph TD
     PgSelectSingle33 --> PgClassExpression35
     PgSelect43[["PgSelect[43∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda80 & Lambda83 & Lambda102 & Lambda107 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda80 & Access84 & Lambda104 & Lambda109 --> PgSelect43
     PgCursor38{{"PgCursor[38∈7]"}}:::plan
     List40{{"List[40∈7]<br />ᐸ39ᐳ"}}:::plan
     List40 --> PgCursor38
@@ -171,28 +175,28 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 84, 85, 86, 98, 99, 113, 114, 115, 127, 141, 142, 143, 151, 152, 153, 154, 155, 156, 157, 158, 11, 80, 83, 144, 145, 150<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 85, 86, 87, 100, 101, 116, 117, 118, 131, 146, 147, 148, 156, 157, 158, 159, 160, 161, 162, 163, 11, 80, 83, 84, 88, 89, 94, 103, 104, 109, 114, 115, 119, 120, 125, 134, 135, 140, 149, 150, 155<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda80,Lambda83,Constant84,Constant85,Constant86,Constant98,Constant99,Constant113,Constant114,Constant115,Constant127,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 80, 84, 85, 86, 154, 98, 99, 155, 153, 113, 114, 115, 156, 127, 157, 11, 21, 6, 83<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda80,Lambda83,Access84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant100,Constant101,Object103,Lambda104,Lambda109,Lambda114,Access115,Constant116,Constant117,Constant118,Object119,Lambda120,Lambda125,Constant131,Object134,Lambda135,Lambda140,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 80, 115, 120, 125, 6, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object87,Lambda88,Lambda93,Object101,Lambda102,Lambda107,Lambda112,Object116,Lambda117,Lambda122,Object130,Lambda131,Lambda136 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 112, 117, 122, 6, 83, 131, 136, 88, 93, 102, 107<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 115, 120, 125, 6, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 112, 117, 122, 6, 83, 131, 136, 88, 93, 102, 107<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 52<br />2: PgSelect[23], PgSelect[74]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 65, 71"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 80, 115, 120, 125, 6, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 52<br />2: PgSelect[23], PgSelect[74]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 65, 71"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,PgSelect74,First75,PgSelectSingle76,PgClassExpression77 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 83, 88, 93, 102, 107<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 84, 89, 94, 104, 109<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 88, 93<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 89, 94<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 102, 107<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 104, 109<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.mermaid
@@ -11,102 +11,106 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access84{{"Access[84∈0] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access119{{"Access[119∈0] ➊<br />ᐸ118.0ᐳ"}}:::plan
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda83 & Lambda88 & Lambda93 & Lambda104 & Lambda109 & Lambda116 & Lambda121 & Lambda126 & Lambda83 & Lambda140 & Lambda145 & Lambda80 & Lambda83 & Lambda158 & Lambda163 --> PgSelect8
-    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda80 & Constant84 & Constant85 & Constant86 --> Object87
-    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Lambda80 & Constant100 & Constant101 & Constant86 --> Object103
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda80 & Constant117 & Constant118 & Constant119 --> Object120
-    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda80 & Constant136 & Constant118 & Constant119 --> Object139
-    Object157{{"Object[157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda80 & Constant154 & Constant155 & Constant156 --> Object157
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access84 & Lambda89 & Lambda94 & Lambda106 & Lambda111 & Access119 & Lambda124 & Lambda129 & Access84 & Lambda144 & Lambda149 & Lambda80 & Access84 & Lambda163 & Lambda168 --> PgSelect8
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda80 & Constant85 & Constant86 & Constant87 --> Object88
+    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda80 & Constant102 & Constant103 & Constant87 --> Object105
+    Object123{{"Object[123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda80 & Constant120 & Constant121 & Constant122 --> Object123
+    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda80 & Constant140 & Constant121 & Constant122 --> Object143
+    Object162{{"Object[162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda80 & Constant159 & Constant160 & Constant161 --> Object162
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant164 --> Lambda80
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant165 --> Lambda83
-    Object87 --> Lambda88
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant167 --> Lambda93
-    Object103 --> Lambda104
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant168 --> Lambda109
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant166 --> Lambda116
-    Object120 --> Lambda121
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant169 --> Lambda126
-    Object139 --> Lambda140
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant170 --> Lambda145
-    Object157 --> Lambda158
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant171 --> Lambda163
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant169 --> Lambda80
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant170 --> Lambda83
+    Lambda83 --> Access84
+    Object88 --> Lambda89
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant172 --> Lambda94
+    Object105 --> Lambda106
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant173 --> Lambda111
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant171 --> Lambda118
+    Lambda118 --> Access119
+    Object123 --> Lambda124
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant174 --> Lambda129
+    Object143 --> Lambda144
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant175 --> Lambda149
+    Object162 --> Lambda163
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant176 --> Lambda168
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
     Constant78{{"Constant[78∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant81{{"Constant[81∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object130{{"Object[130∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access128{{"Access[128∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access128 & Constant78 & Constant78 & Lambda80 & Constant114 --> Object130
-    Object148{{"Object[148∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access146{{"Access[146∈3]<br />ᐸ12.2ᐳ"}}:::plan
-    Access146 & Constant78 & Constant78 & Lambda80 & Constant81 --> Object148
+    Object133{{"Object[133∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access131{{"Access[131∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access131 & Constant78 & Constant78 & Lambda80 & Constant116 --> Object133
+    Object152{{"Object[152∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access150{{"Access[150∈3]<br />ᐸ12.2ᐳ"}}:::plan
+    Access150 & Constant78 & Constant78 & Lambda80 & Constant81 --> Object152
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access55{{"Access[55∈3]<br />ᐸ131.hasMoreᐳ"}}:::plan
+    Access55{{"Access[55∈3]<br />ᐸ134.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
     Object56{{"Object[56∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access55 --> Object56
     PgPageInfo52{{"PgPageInfo[52∈3] ➊"}}:::plan
     Connection21 --> PgPageInfo52
-    Lambda131{{"Lambda[131∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda131 --> Access55
+    Lambda134{{"Lambda[134∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda134 --> Access55
     Lambda57{{"Lambda[57∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object56 --> Lambda57
     Lambda61{{"Lambda[61∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object60 --> Lambda61
     First63{{"First[63∈3]"}}:::plan
-    Lambda131 --> First63
+    Lambda134 --> First63
     PgSelectSingle64{{"PgSelectSingle[64∈3]<br />ᐸmessagesᐳ"}}:::plan
     First63 --> PgSelectSingle64
     PgCursor65{{"PgCursor[65∈3]"}}:::plan
@@ -116,7 +120,7 @@ graph TD
     PgSelectSingle64 --> PgClassExpression66
     PgClassExpression66 --> List67
     Last69{{"Last[69∈3]"}}:::plan
-    Lambda131 --> Last69
+    Lambda134 --> Last69
     PgSelectSingle70{{"PgSelectSingle[70∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last69 --> PgSelectSingle70
     PgCursor71{{"PgCursor[71∈3]"}}:::plan
@@ -126,26 +130,26 @@ graph TD
     PgSelectSingle70 --> PgClassExpression72
     PgClassExpression72 --> List73
     First75{{"First[75∈3]"}}:::plan
-    Lambda149{{"Lambda[149∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda149 --> First75
+    Lambda153{{"Lambda[153∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda153 --> First75
     PgSelectSingle76{{"PgSelectSingle[76∈3]<br />ᐸmessagesᐳ"}}:::plan
     First75 --> PgSelectSingle76
     PgClassExpression77{{"PgClassExpression[77∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle76 --> PgClassExpression77
-    __Item12 --> Access128
-    Object130 --> Lambda131
-    __Item12 --> Access146
-    Object148 --> Lambda149
-    __Item24[/"__Item[24∈4]<br />ᐸ131ᐳ"\]:::itemplan
-    Lambda131 ==> __Item24
+    __Item12 --> Access131
+    Object133 --> Lambda134
+    __Item12 --> Access150
+    Object152 --> Lambda153
+    __Item24[/"__Item[24∈4]<br />ᐸ134ᐳ"\]:::itemplan
+    Lambda134 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys94{{"RemapKeys[94∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys94 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys94
+    RemapKeys95{{"RemapKeys[95∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys95 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys95
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -159,9 +163,9 @@ graph TD
     PgClassExpression41{{"PgClassExpression[41∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression41
     PgSelectSingle48{{"PgSelectSingle[48∈7]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys110{{"RemapKeys[110∈7]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys110 --> PgSelectSingle48
-    PgSelectSingle25 --> RemapKeys110
+    RemapKeys112{{"RemapKeys[112∈7]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys112 --> PgSelectSingle48
+    PgSelectSingle25 --> RemapKeys112
     PgClassExpression49{{"PgClassExpression[49∈8]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈8]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -170,30 +174,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 78, 81, 84, 85, 86, 100, 101, 114, 117, 118, 119, 136, 154, 155, 156, 164, 165, 166, 167, 168, 169, 170, 171, 11, 80, 83, 87, 88, 93, 103, 104, 109, 116, 120, 121, 126, 139, 140, 145, 157, 158, 163<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 78, 81, 85, 86, 87, 102, 103, 116, 120, 121, 122, 140, 159, 160, 161, 169, 170, 171, 172, 173, 174, 175, 176, 11, 80, 83, 84, 88, 89, 94, 105, 106, 111, 118, 119, 123, 124, 129, 143, 144, 149, 162, 163, 168<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant78,Lambda80,Constant81,Lambda83,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant100,Constant101,Object103,Lambda104,Lambda109,Constant114,Lambda116,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant136,Object139,Lambda140,Lambda145,Constant154,Constant155,Constant156,Object157,Lambda158,Lambda163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169,Constant170,Constant171 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 6, 78, 80, 114, 81<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant78,Lambda80,Constant81,Lambda83,Access84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant102,Constant103,Object105,Lambda106,Lambda111,Constant116,Lambda118,Access119,Constant120,Constant121,Constant122,Object123,Lambda124,Lambda129,Constant140,Object143,Lambda144,Lambda149,Constant159,Constant160,Constant161,Object162,Lambda163,Lambda168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 21, 6, 78, 80, 116, 81<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 6, 12, 78, 80, 114, 81<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 21, 6, 12, 78, 80, 116, 81<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 78, 80, 114, 81<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 78, 80, 116, 81<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,First75,PgSelectSingle76,PgClassExpression77,Access128,Object130,Lambda131,Access146,Object148,Lambda149 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ131ᐳ[24]"):::bucket
+    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,First75,PgSelectSingle76,PgClassExpression77,Access131,Object133,Lambda134,Access150,Object152,Lambda153 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ134ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys94 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys95 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys110 bucket7
+    class Bucket7,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys112 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[48]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression49,PgClassExpression50 bucket8

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.deopt.mermaid
@@ -12,60 +12,62 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda38 & Lambda41 & Lambda74 & Lambda79 --> PgSelect8
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant70 & Constant71 & Constant72 --> Object73
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda38 & Access42 & Lambda77 & Lambda82 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant73 & Constant74 & Constant75 --> Object76
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant80 --> Lambda38
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda41
-    Object73 --> Lambda74
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant84 --> Lambda79
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda41
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant85 --> Lambda52
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant86 --> Lambda67
+    Object76 --> Lambda77
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant87 --> Lambda82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant56 & Constant57 & Constant58 --> Object59
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant82 --> Lambda51
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object59 --> Lambda60
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant83 --> Lambda65
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda38 & Lambda41 & Lambda60 & Lambda65 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda38 & Access42 & Lambda62 & Lambda67 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -74,7 +76,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda38 & Lambda41 & Lambda46 & Lambda51 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda38 & Access42 & Lambda47 & Lambda52 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -90,22 +92,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 42, 43, 44, 56, 57, 58, 70, 71, 72, 80, 81, 82, 83, 84, 11, 38, 41, 73, 74, 79<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 43, 44, 45, 58, 59, 60, 73, 74, 75, 83, 84, 85, 86, 87, 11, 38, 41, 42, 46, 47, 52, 61, 62, 67, 76, 77, 82<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Constant42,Constant43,Constant44,Constant56,Constant57,Constant58,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant80,Constant81,Constant82,Constant83,Constant84 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 38, 42, 43, 44, 82, 56, 57, 58, 83, 11, 21, 41<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86,Constant87 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object45,Lambda46,Lambda51,Object59,Lambda60,Lambda65 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 41, 60, 65, 46, 51<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 41, 60, 65, 46, 51<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 38, 41, 46, 51<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 38, 42, 47, 52<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 38, 41, 46, 51<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 38, 42, 47, 52<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-1.mermaid
@@ -12,60 +12,62 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda38 & Lambda41 & Lambda76 & Lambda81 --> PgSelect8
-    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant72 & Constant73 & Constant74 --> Object75
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda38 & Access42 & Lambda79 & Lambda84 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant60 & Constant61 & Constant62 --> Object63
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant75 & Constant76 & Constant77 --> Object78
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda38
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda41
-    Object75 --> Lambda76
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant86 --> Lambda81
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda41
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant87 --> Lambda52
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object63 --> Lambda64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant88 --> Lambda69
+    Object78 --> Lambda79
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant89 --> Lambda84
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object61{{"Object[61∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant58 & Constant59 & Constant60 --> Object61
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant84 --> Lambda51
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant85 --> Lambda67
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda41 & Lambda46 & Lambda51 & Lambda38 & Lambda41 & Lambda62 & Lambda67 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access42 & Lambda47 & Lambda52 & Lambda38 & Access42 & Lambda64 & Lambda69 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -75,9 +77,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys52{{"RemapKeys[52∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys52 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys52
+    RemapKeys53{{"RemapKeys[53∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys53 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys53
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -86,16 +88,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 42, 43, 44, 58, 59, 60, 72, 73, 74, 82, 83, 84, 85, 86, 11, 38, 41, 75, 76, 81<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 43, 44, 45, 60, 61, 62, 75, 76, 77, 85, 86, 87, 88, 89, 11, 38, 41, 42, 46, 47, 52, 63, 64, 69, 78, 79, 84<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Constant42,Constant43,Constant44,Constant58,Constant59,Constant60,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 38, 42, 43, 44, 84, 58, 59, 60, 85, 11, 21, 41<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant75,Constant76,Constant77,Object78,Lambda79,Lambda84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object45,Lambda46,Lambda51,Object61,Lambda62,Lambda67 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 41, 46, 51, 38, 62, 67<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 41, 46, 51, 38, 62, 67<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
@@ -103,7 +105,7 @@ graph TD
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys52 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys53 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.deopt.mermaid
@@ -12,103 +12,107 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda69 & Lambda72 & Lambda162 & Lambda167 --> PgSelect8
-    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda69 & Constant158 & Constant159 & Constant160 --> Object161
+    Access73{{"Access[73∈0] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda69 & Access73 & Lambda169 & Lambda174 --> PgSelect8
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda69 & Constant74 & Constant75 & Constant76 --> Object77
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda69 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda69 & Constant104 & Constant105 & Constant76 --> Object107
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant119 & Constant90 & Constant91 --> Object122
+    Object138{{"Object[138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant135 & Constant90 & Constant91 --> Object138
+    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda69 & Constant150 & Constant90 & Constant91 --> Object153
+    Object168{{"Object[168∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda69 & Constant165 & Constant166 & Constant167 --> Object168
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant168 --> Lambda69
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant169 --> Lambda72
-    Object161 --> Lambda162
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant177 --> Lambda167
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant175 --> Lambda69
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant176 --> Lambda72
+    Lambda72 --> Access73
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant178 --> Lambda83
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant179 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant180 --> Lambda113
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant181 --> Lambda128
+    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant177 --> Lambda133
+    Access134{{"Access[134∈0] ➊<br />ᐸ133.0ᐳ"}}:::plan
+    Lambda133 --> Access134
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object138 --> Lambda139
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant182 --> Lambda144
+    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object153 --> Lambda154
+    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant183 --> Lambda159
+    Object168 --> Lambda169
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant184 --> Lambda174
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object76{{"Object[76∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant73 & Constant74 & Constant75 --> Object76
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant101 & Constant102 & Constant75 --> Object104
-    Object118{{"Object[118∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant115 & Constant88 & Constant89 --> Object118
-    Object133{{"Object[133∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant130 & Constant88 & Constant89 --> Object133
-    Object147{{"Object[147∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant144 & Constant88 & Constant89 --> Object147
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant171 --> Lambda82
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object90 --> Lambda91
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant172 --> Lambda96
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 --> Lambda105
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant173 --> Lambda110
-    Lambda119{{"Lambda[119∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object118 --> Lambda119
-    Lambda124{{"Lambda[124∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant174 --> Lambda124
-    Lambda129{{"Lambda[129∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant170 --> Lambda129
-    Lambda134{{"Lambda[134∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object133 --> Lambda134
-    Lambda139{{"Lambda[139∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant175 --> Lambda139
-    Lambda148{{"Lambda[148∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object147 --> Lambda148
-    Lambda153{{"Lambda[153∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant176 --> Lambda153
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda91 & Lambda96 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda93 & Lambda98 --> PgSelect23
     PgSelect36[["PgSelect[36∈3@s]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda119 & Lambda124 --> PgSelect36
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda123 & Lambda128 --> PgSelect36
     PgSelect52[["PgSelect[52∈3]<br />ᐸmessages+1ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda129 & Lambda134 & Lambda139 --> PgSelect52
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access134 & Lambda139 & Lambda144 --> PgSelect52
     PgSelect63[["PgSelect[63∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda148 & Lambda153 --> PgSelect63
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda154 & Lambda159 --> PgSelect63
     Object61{{"Object[61∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access56{{"Access[56∈3]<br />ᐸ52.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access56 --> Object61
@@ -135,7 +139,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda69 & Lambda72 & Lambda77 & Lambda82 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda69 & Access73 & Lambda78 & Lambda83 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -153,7 +157,7 @@ graph TD
     __Item37 --> PgSelectSingle38
     PgSelect44[["PgSelect[44∈8]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression43{{"PgClassExpression[43∈8]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression43 & Lambda69 & Lambda72 & Lambda105 & Lambda110 --> PgSelect44
+    Object11 & PgClassExpression43 & Lambda69 & Access73 & Lambda108 & Lambda113 --> PgSelect44
     PgCursor39{{"PgCursor[39∈8]"}}:::plan
     List41{{"List[41∈8]<br />ᐸ40ᐳ"}}:::plan
     List41 --> PgCursor39
@@ -175,31 +179,31 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-2"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 73, 74, 75, 87, 88, 89, 101, 102, 115, 130, 144, 158, 159, 160, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 11, 69, 72, 161, 162, 167<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 74, 75, 76, 89, 90, 91, 104, 105, 119, 135, 150, 165, 166, 167, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 11, 69, 72, 73, 77, 78, 83, 92, 93, 98, 107, 108, 113, 122, 123, 128, 133, 134, 138, 139, 144, 153, 154, 159, 168, 169, 174<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda69,Lambda72,Constant73,Constant74,Constant75,Constant87,Constant88,Constant89,Constant101,Constant102,Constant115,Constant130,Constant144,Constant158,Constant159,Constant160,Object161,Lambda162,Lambda167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 69, 73, 74, 75, 171, 87, 88, 89, 172, 101, 102, 173, 115, 174, 170, 130, 175, 144, 176, 11, 21, 72, 6<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda69,Lambda72,Access73,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Constant105,Object107,Lambda108,Lambda113,Constant119,Object122,Lambda123,Lambda128,Lambda133,Access134,Constant135,Object138,Lambda139,Lambda144,Constant150,Object153,Lambda154,Lambda159,Constant165,Constant166,Constant167,Object168,Lambda169,Lambda174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 69, 73, 93, 98, 123, 128, 134, 139, 144, 6, 154, 159, 78, 83, 108, 113<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object76,Lambda77,Lambda82,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110,Object118,Lambda119,Lambda124,Lambda129,Object133,Lambda134,Lambda139,Object147,Lambda148,Lambda153 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 69, 72, 91, 96, 119, 124, 129, 134, 139, 6, 148, 153, 77, 82, 105, 110<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 69, 73, 93, 98, 123, 128, 134, 139, 144, 6, 154, 159, 78, 83, 108, 113<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 69, 72, 91, 96, 119, 124, 129, 134, 139, 6, 148, 153, 77, 82, 105, 110<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 53<br />2: 23, 36, 52, 63<br />ᐳ: 56, 57, 58, 61, 62, 64, 65, 66"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 69, 73, 93, 98, 123, 128, 134, 139, 144, 6, 154, 159, 78, 83, 108, 113<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 53<br />2: 23, 36, 52, 63<br />ᐳ: 56, 57, 58, 61, 62, 64, 65, 66"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgSelect36,PgSelect52,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,PgSelect63,First64,PgSelectSingle65,PgClassExpression66 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 69, 72, 77, 82<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 69, 73, 78, 83<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 69, 72, 77, 82<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 69, 73, 78, 83<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 11, 69, 72, 105, 110<br /><br />ROOT __Item{7}ᐸ36ᐳ[37]"):::bucket
+    Bucket7("Bucket 7 (listItem)<br />Deps: 11, 69, 73, 108, 113<br /><br />ROOT __Item{7}ᐸ36ᐳ[37]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item37,PgSelectSingle38 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38, 11, 69, 72, 105, 110<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[38]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38, 11, 69, 73, 108, 113<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[38]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgClassExpression43,PgSelect44,First48,PgSelectSingle49 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[49]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.mermaid
@@ -11,111 +11,115 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access138{{"Access[138∈0] ➊<br />ᐸ137.0ᐳ"}}:::plan
     Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access73{{"Access[73∈0] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda133 & Lambda138 & Lambda143 & Lambda72 & Lambda157 & Lambda162 & Lambda69 & Lambda72 & Lambda175 & Lambda180 --> PgSelect8
-    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda69 & Constant134 & Constant90 & Constant91 --> Object137
-    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda69 & Constant153 & Constant90 & Constant91 --> Object156
-    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda69 & Constant171 & Constant172 & Constant173 --> Object174
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access138 & Lambda143 & Lambda148 & Access73 & Lambda163 & Lambda168 & Lambda69 & Access73 & Lambda182 & Lambda187 --> PgSelect8
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda69 & Constant74 & Constant75 & Constant76 --> Object77
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda69 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda69 & Constant106 & Constant107 & Constant76 --> Object109
+    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant123 & Constant92 & Constant93 --> Object126
+    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant139 & Constant92 & Constant93 --> Object142
+    Object162{{"Object[162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda69 & Constant159 & Constant92 & Constant93 --> Object162
+    Object181{{"Object[181∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda69 & Constant178 & Constant179 & Constant180 --> Object181
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant181 --> Lambda69
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant182 --> Lambda72
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant183 --> Lambda133
-    Object137 --> Lambda138
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant188 --> Lambda143
-    Object156 --> Lambda157
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant189 --> Lambda162
-    Object174 --> Lambda175
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant190 --> Lambda180
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant188 --> Lambda69
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant189 --> Lambda72
+    Lambda72 --> Access73
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant191 --> Lambda83
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant192 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant193 --> Lambda115
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object126 --> Lambda127
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant194 --> Lambda132
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant190 --> Lambda137
+    Lambda137 --> Access138
+    Object142 --> Lambda143
+    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant195 --> Lambda148
+    Object162 --> Lambda163
+    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant196 --> Lambda168
+    Object181 --> Lambda182
+    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant197 --> Lambda187
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
     Constant67{{"Constant[67∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant70{{"Constant[70∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object76{{"Object[76∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant73 & Constant74 & Constant75 --> Object76
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant103 & Constant104 & Constant75 --> Object106
-    Object122{{"Object[122∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant119 & Constant90 & Constant91 --> Object122
+    Constant135{{"Constant[135∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant184 --> Lambda82
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object92 --> Lambda93
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant185 --> Lambda98
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object106 --> Lambda107
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant186 --> Lambda112
-    Lambda123{{"Lambda[123∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object122 --> Lambda123
-    Lambda128{{"Lambda[128∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant187 --> Lambda128
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda72 & Lambda77 & Lambda82 & Lambda69 & Lambda72 & Lambda93 & Lambda98 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access73 & Lambda78 & Lambda83 & Lambda69 & Access73 & Lambda95 & Lambda100 --> PgSelect23
     PgSelect36[["PgSelect[36∈3@s]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda72 & Lambda107 & Lambda112 & Lambda69 & Lambda72 & Lambda123 & Lambda128 --> PgSelect36
-    Object147{{"Object[147∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access145{{"Access[145∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access145 & Constant67 & Constant67 & Lambda69 & Constant131 --> Object147
-    Object165{{"Object[165∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access163{{"Access[163∈3]<br />ᐸ12.2ᐳ"}}:::plan
-    Access163 & Constant67 & Constant67 & Lambda69 & Constant70 --> Object165
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access73 & Lambda110 & Lambda115 & Lambda69 & Access73 & Lambda127 & Lambda132 --> PgSelect36
+    Object152{{"Object[152∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access150{{"Access[150∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access150 & Constant67 & Constant67 & Lambda69 & Constant135 --> Object152
+    Object171{{"Object[171∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access169{{"Access[169∈3]<br />ᐸ12.2ᐳ"}}:::plan
+    Access169 & Constant67 & Constant67 & Lambda69 & Constant70 --> Object171
     Object61{{"Object[61∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access56{{"Access[56∈3]<br />ᐸ148.hasMoreᐳ"}}:::plan
+    Access56{{"Access[56∈3]<br />ᐸ153.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access56 --> Object61
     Object57{{"Object[57∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access56 --> Object57
@@ -123,23 +127,23 @@ graph TD
     PgSelectSingle13 --> PgClassExpression22
     PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
     Connection21 --> PgPageInfo53
-    Lambda148{{"Lambda[148∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda148 --> Access56
+    Lambda153{{"Lambda[153∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda153 --> Access56
     Lambda58{{"Lambda[58∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object57 --> Lambda58
     Lambda62{{"Lambda[62∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object61 --> Lambda62
     First64{{"First[64∈3]"}}:::plan
-    Lambda166{{"Lambda[166∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda166 --> First64
+    Lambda172{{"Lambda[172∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda172 --> First64
     PgSelectSingle65{{"PgSelectSingle[65∈3]<br />ᐸmessagesᐳ"}}:::plan
     First64 --> PgSelectSingle65
     PgClassExpression66{{"PgClassExpression[66∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle65 --> PgClassExpression66
-    __Item12 --> Access145
-    Object147 --> Lambda148
-    __Item12 --> Access163
-    Object165 --> Lambda166
+    __Item12 --> Access150
+    Object152 --> Lambda153
+    __Item12 --> Access169
+    Object171 --> Lambda172
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
@@ -147,9 +151,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys83{{"RemapKeys[83∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys83 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys83
+    RemapKeys84{{"RemapKeys[84∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys84 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys84
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -167,9 +171,9 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈8]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression42
     PgSelectSingle49{{"PgSelectSingle[49∈8]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys113{{"RemapKeys[113∈8]<br />ᐸ38:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys113 --> PgSelectSingle49
-    PgSelectSingle38 --> RemapKeys113
+    RemapKeys116{{"RemapKeys[116∈8]<br />ᐸ38:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys116 --> PgSelectSingle49
+    PgSelectSingle38 --> RemapKeys116
     PgClassExpression50{{"PgClassExpression[50∈9]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression51{{"PgClassExpression[51∈9]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -178,24 +182,24 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-2"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 67, 70, 73, 74, 75, 89, 90, 91, 103, 104, 119, 131, 134, 153, 171, 172, 173, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 11, 69, 72, 133, 137, 138, 143, 156, 157, 162, 174, 175, 180<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 67, 70, 74, 75, 76, 91, 92, 93, 106, 107, 123, 135, 139, 159, 178, 179, 180, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 11, 69, 72, 73, 77, 78, 83, 94, 95, 100, 109, 110, 115, 126, 127, 132, 137, 138, 142, 143, 148, 162, 163, 168, 181, 182, 187<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant67,Lambda69,Constant70,Lambda72,Constant73,Constant74,Constant75,Constant89,Constant90,Constant91,Constant103,Constant104,Constant119,Constant131,Lambda133,Constant134,Object137,Lambda138,Lambda143,Constant153,Object156,Lambda157,Lambda162,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189,Constant190 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 69, 73, 74, 75, 184, 89, 90, 91, 185, 103, 104, 186, 119, 187, 11, 21, 72, 6, 67, 131, 70<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant67,Lambda69,Constant70,Lambda72,Access73,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Constant107,Object109,Lambda110,Lambda115,Constant123,Object126,Lambda127,Lambda132,Constant135,Lambda137,Access138,Constant139,Object142,Lambda143,Lambda148,Constant159,Object162,Lambda163,Lambda168,Constant178,Constant179,Constant180,Object181,Lambda182,Lambda187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193,Constant194,Constant195,Constant196,Constant197 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 73, 78, 83, 69, 95, 100, 110, 115, 127, 132, 6, 67, 135, 70<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object76,Lambda77,Lambda82,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112,Object122,Lambda123,Lambda128 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 72, 77, 82, 69, 93, 98, 107, 112, 123, 128, 6, 12, 67, 131, 70<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 73, 78, 83, 69, 95, 100, 110, 115, 127, 132, 6, 12, 67, 135, 70<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 72, 77, 82, 69, 93, 98, 107, 112, 123, 128, 6, 12, 67, 131, 70<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 53, 145, 163, 147, 148, 165, 166, 56, 57, 58, 61, 62, 64, 65, 66<br />2: PgSelect[23], PgSelect[36]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 73, 78, 83, 69, 95, 100, 110, 115, 127, 132, 6, 12, 67, 135, 70<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 53, 150, 169, 152, 153, 171, 172, 56, 57, 58, 61, 62, 64, 65, 66<br />2: PgSelect[23], PgSelect[36]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgSelect36,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgClassExpression66,Access145,Object147,Lambda148,Access163,Object165,Lambda166 bucket3
+    class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgSelect36,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgClassExpression66,Access150,Object152,Lambda153,Access169,Object171,Lambda172 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys83 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys84 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
@@ -204,7 +208,7 @@ graph TD
     class Bucket7,__Item37,PgSelectSingle38 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[38]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys113 bucket8
+    class Bucket8,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys116 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[49]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression50,PgClassExpression51 bucket9

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.deopt.mermaid
@@ -12,60 +12,62 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda38 & Lambda41 & Lambda74 & Lambda79 --> PgSelect8
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant70 & Constant71 & Constant72 --> Object73
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda38 & Access42 & Lambda77 & Lambda82 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant73 & Constant74 & Constant75 --> Object76
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant80 --> Lambda38
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda41
-    Object73 --> Lambda74
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant84 --> Lambda79
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda41
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant85 --> Lambda52
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant86 --> Lambda67
+    Object76 --> Lambda77
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant87 --> Lambda82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant56 & Constant57 & Constant58 --> Object59
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant82 --> Lambda51
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object59 --> Lambda60
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant83 --> Lambda65
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s1]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda38 & Lambda41 & Lambda60 & Lambda65 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda38 & Access42 & Lambda62 & Lambda67 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -74,7 +76,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda38 & Lambda41 & Lambda46 & Lambda51 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda38 & Access42 & Lambda47 & Lambda52 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -90,22 +92,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-3"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 42, 43, 44, 56, 57, 58, 70, 71, 72, 80, 81, 82, 83, 84, 11, 38, 41, 73, 74, 79<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 43, 44, 45, 58, 59, 60, 73, 74, 75, 83, 84, 85, 86, 87, 11, 38, 41, 42, 46, 47, 52, 61, 62, 67, 76, 77, 82<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Constant42,Constant43,Constant44,Constant56,Constant57,Constant58,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant80,Constant81,Constant82,Constant83,Constant84 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 38, 42, 43, 44, 82, 56, 57, 58, 83, 11, 21, 41<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86,Constant87 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object45,Lambda46,Lambda51,Object59,Lambda60,Lambda65 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 41, 60, 65, 46, 51<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 41, 60, 65, 46, 51<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 38, 41, 46, 51<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 38, 42, 47, 52<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 38, 41, 46, 51<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 38, 42, 47, 52<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-3.mermaid
@@ -12,60 +12,62 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda38 & Lambda41 & Lambda76 & Lambda81 --> PgSelect8
-    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant72 & Constant73 & Constant74 --> Object75
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda38 & Access42 & Lambda79 & Lambda84 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant60 & Constant61 & Constant62 --> Object63
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant75 & Constant76 & Constant77 --> Object78
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda38
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda41
-    Object75 --> Lambda76
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant86 --> Lambda81
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda41
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant87 --> Lambda52
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object63 --> Lambda64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant88 --> Lambda69
+    Object78 --> Lambda79
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant89 --> Lambda84
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object61{{"Object[61∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant58 & Constant59 & Constant60 --> Object61
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant84 --> Lambda51
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant85 --> Lambda67
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s1]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda41 & Lambda46 & Lambda51 & Lambda38 & Lambda41 & Lambda62 & Lambda67 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access42 & Lambda47 & Lambda52 & Lambda38 & Access42 & Lambda64 & Lambda69 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -75,9 +77,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys52{{"RemapKeys[52∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys52 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys52
+    RemapKeys53{{"RemapKeys[53∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys53 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys53
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -86,16 +88,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-3"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 42, 43, 44, 58, 59, 60, 72, 73, 74, 82, 83, 84, 85, 86, 11, 38, 41, 75, 76, 81<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 43, 44, 45, 60, 61, 62, 75, 76, 77, 85, 86, 87, 88, 89, 11, 38, 41, 42, 46, 47, 52, 63, 64, 69, 78, 79, 84<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Constant42,Constant43,Constant44,Constant58,Constant59,Constant60,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 38, 42, 43, 44, 84, 58, 59, 60, 85, 11, 21, 41<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant75,Constant76,Constant77,Object78,Lambda79,Lambda84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object45,Lambda46,Lambda51,Object61,Lambda62,Lambda67 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 41, 46, 51, 38, 62, 67<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 41, 46, 51, 38, 62, 67<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
@@ -103,7 +105,7 @@ graph TD
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys52 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys53 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.deopt.mermaid
@@ -12,60 +12,62 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda38 & Lambda41 & Lambda74 & Lambda79 --> PgSelect8
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant70 & Constant71 & Constant72 --> Object73
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda38 & Access42 & Lambda77 & Lambda82 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant73 & Constant74 & Constant75 --> Object76
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant80 --> Lambda38
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda41
-    Object73 --> Lambda74
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant84 --> Lambda79
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda41
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant85 --> Lambda52
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant86 --> Lambda67
+    Object76 --> Lambda77
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant87 --> Lambda82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant56 & Constant57 & Constant58 --> Object59
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant82 --> Lambda51
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object59 --> Lambda60
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant83 --> Lambda65
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda38 & Lambda41 & Lambda60 & Lambda65 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda38 & Access42 & Lambda62 & Lambda67 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -74,7 +76,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda38 & Lambda41 & Lambda46 & Lambda51 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda38 & Access42 & Lambda47 & Lambda52 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -90,22 +92,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-4"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 42, 43, 44, 56, 57, 58, 70, 71, 72, 80, 81, 82, 83, 84, 11, 38, 41, 73, 74, 79<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 43, 44, 45, 58, 59, 60, 73, 74, 75, 83, 84, 85, 86, 87, 11, 38, 41, 42, 46, 47, 52, 61, 62, 67, 76, 77, 82<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Constant42,Constant43,Constant44,Constant56,Constant57,Constant58,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant80,Constant81,Constant82,Constant83,Constant84 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 38, 42, 43, 44, 82, 56, 57, 58, 83, 11, 21, 41<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86,Constant87 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object45,Lambda46,Lambda51,Object59,Lambda60,Lambda65 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 41, 60, 65, 46, 51<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 41, 60, 65, 46, 51<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 38, 42, 62, 67, 47, 52<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 38, 41, 46, 51<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 38, 42, 47, 52<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 38, 41, 46, 51<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 38, 42, 47, 52<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-4.mermaid
@@ -12,60 +12,62 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda38 & Lambda41 & Lambda76 & Lambda81 --> PgSelect8
-    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant72 & Constant73 & Constant74 --> Object75
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda38 & Access42 & Lambda79 & Lambda84 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant60 & Constant61 & Constant62 --> Object63
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant75 & Constant76 & Constant77 --> Object78
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda38
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda41
-    Object75 --> Lambda76
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant86 --> Lambda81
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda41
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant87 --> Lambda52
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object63 --> Lambda64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant88 --> Lambda69
+    Object78 --> Lambda79
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant89 --> Lambda84
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object61{{"Object[61∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant58 & Constant59 & Constant60 --> Object61
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant84 --> Lambda51
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant85 --> Lambda67
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3@s2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda41 & Lambda46 & Lambda51 & Lambda38 & Lambda41 & Lambda62 & Lambda67 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access42 & Lambda47 & Lambda52 & Lambda38 & Access42 & Lambda64 & Lambda69 --> PgSelect23
     PgSelectSingle13 --> PgClassExpression16
     PgSelectSingle13 --> PgClassExpression22
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
@@ -75,9 +77,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys52{{"RemapKeys[52∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys52 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys52
+    RemapKeys53{{"RemapKeys[53∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys53 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys53
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -86,16 +88,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-4"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 42, 43, 44, 58, 59, 60, 72, 73, 74, 82, 83, 84, 85, 86, 11, 38, 41, 75, 76, 81<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 43, 44, 45, 60, 61, 62, 75, 76, 77, 85, 86, 87, 88, 89, 11, 38, 41, 42, 46, 47, 52, 63, 64, 69, 78, 79, 84<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Constant42,Constant43,Constant44,Constant58,Constant59,Constant60,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 38, 42, 43, 44, 84, 58, 59, 60, 85, 11, 21, 41<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection21,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant75,Constant76,Constant77,Object78,Lambda79,Lambda84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object45,Lambda46,Lambda51,Object61,Lambda62,Lambda67 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 41, 46, 51, 38, 62, 67<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 41, 46, 51, 38, 62, 67<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 42, 47, 52, 38, 64, 69<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22<br />2: PgSelect[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
@@ -103,7 +105,7 @@ graph TD
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys52 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys53 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-5.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-5.deopt.mermaid
@@ -12,15 +12,26 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda39 & Lambda42 & Lambda75 & Lambda80 --> PgSelect8
-    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda39 & Constant71 & Constant72 & Constant73 --> Object74
+    Access43{{"Access[43∈0] ➊<br />ᐸ42.0ᐳ"}}:::plan
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda39 & Access43 & Lambda78 & Lambda83 --> PgSelect8
+    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda39 & Constant44 & Constant45 & Constant46 --> Object47
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda55 & Constant59 & Constant60 & Constant61 --> Object62
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda39 & Constant74 & Constant75 & Constant76 --> Object77
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -28,52 +39,45 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection22{{"Connection[22∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant81 --> Connection22
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda39
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda42
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant87 --> Lambda54
-    Object74 --> Lambda75
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant86 --> Lambda80
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant84 --> Connection22
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda39
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda42
+    Lambda42 --> Access43
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object47 --> Lambda48
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant87 --> Lambda53
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant90 --> Lambda55
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant91 --> Lambda57
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda57 --> Access58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant88 --> Lambda68
+    Object77 --> Lambda78
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant89 --> Lambda83
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object46{{"Object[46∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda39 & Constant43 & Constant44 & Constant45 --> Object46
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant57 & Constant58 & Constant59 --> Object60
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda47{{"Lambda[47∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object46 --> Lambda47
-    Lambda52{{"Lambda[52∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant84 --> Lambda52
-    Lambda56{{"Lambda[56∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant88 --> Lambda56
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant85 --> Lambda66
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect24[["PgSelect[24∈3@s1]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression17 & PgClassExpression23 & Connection22 & Constant81 & Lambda54 & Lambda56 & Lambda61 & Lambda66 --> PgSelect24
+    Object11 & PgClassExpression17 & PgClassExpression23 & Connection22 & Constant84 & Lambda55 & Access58 & Lambda63 & Lambda68 --> PgSelect24
     PgSelectSingle13 --> PgClassExpression17
     PgSelectSingle13 --> PgClassExpression23
     __Item25[/"__Item[25∈4]<br />ᐸ24ᐳ"\]:::itemplan
@@ -82,7 +86,7 @@ graph TD
     __Item25 --> PgSelectSingle26
     PgSelect29[["PgSelect[29∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression28 & Lambda39 & Lambda42 & Lambda47 & Lambda52 --> PgSelect29
+    Object11 & PgClassExpression28 & Lambda39 & Access43 & Lambda48 & Lambda53 --> PgSelect29
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle26 --> PgClassExpression28
@@ -98,22 +102,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-5"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 43, 44, 45, 57, 58, 59, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87, 88, 11, 22, 39, 42, 54, 74, 75, 80<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 44, 45, 46, 59, 60, 61, 74, 75, 76, 84, 85, 86, 87, 88, 89, 90, 91, 11, 22, 39, 42, 43, 47, 48, 53, 55, 57, 58, 62, 63, 68, 77, 78, 83<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection22,Lambda39,Lambda42,Constant43,Constant44,Constant45,Lambda54,Constant57,Constant58,Constant59,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 39, 43, 44, 45, 84, 88, 54, 57, 58, 59, 85, 11, 22, 81, 42<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection22,Lambda39,Lambda42,Access43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Lambda55,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 22, 84, 55, 58, 63, 68, 39, 43, 48, 53<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object46,Lambda47,Lambda52,Lambda56,Object60,Lambda61,Lambda66 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 22, 81, 54, 56, 61, 66, 39, 42, 47, 52<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 22, 84, 55, 58, 63, 68, 39, 43, 48, 53<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 22, 81, 54, 56, 61, 66, 39, 42, 47, 52<br /><br />ROOT Connectionᐸ18ᐳ[22]<br />1: <br />ᐳ: 17, 23<br />2: PgSelect[24]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 22, 84, 55, 58, 63, 68, 39, 43, 48, 53<br /><br />ROOT Connectionᐸ18ᐳ[22]<br />1: <br />ᐳ: 17, 23<br />2: PgSelect[24]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression23,PgSelect24 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 39, 42, 47, 52<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 39, 43, 48, 53<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 11, 39, 42, 47, 52<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 11, 39, 43, 48, 53<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression27,PgClassExpression28,PgSelect29,First33,PgSelectSingle34 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-5.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-5.mermaid
@@ -12,15 +12,26 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda39 & Lambda42 & Lambda77 & Lambda82 --> PgSelect8
-    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda39 & Constant73 & Constant74 & Constant75 --> Object76
+    Access43{{"Access[43∈0] ➊<br />ᐸ42.0ᐳ"}}:::plan
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda39 & Access43 & Lambda80 & Lambda85 --> PgSelect8
+    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda39 & Constant44 & Constant45 & Constant46 --> Object47
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda57 & Constant61 & Constant62 & Constant63 --> Object64
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda39 & Constant76 & Constant77 & Constant78 --> Object79
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -28,52 +39,45 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection22{{"Connection[22∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant83 --> Connection22
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant84 --> Lambda39
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda42
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant89 --> Lambda56
-    Object76 --> Lambda77
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant88 --> Lambda82
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant86 --> Connection22
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda39
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda42
+    Lambda42 --> Access43
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object47 --> Lambda48
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant89 --> Lambda53
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant92 --> Lambda57
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant93 --> Lambda59
+    Access60{{"Access[60∈0] ➊<br />ᐸ59.0ᐳ"}}:::plan
+    Lambda59 --> Access60
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object64 --> Lambda65
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant90 --> Lambda70
+    Object79 --> Lambda80
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant91 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object46{{"Object[46∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda39 & Constant43 & Constant44 & Constant45 --> Object46
-    Object62{{"Object[62∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda56 & Constant59 & Constant60 & Constant61 --> Object62
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda47{{"Lambda[47∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object46 --> Lambda47
-    Lambda52{{"Lambda[52∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant86 --> Lambda52
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant90 --> Lambda58
-    Lambda63{{"Lambda[63∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object62 --> Lambda63
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant87 --> Lambda68
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect24[["PgSelect[24∈3@s1]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression17 & PgClassExpression23 & Connection22 & Constant83 & Lambda42 & Lambda47 & Lambda52 & Lambda56 & Lambda58 & Lambda63 & Lambda68 --> PgSelect24
+    Object11 & PgClassExpression17 & PgClassExpression23 & Connection22 & Constant86 & Access43 & Lambda48 & Lambda53 & Lambda57 & Access60 & Lambda65 & Lambda70 --> PgSelect24
     PgSelectSingle13 --> PgClassExpression17
     PgSelectSingle13 --> PgClassExpression23
     __Item25[/"__Item[25∈4]<br />ᐸ24ᐳ"\]:::itemplan
@@ -83,9 +87,9 @@ graph TD
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys53{{"RemapKeys[53∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys53 --> PgSelectSingle34
-    PgSelectSingle26 --> RemapKeys53
+    RemapKeys54{{"RemapKeys[54∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys54 --> PgSelectSingle34
+    PgSelectSingle26 --> RemapKeys54
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
     PgClassExpression36{{"PgClassExpression[36∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -94,16 +98,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-5"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 43, 44, 45, 59, 60, 61, 73, 74, 75, 83, 84, 85, 86, 87, 88, 89, 90, 11, 22, 39, 42, 56, 76, 77, 82<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 44, 45, 46, 61, 62, 63, 76, 77, 78, 86, 87, 88, 89, 90, 91, 92, 93, 11, 22, 39, 42, 43, 47, 48, 53, 57, 59, 60, 64, 65, 70, 79, 80, 85<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection22,Lambda39,Lambda42,Constant43,Constant44,Constant45,Lambda56,Constant59,Constant60,Constant61,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 39, 43, 44, 45, 86, 90, 56, 59, 60, 61, 87, 11, 22, 83, 42<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Connection22,Lambda39,Lambda42,Access43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Lambda57,Lambda59,Access60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92,Constant93 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 22, 86, 43, 48, 53, 57, 60, 65, 70<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object46,Lambda47,Lambda52,Lambda58,Object62,Lambda63,Lambda68 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 22, 83, 42, 47, 52, 56, 58, 63, 68<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 22, 86, 43, 48, 53, 57, 60, 65, 70<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 22, 83, 42, 47, 52, 56, 58, 63, 68<br /><br />ROOT Connectionᐸ18ᐳ[22]<br />1: <br />ᐳ: 17, 23<br />2: PgSelect[24]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 22, 86, 43, 48, 53, 57, 60, 65, 70<br /><br />ROOT Connectionᐸ18ᐳ[22]<br />1: <br />ᐳ: 17, 23<br />2: PgSelect[24]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression23,PgSelect24 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
@@ -111,7 +115,7 @@ graph TD
     class Bucket4,__Item25,PgSelectSingle26 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys53 bucket5
+    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys54 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression35,PgClassExpression36 bucket6

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.deopt.mermaid
@@ -12,91 +12,95 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda69 & Lambda72 & Lambda162 & Lambda167 --> PgSelect8
-    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda69 & Constant158 & Constant159 & Constant160 --> Object161
+    Access73{{"Access[73∈0] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda69 & Access73 & Lambda169 & Lambda174 --> PgSelect8
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda69 & Constant74 & Constant75 & Constant76 --> Object77
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda69 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda69 & Constant104 & Constant105 & Constant76 --> Object107
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant119 & Constant90 & Constant91 --> Object122
+    Object138{{"Object[138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant135 & Constant90 & Constant91 --> Object138
+    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda69 & Constant150 & Constant90 & Constant91 --> Object153
+    Object168{{"Object[168∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda69 & Constant165 & Constant166 & Constant167 --> Object168
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant168 --> Lambda69
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant169 --> Lambda72
-    Object161 --> Lambda162
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant177 --> Lambda167
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant175 --> Lambda69
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant176 --> Lambda72
+    Lambda72 --> Access73
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant178 --> Lambda83
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant179 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant180 --> Lambda113
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant181 --> Lambda128
+    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant177 --> Lambda133
+    Access134{{"Access[134∈0] ➊<br />ᐸ133.0ᐳ"}}:::plan
+    Lambda133 --> Access134
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object138 --> Lambda139
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant182 --> Lambda144
+    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object153 --> Lambda154
+    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant183 --> Lambda159
+    Object168 --> Lambda169
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant184 --> Lambda174
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object76{{"Object[76∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant73 & Constant74 & Constant75 --> Object76
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant101 & Constant102 & Constant75 --> Object104
-    Object118{{"Object[118∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant115 & Constant88 & Constant89 --> Object118
-    Object133{{"Object[133∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant130 & Constant88 & Constant89 --> Object133
-    Object147{{"Object[147∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant144 & Constant88 & Constant89 --> Object147
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant171 --> Lambda82
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object90 --> Lambda91
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant172 --> Lambda96
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 --> Lambda105
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant173 --> Lambda110
-    Lambda119{{"Lambda[119∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object118 --> Lambda119
-    Lambda124{{"Lambda[124∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant174 --> Lambda124
-    Lambda129{{"Lambda[129∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant170 --> Lambda129
-    Lambda134{{"Lambda[134∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object133 --> Lambda134
-    Lambda139{{"Lambda[139∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant175 --> Lambda139
-    Lambda148{{"Lambda[148∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object147 --> Lambda148
-    Lambda153{{"Lambda[153∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant176 --> Lambda153
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -104,16 +108,18 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈3@s]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda91 & Lambda96 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda93 & Lambda98 --> PgSelect23
     PgSelect36[["PgSelect[36∈3@s]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda119 & Lambda124 --> PgSelect36
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda123 & Lambda128 --> PgSelect36
+    PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
+    Connection21 --> PgPageInfo53
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda69 & Lambda72 & Lambda77 & Lambda82 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda69 & Access73 & Lambda78 & Lambda83 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -131,7 +137,7 @@ graph TD
     __Item37 --> PgSelectSingle38
     PgSelect44[["PgSelect[44∈8]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression43{{"PgClassExpression[43∈8]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression43 & Lambda69 & Lambda72 & Lambda105 & Lambda110 --> PgSelect44
+    Object11 & PgClassExpression43 & Lambda69 & Access73 & Lambda108 & Lambda113 --> PgSelect44
     PgCursor39{{"PgCursor[39∈8]"}}:::plan
     List41{{"List[41∈8]<br />ᐸ40ᐳ"}}:::plan
     List41 --> PgCursor39
@@ -150,16 +156,14 @@ graph TD
     PgClassExpression51{{"PgClassExpression[51∈9]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression51
     PgSelect52[["PgSelect[52∈10]<br />ᐸmessages+1ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda129 & Lambda134 & Lambda139 --> PgSelect52
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access134 & Lambda139 & Lambda144 --> PgSelect52
     PgSelect63[["PgSelect[63∈10]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda148 & Lambda153 --> PgSelect63
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda154 & Lambda159 --> PgSelect63
     Object61{{"Object[61∈10]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access56{{"Access[56∈10]<br />ᐸ52.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access56 --> Object61
     Object57{{"Object[57∈10]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access56 --> Object57
-    PgPageInfo53{{"PgPageInfo[53∈10] ➊"}}:::plan
-    Connection21 --> PgPageInfo53
     PgSelect52 --> Access56
     Lambda58{{"Lambda[58∈10]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object57 --> Lambda58
@@ -175,39 +179,39 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-6"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 73, 74, 75, 87, 88, 89, 101, 102, 115, 130, 144, 158, 159, 160, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 11, 69, 72, 161, 162, 167<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 74, 75, 76, 89, 90, 91, 104, 105, 119, 135, 150, 165, 166, 167, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 11, 69, 72, 73, 77, 78, 83, 92, 93, 98, 107, 108, 113, 122, 123, 128, 133, 134, 138, 139, 144, 153, 154, 159, 168, 169, 174<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda69,Lambda72,Constant73,Constant74,Constant75,Constant87,Constant88,Constant89,Constant101,Constant102,Constant115,Constant130,Constant144,Constant158,Constant159,Constant160,Object161,Lambda162,Lambda167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 69, 73, 74, 75, 171, 87, 88, 89, 172, 101, 102, 173, 115, 174, 170, 130, 175, 144, 176, 11, 21, 72, 6<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda69,Lambda72,Access73,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Constant105,Object107,Lambda108,Lambda113,Constant119,Object122,Lambda123,Lambda128,Lambda133,Access134,Constant135,Object138,Lambda139,Lambda144,Constant150,Object153,Lambda154,Lambda159,Constant165,Constant166,Constant167,Object168,Lambda169,Lambda174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 69, 73, 93, 98, 123, 128, 78, 83, 108, 113, 134, 139, 144, 6, 154, 159<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object76,Lambda77,Lambda82,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110,Object118,Lambda119,Lambda124,Lambda129,Object133,Lambda134,Lambda139,Object147,Lambda148,Lambda153 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 69, 72, 91, 96, 119, 124, 77, 82, 105, 110, 129, 134, 139, 6, 148, 153<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 69, 73, 93, 98, 123, 128, 78, 83, 108, 113, 134, 139, 144, 6, 154, 159<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression16,PgClassExpression22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 69, 72, 91, 96, 119, 124, 77, 82, 105, 110, 129, 134, 139, 6, 148, 153<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 69, 73, 93, 98, 123, 128, 78, 83, 108, 113, 134, 139, 144, 6, 154, 159<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect23,PgSelect36 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 69, 72, 77, 82<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    class Bucket3,PgSelect23,PgSelect36,PgPageInfo53 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 69, 73, 78, 83<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 69, 72, 77, 82<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 69, 73, 78, 83<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 11, 69, 72, 105, 110<br /><br />ROOT __Item{7}ᐸ36ᐳ[37]"):::bucket
+    Bucket7("Bucket 7 (listItem)<br />Deps: 11, 69, 73, 108, 113<br /><br />ROOT __Item{7}ᐸ36ᐳ[37]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item37,PgSelectSingle38 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38, 11, 69, 72, 105, 110<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[38]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38, 11, 69, 73, 108, 113<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[38]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgClassExpression43,PgSelect44,First48,PgSelectSingle49 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[49]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression50,PgClassExpression51 bucket9
-    Bucket10("Bucket 10 (defer)<br />Deps: 11, 16, 22, 21, 69, 129, 134, 139, 6, 72, 148, 153"):::bucket
+    Bucket10("Bucket 10 (defer)<br />Deps: 11, 16, 22, 21, 69, 134, 139, 144, 6, 73, 154, 159, 53"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect52,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,PgSelect63,First64,PgSelectSingle65,PgClassExpression66 bucket10
+    class Bucket10,PgSelect52,Access56,Object57,Lambda58,Object61,Lambda62,PgSelect63,First64,PgSelectSingle65,PgClassExpression66 bucket10
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.mermaid
@@ -12,91 +12,95 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda69 & Lambda72 & Lambda166 & Lambda171 --> PgSelect8
-    Object165{{"Object[165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda69 & Constant162 & Constant163 & Constant164 --> Object165
+    Access73{{"Access[73∈0] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda69 & Access73 & Lambda173 & Lambda178 --> PgSelect8
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda69 & Constant74 & Constant75 & Constant76 --> Object77
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda69 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda69 & Constant106 & Constant107 & Constant76 --> Object109
+    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant123 & Constant92 & Constant93 --> Object126
+    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda69 & Constant139 & Constant92 & Constant93 --> Object142
+    Object157{{"Object[157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda69 & Constant154 & Constant92 & Constant93 --> Object157
+    Object172{{"Object[172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda69 & Constant169 & Constant170 & Constant171 --> Object172
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant172 --> Lambda69
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant173 --> Lambda72
-    Object165 --> Lambda166
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant181 --> Lambda171
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant179 --> Lambda69
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant180 --> Lambda72
+    Lambda72 --> Access73
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant182 --> Lambda83
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant183 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant184 --> Lambda115
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object126 --> Lambda127
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant185 --> Lambda132
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant181 --> Lambda137
+    Access138{{"Access[138∈0] ➊<br />ᐸ137.0ᐳ"}}:::plan
+    Lambda137 --> Access138
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object142 --> Lambda143
+    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant186 --> Lambda148
+    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object157 --> Lambda158
+    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant187 --> Lambda163
+    Object172 --> Lambda173
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant188 --> Lambda178
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object76{{"Object[76∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant73 & Constant74 & Constant75 --> Object76
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant103 & Constant104 & Constant75 --> Object106
-    Object122{{"Object[122∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant119 & Constant90 & Constant91 --> Object122
-    Object137{{"Object[137∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant134 & Constant90 & Constant91 --> Object137
-    Object151{{"Object[151∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant148 & Constant90 & Constant91 --> Object151
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant175 --> Lambda82
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object92 --> Lambda93
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant176 --> Lambda98
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object106 --> Lambda107
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant177 --> Lambda112
-    Lambda123{{"Lambda[123∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object122 --> Lambda123
-    Lambda128{{"Lambda[128∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant178 --> Lambda128
-    Lambda133{{"Lambda[133∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant174 --> Lambda133
-    Lambda138{{"Lambda[138∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object137 --> Lambda138
-    Lambda143{{"Lambda[143∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant179 --> Lambda143
-    Lambda152{{"Lambda[152∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object151 --> Lambda152
-    Lambda157{{"Lambda[157∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant180 --> Lambda157
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression16{{"PgClassExpression[16∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
@@ -104,9 +108,11 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression22
     PgSelect23[["PgSelect[23∈3@s]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda72 & Lambda77 & Lambda82 & Lambda69 & Lambda72 & Lambda93 & Lambda98 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access73 & Lambda78 & Lambda83 & Lambda69 & Access73 & Lambda95 & Lambda100 --> PgSelect23
     PgSelect36[["PgSelect[36∈3@s]<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda72 & Lambda107 & Lambda112 & Lambda69 & Lambda72 & Lambda123 & Lambda128 --> PgSelect36
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Access73 & Lambda110 & Lambda115 & Lambda69 & Access73 & Lambda127 & Lambda132 --> PgSelect36
+    PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
+    Connection21 --> PgPageInfo53
     __Item24[/"__Item[24∈4]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
@@ -114,9 +120,9 @@ graph TD
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys83{{"RemapKeys[83∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys83 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys83
+    RemapKeys84{{"RemapKeys[84∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys84 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys84
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -134,24 +140,22 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈8]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression42
     PgSelectSingle49{{"PgSelectSingle[49∈8]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys113{{"RemapKeys[113∈8]<br />ᐸ38:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys113 --> PgSelectSingle49
-    PgSelectSingle38 --> RemapKeys113
+    RemapKeys116{{"RemapKeys[116∈8]<br />ᐸ38:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys116 --> PgSelectSingle49
+    PgSelectSingle38 --> RemapKeys116
     PgClassExpression50{{"PgClassExpression[50∈9]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression51{{"PgClassExpression[51∈9]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression51
     PgSelect52[["PgSelect[52∈10]<br />ᐸmessages+1ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda133 & Lambda138 & Lambda143 --> PgSelect52
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access138 & Lambda143 & Lambda148 --> PgSelect52
     PgSelect63[["PgSelect[63∈10]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Lambda72 & Lambda152 & Lambda157 --> PgSelect63
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda69 & Access73 & Lambda158 & Lambda163 --> PgSelect63
     Object61{{"Object[61∈10]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access56{{"Access[56∈10]<br />ᐸ52.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access56 --> Object61
     Object57{{"Object[57∈10]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access56 --> Object57
-    PgPageInfo53{{"PgPageInfo[53∈10] ➊"}}:::plan
-    Connection21 --> PgPageInfo53
     PgSelect52 --> Access56
     Lambda58{{"Lambda[58∈10]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object57 --> Lambda58
@@ -167,24 +171,24 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/archived-forum-inherited-messages.stream-6"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 73, 74, 75, 89, 90, 91, 103, 104, 119, 134, 148, 162, 163, 164, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 11, 69, 72, 165, 166, 171<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 74, 75, 76, 91, 92, 93, 106, 107, 123, 139, 154, 169, 170, 171, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 11, 69, 72, 73, 77, 78, 83, 94, 95, 100, 109, 110, 115, 126, 127, 132, 137, 138, 142, 143, 148, 157, 158, 163, 172, 173, 178<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda69,Lambda72,Constant73,Constant74,Constant75,Constant89,Constant90,Constant91,Constant103,Constant104,Constant119,Constant134,Constant148,Constant162,Constant163,Constant164,Object165,Lambda166,Lambda171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 69, 73, 74, 75, 175, 89, 90, 91, 176, 103, 104, 177, 119, 178, 174, 134, 179, 148, 180, 11, 21, 72, 6<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda69,Lambda72,Access73,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Constant107,Object109,Lambda110,Lambda115,Constant123,Object126,Lambda127,Lambda132,Lambda137,Access138,Constant139,Object142,Lambda143,Lambda148,Constant154,Object157,Lambda158,Lambda163,Constant169,Constant170,Constant171,Object172,Lambda173,Lambda178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 73, 78, 83, 69, 95, 100, 110, 115, 127, 132, 138, 143, 148, 6, 158, 163<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object76,Lambda77,Lambda82,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112,Object122,Lambda123,Lambda128,Lambda133,Object137,Lambda138,Lambda143,Object151,Lambda152,Lambda157 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 72, 77, 82, 69, 93, 98, 107, 112, 123, 128, 133, 138, 143, 6, 152, 157<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 73, 78, 83, 69, 95, 100, 110, 115, 127, 132, 138, 143, 148, 6, 158, 163<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression16,PgClassExpression22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 72, 77, 82, 69, 93, 98, 107, 112, 123, 128, 133, 138, 143, 6, 152, 157<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 16, 22, 21, 73, 78, 83, 69, 95, 100, 110, 115, 127, 132, 138, 143, 148, 6, 158, 163<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect23,PgSelect36 bucket3
+    class Bucket3,PgSelect23,PgSelect36,PgPageInfo53 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys83 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys84 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
@@ -193,13 +197,13 @@ graph TD
     class Bucket7,__Item37,PgSelectSingle38 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[38]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys113 bucket8
+    class Bucket8,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys116 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{8}ᐸusersᐳ[49]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression50,PgClassExpression51 bucket9
-    Bucket10("Bucket 10 (defer)<br />Deps: 11, 16, 22, 21, 69, 133, 138, 143, 6, 72, 152, 157"):::bucket
+    Bucket10("Bucket 10 (defer)<br />Deps: 11, 16, 22, 21, 69, 138, 143, 148, 6, 73, 158, 163, 53"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect52,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,PgSelect63,First64,PgSelectSingle65,PgClassExpression66 bucket10
+    class Bucket10,PgSelect52,Access56,Object57,Lambda58,Object61,Lambda62,PgSelect63,First64,PgSelectSingle65,PgClassExpression66 bucket10
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/conditions/basics-with-author.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/basics-with-author.deopt.mermaid
@@ -12,64 +12,68 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda37 & Lambda40 & Lambda73 & Lambda78 --> PgSelect8
-    Object72{{"Object[72∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda37 & Constant69 & Constant70 & Constant71 --> Object72
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda37 & Access41 & Lambda76 & Lambda81 --> PgSelect8
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
+    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda37 & Constant72 & Constant73 & Constant74 --> Object75
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant80 --> Lambda37
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda40
-    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant85 --> Lambda52
-    Object72 --> Lambda73
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant84 --> Lambda78
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda37
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda40
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant85 --> Lambda51
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant88 --> Lambda53
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant89 --> Lambda55
+    Access56{{"Access[56∈0] ➊<br />ᐸ55.0ᐳ"}}:::plan
+    Lambda55 --> Access56
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object60 --> Lambda61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant86 --> Lambda66
+    Object75 --> Lambda76
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant87 --> Lambda81
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object44{{"Object[44∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object58{{"Object[58∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda52 & Constant55 & Constant56 & Constant57 --> Object58
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object44 --> Lambda45
-    Lambda50{{"Lambda[50∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant82 --> Lambda50
-    Lambda54{{"Lambda[54∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant86 --> Lambda54
-    Lambda59{{"Lambda[59∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object58 --> Lambda59
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant83 --> Lambda64
     PgSelect18[["PgSelect[18∈2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression17 & Constant79 & PgClassExpression22 & Lambda52 & Lambda54 & Lambda59 & Lambda64 --> PgSelect18
+    Object11 & PgClassExpression17 & Constant82 & PgClassExpression22 & Lambda53 & Access56 & Lambda61 & Lambda66 --> PgSelect18
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelectSingle13 --> PgClassExpression17
@@ -80,7 +84,7 @@ graph TD
     __Item23 --> PgSelectSingle24
     PgSelect27[["PgSelect[27∈4]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression26 & Lambda37 & Lambda40 & Lambda45 & Lambda50 --> PgSelect27
+    Object11 & PgClassExpression26 & Lambda37 & Access41 & Lambda46 & Lambda51 --> PgSelect27
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgSelectSingle24 --> PgClassExpression26
@@ -96,19 +100,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/basics-with-author"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 41, 42, 43, 55, 56, 57, 69, 70, 71, 79, 80, 81, 82, 83, 84, 85, 86, 11, 37, 40, 52, 72, 73, 78<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 42, 43, 44, 57, 58, 59, 72, 73, 74, 82, 83, 84, 85, 86, 87, 88, 89, 11, 37, 40, 41, 45, 46, 51, 53, 55, 56, 60, 61, 66, 75, 76, 81<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda37,Lambda40,Constant41,Constant42,Constant43,Lambda52,Constant55,Constant56,Constant57,Constant69,Constant70,Constant71,Object72,Lambda73,Lambda78,Constant79,Constant80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 37, 41, 42, 43, 82, 86, 52, 55, 56, 57, 83, 11, 79, 40<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda37,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Lambda53,Lambda55,Access56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant82,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 82, 53, 56, 61, 66, 37, 41, 46, 51<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object44,Lambda45,Lambda50,Lambda54,Object58,Lambda59,Lambda64 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 79, 52, 54, 59, 64, 37, 40, 45, 50<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: 14, 17, 22<br />2: PgSelect[18]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 82, 53, 56, 61, 66, 37, 41, 46, 51<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: 14, 17, 22<br />2: PgSelect[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression17,PgSelect18,PgClassExpression22 bucket2
-    Bucket3("Bucket 3 (listItem)<br />Deps: 11, 37, 40, 45, 50<br /><br />ROOT __Item{3}ᐸ18ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (listItem)<br />Deps: 11, 37, 41, 46, 51<br /><br />ROOT __Item{3}ᐸ18ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item23,PgSelectSingle24 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24, 11, 37, 40, 45, 50<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]<br />1: <br />ᐳ: 25, 26<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24, 11, 37, 41, 46, 51<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]<br />1: <br />ᐳ: 25, 26<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{4}ᐸusersᐳ[32]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/basics-with-author.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/basics-with-author.mermaid
@@ -11,81 +11,85 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda40 & Lambda45 & Lambda50 & Lambda56 & Lambda61 & Lambda66 & Lambda37 & Lambda40 & Lambda80 & Lambda85 --> PgSelect8
-    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda54 & Constant57 & Constant58 & Constant59 --> Object60
-    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda37 & Constant76 & Constant77 & Constant78 --> Object79
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access41 & Lambda46 & Lambda51 & Access58 & Lambda63 & Lambda68 & Lambda37 & Access41 & Lambda83 & Lambda88 --> PgSelect8
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda55 & Constant59 & Constant60 & Constant61 --> Object62
+    Object82{{"Object[82∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda37 & Constant79 & Constant80 & Constant81 --> Object82
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda37
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant88 --> Lambda40
-    Object44 --> Lambda45
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant89 --> Lambda50
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant92 --> Lambda54
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant93 --> Lambda56
-    Object60 --> Lambda61
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant90 --> Lambda66
-    Object79 --> Lambda80
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant91 --> Lambda85
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant90 --> Lambda37
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant91 --> Lambda40
+    Lambda40 --> Access41
+    Object45 --> Lambda46
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant92 --> Lambda51
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant95 --> Lambda55
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant96 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant93 --> Lambda68
+    Object82 --> Lambda83
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant94 --> Lambda88
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant35{{"Constant[35∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant38{{"Constant[38∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Object70{{"Object[70∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access68{{"Access[68∈2]<br />ᐸ12.1ᐳ"}}:::plan
-    Access68 & Constant86 & Constant35 & Lambda54 & Constant38 --> Object70
+    Object72{{"Object[72∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access70{{"Access[70∈2]<br />ᐸ12.1ᐳ"}}:::plan
+    Access70 & Constant89 & Constant35 & Lambda55 & Constant38 --> Object72
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    __Item12 --> Access68
-    Lambda71{{"Lambda[71∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object70 --> Lambda71
-    __Item23[/"__Item[23∈3]<br />ᐸ71ᐳ"\]:::itemplan
-    Lambda71 ==> __Item23
+    __Item12 --> Access70
+    Lambda73{{"Lambda[73∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object72 --> Lambda73
+    __Item23[/"__Item[23∈3]<br />ᐸ73ᐳ"\]:::itemplan
+    Lambda73 ==> __Item23
     PgSelectSingle24{{"PgSelectSingle[24∈3]<br />ᐸmessagesᐳ"}}:::plan
     __Item23 --> PgSelectSingle24
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgSelectSingle32{{"PgSelectSingle[32∈4]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys51{{"RemapKeys[51∈4]<br />ᐸ24:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys51 --> PgSelectSingle32
-    PgSelectSingle24 --> RemapKeys51
+    RemapKeys52{{"RemapKeys[52∈4]<br />ᐸ24:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys52 --> PgSelectSingle32
+    PgSelectSingle24 --> RemapKeys52
     PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle32 --> PgClassExpression33
     PgClassExpression34{{"PgClassExpression[34∈5]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -94,21 +98,21 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/basics-with-author"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 35, 38, 41, 42, 43, 57, 58, 59, 76, 77, 78, 86, 87, 88, 89, 90, 91, 92, 93, 11, 37, 40, 44, 45, 50, 54, 56, 60, 61, 66, 79, 80, 85<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 35, 38, 42, 43, 44, 59, 60, 61, 79, 80, 81, 89, 90, 91, 92, 93, 94, 95, 96, 11, 37, 40, 41, 45, 46, 51, 55, 57, 58, 62, 63, 68, 82, 83, 88<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Constant35,Lambda37,Constant38,Lambda40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Lambda54,Lambda56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92,Constant93 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 86, 35, 54, 38<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Constant35,Lambda37,Constant38,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Lambda55,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant79,Constant80,Constant81,Object82,Lambda83,Lambda88,Constant89,Constant90,Constant91,Constant92,Constant93,Constant94,Constant95,Constant96 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 89, 35, 55, 38<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 12, 86, 35, 54, 38<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 12, 89, 35, 55, 38<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression14,Access68,Object70,Lambda71 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ71ᐳ[23]"):::bucket
+    class Bucket2,PgClassExpression14,Access70,Object72,Lambda73 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ73ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item23,PgSelectSingle24 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression25,PgSelectSingle32,RemapKeys51 bucket4
+    class Bucket4,PgClassExpression25,PgSelectSingle32,RemapKeys52 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{4}ᐸusersᐳ[32]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression33,PgClassExpression34 bucket5

--- a/grafast/dataplan-pg/__tests__/queries/conditions/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/basics.deopt.mermaid
@@ -11,55 +11,59 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda43 & Lambda45 & Lambda50 & Lambda55 --> PgSelect8
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda43 & Constant46 & Constant47 & Constant48 --> Object49
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access47{{"Access[47∈0] ➊<br />ᐸ46.0ᐳ"}}:::plan
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda44 & Access47 & Lambda52 & Lambda57 --> PgSelect8
+    Object36{{"Object[36∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda28 & Constant33 & Constant34 & Constant35 --> Object36
+    Object51{{"Object[51∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda44 & Constant48 & Constant49 & Constant50 --> Object51
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant61 --> Lambda28
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant57 --> Lambda43
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant58 --> Lambda45
-    Object49 --> Lambda50
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant60 --> Lambda55
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant63 --> Lambda28
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant64 --> Lambda31
+    Access32{{"Access[32∈0] ➊<br />ᐸ31.0ᐳ"}}:::plan
+    Lambda31 --> Access32
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object36 --> Lambda37
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant61 --> Lambda42
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant59 --> Lambda44
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant60 --> Lambda46
+    Lambda46 --> Access47
+    Object51 --> Lambda52
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant62 --> Lambda57
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object35{{"Object[35∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda28 & Constant32 & Constant33 & Constant34 --> Object35
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda31{{"Lambda[31∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant62 --> Lambda31
-    Lambda36{{"Lambda[36∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object35 --> Lambda36
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant59 --> Lambda41
     PgSelect18[["PgSelect[18∈2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression17 & Constant56 & PgClassExpression22 & Lambda28 & Lambda31 & Lambda36 & Lambda41 --> PgSelect18
+    Object11 & PgClassExpression17 & Constant58 & PgClassExpression22 & Lambda28 & Access32 & Lambda37 & Lambda42 --> PgSelect18
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelectSingle13 --> PgClassExpression17
@@ -74,13 +78,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 32, 33, 34, 46, 47, 48, 56, 57, 58, 59, 60, 61, 62, 11, 28, 43, 45, 49, 50, 55<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 33, 34, 35, 48, 49, 50, 58, 59, 60, 61, 62, 63, 64, 11, 28, 31, 32, 36, 37, 42, 44, 46, 47, 51, 52, 57<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda28,Constant32,Constant33,Constant34,Lambda43,Lambda45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant58,Constant59,Constant60,Constant61,Constant62 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 62, 28, 32, 33, 34, 59, 11, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda28,Lambda31,Access32,Constant33,Constant34,Constant35,Object36,Lambda37,Lambda42,Lambda44,Lambda46,Access47,Constant48,Constant49,Constant50,Object51,Lambda52,Lambda57,Constant58,Constant59,Constant60,Constant61,Constant62,Constant63,Constant64 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 58, 28, 32, 37, 42<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Lambda31,Object35,Lambda36,Lambda41 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 56, 28, 31, 36, 41<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: 14, 17, 22<br />2: PgSelect[18]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 58, 28, 32, 37, 42<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: 14, 17, 22<br />2: PgSelect[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression17,PgSelect18,PgClassExpression22 bucket2
     Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ18ᐳ[23]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/basics.mermaid
@@ -11,63 +11,67 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda31 & Lambda36 & Lambda41 & Lambda48 & Lambda50 & Lambda55 & Lambda60 --> PgSelect8
-    Object35{{"Object[35∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Access32{{"Access[32∈0] ➊<br />ᐸ31.0ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access52{{"Access[52∈0] ➊<br />ᐸ51.0ᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access32 & Lambda37 & Lambda42 & Lambda49 & Access52 & Lambda57 & Lambda62 --> PgSelect8
+    Object36{{"Object[36∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda28 & Constant32 & Constant33 & Constant34 --> Object35
-    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda48 & Constant51 & Constant52 & Constant53 --> Object54
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda28 & Constant33 & Constant34 & Constant35 --> Object36
+    Object56{{"Object[56∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda49 & Constant53 & Constant54 & Constant55 --> Object56
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant66 --> Lambda28
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant67 --> Lambda31
-    Object35 --> Lambda36
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant64 --> Lambda41
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda48
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant63 --> Lambda50
-    Object54 --> Lambda55
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant65 --> Lambda60
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant68 --> Lambda28
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant69 --> Lambda31
+    Lambda31 --> Access32
+    Object36 --> Lambda37
+    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant66 --> Lambda42
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda49
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant65 --> Lambda51
+    Lambda51 --> Access52
+    Object56 --> Lambda57
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant67 --> Lambda62
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant26{{"Constant[26∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Object45{{"Object[45∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access43{{"Access[43∈2]<br />ᐸ12.1ᐳ"}}:::plan
-    Access43 & Constant61 & Constant26 & Lambda28 & Constant29 --> Object45
+    Object46{{"Object[46∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access44{{"Access[44∈2]<br />ᐸ12.1ᐳ"}}:::plan
+    Access44 & Constant63 & Constant26 & Lambda28 & Constant29 --> Object46
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    __Item12 --> Access43
-    Lambda46{{"Lambda[46∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object45 --> Lambda46
-    __Item23[/"__Item[23∈3]<br />ᐸ46ᐳ"\]:::itemplan
-    Lambda46 ==> __Item23
+    __Item12 --> Access44
+    Lambda47{{"Lambda[47∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object46 --> Lambda47
+    __Item23[/"__Item[23∈3]<br />ᐸ47ᐳ"\]:::itemplan
+    Lambda47 ==> __Item23
     PgSelectSingle24{{"PgSelectSingle[24∈3]<br />ᐸmessagesᐳ"}}:::plan
     __Item23 --> PgSelectSingle24
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
@@ -76,16 +80,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 26, 29, 32, 33, 34, 51, 52, 53, 61, 62, 63, 64, 65, 66, 67, 11, 28, 31, 35, 36, 41, 48, 50, 54, 55, 60<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 26, 29, 33, 34, 35, 53, 54, 55, 63, 64, 65, 66, 67, 68, 69, 11, 28, 31, 32, 36, 37, 42, 49, 51, 52, 56, 57, 62<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Constant26,Lambda28,Constant29,Lambda31,Constant32,Constant33,Constant34,Object35,Lambda36,Lambda41,Lambda48,Lambda50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant61,Constant62,Constant63,Constant64,Constant65,Constant66,Constant67 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 61, 26, 28, 29<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Constant26,Lambda28,Constant29,Lambda31,Access32,Constant33,Constant34,Constant35,Object36,Lambda37,Lambda42,Lambda49,Lambda51,Access52,Constant53,Constant54,Constant55,Object56,Lambda57,Lambda62,Constant63,Constant64,Constant65,Constant66,Constant67,Constant68,Constant69 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 63, 26, 28, 29<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 12, 61, 26, 28, 29<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 12, 63, 26, 28, 29<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression14,Access43,Object45,Lambda46 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ46ᐳ[23]"):::bucket
+    class Bucket2,PgClassExpression14,Access44,Object46,Lambda47 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ47ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item23,PgSelectSingle24 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-partial-variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-partial-variables.deopt.mermaid
@@ -13,15 +13,20 @@ graph TD
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access20{{"Access[20∈0] ➊<br />ᐸ0.some.featured.equalToᐳ"}}:::plan
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Access20 & Lambda48 & Lambda51 & Lambda70 & Lambda75 --> PgSelect12
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda48 & Constant66 & Constant67 & Constant68 --> Object69
+    Access52{{"Access[52∈0] ➊<br />ᐸ51.0ᐳ"}}:::plan
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object15 & Access20 & Lambda48 & Access52 & Lambda72 & Lambda77 --> PgSelect12
+    Object56{{"Object[56∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda48 & Constant53 & Constant54 & Constant55 --> Object56
+    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda48 & Constant68 & Constant69 & Constant70 --> Object71
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
@@ -30,34 +35,31 @@ graph TD
     __Value2 --> Access14
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access20
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant76 --> Lambda48
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant77 --> Lambda51
-    Object69 --> Lambda70
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant79 --> Lambda75
+    Access38{{"Access[38∈0] ➊<br />ᐸ0.featured.notEqualToᐳ"}}:::plan
+    __Value0 --> Access38
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant78 --> Lambda48
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant79 --> Lambda51
+    Lambda51 --> Access52
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object56 --> Lambda57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant80 --> Lambda62
+    Object71 --> Lambda72
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant81 --> Lambda77
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object55{{"Object[55∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda48 & Constant52 & Constant53 & Constant54 --> Object55
     __Item24[/"__Item[24∈1]<br />ᐸ12ᐳ"\]:::itemplan
     PgSelect12 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
-    Access38{{"Access[38∈1] ➊<br />ᐸ0.featured.notEqualToᐳ"}}:::plan
-    __Value0 --> Access38
-    Lambda56{{"Lambda[56∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object55 --> Lambda56
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant78 --> Lambda61
     PgSelect34[["PgSelect[34∈2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression33{{"PgClassExpression[33∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression41{{"PgClassExpression[41∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object15 & PgClassExpression33 & Access38 & PgClassExpression41 & Lambda48 & Lambda51 & Lambda56 & Lambda61 --> PgSelect34
+    Object15 & PgClassExpression33 & Access38 & PgClassExpression41 & Lambda48 & Access52 & Lambda57 & Lambda62 --> PgSelect34
     PgClassExpression26{{"PgClassExpression[26∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression33
@@ -74,13 +76,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/complex-filter-via-partial-variables"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 13, 14, 20, 52, 53, 54, 66, 67, 68, 76, 77, 78, 79, 15, 48, 51, 69, 70, 75<br />2: PgSelect[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 13, 14, 20, 38, 53, 54, 55, 68, 69, 70, 78, 79, 80, 81, 15, 48, 51, 52, 56, 57, 62, 71, 72, 77<br />2: PgSelect[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect12,Access13,Access14,Object15,Access20,Lambda48,Lambda51,Constant52,Constant53,Constant54,Constant66,Constant67,Constant68,Object69,Lambda70,Lambda75,Constant76,Constant77,Constant78,Constant79 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 0, 48, 52, 53, 54, 78, 15, 51<br /><br />ROOT __Item{1}ᐸ12ᐳ[24]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect12,Access13,Access14,Object15,Access20,Access38,Lambda48,Lambda51,Access52,Constant53,Constant54,Constant55,Object56,Lambda57,Lambda62,Constant68,Constant69,Constant70,Object71,Lambda72,Lambda77,Constant78,Constant79,Constant80,Constant81 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 15, 38, 48, 52, 57, 62<br /><br />ROOT __Item{1}ᐸ12ᐳ[24]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item24,PgSelectSingle25,Access38,Object55,Lambda56,Lambda61 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 25, 15, 38, 48, 51, 56, 61<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[25]<br />1: <br />ᐳ: 26, 33, 41<br />2: PgSelect[34]"):::bucket
+    class Bucket1,__Item24,PgSelectSingle25 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 25, 15, 38, 48, 52, 57, 62<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[25]<br />1: <br />ᐳ: 26, 33, 41<br />2: PgSelect[34]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression26,PgClassExpression33,PgSelect34,PgClassExpression41 bucket2
     Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ34ᐳ[42]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-partial-variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-partial-variables.mermaid
@@ -13,23 +13,23 @@ graph TD
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access20{{"Access[20∈0] ➊<br />ᐸ0.some.featured.equalToᐳ"}}:::plan
     Access38{{"Access[38∈0] ➊<br />ᐸ0.featured.notEqualToᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access52{{"Access[52∈0] ➊<br />ᐸ51.0ᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Access20 & Access38 & Lambda51 & Lambda56 & Lambda61 & Lambda48 & Lambda51 & Lambda75 & Lambda80 --> PgSelect12
-    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda48 & Constant52 & Constant53 & Constant54 --> Object55
-    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda48 & Constant71 & Constant72 & Constant73 --> Object74
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object15 & Access20 & Access38 & Access52 & Lambda57 & Lambda62 & Lambda48 & Access52 & Lambda77 & Lambda82 --> PgSelect12
+    Object56{{"Object[56∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda48 & Constant53 & Constant54 & Constant55 --> Object56
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda48 & Constant73 & Constant74 & Constant75 --> Object76
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
@@ -39,16 +39,18 @@ graph TD
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access20
     __Value0 --> Access38
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda48
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda51
-    Object55 --> Lambda56
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant83 --> Lambda61
-    Object74 --> Lambda75
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant84 --> Lambda80
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda48
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda51
+    Lambda51 --> Access52
+    Object56 --> Lambda57
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant85 --> Lambda62
+    Object76 --> Lambda77
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant86 --> Lambda82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant46{{"Constant[46∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant49{{"Constant[49∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -56,16 +58,16 @@ graph TD
     PgSelect12 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
-    Object65{{"Object[65∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access63{{"Access[63∈2]<br />ᐸ24.1ᐳ"}}:::plan
-    Access63 & Constant46 & Constant46 & Lambda48 & Constant49 --> Object65
+    Object66{{"Object[66∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access64{{"Access[64∈2]<br />ᐸ24.1ᐳ"}}:::plan
+    Access64 & Constant46 & Constant46 & Lambda48 & Constant49 --> Object66
     PgClassExpression26{{"PgClassExpression[26∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
-    __Item24 --> Access63
-    Lambda66{{"Lambda[66∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object65 --> Lambda66
-    __Item42[/"__Item[42∈3]<br />ᐸ66ᐳ"\]:::itemplan
-    Lambda66 ==> __Item42
+    __Item24 --> Access64
+    Lambda67{{"Lambda[67∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object66 --> Lambda67
+    __Item42[/"__Item[42∈3]<br />ᐸ67ᐳ"\]:::itemplan
+    Lambda67 ==> __Item42
     PgSelectSingle43{{"PgSelectSingle[43∈3]<br />ᐸmessagesᐳ"}}:::plan
     __Item42 --> PgSelectSingle43
     PgClassExpression44{{"PgClassExpression[44∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
@@ -76,16 +78,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/complex-filter-via-partial-variables"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 13, 14, 20, 38, 46, 49, 52, 53, 54, 71, 72, 73, 81, 82, 83, 84, 15, 48, 51, 55, 56, 61, 74, 75, 80<br />2: PgSelect[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 13, 14, 20, 38, 46, 49, 53, 54, 55, 73, 74, 75, 83, 84, 85, 86, 15, 48, 51, 52, 56, 57, 62, 76, 77, 82<br />2: PgSelect[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect12,Access13,Access14,Object15,Access20,Access38,Constant46,Lambda48,Constant49,Lambda51,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant81,Constant82,Constant83,Constant84 bucket0
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect12,Access13,Access14,Object15,Access20,Access38,Constant46,Lambda48,Constant49,Lambda51,Access52,Constant53,Constant54,Constant55,Object56,Lambda57,Lambda62,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 46, 48, 49<br /><br />ROOT __Item{1}ᐸ12ᐳ[24]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item24,PgSelectSingle25 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 25, 24, 46, 48, 49<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[25]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression26,Access63,Object65,Lambda66 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ66ᐳ[42]"):::bucket
+    class Bucket2,PgClassExpression26,Access64,Object66,Lambda67 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ67ᐳ[42]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item42,PgSelectSingle43 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 43<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[43]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-variables.deopt.mermaid
@@ -13,15 +13,20 @@ graph TD
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access32{{"Access[32∈0] ➊<br />ᐸ0.forumFilter.messages.some.featured.equalToᐳ"}}:::plan
     Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Access32 & Lambda66 & Lambda69 & Lambda88 & Lambda93 --> PgSelect10
-    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda66 & Constant84 & Constant85 & Constant86 --> Object87
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object13 & Access32 & Lambda66 & Access70 & Lambda90 & Lambda95 --> PgSelect10
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda66 & Constant86 & Constant87 & Constant88 --> Object89
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
@@ -30,34 +35,31 @@ graph TD
     __Value2 --> Access12
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access32
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant94 --> Lambda66
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant95 --> Lambda69
-    Object87 --> Lambda88
-    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant97 --> Lambda93
+    Access53{{"Access[53∈0] ➊<br />ᐸ0.messagesFilter.featured.notEqualToᐳ"}}:::plan
+    __Value0 --> Access53
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant96 --> Lambda66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant97 --> Lambda69
+    Lambda69 --> Access70
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object74 --> Lambda75
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant98 --> Lambda80
+    Object89 --> Lambda90
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant99 --> Lambda95
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object73{{"Object[73∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
     __Item38[/"__Item[38∈1]<br />ᐸ10ᐳ"\]:::itemplan
     PgSelect10 ==> __Item38
     PgSelectSingle39{{"PgSelectSingle[39∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item38 --> PgSelectSingle39
-    Access53{{"Access[53∈1] ➊<br />ᐸ0.messagesFilter.featured.notEqualToᐳ"}}:::plan
-    __Value0 --> Access53
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object73 --> Lambda74
-    Lambda79{{"Lambda[79∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant96 --> Lambda79
     PgSelect45[["PgSelect[45∈2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression44{{"PgClassExpression[44∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression59{{"PgClassExpression[59∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object13 & PgClassExpression44 & Access53 & PgClassExpression59 & Lambda66 & Lambda69 & Lambda74 & Lambda79 --> PgSelect45
+    Object13 & PgClassExpression44 & Access53 & PgClassExpression59 & Lambda66 & Access70 & Lambda75 & Lambda80 --> PgSelect45
     PgClassExpression40{{"PgClassExpression[40∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
     PgSelectSingle39 --> PgClassExpression44
@@ -74,13 +76,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/complex-filter-via-variables"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 32, 70, 71, 72, 84, 85, 86, 94, 95, 96, 97, 13, 66, 69, 87, 88, 93<br />2: PgSelect[10]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 32, 53, 71, 72, 73, 86, 87, 88, 96, 97, 98, 99, 13, 66, 69, 70, 74, 75, 80, 89, 90, 95<br />2: PgSelect[10]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect10,Access11,Access12,Object13,Access32,Lambda66,Lambda69,Constant70,Constant71,Constant72,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant94,Constant95,Constant96,Constant97 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 0, 66, 70, 71, 72, 96, 13, 69<br /><br />ROOT __Item{1}ᐸ10ᐳ[38]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect10,Access11,Access12,Object13,Access32,Access53,Lambda66,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 13, 53, 66, 70, 75, 80<br /><br />ROOT __Item{1}ᐸ10ᐳ[38]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item38,PgSelectSingle39,Access53,Object73,Lambda74,Lambda79 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 39, 13, 53, 66, 69, 74, 79<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[39]<br />1: <br />ᐳ: 40, 44, 59<br />2: PgSelect[45]"):::bucket
+    class Bucket1,__Item38,PgSelectSingle39 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 39, 13, 53, 66, 70, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[39]<br />1: <br />ᐳ: 40, 44, 59<br />2: PgSelect[45]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression40,PgClassExpression44,PgSelect45,PgClassExpression59 bucket2
     Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ45ᐳ[60]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter-via-variables.mermaid
@@ -13,23 +13,23 @@ graph TD
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access32{{"Access[32∈0] ➊<br />ᐸ0.forumFilter.messages.some.featured.equalToᐳ"}}:::plan
     Access53{{"Access[53∈0] ➊<br />ᐸ0.messagesFilter.featured.notEqualToᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Access32 & Access53 & Lambda69 & Lambda74 & Lambda79 & Lambda66 & Lambda69 & Lambda93 & Lambda98 --> PgSelect10
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
-    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda66 & Constant89 & Constant90 & Constant91 --> Object92
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object13 & Access32 & Access53 & Access70 & Lambda75 & Lambda80 & Lambda66 & Access70 & Lambda95 & Lambda100 --> PgSelect10
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda66 & Constant91 & Constant92 & Constant93 --> Object94
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
@@ -39,16 +39,18 @@ graph TD
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access32
     __Value0 --> Access53
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant99 --> Lambda66
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant100 --> Lambda69
-    Object73 --> Lambda74
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant101 --> Lambda79
-    Object92 --> Lambda93
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant102 --> Lambda98
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant101 --> Lambda66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant102 --> Lambda69
+    Lambda69 --> Access70
+    Object74 --> Lambda75
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant103 --> Lambda80
+    Object94 --> Lambda95
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant104 --> Lambda100
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant64{{"Constant[64∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant67{{"Constant[67∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -56,16 +58,16 @@ graph TD
     PgSelect10 ==> __Item38
     PgSelectSingle39{{"PgSelectSingle[39∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item38 --> PgSelectSingle39
-    Object83{{"Object[83∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access81{{"Access[81∈2]<br />ᐸ38.1ᐳ"}}:::plan
-    Access81 & Constant64 & Constant64 & Lambda66 & Constant67 --> Object83
+    Object84{{"Object[84∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access82{{"Access[82∈2]<br />ᐸ38.1ᐳ"}}:::plan
+    Access82 & Constant64 & Constant64 & Lambda66 & Constant67 --> Object84
     PgClassExpression40{{"PgClassExpression[40∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
-    __Item38 --> Access81
-    Lambda84{{"Lambda[84∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object83 --> Lambda84
-    __Item60[/"__Item[60∈3]<br />ᐸ84ᐳ"\]:::itemplan
-    Lambda84 ==> __Item60
+    __Item38 --> Access82
+    Lambda85{{"Lambda[85∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object84 --> Lambda85
+    __Item60[/"__Item[60∈3]<br />ᐸ85ᐳ"\]:::itemplan
+    Lambda85 ==> __Item60
     PgSelectSingle61{{"PgSelectSingle[61∈3]<br />ᐸmessagesᐳ"}}:::plan
     __Item60 --> PgSelectSingle61
     PgClassExpression62{{"PgClassExpression[62∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
@@ -76,16 +78,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/complex-filter-via-variables"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 32, 53, 64, 67, 70, 71, 72, 89, 90, 91, 99, 100, 101, 102, 13, 66, 69, 73, 74, 79, 92, 93, 98<br />2: PgSelect[10]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 32, 53, 64, 67, 71, 72, 73, 91, 92, 93, 101, 102, 103, 104, 13, 66, 69, 70, 74, 75, 80, 94, 95, 100<br />2: PgSelect[10]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect10,Access11,Access12,Object13,Access32,Access53,Constant64,Lambda66,Constant67,Lambda69,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant99,Constant100,Constant101,Constant102 bucket0
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect10,Access11,Access12,Object13,Access32,Access53,Constant64,Lambda66,Constant67,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant101,Constant102,Constant103,Constant104 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 64, 66, 67<br /><br />ROOT __Item{1}ᐸ10ᐳ[38]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item38,PgSelectSingle39 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 39, 38, 64, 66, 67<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[39]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression40,Access81,Object83,Lambda84 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ84ᐳ[60]"):::bucket
+    class Bucket2,PgClassExpression40,Access82,Object84,Lambda85 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ85ᐳ[60]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item60,PgSelectSingle61 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 61<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[61]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter.deopt.mermaid
@@ -11,49 +11,51 @@ graph TD
     %% plan dependencies
     PgSelect13[["PgSelect[13∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object16{{"Object[16∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object16 & Constant64 & Lambda36 & Lambda39 & Lambda58 & Lambda63 --> PgSelect13
-    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda36 & Constant54 & Constant55 & Constant56 --> Object57
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object16 & Constant66 & Lambda36 & Access40 & Lambda60 & Lambda65 --> PgSelect13
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object59{{"Object[59∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda36 & Constant56 & Constant57 & Constant58 --> Object59
     Access14{{"Access[14∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access14 & Access15 --> Object16
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access14
     __Value2 --> Access15
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant65 --> Lambda36
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant66 --> Lambda39
-    Object57 --> Lambda58
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant68 --> Lambda63
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant67 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant68 --> Lambda39
+    Lambda39 --> Access40
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object44 --> Lambda45
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant69 --> Lambda50
+    Object59 --> Lambda60
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant70 --> Lambda65
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object43{{"Object[43∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
     __Item17[/"__Item[17∈1]<br />ᐸ13ᐳ"\]:::itemplan
     PgSelect13 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item17 --> PgSelectSingle18
-    Lambda44{{"Lambda[44∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object43 --> Lambda44
-    Lambda49{{"Lambda[49∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant67 --> Lambda49
     PgSelect25[["PgSelect[25∈2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression24{{"PgClassExpression[24∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression29{{"PgClassExpression[29∈2]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object16 & PgClassExpression24 & Constant64 & PgClassExpression29 & Lambda36 & Lambda39 & Lambda44 & Lambda49 --> PgSelect25
+    Object16 & PgClassExpression24 & Constant66 & PgClassExpression29 & Lambda36 & Access40 & Lambda45 & Lambda50 --> PgSelect25
     PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression19
     PgSelectSingle18 --> PgClassExpression24
@@ -70,13 +72,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/complex-filter"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 14, 15, 40, 41, 42, 54, 55, 56, 64, 65, 66, 67, 68, 16, 36, 39, 57, 58, 63<br />2: PgSelect[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 14, 15, 41, 42, 43, 56, 57, 58, 66, 67, 68, 69, 70, 16, 36, 39, 40, 44, 45, 50, 59, 60, 65<br />2: PgSelect[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect13,Access14,Access15,Object16,Lambda36,Lambda39,Constant40,Constant41,Constant42,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant64,Constant65,Constant66,Constant67,Constant68 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 36, 40, 41, 42, 67, 16, 64, 39<br /><br />ROOT __Item{1}ᐸ13ᐳ[17]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect13,Access14,Access15,Object16,Lambda36,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Constant56,Constant57,Constant58,Object59,Lambda60,Lambda65,Constant66,Constant67,Constant68,Constant69,Constant70 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 16, 66, 36, 40, 45, 50<br /><br />ROOT __Item{1}ᐸ13ᐳ[17]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item17,PgSelectSingle18,Object43,Lambda44,Lambda49 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 18, 16, 64, 36, 39, 44, 49<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[18]<br />1: <br />ᐳ: 19, 24, 29<br />2: PgSelect[25]"):::bucket
+    class Bucket1,__Item17,PgSelectSingle18 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 18, 16, 66, 36, 40, 45, 50<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[18]<br />1: <br />ᐳ: 19, 24, 29<br />2: PgSelect[25]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression19,PgClassExpression24,PgSelect25,PgClassExpression29 bucket2
     Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ25ᐳ[30]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/complex-filter.mermaid
@@ -11,40 +11,42 @@ graph TD
     %% plan dependencies
     PgSelect13[["PgSelect[13∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object16{{"Object[16∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object16 & Constant69 & Constant69 & Lambda39 & Lambda44 & Lambda49 & Lambda36 & Lambda39 & Lambda63 & Lambda68 --> PgSelect13
-    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
-    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda36 & Constant59 & Constant60 & Constant61 --> Object62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object16 & Constant71 & Constant71 & Access40 & Lambda45 & Lambda50 & Lambda36 & Access40 & Lambda65 & Lambda70 --> PgSelect13
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda36 & Constant61 & Constant62 & Constant63 --> Object64
     Access14{{"Access[14∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access14 & Access15 --> Object16
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access14
     __Value2 --> Access15
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda36
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda39
-    Object43 --> Lambda44
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant72 --> Lambda49
-    Object62 --> Lambda63
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant73 --> Lambda68
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant73 --> Lambda39
+    Lambda39 --> Access40
+    Object44 --> Lambda45
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant74 --> Lambda50
+    Object64 --> Lambda65
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant75 --> Lambda70
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant34{{"Constant[34∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant37{{"Constant[37∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -52,16 +54,16 @@ graph TD
     PgSelect13 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item17 --> PgSelectSingle18
-    Object53{{"Object[53∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access51{{"Access[51∈2]<br />ᐸ17.1ᐳ"}}:::plan
-    Access51 & Constant34 & Constant34 & Lambda36 & Constant37 --> Object53
+    Object54{{"Object[54∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access52{{"Access[52∈2]<br />ᐸ17.1ᐳ"}}:::plan
+    Access52 & Constant34 & Constant34 & Lambda36 & Constant37 --> Object54
     PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression19
-    __Item17 --> Access51
-    Lambda54{{"Lambda[54∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object53 --> Lambda54
-    __Item30[/"__Item[30∈3]<br />ᐸ54ᐳ"\]:::itemplan
-    Lambda54 ==> __Item30
+    __Item17 --> Access52
+    Lambda55{{"Lambda[55∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object54 --> Lambda55
+    __Item30[/"__Item[30∈3]<br />ᐸ55ᐳ"\]:::itemplan
+    Lambda55 ==> __Item30
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸmessagesᐳ"}}:::plan
     __Item30 --> PgSelectSingle31
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
@@ -72,16 +74,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/complex-filter"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 14, 15, 34, 37, 40, 41, 42, 59, 60, 61, 69, 70, 71, 72, 73, 16, 36, 39, 43, 44, 49, 62, 63, 68<br />2: PgSelect[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 14, 15, 34, 37, 41, 42, 43, 61, 62, 63, 71, 72, 73, 74, 75, 16, 36, 39, 40, 44, 45, 50, 64, 65, 70<br />2: PgSelect[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect13,Access14,Access15,Object16,Constant34,Lambda36,Constant37,Lambda39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant69,Constant70,Constant71,Constant72,Constant73 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect13,Access14,Access15,Object16,Constant34,Lambda36,Constant37,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant71,Constant72,Constant73,Constant74,Constant75 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 34, 36, 37<br /><br />ROOT __Item{1}ᐸ13ᐳ[17]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item17,PgSelectSingle18 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 18, 17, 34, 36, 37<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression19,Access51,Object53,Lambda54 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ54ᐳ[30]"):::bucket
+    class Bucket2,PgClassExpression19,Access52,Object54,Lambda55 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ55ᐳ[30]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item30,PgSelectSingle31 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[31]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.deopt.mermaid
@@ -11,16 +11,25 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda54 & Lambda56 & Lambda75 & Lambda80 --> PgSelect8
-    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda54 & Constant71 & Constant72 & Constant73 --> Object74
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda55 & Access58 & Lambda78 & Lambda83 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda55 & Constant59 & Constant44 & Constant45 --> Object62
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda55 & Constant74 & Constant75 & Constant76 --> Object77
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -28,55 +37,50 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant81 --> Connection23
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant87 --> Lambda38
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda54
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda56
-    Object74 --> Lambda75
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant86 --> Lambda80
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant84 --> Connection23
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant90 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant91 --> Lambda41
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant87 --> Lambda53
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda55
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda57
+    Lambda57 --> Access58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant88 --> Lambda68
+    Object77 --> Lambda78
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant89 --> Lambda83
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object60{{"Object[60∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda54 & Constant57 & Constant43 & Constant44 --> Object60
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant88 --> Lambda41
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda52{{"Lambda[52∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant84 --> Lambda52
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant85 --> Lambda66
     PgSelect25[["PgSelect[25∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression18 & Constant39 & PgClassExpression24 & Connection23 & Constant81 & Lambda38 & Lambda41 & Lambda46 & Lambda52 --> PgSelect25
+    Object11 & PgClassExpression18 & Constant39 & PgClassExpression24 & Connection23 & Constant84 & Lambda38 & Access42 & Lambda47 & Lambda53 --> PgSelect25
     PgSelect32[["PgSelect[32∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression18 & Constant39 & PgClassExpression24 & Connection23 & Lambda54 & Lambda56 & Lambda61 & Lambda66 --> PgSelect32
+    Object11 & PgClassExpression18 & Constant39 & PgClassExpression24 & Connection23 & Lambda55 & Access58 & Lambda63 & Lambda68 --> PgSelect32
     Object30{{"Object[30∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access29{{"Access[29∈3]<br />ᐸ25.hasMoreᐳ"}}:::plan
-    Constant81 & Constant6 & Access29 --> Object30
+    Constant84 & Constant6 & Access29 --> Object30
     PgSelectSingle13 --> PgClassExpression18
     PgSelectSingle13 --> PgClassExpression24
     PgPageInfo26{{"PgPageInfo[26∈3] ➊"}}:::plan
@@ -94,16 +98,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/condition-featured-messages-minimal"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 39, 42, 43, 44, 57, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87, 88, 11, 23, 38, 54, 56, 74, 75, 80<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 39, 43, 44, 45, 59, 74, 75, 76, 84, 85, 86, 87, 88, 89, 90, 91, 11, 23, 38, 41, 42, 46, 47, 53, 55, 57, 58, 62, 63, 68, 77, 78, 83<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection23,Lambda38,Constant39,Constant42,Constant43,Constant44,Lambda54,Lambda56,Constant57,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 88, 38, 42, 43, 44, 84, 54, 57, 85, 11, 39, 23, 81, 6, 56<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection23,Lambda38,Constant39,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda53,Lambda55,Lambda57,Access58,Constant59,Object62,Lambda63,Lambda68,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 39, 23, 84, 38, 42, 47, 53, 6, 55, 58, 63, 68<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Lambda41,Object45,Lambda46,Lambda52,Object60,Lambda61,Lambda66 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 39, 23, 81, 38, 41, 46, 52, 6, 54, 56, 61, 66<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 39, 23, 84, 38, 42, 47, 53, 6, 55, 58, 63, 68<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 39, 23, 81, 38, 41, 46, 52, 6, 54, 56, 61, 66<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: 18, 24, 26<br />2: PgSelect[25], PgSelect[32]<br />ᐳ: 29, 30, 31, 33, 34, 35"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 39, 23, 84, 38, 42, 47, 53, 6, 55, 58, 63, 68<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: 18, 24, 26<br />2: PgSelect[25], PgSelect[32]<br />ᐳ: 29, 30, 31, 33, 34, 35"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression24,PgSelect25,PgPageInfo26,Access29,Object30,Lambda31,PgSelect32,First33,PgSelectSingle34,PgClassExpression35 bucket3
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.mermaid
@@ -12,30 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Lambda41 & Lambda46 & Lambda52 & Lambda61 & Lambda66 & Lambda71 & Lambda59 & Lambda61 & Lambda84 & Lambda89 --> PgSelect8
-    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access63{{"Access[63∈0] ➊<br />ᐸ62.0ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant39 & Access42 & Lambda47 & Lambda53 & Access63 & Lambda68 & Lambda73 & Lambda60 & Access63 & Lambda87 & Lambda92 --> PgSelect8
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda59 & Constant62 & Constant43 & Constant44 --> Object65
-    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda59 & Constant80 & Constant81 & Constant82 --> Object83
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda60 & Constant64 & Constant44 & Constant45 --> Object67
+    Object86{{"Object[86∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda60 & Constant83 & Constant84 & Constant85 --> Object86
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -43,75 +43,79 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant90 --> Connection23
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant96 --> Lambda38
-    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant97 --> Lambda41
-    Object45 --> Lambda46
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant93 --> Lambda52
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant91 --> Lambda59
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant92 --> Lambda61
-    Object65 --> Lambda66
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant94 --> Lambda71
-    Object83 --> Lambda84
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant95 --> Lambda89
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant93 --> Connection23
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant99 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant100 --> Lambda41
+    Lambda41 --> Access42
+    Object46 --> Lambda47
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant96 --> Lambda53
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda60
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda62
+    Lambda62 --> Access63
+    Object67 --> Lambda68
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant97 --> Lambda73
+    Object86 --> Lambda87
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant98 --> Lambda92
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant36{{"Constant[36∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸfalseᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸfalseᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Object56{{"Object[56∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access54{{"Access[54∈3]<br />ᐸ12.0ᐳ"}}:::plan
-    Access54 & Constant90 & Constant36 & Lambda38 & Constant39 --> Object56
-    Object74{{"Object[74∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access72{{"Access[72∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access72 & Constant36 & Constant36 & Lambda59 & Constant47 --> Object74
+    Object57{{"Object[57∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access55{{"Access[55∈3]<br />ᐸ12.0ᐳ"}}:::plan
+    Access55 & Constant93 & Constant36 & Lambda38 & Constant39 --> Object57
+    Object76{{"Object[76∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access74{{"Access[74∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access74 & Constant36 & Constant36 & Lambda60 & Constant48 --> Object76
     Object30{{"Object[30∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Access29{{"Access[29∈3]<br />ᐸ57.hasMoreᐳ"}}:::plan
-    Constant90 & Constant6 & Access29 --> Object30
+    Access29{{"Access[29∈3]<br />ᐸ58.hasMoreᐳ"}}:::plan
+    Constant93 & Constant6 & Access29 --> Object30
     PgPageInfo26{{"PgPageInfo[26∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo26
-    Lambda57{{"Lambda[57∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda57 --> Access29
+    Lambda58{{"Lambda[58∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda58 --> Access29
     Lambda31{{"Lambda[31∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object30 --> Lambda31
     First33{{"First[33∈3]"}}:::plan
-    Lambda75{{"Lambda[75∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda75 --> First33
+    Lambda77{{"Lambda[77∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda77 --> First33
     PgSelectSingle34{{"PgSelectSingle[34∈3]<br />ᐸmessagesᐳ"}}:::plan
     First33 --> PgSelectSingle34
     PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
-    __Item12 --> Access54
-    Object56 --> Lambda57
-    __Item12 --> Access72
-    Object74 --> Lambda75
+    __Item12 --> Access55
+    Object57 --> Lambda58
+    __Item12 --> Access74
+    Object76 --> Lambda77
 
     %% define steps
 
     subgraph "Buckets for queries/conditions/condition-featured-messages-minimal"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 36, 39, 42, 43, 44, 47, 62, 80, 81, 82, 90, 91, 92, 93, 94, 95, 96, 97, 11, 23, 38, 41, 45, 46, 52, 59, 61, 65, 66, 71, 83, 84, 89<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 36, 39, 43, 44, 45, 48, 64, 83, 84, 85, 93, 94, 95, 96, 97, 98, 99, 100, 11, 23, 38, 41, 42, 46, 47, 53, 60, 62, 63, 67, 68, 73, 86, 87, 92<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection23,Constant36,Lambda38,Constant39,Lambda41,Constant42,Constant43,Constant44,Object45,Lambda46,Constant47,Lambda52,Lambda59,Lambda61,Constant62,Object65,Lambda66,Lambda71,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant90,Constant91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 90, 6, 36, 38, 39, 59, 47<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection23,Constant36,Lambda38,Constant39,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Constant48,Lambda53,Lambda60,Lambda62,Access63,Constant64,Object67,Lambda68,Lambda73,Constant83,Constant84,Constant85,Object86,Lambda87,Lambda92,Constant93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99,Constant100 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 93, 6, 36, 38, 39, 60, 48<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 23, 90, 6, 12, 36, 38, 39, 59, 47<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 23, 93, 6, 12, 36, 38, 39, 60, 48<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 90, 6, 12, 36, 38, 39, 59, 47<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 93, 6, 12, 36, 38, 39, 60, 48<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo26,Access29,Object30,Lambda31,First33,PgSelectSingle34,PgClassExpression35,Access54,Object56,Lambda57,Access72,Object74,Lambda75 bucket3
+    class Bucket3,PgPageInfo26,Access29,Object30,Lambda31,First33,PgSelectSingle34,PgClassExpression35,Access55,Object57,Lambda58,Access74,Object76,Lambda77 bucket3
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.deopt.mermaid
@@ -12,15 +12,33 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access87{{"Access[87∈0] ➊<br />ᐸ86.0ᐳ"}}:::plan
     Lambda153{{"Lambda[153∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda83 & Lambda86 & Lambda148 & Lambda153 --> PgSelect8
-    Object147{{"Object[147∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant145{{"Constant[145∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda83 & Constant144 & Constant145 & Constant146 --> Object147
+    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda83 & Access87 & Lambda153 & Lambda158 --> PgSelect8
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda83 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda83 & Constant103 & Constant104 & Constant90 --> Object106
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda114 & Constant119 & Constant120 & Constant121 --> Object122
+    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda83 & Constant134 & Constant120 & Constant121 --> Object137
+    Object152{{"Object[152∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda83 & Constant149 & Constant150 & Constant151 --> Object152
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -28,78 +46,64 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection24{{"Connection[24∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant154 --> Connection24
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant155 --> Lambda83
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant156 --> Lambda86
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant162 --> Lambda112
-    Object147 --> Lambda148
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant161 --> Lambda153
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant159 --> Connection24
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant160 --> Lambda83
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant161 --> Lambda86
+    Lambda86 --> Access87
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant162 --> Lambda97
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object106 --> Lambda107
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant163 --> Lambda112
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant167 --> Lambda114
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant168 --> Lambda117
+    Access118{{"Access[118∈0] ➊<br />ᐸ117.0ᐳ"}}:::plan
+    Lambda117 --> Access118
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant164 --> Lambda128
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object137 --> Lambda138
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant165 --> Lambda143
+    Object152 --> Lambda153
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant166 --> Lambda158
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant101 & Constant102 & Constant89 --> Object104
-    Object119{{"Object[119∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda112 & Constant116 & Constant117 & Constant118 --> Object119
-    Object133{{"Object[133∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant130 & Constant117 & Constant118 --> Object133
+    Constant115{{"Constant[115∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object90 --> Lambda91
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157 --> Lambda96
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 --> Lambda105
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant158 --> Lambda110
-    Lambda115{{"Lambda[115∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant163 --> Lambda115
-    Lambda120{{"Lambda[120∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object119 --> Lambda120
-    Lambda125{{"Lambda[125∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant159 --> Lambda125
-    Lambda134{{"Lambda[134∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object133 --> Lambda134
-    Lambda139{{"Lambda[139∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant160 --> Lambda139
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect26[["PgSelect[26∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression19 & Constant113 & PgClassExpression25 & Connection24 & Constant154 & Lambda112 & Lambda115 & Lambda120 & Lambda125 --> PgSelect26
+    Object11 & PgClassExpression19 & Constant115 & PgClassExpression25 & Connection24 & Constant159 & Lambda114 & Access118 & Lambda123 & Lambda128 --> PgSelect26
     PgSelect77[["PgSelect[77∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression19 & Constant113 & PgClassExpression25 & Connection24 & Lambda83 & Lambda86 & Lambda134 & Lambda139 --> PgSelect77
+    Object11 & PgClassExpression19 & Constant115 & PgClassExpression25 & Connection24 & Lambda83 & Access87 & Lambda138 & Lambda143 --> PgSelect77
     Object63{{"Object[63∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access58{{"Access[58∈3]<br />ᐸ26.hasMoreᐳ"}}:::plan
-    Constant154 & Constant6 & Constant6 & Access58 --> Object63
+    Constant159 & Constant6 & Constant6 & Access58 --> Object63
     Object59{{"Object[59∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant154 & Constant6 & Access58 --> Object59
+    Constant159 & Constant6 & Access58 --> Object59
     PgSelectSingle13 --> PgClassExpression19
     PgSelectSingle13 --> PgClassExpression25
     PgPageInfo55{{"PgPageInfo[55∈3] ➊"}}:::plan
@@ -141,7 +145,7 @@ graph TD
     __Item27 --> PgSelectSingle28
     PgSelect31[["PgSelect[31∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression30 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect31
+    Object11 & PgClassExpression30 & Lambda83 & Access87 & Lambda92 & Lambda97 --> PgSelect31
     PgClassExpression29{{"PgClassExpression[29∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgSelectSingle28 --> PgClassExpression30
@@ -155,7 +159,7 @@ graph TD
     PgSelectSingle36 --> PgClassExpression38
     PgSelect46[["PgSelect[46∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression45{{"PgClassExpression[45∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression45 & Lambda83 & Lambda86 & Lambda105 & Lambda110 --> PgSelect46
+    Object11 & PgClassExpression45 & Lambda83 & Access87 & Lambda107 & Lambda112 --> PgSelect46
     PgCursor41{{"PgCursor[41∈7]"}}:::plan
     List43{{"List[43∈7]<br />ᐸ42ᐳ"}}:::plan
     List43 --> PgCursor41
@@ -177,28 +181,28 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/condition-featured-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 87, 88, 89, 101, 102, 113, 116, 117, 118, 130, 144, 145, 146, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 11, 24, 83, 86, 112, 147, 148, 153<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 88, 89, 90, 103, 104, 115, 119, 120, 121, 134, 149, 150, 151, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 11, 24, 83, 86, 87, 91, 92, 97, 106, 107, 112, 114, 117, 118, 122, 123, 128, 137, 138, 143, 152, 153, 158<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection24,Lambda83,Lambda86,Constant87,Constant88,Constant89,Constant101,Constant102,Lambda112,Constant113,Constant116,Constant117,Constant118,Constant130,Constant144,Constant145,Constant146,Object147,Lambda148,Lambda153,Constant154,Constant155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 83, 87, 88, 89, 157, 101, 102, 158, 163, 112, 116, 117, 118, 159, 130, 160, 11, 113, 24, 154, 6, 86<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection24,Lambda83,Lambda86,Access87,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Object106,Lambda107,Lambda112,Lambda114,Constant115,Lambda117,Access118,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant134,Object137,Lambda138,Lambda143,Constant149,Constant150,Constant151,Object152,Lambda153,Lambda158,Constant159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 115, 24, 159, 114, 118, 123, 128, 6, 83, 87, 138, 143, 92, 97, 107, 112<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110,Lambda115,Object119,Lambda120,Lambda125,Object133,Lambda134,Lambda139 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 113, 24, 154, 112, 115, 120, 125, 6, 83, 86, 134, 139, 91, 96, 105, 110<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 115, 24, 159, 114, 118, 123, 128, 6, 83, 87, 138, 143, 92, 97, 107, 112<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 113, 24, 154, 112, 115, 120, 125, 6, 83, 86, 134, 139, 91, 96, 105, 110<br /><br />ROOT Connectionᐸ20ᐳ[24]<br />1: <br />ᐳ: 19, 25, 55<br />2: PgSelect[26], PgSelect[77]<br />ᐳ: 58, 59, 60, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 78, 79, 80, 68, 74"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 115, 24, 159, 114, 118, 123, 128, 6, 83, 87, 138, 143, 92, 97, 107, 112<br /><br />ROOT Connectionᐸ20ᐳ[24]<br />1: <br />ᐳ: 19, 25, 55<br />2: PgSelect[26], PgSelect[77]<br />ᐳ: 58, 59, 60, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 78, 79, 80, 68, 74"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression19,PgClassExpression25,PgSelect26,PgPageInfo55,Access58,Object59,Lambda60,Object63,Lambda64,First66,PgSelectSingle67,PgCursor68,PgClassExpression69,List70,Last72,PgSelectSingle73,PgCursor74,PgClassExpression75,List76,PgSelect77,First78,PgSelectSingle79,PgClassExpression80 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 83, 86, 91, 96, 105, 110<br /><br />ROOT __Item{4}ᐸ26ᐳ[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 83, 87, 92, 97, 107, 112<br /><br />ROOT __Item{4}ᐸ26ᐳ[27]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item27,PgSelectSingle28 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 28, 11, 83, 86, 91, 96<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[28]<br />1: <br />ᐳ: 29, 30<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 28, 11, 83, 87, 92, 97<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[28]<br />1: <br />ᐳ: 29, 30<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression29,PgClassExpression30,PgSelect31,First35,PgSelectSingle36 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[36]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression37,PgClassExpression38 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 28, 11, 83, 86, 105, 110<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[28]<br />1: <br />ᐳ: 42, 44, 45, 43, 41<br />2: PgSelect[46]<br />ᐳ: First[50], PgSelectSingle[51]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 28, 11, 83, 87, 107, 112<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[28]<br />1: <br />ᐳ: 42, 44, 45, 43, 41<br />2: PgSelect[46]<br />ᐳ: First[50], PgSelectSingle[51]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgCursor41,PgClassExpression42,List43,PgClassExpression44,PgClassExpression45,PgSelect46,First50,PgSelectSingle51 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 51<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[51]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.mermaid
@@ -11,44 +11,44 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Access87{{"Access[87∈0] ➊<br />ᐸ86.0ᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access122{{"Access[122∈0] ➊<br />ᐸ121.0ᐳ"}}:::plan
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant117 & Lambda86 & Lambda91 & Lambda96 & Lambda107 & Lambda112 & Lambda119 & Lambda124 & Lambda129 & Lambda86 & Lambda143 & Lambda148 & Lambda83 & Lambda86 & Lambda161 & Lambda166 --> PgSelect8
-    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Lambda83 & Constant103 & Constant104 & Constant89 --> Object106
-    Object123{{"Object[123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda116 & Constant120 & Constant121 & Constant122 --> Object123
-    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda83 & Constant139 & Constant121 & Constant122 --> Object142
-    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda83 & Constant157 & Constant158 & Constant159 --> Object160
+    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant119 & Access87 & Lambda92 & Lambda97 & Lambda109 & Lambda114 & Access122 & Lambda127 & Lambda132 & Access87 & Lambda147 & Lambda152 & Lambda83 & Access87 & Lambda166 & Lambda171 --> PgSelect8
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda83 & Constant88 & Constant89 & Constant90 --> Object91
+    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda83 & Constant105 & Constant106 & Constant90 --> Object108
+    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda118 & Constant123 & Constant124 & Constant125 --> Object126
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda83 & Constant143 & Constant124 & Constant125 --> Object146
+    Object165{{"Object[165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda83 & Constant162 & Constant163 & Constant164 --> Object165
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -56,31 +56,35 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection24{{"Connection[24∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant167 --> Connection24
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant168 --> Lambda83
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant169 --> Lambda86
-    Object90 --> Lambda91
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant170 --> Lambda96
-    Object106 --> Lambda107
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant171 --> Lambda112
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant175 --> Lambda116
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant176 --> Lambda119
-    Object123 --> Lambda124
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant172 --> Lambda129
-    Object142 --> Lambda143
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant173 --> Lambda148
-    Object160 --> Lambda161
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant174 --> Lambda166
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant172 --> Connection24
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant173 --> Lambda83
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant174 --> Lambda86
+    Lambda86 --> Access87
+    Object91 --> Lambda92
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant175 --> Lambda97
+    Object108 --> Lambda109
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant176 --> Lambda114
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant180 --> Lambda118
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant181 --> Lambda121
+    Lambda121 --> Access122
+    Object126 --> Lambda127
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant177 --> Lambda132
+    Object146 --> Lambda147
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant178 --> Lambda152
+    Object165 --> Lambda166
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant179 --> Lambda171
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant81{{"Constant[81∈0] ➊<br />ᐸnullᐳ"}}:::plan
@@ -91,27 +95,27 @@ graph TD
     __Item12 --> PgSelectSingle13
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object133{{"Object[133∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access131{{"Access[131∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access131 & Constant167 & Constant81 & Lambda116 & Constant117 --> Object133
-    Object151{{"Object[151∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access149{{"Access[149∈3]<br />ᐸ12.2ᐳ"}}:::plan
-    Access149 & Constant81 & Constant81 & Lambda83 & Constant84 --> Object151
+    Object136{{"Object[136∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access134{{"Access[134∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access134 & Constant172 & Constant81 & Lambda118 & Constant119 --> Object136
+    Object155{{"Object[155∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access153{{"Access[153∈3]<br />ᐸ12.2ᐳ"}}:::plan
+    Access153 & Constant81 & Constant81 & Lambda83 & Constant84 --> Object155
     Object63{{"Object[63∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access58{{"Access[58∈3]<br />ᐸ134.hasMoreᐳ"}}:::plan
-    Constant167 & Constant6 & Constant6 & Access58 --> Object63
+    Access58{{"Access[58∈3]<br />ᐸ137.hasMoreᐳ"}}:::plan
+    Constant172 & Constant6 & Constant6 & Access58 --> Object63
     Object59{{"Object[59∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant167 & Constant6 & Access58 --> Object59
+    Constant172 & Constant6 & Access58 --> Object59
     PgPageInfo55{{"PgPageInfo[55∈3] ➊"}}:::plan
     Connection24 --> PgPageInfo55
-    Lambda134{{"Lambda[134∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda134 --> Access58
+    Lambda137{{"Lambda[137∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda137 --> Access58
     Lambda60{{"Lambda[60∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object59 --> Lambda60
     Lambda64{{"Lambda[64∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object63 --> Lambda64
     First66{{"First[66∈3]"}}:::plan
-    Lambda134 --> First66
+    Lambda137 --> First66
     PgSelectSingle67{{"PgSelectSingle[67∈3]<br />ᐸmessagesᐳ"}}:::plan
     First66 --> PgSelectSingle67
     PgCursor68{{"PgCursor[68∈3]"}}:::plan
@@ -121,7 +125,7 @@ graph TD
     PgSelectSingle67 --> PgClassExpression69
     PgClassExpression69 --> List70
     Last72{{"Last[72∈3]"}}:::plan
-    Lambda134 --> Last72
+    Lambda137 --> Last72
     PgSelectSingle73{{"PgSelectSingle[73∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last72 --> PgSelectSingle73
     PgCursor74{{"PgCursor[74∈3]"}}:::plan
@@ -131,26 +135,26 @@ graph TD
     PgSelectSingle73 --> PgClassExpression75
     PgClassExpression75 --> List76
     First78{{"First[78∈3]"}}:::plan
-    Lambda152{{"Lambda[152∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda152 --> First78
+    Lambda156{{"Lambda[156∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda156 --> First78
     PgSelectSingle79{{"PgSelectSingle[79∈3]<br />ᐸmessagesᐳ"}}:::plan
     First78 --> PgSelectSingle79
     PgClassExpression80{{"PgClassExpression[80∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle79 --> PgClassExpression80
-    __Item12 --> Access131
-    Object133 --> Lambda134
-    __Item12 --> Access149
-    Object151 --> Lambda152
-    __Item27[/"__Item[27∈4]<br />ᐸ134ᐳ"\]:::itemplan
-    Lambda134 ==> __Item27
+    __Item12 --> Access134
+    Object136 --> Lambda137
+    __Item12 --> Access153
+    Object155 --> Lambda156
+    __Item27[/"__Item[27∈4]<br />ᐸ137ᐳ"\]:::itemplan
+    Lambda137 ==> __Item27
     PgSelectSingle28{{"PgSelectSingle[28∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item27 --> PgSelectSingle28
     PgClassExpression29{{"PgClassExpression[29∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys97{{"RemapKeys[97∈5]<br />ᐸ28:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys97 --> PgSelectSingle36
-    PgSelectSingle28 --> RemapKeys97
+    RemapKeys98{{"RemapKeys[98∈5]<br />ᐸ28:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys98 --> PgSelectSingle36
+    PgSelectSingle28 --> RemapKeys98
     PgClassExpression37{{"PgClassExpression[37∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle36 --> PgClassExpression37
     PgClassExpression38{{"PgClassExpression[38∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -164,9 +168,9 @@ graph TD
     PgClassExpression44{{"PgClassExpression[44∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression44
     PgSelectSingle51{{"PgSelectSingle[51∈7]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys113{{"RemapKeys[113∈7]<br />ᐸ28:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys113 --> PgSelectSingle51
-    PgSelectSingle28 --> RemapKeys113
+    RemapKeys115{{"RemapKeys[115∈7]<br />ᐸ28:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys115 --> PgSelectSingle51
+    PgSelectSingle28 --> RemapKeys115
     PgClassExpression52{{"PgClassExpression[52∈8]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle51 --> PgClassExpression52
     PgClassExpression53{{"PgClassExpression[53∈8]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -175,30 +179,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/condition-featured-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 81, 84, 87, 88, 89, 103, 104, 117, 120, 121, 122, 139, 157, 158, 159, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 11, 24, 83, 86, 90, 91, 96, 106, 107, 112, 116, 119, 123, 124, 129, 142, 143, 148, 160, 161, 166<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 81, 84, 88, 89, 90, 105, 106, 119, 123, 124, 125, 143, 162, 163, 164, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 11, 24, 83, 86, 87, 91, 92, 97, 108, 109, 114, 118, 121, 122, 126, 127, 132, 146, 147, 152, 165, 166, 171<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection24,Constant81,Lambda83,Constant84,Lambda86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant103,Constant104,Object106,Lambda107,Lambda112,Lambda116,Constant117,Lambda119,Constant120,Constant121,Constant122,Object123,Lambda124,Lambda129,Constant139,Object142,Lambda143,Lambda148,Constant157,Constant158,Constant159,Object160,Lambda161,Lambda166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 24, 167, 6, 81, 116, 117, 83, 84<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection24,Constant81,Lambda83,Constant84,Lambda86,Access87,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant105,Constant106,Object108,Lambda109,Lambda114,Lambda118,Constant119,Lambda121,Access122,Constant123,Constant124,Constant125,Object126,Lambda127,Lambda132,Constant143,Object146,Lambda147,Lambda152,Constant162,Constant163,Constant164,Object165,Lambda166,Lambda171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 24, 172, 6, 81, 118, 119, 83, 84<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 24, 167, 6, 12, 81, 116, 117, 83, 84<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 24, 172, 6, 12, 81, 118, 119, 83, 84<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 167, 6, 12, 81, 116, 117, 83, 84<br /><br />ROOT Connectionᐸ20ᐳ[24]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 172, 6, 12, 81, 118, 119, 83, 84<br /><br />ROOT Connectionᐸ20ᐳ[24]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo55,Access58,Object59,Lambda60,Object63,Lambda64,First66,PgSelectSingle67,PgCursor68,PgClassExpression69,List70,Last72,PgSelectSingle73,PgCursor74,PgClassExpression75,List76,First78,PgSelectSingle79,PgClassExpression80,Access131,Object133,Lambda134,Access149,Object151,Lambda152 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ134ᐳ[27]"):::bucket
+    class Bucket3,PgPageInfo55,Access58,Object59,Lambda60,Object63,Lambda64,First66,PgSelectSingle67,PgCursor68,PgClassExpression69,List70,Last72,PgSelectSingle73,PgCursor74,PgClassExpression75,List76,First78,PgSelectSingle79,PgClassExpression80,Access134,Object136,Lambda137,Access153,Object155,Lambda156 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ137ᐳ[27]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item27,PgSelectSingle28 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[28]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression29,PgSelectSingle36,RemapKeys97 bucket5
+    class Bucket5,PgClassExpression29,PgSelectSingle36,RemapKeys98 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[36]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression37,PgClassExpression38 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[28]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgCursor41,PgClassExpression42,List43,PgClassExpression44,PgSelectSingle51,RemapKeys113 bucket7
+    class Bucket7,PgCursor41,PgClassExpression42,List43,PgClassExpression44,PgSelectSingle51,RemapKeys115 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 51<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[51]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression52,PgClassExpression53 bucket8

--- a/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.deopt.mermaid
@@ -12,15 +12,33 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access84{{"Access[84∈0] ➊<br />ᐸ83.0ᐳ"}}:::plan
     Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda80 & Lambda83 & Lambda145 & Lambda150 --> PgSelect8
-    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda80 & Constant141 & Constant142 & Constant143 --> Object144
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda80 & Access84 & Lambda150 & Lambda155 --> PgSelect8
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda80 & Constant85 & Constant86 & Constant87 --> Object88
+    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda80 & Constant100 & Constant101 & Constant87 --> Object103
+    Object119{{"Object[119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda111 & Constant116 & Constant117 & Constant118 --> Object119
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda80 & Constant131 & Constant117 & Constant118 --> Object134
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda80 & Constant146 & Constant147 & Constant148 --> Object149
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -28,76 +46,62 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection22{{"Connection[22∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant151 --> Connection22
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant152 --> Lambda80
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant153 --> Lambda83
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant159 --> Lambda109
-    Object144 --> Lambda145
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant158 --> Lambda150
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant156 --> Connection22
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant157 --> Lambda80
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda83
+    Lambda83 --> Access84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object88 --> Lambda89
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant159 --> Lambda94
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object103 --> Lambda104
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant160 --> Lambda109
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant164 --> Lambda111
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant165 --> Lambda114
+    Access115{{"Access[115∈0] ➊<br />ᐸ114.0ᐳ"}}:::plan
+    Lambda114 --> Access115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object119 --> Lambda120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant161 --> Lambda125
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object134 --> Lambda135
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant162 --> Lambda140
+    Object149 --> Lambda150
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant163 --> Lambda155
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object87{{"Object[87∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant84 & Constant85 & Constant86 --> Object87
-    Object101{{"Object[101∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant98 & Constant99 & Constant86 --> Object101
-    Object116{{"Object[116∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant113 & Constant114 & Constant115 --> Object116
-    Object130{{"Object[130∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda80 & Constant127 & Constant114 & Constant115 --> Object130
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object87 --> Lambda88
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant154 --> Lambda93
-    Lambda102{{"Lambda[102∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object101 --> Lambda102
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant155 --> Lambda107
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant160 --> Lambda112
-    Lambda117{{"Lambda[117∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object116 --> Lambda117
-    Lambda122{{"Lambda[122∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant156 --> Lambda122
-    Lambda131{{"Lambda[131∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object130 --> Lambda131
-    Lambda136{{"Lambda[136∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157 --> Lambda136
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    Object11 & PgClassExpression17 & Connection22 & Constant151 & Lambda109 & Lambda112 & Lambda117 & Lambda122 --> PgSelect23
+    Object11 & PgClassExpression17 & Connection22 & Constant156 & Lambda111 & Access115 & Lambda120 & Lambda125 --> PgSelect23
     PgSelect74[["PgSelect[74∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object11 & PgClassExpression17 & Connection22 & Lambda80 & Lambda83 & Lambda131 & Lambda136 --> PgSelect74
+    Object11 & PgClassExpression17 & Connection22 & Lambda80 & Access84 & Lambda135 & Lambda140 --> PgSelect74
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access55{{"Access[55∈3]<br />ᐸ23.hasMoreᐳ"}}:::plan
-    Constant151 & Constant6 & Constant6 & Access55 --> Object60
+    Constant156 & Constant6 & Constant6 & Access55 --> Object60
     Object56{{"Object[56∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant151 & Constant6 & Access55 --> Object56
+    Constant156 & Constant6 & Access55 --> Object56
     PgSelectSingle13 --> PgClassExpression17
     PgPageInfo52{{"PgPageInfo[52∈3] ➊"}}:::plan
     Connection22 --> PgPageInfo52
@@ -138,7 +142,7 @@ graph TD
     __Item24 --> PgSelectSingle25
     PgSelect28[["PgSelect[28∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression27 & Lambda80 & Lambda83 & Lambda88 & Lambda93 --> PgSelect28
+    Object11 & PgClassExpression27 & Lambda80 & Access84 & Lambda89 & Lambda94 --> PgSelect28
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle25 --> PgClassExpression27
@@ -152,7 +156,7 @@ graph TD
     PgSelectSingle33 --> PgClassExpression35
     PgSelect43[["PgSelect[43∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression42{{"PgClassExpression[42∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression42 & Lambda80 & Lambda83 & Lambda102 & Lambda107 --> PgSelect43
+    Object11 & PgClassExpression42 & Lambda80 & Access84 & Lambda104 & Lambda109 --> PgSelect43
     PgCursor38{{"PgCursor[38∈7]"}}:::plan
     List40{{"List[40∈7]<br />ᐸ39ᐳ"}}:::plan
     List40 --> PgCursor38
@@ -174,28 +178,28 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/exclusively-archived-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 84, 85, 86, 98, 99, 113, 114, 115, 127, 141, 142, 143, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 11, 22, 80, 83, 109, 144, 145, 150<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 85, 86, 87, 100, 101, 116, 117, 118, 131, 146, 147, 148, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 11, 22, 80, 83, 84, 88, 89, 94, 103, 104, 109, 111, 114, 115, 119, 120, 125, 134, 135, 140, 149, 150, 155<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection22,Lambda80,Lambda83,Constant84,Constant85,Constant86,Constant98,Constant99,Lambda109,Constant113,Constant114,Constant115,Constant127,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158,Constant159,Constant160 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 80, 84, 85, 86, 154, 98, 99, 155, 160, 109, 113, 114, 115, 156, 127, 157, 11, 22, 151, 6, 83<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection22,Lambda80,Lambda83,Access84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant100,Constant101,Object103,Lambda104,Lambda109,Lambda111,Lambda114,Access115,Constant116,Constant117,Constant118,Object119,Lambda120,Lambda125,Constant131,Object134,Lambda135,Lambda140,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 22, 156, 111, 115, 120, 125, 6, 80, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object87,Lambda88,Lambda93,Object101,Lambda102,Lambda107,Lambda112,Object116,Lambda117,Lambda122,Object130,Lambda131,Lambda136 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 22, 151, 109, 112, 117, 122, 6, 80, 83, 131, 136, 88, 93, 102, 107<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 22, 156, 111, 115, 120, 125, 6, 80, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 22, 151, 109, 112, 117, 122, 6, 80, 83, 131, 136, 88, 93, 102, 107<br /><br />ROOT Connectionᐸ18ᐳ[22]<br />1: <br />ᐳ: PgClassExpression[17], PgPageInfo[52]<br />2: PgSelect[23], PgSelect[74]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 65, 71"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 22, 156, 111, 115, 120, 125, 6, 80, 84, 135, 140, 89, 94, 104, 109<br /><br />ROOT Connectionᐸ18ᐳ[22]<br />1: <br />ᐳ: PgClassExpression[17], PgPageInfo[52]<br />2: PgSelect[23], PgSelect[74]<br />ᐳ: 55, 56, 57, 60, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 65, 71"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgSelect23,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,PgSelect74,First75,PgSelectSingle76,PgClassExpression77 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 83, 88, 93, 102, 107<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 80, 84, 89, 94, 104, 109<br /><br />ROOT __Item{4}ᐸ23ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 88, 93<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 89, 94<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 26, 27<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25, 11, 80, 83, 102, 107<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25, 11, 80, 84, 104, 109<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]<br />1: <br />ᐳ: 39, 41, 42, 40, 38<br />2: PgSelect[43]<br />ᐳ: First[47], PgSelectSingle[48]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectSingle48 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[48]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.mermaid
@@ -11,43 +11,43 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access84{{"Access[84∈0] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access119{{"Access[119∈0] ➊<br />ᐸ118.0ᐳ"}}:::plan
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda83 & Lambda88 & Lambda93 & Lambda104 & Lambda109 & Lambda116 & Lambda121 & Lambda126 & Lambda83 & Lambda140 & Lambda145 & Lambda80 & Lambda83 & Lambda158 & Lambda163 --> PgSelect8
-    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda80 & Constant84 & Constant85 & Constant86 --> Object87
-    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Lambda80 & Constant100 & Constant101 & Constant86 --> Object103
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda113 & Constant117 & Constant118 & Constant119 --> Object120
-    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda80 & Constant136 & Constant118 & Constant119 --> Object139
-    Object157{{"Object[157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda80 & Constant154 & Constant155 & Constant156 --> Object157
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access84 & Lambda89 & Lambda94 & Lambda106 & Lambda111 & Access119 & Lambda124 & Lambda129 & Access84 & Lambda144 & Lambda149 & Lambda80 & Access84 & Lambda163 & Lambda168 --> PgSelect8
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda80 & Constant85 & Constant86 & Constant87 --> Object88
+    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda80 & Constant102 & Constant103 & Constant87 --> Object105
+    Object123{{"Object[123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda115 & Constant120 & Constant121 & Constant122 --> Object123
+    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda80 & Constant140 & Constant121 & Constant122 --> Object143
+    Object162{{"Object[162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda80 & Constant159 & Constant160 & Constant161 --> Object162
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -55,63 +55,67 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection22{{"Connection[22∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant164 --> Connection22
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant165 --> Lambda80
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant166 --> Lambda83
-    Object87 --> Lambda88
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant167 --> Lambda93
-    Object103 --> Lambda104
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant168 --> Lambda109
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant172 --> Lambda113
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant173 --> Lambda116
-    Object120 --> Lambda121
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant169 --> Lambda126
-    Object139 --> Lambda140
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant170 --> Lambda145
-    Object157 --> Lambda158
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant171 --> Lambda163
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant169 --> Connection22
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant170 --> Lambda80
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant171 --> Lambda83
+    Lambda83 --> Access84
+    Object88 --> Lambda89
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant172 --> Lambda94
+    Object105 --> Lambda106
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant173 --> Lambda111
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant177 --> Lambda115
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant178 --> Lambda118
+    Lambda118 --> Access119
+    Object123 --> Lambda124
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant174 --> Lambda129
+    Object143 --> Lambda144
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant175 --> Lambda149
+    Object162 --> Lambda163
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant176 --> Lambda168
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant78{{"Constant[78∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant81{{"Constant[81∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object130{{"Object[130∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access128{{"Access[128∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access128 & Constant164 & Constant78 & Lambda113 & Constant114 --> Object130
-    Object148{{"Object[148∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access146{{"Access[146∈3]<br />ᐸ12.2ᐳ"}}:::plan
-    Access146 & Constant78 & Constant78 & Lambda80 & Constant81 --> Object148
+    Object133{{"Object[133∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access131{{"Access[131∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access131 & Constant169 & Constant78 & Lambda115 & Constant116 --> Object133
+    Object152{{"Object[152∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access150{{"Access[150∈3]<br />ᐸ12.2ᐳ"}}:::plan
+    Access150 & Constant78 & Constant78 & Lambda80 & Constant81 --> Object152
     Object60{{"Object[60∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access55{{"Access[55∈3]<br />ᐸ131.hasMoreᐳ"}}:::plan
-    Constant164 & Constant6 & Constant6 & Access55 --> Object60
+    Access55{{"Access[55∈3]<br />ᐸ134.hasMoreᐳ"}}:::plan
+    Constant169 & Constant6 & Constant6 & Access55 --> Object60
     Object56{{"Object[56∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant164 & Constant6 & Access55 --> Object56
+    Constant169 & Constant6 & Access55 --> Object56
     PgPageInfo52{{"PgPageInfo[52∈3] ➊"}}:::plan
     Connection22 --> PgPageInfo52
-    Lambda131{{"Lambda[131∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda131 --> Access55
+    Lambda134{{"Lambda[134∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda134 --> Access55
     Lambda57{{"Lambda[57∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object56 --> Lambda57
     Lambda61{{"Lambda[61∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object60 --> Lambda61
     First63{{"First[63∈3]"}}:::plan
-    Lambda131 --> First63
+    Lambda134 --> First63
     PgSelectSingle64{{"PgSelectSingle[64∈3]<br />ᐸmessagesᐳ"}}:::plan
     First63 --> PgSelectSingle64
     PgCursor65{{"PgCursor[65∈3]"}}:::plan
@@ -121,7 +125,7 @@ graph TD
     PgSelectSingle64 --> PgClassExpression66
     PgClassExpression66 --> List67
     Last69{{"Last[69∈3]"}}:::plan
-    Lambda131 --> Last69
+    Lambda134 --> Last69
     PgSelectSingle70{{"PgSelectSingle[70∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last69 --> PgSelectSingle70
     PgCursor71{{"PgCursor[71∈3]"}}:::plan
@@ -131,26 +135,26 @@ graph TD
     PgSelectSingle70 --> PgClassExpression72
     PgClassExpression72 --> List73
     First75{{"First[75∈3]"}}:::plan
-    Lambda149{{"Lambda[149∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda149 --> First75
+    Lambda153{{"Lambda[153∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda153 --> First75
     PgSelectSingle76{{"PgSelectSingle[76∈3]<br />ᐸmessagesᐳ"}}:::plan
     First75 --> PgSelectSingle76
     PgClassExpression77{{"PgClassExpression[77∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle76 --> PgClassExpression77
-    __Item12 --> Access128
-    Object130 --> Lambda131
-    __Item12 --> Access146
-    Object148 --> Lambda149
-    __Item24[/"__Item[24∈4]<br />ᐸ131ᐳ"\]:::itemplan
-    Lambda131 ==> __Item24
+    __Item12 --> Access131
+    Object133 --> Lambda134
+    __Item12 --> Access150
+    Object152 --> Lambda153
+    __Item24[/"__Item[24∈4]<br />ᐸ134ᐳ"\]:::itemplan
+    Lambda134 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys94{{"RemapKeys[94∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys94 --> PgSelectSingle33
-    PgSelectSingle25 --> RemapKeys94
+    RemapKeys95{{"RemapKeys[95∈5]<br />ᐸ25:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys95 --> PgSelectSingle33
+    PgSelectSingle25 --> RemapKeys95
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -164,9 +168,9 @@ graph TD
     PgClassExpression41{{"PgClassExpression[41∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression41
     PgSelectSingle48{{"PgSelectSingle[48∈7]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys110{{"RemapKeys[110∈7]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys110 --> PgSelectSingle48
-    PgSelectSingle25 --> RemapKeys110
+    RemapKeys112{{"RemapKeys[112∈7]<br />ᐸ25:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys112 --> PgSelectSingle48
+    PgSelectSingle25 --> RemapKeys112
     PgClassExpression49{{"PgClassExpression[49∈8]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
     PgClassExpression50{{"PgClassExpression[50∈8]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -175,30 +179,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/exclusively-archived-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 78, 81, 84, 85, 86, 100, 101, 114, 117, 118, 119, 136, 154, 155, 156, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 11, 22, 80, 83, 87, 88, 93, 103, 104, 109, 113, 116, 120, 121, 126, 139, 140, 145, 157, 158, 163<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 78, 81, 85, 86, 87, 102, 103, 116, 120, 121, 122, 140, 159, 160, 161, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 11, 22, 80, 83, 84, 88, 89, 94, 105, 106, 111, 115, 118, 119, 123, 124, 129, 143, 144, 149, 162, 163, 168<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection22,Constant78,Lambda80,Constant81,Lambda83,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant100,Constant101,Object103,Lambda104,Lambda109,Lambda113,Constant114,Lambda116,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant136,Object139,Lambda140,Lambda145,Constant154,Constant155,Constant156,Object157,Lambda158,Lambda163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 22, 164, 6, 78, 113, 114, 80, 81<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection22,Constant78,Lambda80,Constant81,Lambda83,Access84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant102,Constant103,Object105,Lambda106,Lambda111,Lambda115,Constant116,Lambda118,Access119,Constant120,Constant121,Constant122,Object123,Lambda124,Lambda129,Constant140,Object143,Lambda144,Lambda149,Constant159,Constant160,Constant161,Object162,Lambda163,Lambda168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 22, 169, 6, 78, 115, 116, 80, 81<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 22, 164, 6, 12, 78, 113, 114, 80, 81<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 22, 169, 6, 12, 78, 115, 116, 80, 81<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 164, 6, 12, 78, 113, 114, 80, 81<br /><br />ROOT Connectionᐸ18ᐳ[22]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 169, 6, 12, 78, 115, 116, 80, 81<br /><br />ROOT Connectionᐸ18ᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,First75,PgSelectSingle76,PgClassExpression77,Access128,Object130,Lambda131,Access146,Object148,Lambda149 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ131ᐳ[24]"):::bucket
+    class Bucket3,PgPageInfo52,Access55,Object56,Lambda57,Object60,Lambda61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,First75,PgSelectSingle76,PgClassExpression77,Access131,Object133,Lambda134,Access150,Object152,Lambda153 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ134ᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item24,PgSelectSingle25 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys94 bucket5
+    class Bucket5,PgClassExpression26,PgSelectSingle33,RemapKeys95 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[33]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression34,PgClassExpression35 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[25]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys110 bucket7
+    class Bucket7,PgCursor38,PgClassExpression39,List40,PgClassExpression41,PgSelectSingle48,RemapKeys112 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[48]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression49,PgClassExpression50 bucket8

--- a/grafast/dataplan-pg/__tests__/queries/conditions/include-all-archived.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/include-all-archived.deopt.mermaid
@@ -11,64 +11,68 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant79 & Lambda52 & Lambda54 & Lambda73 & Lambda78 --> PgSelect9
-    Object72{{"Object[72∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda52 & Constant69 & Constant70 & Constant71 --> Object72
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access56{{"Access[56∈0] ➊<br />ᐸ55.0ᐳ"}}:::plan
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant82 & Lambda53 & Access56 & Lambda76 & Lambda81 --> PgSelect9
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
+    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda53 & Constant72 & Constant73 & Constant74 --> Object75
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant80 --> Lambda37
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant85 --> Lambda52
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant86 --> Lambda54
-    Object72 --> Lambda73
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant84 --> Lambda78
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda37
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda40
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant85 --> Lambda51
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant88 --> Lambda53
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant89 --> Lambda55
+    Lambda55 --> Access56
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object60 --> Lambda61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant86 --> Lambda66
+    Object75 --> Lambda76
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant87 --> Lambda81
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object44{{"Object[44∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object58{{"Object[58∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda52 & Constant55 & Constant56 & Constant57 --> Object58
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
-    Lambda40{{"Lambda[40∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant81 --> Lambda40
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object44 --> Lambda45
-    Lambda50{{"Lambda[50∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant82 --> Lambda50
-    Lambda59{{"Lambda[59∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object58 --> Lambda59
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant83 --> Lambda64
     PgSelect19[["PgSelect[19∈2]<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression18 & Constant79 & Lambda52 & Lambda54 & Lambda59 & Lambda64 --> PgSelect19
+    Object12 & PgClassExpression18 & Constant82 & Lambda53 & Access56 & Lambda61 & Lambda66 --> PgSelect19
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
     PgSelectSingle14 --> PgClassExpression18
@@ -78,7 +82,7 @@ graph TD
     __Item23 --> PgSelectSingle24
     PgSelect27[["PgSelect[27∈4]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression26 & Lambda37 & Lambda40 & Lambda45 & Lambda50 --> PgSelect27
+    Object12 & PgClassExpression26 & Lambda37 & Access41 & Lambda46 & Lambda51 --> PgSelect27
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgSelectSingle24 --> PgClassExpression26
@@ -94,19 +98,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/include-all-archived"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 41, 42, 43, 55, 56, 57, 69, 70, 71, 79, 80, 81, 82, 83, 84, 85, 86, 12, 37, 52, 54, 72, 73, 78<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 42, 43, 44, 57, 58, 59, 72, 73, 74, 82, 83, 84, 85, 86, 87, 88, 89, 12, 37, 40, 41, 45, 46, 51, 53, 55, 56, 60, 61, 66, 75, 76, 81<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect9,Access10,Access11,Object12,Lambda37,Constant41,Constant42,Constant43,Lambda52,Lambda54,Constant55,Constant56,Constant57,Constant69,Constant70,Constant71,Object72,Lambda73,Lambda78,Constant79,Constant80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 81, 37, 41, 42, 43, 82, 52, 55, 56, 57, 83, 12, 79, 54<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect9,Access10,Access11,Object12,Lambda37,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Lambda53,Lambda55,Access56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant82,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 12, 82, 53, 56, 61, 66, 37, 41, 46, 51<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item13,PgSelectSingle14,Lambda40,Object44,Lambda45,Lambda50,Object58,Lambda59,Lambda64 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 79, 52, 54, 59, 64, 37, 40, 45, 50<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]<br />1: <br />ᐳ: 15, 18<br />2: PgSelect[19]"):::bucket
+    class Bucket1,__Item13,PgSelectSingle14 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 82, 53, 56, 61, 66, 37, 41, 46, 51<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]<br />1: <br />ᐳ: 15, 18<br />2: PgSelect[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15,PgClassExpression18,PgSelect19 bucket2
-    Bucket3("Bucket 3 (listItem)<br />Deps: 12, 37, 40, 45, 50<br /><br />ROOT __Item{3}ᐸ19ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (listItem)<br />Deps: 12, 37, 41, 46, 51<br /><br />ROOT __Item{3}ᐸ19ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item23,PgSelectSingle24 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24, 12, 37, 40, 45, 50<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]<br />1: <br />ᐳ: 25, 26<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24, 12, 37, 41, 46, 51<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]<br />1: <br />ᐳ: 25, 26<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{4}ᐸusersᐳ[32]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/conditions/include-all-archived.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/include-all-archived.mermaid
@@ -11,56 +11,60 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant86 & Lambda40 & Lambda45 & Lambda50 & Lambda56 & Lambda61 & Lambda66 & Lambda54 & Lambda56 & Lambda80 & Lambda85 --> PgSelect9
-    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant89 & Access41 & Lambda46 & Lambda51 & Access58 & Lambda63 & Lambda68 & Lambda55 & Access58 & Lambda83 & Lambda88 --> PgSelect9
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda54 & Constant57 & Constant58 & Constant59 --> Object60
-    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda55 & Constant59 & Constant60 & Constant61 --> Object62
+    Object82{{"Object[82∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda55 & Constant79 & Constant80 & Constant81 --> Object82
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda37
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant88 --> Lambda40
-    Object44 --> Lambda45
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant89 --> Lambda50
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant92 --> Lambda54
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant93 --> Lambda56
-    Object60 --> Lambda61
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant90 --> Lambda66
-    Object79 --> Lambda80
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant91 --> Lambda85
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant90 --> Lambda37
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant91 --> Lambda40
+    Lambda40 --> Access41
+    Object45 --> Lambda46
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant92 --> Lambda51
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant95 --> Lambda55
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant96 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant93 --> Lambda68
+    Object82 --> Lambda83
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant94 --> Lambda88
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant35{{"Constant[35∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant38{{"Constant[38∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -68,24 +72,24 @@ graph TD
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
-    Object70{{"Object[70∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access68{{"Access[68∈2]<br />ᐸ13.1ᐳ"}}:::plan
-    Access68 & Constant86 & Constant35 & Lambda54 & Constant38 --> Object70
+    Object72{{"Object[72∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access70{{"Access[70∈2]<br />ᐸ13.1ᐳ"}}:::plan
+    Access70 & Constant89 & Constant35 & Lambda55 & Constant38 --> Object72
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
-    __Item13 --> Access68
-    Lambda71{{"Lambda[71∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object70 --> Lambda71
-    __Item23[/"__Item[23∈3]<br />ᐸ71ᐳ"\]:::itemplan
-    Lambda71 ==> __Item23
+    __Item13 --> Access70
+    Lambda73{{"Lambda[73∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object72 --> Lambda73
+    __Item23[/"__Item[23∈3]<br />ᐸ73ᐳ"\]:::itemplan
+    Lambda73 ==> __Item23
     PgSelectSingle24{{"PgSelectSingle[24∈3]<br />ᐸmessagesᐳ"}}:::plan
     __Item23 --> PgSelectSingle24
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgSelectSingle32{{"PgSelectSingle[32∈4]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys51{{"RemapKeys[51∈4]<br />ᐸ24:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys51 --> PgSelectSingle32
-    PgSelectSingle24 --> RemapKeys51
+    RemapKeys52{{"RemapKeys[52∈4]<br />ᐸ24:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys52 --> PgSelectSingle32
+    PgSelectSingle24 --> RemapKeys52
     PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle32 --> PgClassExpression33
     PgClassExpression34{{"PgClassExpression[34∈5]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -94,21 +98,21 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/conditions/include-all-archived"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 35, 38, 41, 42, 43, 57, 58, 59, 76, 77, 78, 86, 87, 88, 89, 90, 91, 92, 93, 12, 37, 40, 44, 45, 50, 54, 56, 60, 61, 66, 79, 80, 85<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 35, 38, 42, 43, 44, 59, 60, 61, 79, 80, 81, 89, 90, 91, 92, 93, 94, 95, 96, 12, 37, 40, 41, 45, 46, 51, 55, 57, 58, 62, 63, 68, 82, 83, 88<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect9,Access10,Access11,Object12,Constant35,Lambda37,Constant38,Lambda40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Lambda54,Lambda56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92,Constant93 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 86, 35, 54, 38<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect9,Access10,Access11,Object12,Constant35,Lambda37,Constant38,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Lambda55,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant79,Constant80,Constant81,Object82,Lambda83,Lambda88,Constant89,Constant90,Constant91,Constant92,Constant93,Constant94,Constant95,Constant96 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 89, 35, 55, 38<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13,PgSelectSingle14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 13, 86, 35, 54, 38<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 13, 89, 35, 55, 38<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression15,Access68,Object70,Lambda71 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ71ᐳ[23]"):::bucket
+    class Bucket2,PgClassExpression15,Access70,Object72,Lambda73 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ73ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item23,PgSelectSingle24 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24<br /><br />ROOT PgSelectSingle{3}ᐸmessagesᐳ[24]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression25,PgSelectSingle32,RemapKeys51 bucket4
+    class Bucket4,PgClassExpression25,PgSelectSingle32,RemapKeys52 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{4}ᐸusersᐳ[32]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression33,PgClassExpression34 bucket5

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.deopt.mermaid
@@ -9,6 +9,21 @@ graph TD
 
 
     %% plan dependencies
+    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda59 & Constant64 & Constant65 & Constant66 --> Object67
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda75 & Constant80 & Constant81 & Constant82 --> Object83
+    Object98{{"Object[98∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda59 & Constant95 & Constant81 & Constant82 --> Object98
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -17,49 +32,48 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant102 --> Connection13
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant103 --> Lambda59
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant105 --> Connection13
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant106 --> Lambda59
     Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant104 --> Lambda62
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant107 --> Lambda62
+    Access63{{"Access[63∈0] ➊<br />ᐸ62.0ᐳ"}}:::plan
+    Lambda62 --> Access63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object67 --> Lambda68
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant108 --> Lambda73
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant111 --> Lambda75
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant112 --> Lambda78
+    Access79{{"Access[79∈0] ➊<br />ᐸ78.0ᐳ"}}:::plan
+    Lambda78 --> Access79
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object83 --> Lambda84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant109 --> Lambda89
+    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object98 --> Lambda99
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant110 --> Lambda104
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda87{{"Lambda[87∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Constant102 & Lambda74 & Lambda77 & Lambda82 & Lambda87 --> PgSelect14
+    Object12 & Connection13 & Constant105 & Lambda75 & Access79 & Lambda84 & Lambda89 --> PgSelect14
     PgSelect53[["PgSelect[53∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda101{{"Lambda[101∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda59 & Lambda62 & Lambda96 & Lambda101 --> PgSelect53
+    Object12 & Connection13 & Lambda59 & Access63 & Lambda99 & Lambda104 --> PgSelect53
     Object39{{"Object[39∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access34{{"Access[34∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
-    Constant102 & Constant6 & Constant6 & Access34 --> Object39
-    Object66{{"Object[66∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant63 & Constant64 & Constant65 --> Object66
-    Object81{{"Object[81∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda74 & Constant78 & Constant79 & Constant80 --> Object81
-    Object95{{"Object[95∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant92 & Constant79 & Constant80 --> Object95
+    Constant105 & Constant6 & Constant6 & Access34 --> Object39
     Object35{{"Object[35∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant102 & Constant6 & Access34 --> Object35
+    Constant105 & Constant6 & Access34 --> Object35
     PgPageInfo31{{"PgPageInfo[31∈1] ➊"}}:::plan
     Connection13 --> PgPageInfo31
     PgSelect14 --> Access34
@@ -93,23 +107,13 @@ graph TD
     First54 --> PgSelectSingle55
     PgClassExpression56{{"PgClassExpression[56∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle55 --> PgClassExpression56
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object66 --> Lambda67
-    Lambda72{{"Lambda[72∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant105 --> Lambda72
-    Constant108 --> Lambda74
-    Constant109 --> Lambda77
-    Object81 --> Lambda82
-    Constant106 --> Lambda87
-    Object95 --> Lambda96
-    Constant107 --> Lambda101
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
     PgSelect22[["PgSelect[22∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression21 & Lambda59 & Lambda62 & Lambda67 & Lambda72 --> PgSelect22
+    Object12 & PgClassExpression21 & Lambda59 & Access63 & Lambda68 & Lambda73 --> PgSelect22
     PgCursor17{{"PgCursor[17∈3]"}}:::plan
     List19{{"List[19∈3]<br />ᐸ18ᐳ"}}:::plan
     List19 --> PgCursor17
@@ -133,14 +137,14 @@ graph TD
     subgraph "Buckets for queries/connections/basics-limit3"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Lambda59,Lambda62,Constant63,Constant64,Constant65,Constant78,Constant79,Constant80,Constant92,Constant102,Constant103,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 102, 6, 59, 62, 63, 64, 65, 105, 108, 109, 78, 79, 80, 106, 92, 107<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 31, 66, 72, 74, 77, 87, 95, 101, 67, 81, 82, 96<br />2: PgSelect[14], PgSelect[53]<br />ᐳ: 34, 35, 36, 39, 40, 42, 43, 45, 46, 48, 49, 51, 52, 54, 55, 56, 44, 50"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Lambda59,Lambda62,Access63,Constant64,Constant65,Constant66,Object67,Lambda68,Lambda73,Lambda75,Lambda78,Access79,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant95,Object98,Lambda99,Lambda104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111,Constant112 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 105, 75, 79, 84, 89, 6, 59, 63, 99, 104, 68, 73<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,PgPageInfo31,Access34,Object35,Lambda36,Object39,Lambda40,First42,PgSelectSingle43,PgCursor44,PgClassExpression45,List46,Last48,PgSelectSingle49,PgCursor50,PgClassExpression51,List52,PgSelect53,First54,PgSelectSingle55,PgClassExpression56,Object66,Lambda67,Lambda72,Lambda74,Lambda77,Object81,Lambda82,Lambda87,Object95,Lambda96,Lambda101 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 59, 62, 67, 72<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14,PgPageInfo31,Access34,Object35,Lambda36,Object39,Lambda40,First42,PgSelectSingle43,PgCursor44,PgClassExpression45,List46,Last48,PgSelectSingle49,PgCursor50,PgClassExpression51,List52,PgSelect53,First54,PgSelectSingle55,PgClassExpression56 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 59, 63, 68, 73<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 59, 62, 67, 72<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[16]<br />1: <br />ᐳ: 18, 20, 21, 19, 17<br />2: PgSelect[22]<br />ᐳ: First[26], PgSelectSingle[27]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 59, 63, 68, 73<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[16]<br />1: <br />ᐳ: 18, 20, 21, 19, 17<br />2: PgSelect[22]<br />ᐳ: First[26], PgSelectSingle[27]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression20,PgClassExpression21,PgSelect22,First26,PgSelectSingle27 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 27<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[27]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.mermaid
@@ -9,57 +9,71 @@ graph TD
 
 
     %% plan dependencies
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant104 --> Connection13
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Constant104 & Lambda62 & Lambda67 & Lambda72 & Lambda76 & Lambda79 & Lambda84 & Lambda89 --> PgSelect14
-    PgSelect53[["PgSelect[53∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda59{{"Lambda[59∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda59 & Lambda62 & Lambda98 & Lambda103 --> PgSelect53
-    Object39{{"Object[39∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access34{{"Access[34∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
-    Constant104 & Constant6 & Constant6 & Access34 --> Object39
-    Object66{{"Object[66∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant63 & Constant64 & Constant65 --> Object66
-    Object83{{"Object[83∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda76 & Constant80 & Constant81 & Constant82 --> Object83
-    Object97{{"Object[97∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda59 & Constant94 & Constant81 & Constant82 --> Object97
-    Object35{{"Object[35∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant104 & Constant6 & Access34 --> Object35
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda59 & Constant64 & Constant65 & Constant66 --> Object67
+    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda77 & Constant82 & Constant83 & Constant84 --> Object85
+    Object100{{"Object[100∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda59 & Constant97 & Constant83 & Constant84 --> Object100
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant107 --> Connection13
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant108 --> Lambda59
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant109 --> Lambda62
+    Access63{{"Access[63∈0] ➊<br />ᐸ62.0ᐳ"}}:::plan
+    Lambda62 --> Access63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object67 --> Lambda68
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant110 --> Lambda73
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant113 --> Lambda77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant114 --> Lambda80
+    Access81{{"Access[81∈0] ➊<br />ᐸ80.0ᐳ"}}:::plan
+    Lambda80 --> Access81
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object85 --> Lambda86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant111 --> Lambda91
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object100 --> Lambda101
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant112 --> Lambda106
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object12 & Connection13 & Constant107 & Access63 & Lambda68 & Lambda73 & Lambda77 & Access81 & Lambda86 & Lambda91 --> PgSelect14
+    PgSelect53[["PgSelect[53∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object12 & Connection13 & Lambda59 & Access63 & Lambda101 & Lambda106 --> PgSelect53
+    Object39{{"Object[39∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access34{{"Access[34∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
+    Constant107 & Constant6 & Constant6 & Access34 --> Object39
+    Object35{{"Object[35∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant107 & Constant6 & Access34 --> Object35
     PgPageInfo31{{"PgPageInfo[31∈1] ➊"}}:::plan
     Connection13 --> PgPageInfo31
     PgSelect14 --> Access34
@@ -93,16 +107,6 @@ graph TD
     First54 --> PgSelectSingle55
     PgClassExpression56{{"PgClassExpression[56∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle55 --> PgClassExpression56
-    Constant105 --> Lambda59
-    Constant106 --> Lambda62
-    Object66 --> Lambda67
-    Constant107 --> Lambda72
-    Constant110 --> Lambda76
-    Constant111 --> Lambda79
-    Object83 --> Lambda84
-    Constant108 --> Lambda89
-    Object97 --> Lambda98
-    Constant109 --> Lambda103
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -116,9 +120,9 @@ graph TD
     PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression20
     PgSelectSingle27{{"PgSelectSingle[27∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys73{{"RemapKeys[73∈3]<br />ᐸ16:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys73 --> PgSelectSingle27
-    PgSelectSingle16 --> RemapKeys73
+    RemapKeys74{{"RemapKeys[74∈3]<br />ᐸ16:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys74 --> PgSelectSingle27
+    PgSelectSingle16 --> RemapKeys74
     PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle27 --> PgClassExpression28
     PgClassExpression29{{"PgClassExpression[29∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -129,16 +133,16 @@ graph TD
     subgraph "Buckets for queries/connections/basics-limit3"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection13,Constant63,Constant64,Constant65,Constant80,Constant81,Constant82,Constant94,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 104, 6, 105, 106, 63, 64, 65, 107, 110, 111, 80, 81, 82, 108, 94, 109<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 31, 59, 62, 72, 76, 79, 89, 103, 12, 66, 67, 83, 84, 97, 98<br />2: PgSelect[14], PgSelect[53]<br />ᐳ: 34, 35, 36, 39, 40, 42, 43, 45, 46, 48, 49, 51, 52, 54, 55, 56, 44, 50"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Lambda59,Lambda62,Access63,Constant64,Constant65,Constant66,Object67,Lambda68,Lambda73,Lambda77,Lambda80,Access81,Constant82,Constant83,Constant84,Object85,Lambda86,Lambda91,Constant97,Object100,Lambda101,Lambda106,Constant107,Constant108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 107, 63, 68, 73, 77, 81, 86, 91, 6, 59, 101, 106<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,PgPageInfo31,Access34,Object35,Lambda36,Object39,Lambda40,First42,PgSelectSingle43,PgCursor44,PgClassExpression45,List46,Last48,PgSelectSingle49,PgCursor50,PgClassExpression51,List52,PgSelect53,First54,PgSelectSingle55,PgClassExpression56,Lambda59,Lambda62,Object66,Lambda67,Lambda72,Lambda76,Lambda79,Object83,Lambda84,Lambda89,Object97,Lambda98,Lambda103 bucket1
+    class Bucket1,PgSelect14,PgPageInfo31,Access34,Object35,Lambda36,Object39,Lambda40,First42,PgSelectSingle43,PgCursor44,PgClassExpression45,List46,Last48,PgSelectSingle49,PgCursor50,PgClassExpression51,List52,PgSelect53,First54,PgSelectSingle55,PgClassExpression56 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression20,PgSelectSingle27,RemapKeys73 bucket3
+    class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression20,PgSelectSingle27,RemapKeys74 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 27<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[27]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression28,PgClassExpression29 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics.deopt.mermaid
@@ -9,6 +9,20 @@ graph TD
 
 
     %% plan dependencies
+    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda58 & Constant63 & Constant64 & Constant65 --> Object66
+    Object82{{"Object[82∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda58 & Constant79 & Constant80 & Constant81 --> Object82
+    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda58 & Constant94 & Constant80 & Constant81 --> Object97
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,44 +30,43 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant101 --> Lambda58
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant104 --> Lambda58
     Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant102 --> Lambda61
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant105 --> Lambda61
+    Access62{{"Access[62∈0] ➊<br />ᐸ61.0ᐳ"}}:::plan
+    Lambda61 --> Access62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object66 --> Lambda67
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant107 --> Lambda72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant106 --> Lambda77
+    Access78{{"Access[78∈0] ➊<br />ᐸ77.0ᐳ"}}:::plan
+    Lambda77 --> Access78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object82 --> Lambda83
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant108 --> Lambda88
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object97 --> Lambda98
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant109 --> Lambda103
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
     PgSelect13[["PgSelect[13∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection12 & Lambda58 & Lambda76 & Lambda81 & Lambda86 --> PgSelect13
+    Object11 & Connection12 & Lambda58 & Access78 & Lambda83 & Lambda88 --> PgSelect13
     PgSelect52[["PgSelect[52∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda95{{"Lambda[95∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda100{{"Lambda[100∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection12 & Lambda58 & Lambda61 & Lambda95 & Lambda100 --> PgSelect52
+    Object11 & Connection12 & Lambda58 & Access62 & Lambda98 & Lambda103 --> PgSelect52
     Object38{{"Object[38∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access33{{"Access[33∈1] ➊<br />ᐸ13.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access33 --> Object38
-    Object65{{"Object[65∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant62 & Constant63 & Constant64 --> Object65
-    Object80{{"Object[80∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant77 & Constant78 & Constant79 --> Object80
-    Object94{{"Object[94∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant91 & Constant78 & Constant79 --> Object94
     Object34{{"Object[34∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access33 --> Object34
     PgPageInfo30{{"PgPageInfo[30∈1] ➊"}}:::plan
@@ -89,22 +102,13 @@ graph TD
     First53 --> PgSelectSingle54
     PgClassExpression55{{"PgClassExpression[55∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle54 --> PgClassExpression55
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object65 --> Lambda66
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant104 --> Lambda71
-    Constant103 --> Lambda76
-    Object80 --> Lambda81
-    Constant105 --> Lambda86
-    Object94 --> Lambda95
-    Constant106 --> Lambda100
     __Item14[/"__Item[14∈2]<br />ᐸ13ᐳ"\]:::itemplan
     PgSelect13 ==> __Item14
     PgSelectSingle15{{"PgSelectSingle[15∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item14 --> PgSelectSingle15
     PgSelect21[["PgSelect[21∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression20 & Lambda58 & Lambda61 & Lambda66 & Lambda71 --> PgSelect21
+    Object11 & PgClassExpression20 & Lambda58 & Access62 & Lambda67 & Lambda72 --> PgSelect21
     PgCursor16{{"PgCursor[16∈3]"}}:::plan
     List18{{"List[18∈3]<br />ᐸ17ᐳ"}}:::plan
     List18 --> PgCursor16
@@ -128,14 +132,14 @@ graph TD
     subgraph "Buckets for queries/connections/basics"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access9,Access10,Object11,Connection12,Lambda58,Lambda61,Constant62,Constant63,Constant64,Constant77,Constant78,Constant79,Constant91,Constant101,Constant102,Constant103,Constant104,Constant105,Constant106 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 58, 6, 61, 62, 63, 64, 104, 103, 77, 78, 79, 105, 91, 106<br /><br />ROOT Connectionᐸ8ᐳ[12]<br />1: <br />ᐳ: 30, 65, 71, 76, 80, 86, 94, 100, 66, 81, 95<br />2: PgSelect[13], PgSelect[52]<br />ᐳ: 33, 34, 35, 38, 39, 41, 42, 44, 45, 47, 48, 50, 51, 53, 54, 55, 43, 49"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access9,Access10,Object11,Connection12,Lambda58,Lambda61,Access62,Constant63,Constant64,Constant65,Object66,Lambda67,Lambda72,Lambda77,Access78,Constant79,Constant80,Constant81,Object82,Lambda83,Lambda88,Constant94,Object97,Lambda98,Lambda103,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 58, 78, 83, 88, 6, 62, 98, 103, 67, 72<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect13,PgPageInfo30,Access33,Object34,Lambda35,Object38,Lambda39,First41,PgSelectSingle42,PgCursor43,PgClassExpression44,List45,Last47,PgSelectSingle48,PgCursor49,PgClassExpression50,List51,PgSelect52,First53,PgSelectSingle54,PgClassExpression55,Object65,Lambda66,Lambda71,Lambda76,Object80,Lambda81,Lambda86,Object94,Lambda95,Lambda100 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 58, 61, 66, 71<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
+    class Bucket1,PgSelect13,PgPageInfo30,Access33,Object34,Lambda35,Object38,Lambda39,First41,PgSelectSingle42,PgCursor43,PgClassExpression44,List45,Last47,PgSelectSingle48,PgCursor49,PgClassExpression50,List51,PgSelect52,First53,PgSelectSingle54,PgClassExpression55 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 58, 62, 67, 72<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 11, 58, 61, 66, 71<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[15]<br />1: <br />ᐳ: 17, 19, 20, 18, 16<br />2: PgSelect[21]<br />ᐳ: First[25], PgSelectSingle[26]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 11, 58, 62, 67, 72<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[15]<br />1: <br />ᐳ: 17, 19, 20, 18, 16<br />2: PgSelect[21]<br />ᐳ: First[25], PgSelectSingle[26]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor16,PgClassExpression17,List18,PgClassExpression19,PgClassExpression20,PgSelect21,First25,PgSelectSingle26 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[26]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics.mermaid
@@ -9,53 +9,66 @@ graph TD
 
 
     %% plan dependencies
+    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda58 & Constant63 & Constant64 & Constant65 --> Object66
+    Object84{{"Object[84∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda58 & Constant81 & Constant82 & Constant83 --> Object84
+    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda58 & Constant96 & Constant82 & Constant83 --> Object99
+    Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access9
+    __Value2 --> Access10
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant106 --> Lambda58
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant107 --> Lambda61
+    Access62{{"Access[62∈0] ➊<br />ᐸ61.0ᐳ"}}:::plan
+    Lambda61 --> Access62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object66 --> Lambda67
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant109 --> Lambda72
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant108 --> Lambda79
+    Access80{{"Access[80∈0] ➊<br />ᐸ79.0ᐳ"}}:::plan
+    Lambda79 --> Access80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object84 --> Lambda85
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant110 --> Lambda90
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object99 --> Lambda100
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant111 --> Lambda105
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
     PgSelect13[["PgSelect[13∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object11{{"Object[11∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection12 & Lambda61 & Lambda66 & Lambda71 & Lambda58 & Lambda78 & Lambda83 & Lambda88 --> PgSelect13
+    Object11 & Connection12 & Access62 & Lambda67 & Lambda72 & Lambda58 & Access80 & Lambda85 & Lambda90 --> PgSelect13
     PgSelect52[["PgSelect[52∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda97{{"Lambda[97∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda102{{"Lambda[102∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection12 & Lambda58 & Lambda61 & Lambda97 & Lambda102 --> PgSelect52
+    Object11 & Connection12 & Lambda58 & Access62 & Lambda100 & Lambda105 --> PgSelect52
     Object38{{"Object[38∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access33{{"Access[33∈1] ➊<br />ᐸ13.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access33 --> Object38
-    Object65{{"Object[65∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant62 & Constant63 & Constant64 --> Object65
-    Object82{{"Object[82∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant79 & Constant80 & Constant81 --> Object82
-    Object96{{"Object[96∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant93 & Constant80 & Constant81 --> Object96
     Object34{{"Object[34∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access33 --> Object34
-    Access9{{"Access[9∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access9 & Access10 --> Object11
-    __Value2 --> Access9
-    __Value2 --> Access10
     PgPageInfo30{{"PgPageInfo[30∈1] ➊"}}:::plan
     Connection12 --> PgPageInfo30
     PgSelect13 --> Access33
@@ -89,15 +102,6 @@ graph TD
     First53 --> PgSelectSingle54
     PgClassExpression55{{"PgClassExpression[55∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle54 --> PgClassExpression55
-    Constant103 --> Lambda58
-    Constant104 --> Lambda61
-    Object65 --> Lambda66
-    Constant106 --> Lambda71
-    Constant105 --> Lambda78
-    Object82 --> Lambda83
-    Constant107 --> Lambda88
-    Object96 --> Lambda97
-    Constant108 --> Lambda102
     __Item14[/"__Item[14∈2]<br />ᐸ13ᐳ"\]:::itemplan
     PgSelect13 ==> __Item14
     PgSelectSingle15{{"PgSelectSingle[15∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -111,9 +115,9 @@ graph TD
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle15 --> PgClassExpression19
     PgSelectSingle26{{"PgSelectSingle[26∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys72{{"RemapKeys[72∈3]<br />ᐸ15:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys72 --> PgSelectSingle26
-    PgSelectSingle15 --> RemapKeys72
+    RemapKeys73{{"RemapKeys[73∈3]<br />ᐸ15:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys73 --> PgSelectSingle26
+    PgSelectSingle15 --> RemapKeys73
     PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -124,16 +128,16 @@ graph TD
     subgraph "Buckets for queries/connections/basics"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection12,Constant62,Constant63,Constant64,Constant79,Constant80,Constant81,Constant93,Constant103,Constant104,Constant105,Constant106,Constant107,Constant108 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 12, 6, 103, 104, 62, 63, 64, 106, 105, 79, 80, 81, 107, 93, 108<br /><br />ROOT Connectionᐸ8ᐳ[12]<br />1: <br />ᐳ: 9, 10, 30, 58, 61, 71, 78, 88, 102, 11, 65, 66, 82, 83, 96, 97<br />2: PgSelect[13], PgSelect[52]<br />ᐳ: 33, 34, 35, 38, 39, 41, 42, 44, 45, 47, 48, 50, 51, 53, 54, 55, 43, 49"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access9,Access10,Object11,Connection12,Lambda58,Lambda61,Access62,Constant63,Constant64,Constant65,Object66,Lambda67,Lambda72,Lambda79,Access80,Constant81,Constant82,Constant83,Object84,Lambda85,Lambda90,Constant96,Object99,Lambda100,Lambda105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 62, 67, 72, 58, 80, 85, 90, 6, 100, 105<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access9,Access10,Object11,PgSelect13,PgPageInfo30,Access33,Object34,Lambda35,Object38,Lambda39,First41,PgSelectSingle42,PgCursor43,PgClassExpression44,List45,Last47,PgSelectSingle48,PgCursor49,PgClassExpression50,List51,PgSelect52,First53,PgSelectSingle54,PgClassExpression55,Lambda58,Lambda61,Object65,Lambda66,Lambda71,Lambda78,Object82,Lambda83,Lambda88,Object96,Lambda97,Lambda102 bucket1
+    class Bucket1,PgSelect13,PgPageInfo30,Access33,Object34,Lambda35,Object38,Lambda39,First41,PgSelectSingle42,PgCursor43,PgClassExpression44,List45,Last47,PgSelectSingle48,PgCursor49,PgClassExpression50,List51,PgSelect52,First53,PgSelectSingle54,PgClassExpression55 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[15]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor16,PgClassExpression17,List18,PgClassExpression19,PgSelectSingle26,RemapKeys72 bucket3
+    class Bucket3,PgCursor16,PgClassExpression17,List18,PgClassExpression19,PgSelectSingle26,RemapKeys73 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression27,PgClassExpression28 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/empty.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/empty.deopt.mermaid
@@ -12,54 +12,58 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda36 & Lambda54 & Lambda59 & Lambda64 --> PgSelect8
-    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda36 & Constant55 & Constant56 & Constant57 --> Object58
+    Access56{{"Access[56∈0] ➊<br />ᐸ55.0ᐳ"}}:::plan
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda36 & Access56 & Lambda61 & Lambda66 --> PgSelect8
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda36 & Constant57 & Constant58 & Constant59 --> Object60
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant65 --> Lambda36
     Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant67 --> Lambda54
-    Object58 --> Lambda59
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant69 --> Lambda64
+    Constant67 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant68 --> Lambda39
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda39 --> Access40
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object44 --> Lambda45
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant70 --> Lambda51
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant69 --> Lambda55
+    Lambda55 --> Access56
+    Object60 --> Lambda61
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant71 --> Lambda66
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object43{{"Object[43∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda39{{"Lambda[39∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant66 --> Lambda39
-    Lambda44{{"Lambda[44∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object43 --> Lambda44
-    Lambda50{{"Lambda[50∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant68 --> Lambda50
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgSelect23[["PgSelect[23∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums__...chived_at”ᐳ"}}:::plan
-    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda36 & Lambda39 & Lambda44 & Lambda50 --> PgSelect23
+    Object11 & PgClassExpression16 & PgClassExpression22 & Connection21 & Lambda36 & Access40 & Lambda45 & Lambda51 --> PgSelect23
     Object32{{"Object[32∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access27{{"Access[27∈3]<br />ᐸ23.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access27 --> Object32
@@ -78,16 +82,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/empty"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 40, 41, 42, 55, 56, 57, 65, 66, 67, 68, 69, 11, 36, 54, 58, 59, 64<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 41, 42, 43, 57, 58, 59, 67, 68, 69, 70, 71, 11, 36, 39, 40, 44, 45, 51, 55, 56, 60, 61, 66<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda36,Constant40,Constant41,Constant42,Lambda54,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant65,Constant66,Constant67,Constant68,Constant69 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 66, 36, 40, 41, 42, 68, 11, 21, 6<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Lambda36,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda51,Lambda55,Access56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant67,Constant68,Constant69,Constant70,Constant71 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 21, 36, 40, 45, 51, 6<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Lambda39,Object43,Lambda44,Lambda50 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 36, 39, 44, 50, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 21, 36, 40, 45, 51, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 36, 39, 44, 50, 6<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 24<br />2: PgSelect[23]<br />ᐳ: 27, 28, 29, 32, 33"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 11, 21, 36, 40, 45, 51, 6<br /><br />ROOT Connectionᐸ17ᐳ[21]<br />1: <br />ᐳ: 16, 22, 24<br />2: PgSelect[23]<br />ᐳ: 27, 28, 29, 32, 33"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression16,PgClassExpression22,PgSelect23,PgPageInfo24,Access27,Object28,Lambda29,Object32,Lambda33 bucket3
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/connections/empty.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/empty.mermaid
@@ -11,42 +11,46 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda39 & Lambda44 & Lambda50 & Lambda36 & Lambda59 & Lambda64 & Lambda69 --> PgSelect8
-    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda36 & Constant60 & Constant61 & Constant62 --> Object63
+    Access61{{"Access[61∈0] ➊<br />ᐸ60.0ᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access40 & Lambda45 & Lambda51 & Lambda36 & Access61 & Lambda66 & Lambda71 --> PgSelect8
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda36 & Constant62 & Constant63 & Constant64 --> Object65
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda36
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda39
-    Object43 --> Lambda44
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant73 --> Lambda50
     Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant72 --> Lambda59
-    Object63 --> Lambda64
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant74 --> Lambda69
+    Constant72 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant73 --> Lambda39
+    Lambda39 --> Access40
+    Object44 --> Lambda45
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant75 --> Lambda51
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant74 --> Lambda60
+    Lambda60 --> Access61
+    Object65 --> Lambda66
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant76 --> Lambda71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
@@ -58,31 +62,31 @@ graph TD
     __Item12 --> PgSelectSingle13
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
-    Object54{{"Object[54∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access52{{"Access[52∈3]<br />ᐸ12.1ᐳ"}}:::plan
-    Access52 & Constant34 & Constant34 & Lambda36 & Constant37 --> Object54
+    Object55{{"Object[55∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access53{{"Access[53∈3]<br />ᐸ12.1ᐳ"}}:::plan
+    Access53 & Constant34 & Constant34 & Lambda36 & Constant37 --> Object55
     Object32{{"Object[32∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access27{{"Access[27∈3]<br />ᐸ55.hasMoreᐳ"}}:::plan
+    Access27{{"Access[27∈3]<br />ᐸ56.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access27 --> Object32
     Object28{{"Object[28∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access27 --> Object28
     PgPageInfo24{{"PgPageInfo[24∈3] ➊"}}:::plan
     Connection21 --> PgPageInfo24
-    Lambda55{{"Lambda[55∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda55 --> Access27
+    Lambda56{{"Lambda[56∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda56 --> Access27
     Lambda29{{"Lambda[29∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object28 --> Lambda29
     Lambda33{{"Lambda[33∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object32 --> Lambda33
-    __Item12 --> Access52
-    Object54 --> Lambda55
+    __Item12 --> Access53
+    Object55 --> Lambda56
 
     %% define steps
 
     subgraph "Buckets for queries/connections/empty"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 34, 37, 40, 41, 42, 60, 61, 62, 70, 71, 72, 73, 74, 11, 36, 39, 43, 44, 50, 59, 63, 64, 69<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 21, 34, 37, 41, 42, 43, 62, 63, 64, 72, 73, 74, 75, 76, 11, 36, 39, 40, 44, 45, 51, 60, 61, 65, 66, 71<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant34,Lambda36,Constant37,Lambda39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda50,Lambda59,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant70,Constant71,Constant72,Constant73,Constant74 bucket0
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect8,Access9,Access10,Object11,Connection21,Constant34,Lambda36,Constant37,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda51,Lambda60,Access61,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant72,Constant73,Constant74,Constant75,Constant76 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 21, 6, 34, 36, 37<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
@@ -91,7 +95,7 @@ graph TD
     class Bucket2,PgClassExpression14 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 6, 12, 34, 36, 37<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo24,Access27,Object28,Lambda29,Object32,Lambda33,Access52,Object54,Lambda55 bucket3
+    class Bucket3,PgPageInfo24,Access27,Object28,Lambda29,Object32,Lambda33,Access53,Object55,Lambda56 bucket3
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.deopt.mermaid
@@ -9,6 +9,21 @@ graph TD
 
 
     %% plan dependencies
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 857ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant90 & Constant91 --> Object107
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -17,49 +32,48 @@ graph TD
     __Value2 --> Access13
     __Value2 --> Access14
     Connection16{{"Connection[16∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant111 --> Connection16
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant112 --> Lambda68
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant114 --> Connection16
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant115 --> Lambda68
     Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda71
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant117 --> Lambda82
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant120 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant121 --> Lambda87
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda87 --> Access88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
+    Constant118 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant119 --> Lambda113
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 857ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Constant111 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect17
+    Object15 & Connection16 & Constant114 & Lambda84 & Access88 & Lambda93 & Lambda98 --> PgSelect17
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Lambda68 & Lambda71 & Lambda105 & Lambda110 --> PgSelect62
+    Object15 & Connection16 & Lambda68 & Access72 & Lambda108 & Lambda113 --> PgSelect62
     Object44{{"Object[44∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ17.hasMoreᐳ"}}:::plan
-    Constant111 & Constant6 & Constant6 & Access39 --> Object44
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant88 & Constant89 --> Object104
+    Constant114 & Constant6 & Constant6 & Access39 --> Object44
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant111 & Constant6 & Access39 --> Object40
+    Constant114 & Constant6 & Access39 --> Object40
     List53{{"List[53∈1] ➊<br />ᐸ50,51,52ᐳ"}}:::plan
     PgClassExpression50{{"PgClassExpression[50∈1] ➊<br />ᐸ__author__.usernameᐳ"}}:::plan
     PgClassExpression51{{"PgClassExpression[51∈1] ➊<br />ᐸ__messages__.bodyᐳ"}}:::plan
@@ -101,23 +115,13 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant114 --> Lambda81
-    Constant117 --> Lambda83
-    Constant118 --> Lambda86
-    Object90 --> Lambda91
-    Constant115 --> Lambda96
-    Object104 --> Lambda105
-    Constant116 --> Lambda110
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgSelect17 ==> __Item18
     PgSelectSingle19{{"PgSelectSingle[19∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item18 --> PgSelectSingle19
     PgSelect27[["PgSelect[27∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object15 & PgClassExpression26 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect27
+    Object15 & PgClassExpression26 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect27
     List24{{"List[24∈3]<br />ᐸ21,22,23ᐳ"}}:::plan
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__author__.usernameᐳ"}}:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__messages__.bodyᐳ"}}:::plan
@@ -145,14 +149,14 @@ graph TD
     subgraph "Buckets for queries/connections/order"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access13,Access14,Object15,Connection16,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant87,Constant88,Constant89,Constant101,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 111, 6, 68, 71, 72, 73, 74, 114, 117, 118, 87, 88, 89, 115, 101, 116<br /><br />ROOT Connectionᐸ12ᐳ[16]<br />1: <br />ᐳ: 36, 75, 81, 83, 86, 96, 104, 110, 76, 90, 91, 105<br />2: PgSelect[17], PgSelect[62]<br />ᐳ: 39, 40, 41, 44, 45, 47, 48, 50, 51, 52, 53, 55, 56, 58, 59, 60, 61, 63, 64, 65, 49, 57"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access13,Access14,Object15,Connection16,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda84,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 114, 84, 88, 93, 98, 6, 68, 72, 108, 113, 77, 82<br /><br />ROOT Connectionᐸ12ᐳ[16]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect17,PgPageInfo36,Access39,Object40,Lambda41,Object44,Lambda45,First47,PgSelectSingle48,PgCursor49,PgClassExpression50,PgClassExpression51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,PgClassExpression59,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Object75,Lambda76,Lambda81,Lambda83,Lambda86,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 15, 68, 71, 76, 81<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
+    class Bucket1,PgSelect17,PgPageInfo36,Access39,Object40,Lambda41,Object44,Lambda45,First47,PgSelectSingle48,PgCursor49,PgClassExpression50,PgClassExpression51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,PgClassExpression59,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 15, 68, 72, 77, 82<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgSelectSingle19 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 15, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[19]<br />1: <br />ᐳ: 21, 22, 23, 25, 26, 24, 20<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 15, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[19]<br />1: <br />ᐳ: 21, 22, 23, 25, 26, 24, 20<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor20,PgClassExpression21,PgClassExpression22,PgClassExpression23,List24,PgClassExpression25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[32]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.mermaid
@@ -9,52 +9,71 @@ graph TD
 
 
     %% plan dependencies
-    Connection16{{"Connection[16∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant113 --> Connection16
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 857ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant106 & Constant92 & Constant93 --> Object109
+    Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access13 & Access14 --> Object15
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access13
+    __Value2 --> Access14
+    Connection16{{"Connection[16∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant116 --> Connection16
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant119 --> Lambda82
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
+    Constant120 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant121 --> Lambda115
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 857ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object15{{"Object[15∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Constant113 & Lambda71 & Lambda76 & Lambda81 & Lambda85 & Lambda88 & Lambda93 & Lambda98 --> PgSelect17
+    Object15 & Connection16 & Constant116 & Access72 & Lambda77 & Lambda82 & Lambda86 & Access90 & Lambda95 & Lambda100 --> PgSelect17
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Lambda68 & Lambda71 & Lambda107 & Lambda112 --> PgSelect62
+    Object15 & Connection16 & Lambda68 & Access72 & Lambda110 & Lambda115 --> PgSelect62
     Object44{{"Object[44∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ17.hasMoreᐳ"}}:::plan
-    Constant113 & Constant6 & Constant6 & Access39 --> Object44
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda85 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant103 & Constant90 & Constant91 --> Object106
+    Constant116 & Constant6 & Constant6 & Access39 --> Object44
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant113 & Constant6 & Access39 --> Object40
+    Constant116 & Constant6 & Access39 --> Object40
     List53{{"List[53∈1] ➊<br />ᐸ50,51,52ᐳ"}}:::plan
     PgClassExpression50{{"PgClassExpression[50∈1] ➊<br />ᐸ__author__.usernameᐳ"}}:::plan
     PgClassExpression51{{"PgClassExpression[51∈1] ➊<br />ᐸ__messages__.bodyᐳ"}}:::plan
@@ -65,11 +84,6 @@ graph TD
     PgClassExpression59{{"PgClassExpression[59∈1] ➊<br />ᐸ__messages__.bodyᐳ"}}:::plan
     PgClassExpression60{{"PgClassExpression[60∈1] ➊<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgClassExpression58 & PgClassExpression59 & PgClassExpression60 --> List61
-    Access13{{"Access[13∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access14{{"Access[14∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access13 & Access14 --> Object15
-    __Value2 --> Access13
-    __Value2 --> Access14
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection16 --> PgPageInfo36
     PgSelect17 --> Access39
@@ -101,16 +115,6 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Constant114 --> Lambda68
-    Constant115 --> Lambda71
-    Object75 --> Lambda76
-    Constant116 --> Lambda81
-    Constant119 --> Lambda85
-    Constant120 --> Lambda88
-    Object92 --> Lambda93
-    Constant117 --> Lambda98
-    Object106 --> Lambda107
-    Constant118 --> Lambda112
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgSelect17 ==> __Item18
     PgSelectSingle19{{"PgSelectSingle[19∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -128,9 +132,9 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression25
     PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈3]<br />ᐸ19:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle32
-    PgSelectSingle19 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈3]<br />ᐸ19:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle32
+    PgSelectSingle19 --> RemapKeys83
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle32 --> PgClassExpression33
     PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -141,16 +145,16 @@ graph TD
     subgraph "Buckets for queries/connections/order"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection16,Constant72,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 16, 113, 6, 114, 115, 72, 73, 74, 116, 119, 120, 89, 90, 91, 117, 103, 118<br /><br />ROOT Connectionᐸ12ᐳ[16]<br />1: <br />ᐳ: 13, 14, 36, 68, 71, 81, 85, 88, 98, 112, 15, 75, 76, 92, 93, 106, 107<br />2: PgSelect[17], PgSelect[62]<br />ᐳ: 39, 40, 41, 44, 45, 47, 48, 50, 51, 52, 53, 55, 56, 58, 59, 60, 61, 63, 64, 65, 49, 57"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access13,Access14,Object15,Connection16,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Object109,Lambda110,Lambda115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 116, 72, 77, 82, 86, 90, 95, 100, 6, 68, 110, 115<br /><br />ROOT Connectionᐸ12ᐳ[16]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access13,Access14,Object15,PgSelect17,PgPageInfo36,Access39,Object40,Lambda41,Object44,Lambda45,First47,PgSelectSingle48,PgCursor49,PgClassExpression50,PgClassExpression51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,PgClassExpression59,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Lambda68,Lambda71,Object75,Lambda76,Lambda81,Lambda85,Lambda88,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112 bucket1
+    class Bucket1,PgSelect17,PgPageInfo36,Access39,Object40,Lambda41,Object44,Lambda45,First47,PgSelectSingle48,PgCursor49,PgClassExpression50,PgClassExpression51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,PgClassExpression59,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgSelectSingle19 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[19]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor20,PgClassExpression21,PgClassExpression22,PgClassExpression23,List24,PgClassExpression25,PgSelectSingle32,RemapKeys82 bucket3
+    class Bucket3,PgCursor20,PgClassExpression21,PgClassExpression22,PgClassExpression23,List24,PgClassExpression25,PgSelectSingle32,RemapKeys83 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[32]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression33,PgClassExpression34 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.deopt.mermaid
@@ -10,10 +10,25 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant111 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Constant114 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant90 & Constant91 --> Object107
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -21,52 +36,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
-    Constant112 --> Lambda15
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
+    Constant115 --> Lambda15
     Lambda15 --> PgValidateParsedCursor17
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda68
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
+    Lambda15 --> Access18
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda68
     Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda71
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant118 --> Lambda82
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant121 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda87
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda87 --> Access88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant119 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant120 --> Lambda113
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant111 & Access18 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect16
+    Object13 & Connection14 & Lambda15 & Constant114 & Access18 & Lambda84 & Access88 & Lambda93 & Lambda98 --> PgSelect16
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda105 & Lambda110 --> PgSelect62
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda108 & Lambda113 --> PgSelect62
     Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant111 & Constant6 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant88 & Constant89 --> Object104
+    Constant114 & Constant6 & Constant6 & Access39 --> Object45
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant111 & Constant6 & Access39 --> Object40
-    Lambda15 --> Access18
+    Constant114 & Constant6 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,23 +114,13 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda81
-    Constant118 --> Lambda83
-    Constant119 --> Lambda86
-    Object90 --> Lambda91
-    Constant116 --> Lambda96
-    Object104 --> Lambda105
-    Constant117 --> Lambda110
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSelect26[["PgSelect[26∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression25 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect26
+    Object13 & PgClassExpression25 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect26
     PgCursor21{{"PgCursor[21∈3]"}}:::plan
     List23{{"List[23∈3]<br />ᐸ22ᐳ"}}:::plan
     List23 --> PgCursor21
@@ -138,16 +142,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-after"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 72, 73, 74, 87, 88, 89, 101, 111, 112, 113, 114, 115, 116, 117, 118, 119, 13, 15, 68, 71<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 89, 90, 91, 104, 114, 115, 116, 117, 118, 119, 120, 121, 122, 13, 15, 18, 68, 71, 72, 76, 77, 82, 84, 87, 88, 92, 93, 98, 107, 108, 113<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant87,Constant88,Constant89,Constant101,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 111, 6, 68, 71, 72, 73, 74, 115, 118, 119, 87, 88, 89, 116, 101, 117<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 18, 36, 75, 81, 83, 86, 96, 104, 110, 76, 90, 91, 105<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda84,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 114, 18, 84, 88, 93, 98, 6, 68, 72, 108, 113, 77, 82<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Object75,Lambda76,Lambda81,Lambda83,Lambda86,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 71, 76, 81<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 72, 77, 82<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgClassExpression25,PgSelect26,First30,PgSelectSingle31 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.mermaid
@@ -10,63 +10,77 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant113 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
-    Constant114 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant113 & Access18 & Lambda71 & Lambda76 & Lambda81 & Lambda85 & Lambda88 & Lambda93 & Lambda98 --> PgSelect16
-    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda107 & Lambda112 --> PgSelect62
-    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant113 & Constant6 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda85 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant103 & Constant90 & Constant91 --> Object106
-    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant113 & Constant6 & Access39 --> Object40
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant116 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant106 & Constant92 & Constant93 --> Object109
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
+    Constant117 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant119 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda82
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant124 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant122 --> Lambda115
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant116 & Access18 & Access72 & Lambda77 & Lambda82 & Lambda86 & Access90 & Lambda95 & Lambda100 --> PgSelect16
+    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda110 & Lambda115 --> PgSelect62
+    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant116 & Constant6 & Constant6 & Access39 --> Object45
+    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant116 & Constant6 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,16 +114,6 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Constant115 --> Lambda68
-    Constant116 --> Lambda71
-    Object75 --> Lambda76
-    Constant117 --> Lambda81
-    Constant120 --> Lambda85
-    Constant121 --> Lambda88
-    Object92 --> Lambda93
-    Constant118 --> Lambda98
-    Object106 --> Lambda107
-    Constant119 --> Lambda112
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -123,9 +127,9 @@ graph TD
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression24
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle31
-    PgSelectSingle20 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle31
+    PgSelectSingle20 --> RemapKeys83
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression32
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -134,18 +138,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-after"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 72, 73, 74, 89, 90, 91, 103, 113, 114, 115, 116, 117, 118, 119, 120, 121, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 91, 92, 93, 106, 116, 117, 118, 119, 120, 121, 122, 123, 124, 13, 15, 18, 68, 71, 72, 76, 77, 82, 86, 89, 90, 94, 95, 100, 109, 110, 115<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant72,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 113, 6, 115, 116, 72, 73, 74, 117, 120, 121, 89, 90, 91, 118, 103, 119<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 36, 68, 71, 81, 85, 88, 98, 112, 13, 75, 76, 92, 93, 106, 107<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Object109,Lambda110,Lambda115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 116, 18, 72, 77, 82, 86, 90, 95, 100, 6, 68, 110, 115<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Lambda68,Lambda71,Object75,Lambda76,Lambda81,Lambda85,Lambda88,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112 bucket1
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys82 bucket3
+    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys83 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression32,PgClassExpression33 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.deopt.mermaid
@@ -10,10 +10,25 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant111 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Constant114 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant90 & Constant91 --> Object107
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -21,52 +36,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
-    Constant112 --> Lambda15
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
+    Constant115 --> Lambda15
     Lambda15 --> PgValidateParsedCursor17
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda68
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
+    Lambda15 --> Access18
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda68
     Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda71
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant118 --> Lambda82
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant121 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda87
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda87 --> Access88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant119 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant120 --> Lambda113
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant111 & Access18 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect16
+    Object13 & Connection14 & Lambda15 & Constant114 & Access18 & Lambda84 & Access88 & Lambda93 & Lambda98 --> PgSelect16
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda105 & Lambda110 --> PgSelect62
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda108 & Lambda113 --> PgSelect62
     Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant6 & Constant111 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant88 & Constant89 --> Object104
+    Constant6 & Constant114 & Constant6 & Access39 --> Object45
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant111 & Access39 --> Object40
-    Lambda15 --> Access18
+    Constant6 & Constant114 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,23 +114,13 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda81
-    Constant118 --> Lambda83
-    Constant119 --> Lambda86
-    Object90 --> Lambda91
-    Constant116 --> Lambda96
-    Object104 --> Lambda105
-    Constant117 --> Lambda110
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSelect26[["PgSelect[26∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression25 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect26
+    Object13 & PgClassExpression25 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect26
     PgCursor21{{"PgCursor[21∈3]"}}:::plan
     List23{{"List[23∈3]<br />ᐸ22ᐳ"}}:::plan
     List23 --> PgCursor21
@@ -138,16 +142,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-end-last"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 72, 73, 74, 87, 88, 89, 101, 111, 112, 113, 114, 115, 116, 117, 118, 119, 13, 15, 68, 71<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 89, 90, 91, 104, 114, 115, 116, 117, 118, 119, 120, 121, 122, 13, 15, 18, 68, 71, 72, 76, 77, 82, 84, 87, 88, 92, 93, 98, 107, 108, 113<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant87,Constant88,Constant89,Constant101,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 111, 6, 68, 71, 72, 73, 74, 115, 118, 119, 87, 88, 89, 116, 101, 117<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 18, 36, 75, 81, 83, 86, 96, 104, 110, 76, 90, 91, 105<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda84,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 114, 18, 84, 88, 93, 98, 6, 68, 72, 108, 113, 77, 82<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Object75,Lambda76,Lambda81,Lambda83,Lambda86,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 71, 76, 81<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 72, 77, 82<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgClassExpression25,PgSelect26,First30,PgSelectSingle31 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.mermaid
@@ -10,63 +10,77 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant113 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
-    Constant114 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant113 & Access18 & Lambda71 & Lambda76 & Lambda81 & Lambda85 & Lambda88 & Lambda93 & Lambda98 --> PgSelect16
-    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda107 & Lambda112 --> PgSelect62
-    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant6 & Constant113 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda85 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant103 & Constant90 & Constant91 --> Object106
-    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant113 & Access39 --> Object40
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant116 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant106 & Constant92 & Constant93 --> Object109
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
+    Constant117 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant119 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda82
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant124 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant122 --> Lambda115
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant116 & Access18 & Access72 & Lambda77 & Lambda82 & Lambda86 & Access90 & Lambda95 & Lambda100 --> PgSelect16
+    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda110 & Lambda115 --> PgSelect62
+    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant6 & Constant116 & Constant6 & Access39 --> Object45
+    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant6 & Constant116 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,16 +114,6 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Constant115 --> Lambda68
-    Constant116 --> Lambda71
-    Object75 --> Lambda76
-    Constant117 --> Lambda81
-    Constant120 --> Lambda85
-    Constant121 --> Lambda88
-    Object92 --> Lambda93
-    Constant118 --> Lambda98
-    Object106 --> Lambda107
-    Constant119 --> Lambda112
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -123,9 +127,9 @@ graph TD
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression24
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle31
-    PgSelectSingle20 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle31
+    PgSelectSingle20 --> RemapKeys83
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression32
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -134,18 +138,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-end-last"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 72, 73, 74, 89, 90, 91, 103, 113, 114, 115, 116, 117, 118, 119, 120, 121, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 91, 92, 93, 106, 116, 117, 118, 119, 120, 121, 122, 123, 124, 13, 15, 18, 68, 71, 72, 76, 77, 82, 86, 89, 90, 94, 95, 100, 109, 110, 115<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant72,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 113, 6, 115, 116, 72, 73, 74, 117, 120, 121, 89, 90, 91, 118, 103, 119<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 36, 68, 71, 81, 85, 88, 98, 112, 13, 75, 76, 92, 93, 106, 107<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Object109,Lambda110,Lambda115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 116, 18, 72, 77, 82, 86, 90, 95, 100, 6, 68, 110, 115<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Lambda68,Lambda71,Object75,Lambda76,Lambda81,Lambda85,Lambda88,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112 bucket1
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys82 bucket3
+    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys83 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression32,PgClassExpression33 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.deopt.mermaid
@@ -10,10 +10,25 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant111 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Constant114 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant90 & Constant91 --> Object107
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -21,52 +36,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
-    Constant112 --> Lambda15
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
+    Constant115 --> Lambda15
     Lambda15 --> PgValidateParsedCursor17
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda68
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
+    Lambda15 --> Access18
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda68
     Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda71
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant118 --> Lambda82
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant121 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda87
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda87 --> Access88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant119 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant120 --> Lambda113
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant111 & Access18 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect16
+    Object13 & Connection14 & Lambda15 & Constant114 & Access18 & Lambda84 & Access88 & Lambda93 & Lambda98 --> PgSelect16
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda105 & Lambda110 --> PgSelect62
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda108 & Lambda113 --> PgSelect62
     Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant111 & Constant6 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant88 & Constant89 --> Object104
+    Constant114 & Constant6 & Constant6 & Access39 --> Object45
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant111 & Constant6 & Access39 --> Object40
-    Lambda15 --> Access18
+    Constant114 & Constant6 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,23 +114,13 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda81
-    Constant118 --> Lambda83
-    Constant119 --> Lambda86
-    Object90 --> Lambda91
-    Constant116 --> Lambda96
-    Object104 --> Lambda105
-    Constant117 --> Lambda110
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSelect26[["PgSelect[26∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression25 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect26
+    Object13 & PgClassExpression25 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect26
     PgCursor21{{"PgCursor[21∈3]"}}:::plan
     List23{{"List[23∈3]<br />ᐸ22ᐳ"}}:::plan
     List23 --> PgCursor21
@@ -138,16 +142,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-end"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 72, 73, 74, 87, 88, 89, 101, 111, 112, 113, 114, 115, 116, 117, 118, 119, 13, 15, 68, 71<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 89, 90, 91, 104, 114, 115, 116, 117, 118, 119, 120, 121, 122, 13, 15, 18, 68, 71, 72, 76, 77, 82, 84, 87, 88, 92, 93, 98, 107, 108, 113<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant87,Constant88,Constant89,Constant101,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 111, 6, 68, 71, 72, 73, 74, 115, 118, 119, 87, 88, 89, 116, 101, 117<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 18, 36, 75, 81, 83, 86, 96, 104, 110, 76, 90, 91, 105<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda84,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 114, 18, 84, 88, 93, 98, 6, 68, 72, 108, 113, 77, 82<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Object75,Lambda76,Lambda81,Lambda83,Lambda86,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 71, 76, 81<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 72, 77, 82<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgClassExpression25,PgSelect26,First30,PgSelectSingle31 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.mermaid
@@ -10,63 +10,77 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant113 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
-    Constant114 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant113 & Access18 & Lambda71 & Lambda76 & Lambda81 & Lambda85 & Lambda88 & Lambda93 & Lambda98 --> PgSelect16
-    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda107 & Lambda112 --> PgSelect62
-    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant113 & Constant6 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda85 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant103 & Constant90 & Constant91 --> Object106
-    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant113 & Constant6 & Access39 --> Object40
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant116 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant106 & Constant92 & Constant93 --> Object109
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
+    Constant117 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant119 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda82
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant124 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant122 --> Lambda115
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant116 & Access18 & Access72 & Lambda77 & Lambda82 & Lambda86 & Access90 & Lambda95 & Lambda100 --> PgSelect16
+    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda110 & Lambda115 --> PgSelect62
+    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant116 & Constant6 & Constant6 & Access39 --> Object45
+    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant116 & Constant6 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,16 +114,6 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Constant115 --> Lambda68
-    Constant116 --> Lambda71
-    Object75 --> Lambda76
-    Constant117 --> Lambda81
-    Constant120 --> Lambda85
-    Constant121 --> Lambda88
-    Object92 --> Lambda93
-    Constant118 --> Lambda98
-    Object106 --> Lambda107
-    Constant119 --> Lambda112
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -123,9 +127,9 @@ graph TD
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression24
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle31
-    PgSelectSingle20 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle31
+    PgSelectSingle20 --> RemapKeys83
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression32
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -134,18 +138,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-end"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 72, 73, 74, 89, 90, 91, 103, 113, 114, 115, 116, 117, 118, 119, 120, 121, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 91, 92, 93, 106, 116, 117, 118, 119, 120, 121, 122, 123, 124, 13, 15, 18, 68, 71, 72, 76, 77, 82, 86, 89, 90, 94, 95, 100, 109, 110, 115<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant72,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 113, 6, 115, 116, 72, 73, 74, 117, 120, 121, 89, 90, 91, 118, 103, 119<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 36, 68, 71, 81, 85, 88, 98, 112, 13, 75, 76, 92, 93, 106, 107<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Object109,Lambda110,Lambda115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 116, 18, 72, 77, 82, 86, 90, 95, 100, 6, 68, 110, 115<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Lambda68,Lambda71,Object75,Lambda76,Lambda81,Lambda85,Lambda88,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112 bucket1
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys82 bucket3
+    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys83 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression32,PgClassExpression33 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.deopt.mermaid
@@ -10,55 +10,67 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant66 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
-    Constant67 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant66 & Access18 & Lambda37 & Lambda40 & Lambda45 & Lambda51 --> PgSelect16
-    PgSelect31[["PgSelect[31∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda53 & Lambda55 & Lambda60 & Lambda65 --> PgSelect31
-    Object28{{"Object[28∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant6 & Constant66 & Constant6 & Access22 --> Object28
-    Object44{{"Object[44∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant56 & Constant42 & Constant43 --> Object59
-    Object23{{"Object[23∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant66 & Access22 --> Object23
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant68 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda54 & Constant58 & Constant43 & Constant44 --> Object61
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
+    Constant69 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant74 --> Lambda37
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant75 --> Lambda40
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant72 --> Lambda52
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant70 --> Lambda54
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant71 --> Lambda56
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant73 --> Lambda67
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant68 & Access18 & Lambda37 & Access41 & Lambda46 & Lambda52 --> PgSelect16
+    PgSelect31[["PgSelect[31∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda54 & Access57 & Lambda62 & Lambda67 --> PgSelect31
+    Object28{{"Object[28∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access22{{"Access[22∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant6 & Constant68 & Constant6 & Access22 --> Object28
+    Object23{{"Object[23∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant6 & Constant68 & Access22 --> Object23
     PgPageInfo19{{"PgPageInfo[19∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo19
     PgSelect16 --> Access22
@@ -72,23 +84,15 @@ graph TD
     First32 --> PgSelectSingle33
     PgClassExpression34{{"PgClassExpression[34∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
-    Constant72 --> Lambda37
-    Constant73 --> Lambda40
-    Object44 --> Lambda45
-    Constant70 --> Lambda51
-    Constant68 --> Lambda53
-    Constant69 --> Lambda55
-    Object59 --> Lambda60
-    Constant71 --> Lambda65
 
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-last-pagination-only"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 41, 42, 43, 56, 66, 67, 68, 69, 70, 71, 72, 73, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 42, 43, 44, 58, 68, 69, 70, 71, 72, 73, 74, 75, 13, 15, 18, 37, 40, 41, 45, 46, 52, 54, 56, 57, 61, 62, 67<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant41,Constant42,Constant43,Constant56,Constant66,Constant67,Constant68,Constant69,Constant70,Constant71,Constant72,Constant73 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 66, 6, 72, 73, 41, 42, 43, 70, 68, 69, 56, 71<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 19, 37, 40, 51, 53, 55, 65, 13, 44, 45, 59, 60<br />2: PgSelect[16], PgSelect[31]<br />ᐳ: 22, 23, 24, 28, 29, 32, 33, 34"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda37,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda52,Lambda54,Lambda56,Access57,Constant58,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71,Constant72,Constant73,Constant74,Constant75 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 68, 18, 37, 41, 46, 52, 6, 54, 57, 62, 67<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo19,Access22,Object23,Lambda24,Object28,Lambda29,PgSelect31,First32,PgSelectSingle33,PgClassExpression34,Lambda37,Lambda40,Object44,Lambda45,Lambda51,Lambda53,Lambda55,Object59,Lambda60,Lambda65 bucket1
+    class Bucket1,PgSelect16,PgPageInfo19,Access22,Object23,Lambda24,Object28,Lambda29,PgSelect31,First32,PgSelectSingle33,PgClassExpression34 bucket1
     Bucket0 --> Bucket1
     end

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.mermaid
@@ -10,55 +10,67 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant66 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
-    Constant67 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant66 & Access18 & Lambda37 & Lambda40 & Lambda45 & Lambda51 --> PgSelect16
-    PgSelect31[["PgSelect[31∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda53 & Lambda55 & Lambda60 & Lambda65 --> PgSelect31
-    Object28{{"Object[28∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant6 & Constant66 & Constant6 & Access22 --> Object28
-    Object44{{"Object[44∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant56 & Constant42 & Constant43 --> Object59
-    Object23{{"Object[23∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant66 & Access22 --> Object23
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant68 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda54 & Constant58 & Constant43 & Constant44 --> Object61
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
+    Constant69 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant74 --> Lambda37
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant75 --> Lambda40
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant72 --> Lambda52
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant70 --> Lambda54
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant71 --> Lambda56
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant73 --> Lambda67
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant68 & Access18 & Lambda37 & Access41 & Lambda46 & Lambda52 --> PgSelect16
+    PgSelect31[["PgSelect[31∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda54 & Access57 & Lambda62 & Lambda67 --> PgSelect31
+    Object28{{"Object[28∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access22{{"Access[22∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant6 & Constant68 & Constant6 & Access22 --> Object28
+    Object23{{"Object[23∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant6 & Constant68 & Access22 --> Object23
     PgPageInfo19{{"PgPageInfo[19∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo19
     PgSelect16 --> Access22
@@ -72,23 +84,15 @@ graph TD
     First32 --> PgSelectSingle33
     PgClassExpression34{{"PgClassExpression[34∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
-    Constant72 --> Lambda37
-    Constant73 --> Lambda40
-    Object44 --> Lambda45
-    Constant70 --> Lambda51
-    Constant68 --> Lambda53
-    Constant69 --> Lambda55
-    Object59 --> Lambda60
-    Constant71 --> Lambda65
 
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-last-pagination-only"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 41, 42, 43, 56, 66, 67, 68, 69, 70, 71, 72, 73, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 42, 43, 44, 58, 68, 69, 70, 71, 72, 73, 74, 75, 13, 15, 18, 37, 40, 41, 45, 46, 52, 54, 56, 57, 61, 62, 67<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant41,Constant42,Constant43,Constant56,Constant66,Constant67,Constant68,Constant69,Constant70,Constant71,Constant72,Constant73 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 66, 6, 72, 73, 41, 42, 43, 70, 68, 69, 56, 71<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 19, 37, 40, 51, 53, 55, 65, 13, 44, 45, 59, 60<br />2: PgSelect[16], PgSelect[31]<br />ᐳ: 22, 23, 24, 28, 29, 32, 33, 34"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda37,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda52,Lambda54,Lambda56,Access57,Constant58,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71,Constant72,Constant73,Constant74,Constant75 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 68, 18, 37, 41, 46, 52, 6, 54, 57, 62, 67<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo19,Access22,Object23,Lambda24,Object28,Lambda29,PgSelect31,First32,PgSelectSingle33,PgClassExpression34,Lambda37,Lambda40,Object44,Lambda45,Lambda51,Lambda53,Lambda55,Object59,Lambda60,Lambda65 bucket1
+    class Bucket1,PgSelect16,PgPageInfo19,Access22,Object23,Lambda24,Object28,Lambda29,PgSelect31,First32,PgSelectSingle33,PgClassExpression34 bucket1
     Bucket0 --> Bucket1
     end

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.deopt.mermaid
@@ -10,10 +10,25 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant111 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Constant114 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant90 & Constant91 --> Object107
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -21,52 +36,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
-    Constant112 --> Lambda15
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
+    Constant115 --> Lambda15
     Lambda15 --> PgValidateParsedCursor17
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda68
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
+    Lambda15 --> Access18
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda68
     Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda71
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant118 --> Lambda82
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant121 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda87
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda87 --> Access88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant119 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant120 --> Lambda113
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant111 & Access18 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect16
+    Object13 & Connection14 & Lambda15 & Constant114 & Access18 & Lambda84 & Access88 & Lambda93 & Lambda98 --> PgSelect16
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda105 & Lambda110 --> PgSelect62
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda108 & Lambda113 --> PgSelect62
     Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant6 & Constant111 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant88 & Constant89 --> Object104
+    Constant6 & Constant114 & Constant6 & Access39 --> Object45
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant111 & Access39 --> Object40
-    Lambda15 --> Access18
+    Constant6 & Constant114 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,23 +114,13 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda81
-    Constant118 --> Lambda83
-    Constant119 --> Lambda86
-    Object90 --> Lambda91
-    Constant116 --> Lambda96
-    Object104 --> Lambda105
-    Constant117 --> Lambda110
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSelect26[["PgSelect[26∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression25 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect26
+    Object13 & PgClassExpression25 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect26
     PgCursor21{{"PgCursor[21∈3]"}}:::plan
     List23{{"List[23∈3]<br />ᐸ22ᐳ"}}:::plan
     List23 --> PgCursor21
@@ -138,16 +142,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-last"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 72, 73, 74, 87, 88, 89, 101, 111, 112, 113, 114, 115, 116, 117, 118, 119, 13, 15, 68, 71<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 89, 90, 91, 104, 114, 115, 116, 117, 118, 119, 120, 121, 122, 13, 15, 18, 68, 71, 72, 76, 77, 82, 84, 87, 88, 92, 93, 98, 107, 108, 113<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant87,Constant88,Constant89,Constant101,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 111, 6, 68, 71, 72, 73, 74, 115, 118, 119, 87, 88, 89, 116, 101, 117<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 18, 36, 75, 81, 83, 86, 96, 104, 110, 76, 90, 91, 105<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda84,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 114, 18, 84, 88, 93, 98, 6, 68, 72, 108, 113, 77, 82<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Object75,Lambda76,Lambda81,Lambda83,Lambda86,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 71, 76, 81<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 72, 77, 82<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgClassExpression25,PgSelect26,First30,PgSelectSingle31 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.mermaid
@@ -10,63 +10,77 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant113 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
-    Constant114 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant113 & Access18 & Lambda71 & Lambda76 & Lambda81 & Lambda85 & Lambda88 & Lambda93 & Lambda98 --> PgSelect16
-    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda107 & Lambda112 --> PgSelect62
-    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant6 & Constant113 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda85 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant103 & Constant90 & Constant91 --> Object106
-    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant113 & Access39 --> Object40
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant116 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant106 & Constant92 & Constant93 --> Object109
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiZjE3MGYxNzAtMDAwMC0wMDAwLTAwMDAtYjBiMDAᐳ"}}:::plan
+    Constant117 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant119 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda82
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: 3, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant124 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant122 --> Lambda115
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant116 & Access18 & Access72 & Lambda77 & Lambda82 & Lambda86 & Access90 & Lambda95 & Lambda100 --> PgSelect16
+    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda110 & Lambda115 --> PgSelect62
+    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant6 & Constant116 & Constant6 & Access39 --> Object45
+    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant6 & Constant116 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,16 +114,6 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Constant115 --> Lambda68
-    Constant116 --> Lambda71
-    Object75 --> Lambda76
-    Constant117 --> Lambda81
-    Constant120 --> Lambda85
-    Constant121 --> Lambda88
-    Object92 --> Lambda93
-    Constant118 --> Lambda98
-    Object106 --> Lambda107
-    Constant119 --> Lambda112
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -123,9 +127,9 @@ graph TD
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression24
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle31
-    PgSelectSingle20 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle31
+    PgSelectSingle20 --> RemapKeys83
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression32
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -134,18 +138,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before-last"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 72, 73, 74, 89, 90, 91, 103, 113, 114, 115, 116, 117, 118, 119, 120, 121, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 91, 92, 93, 106, 116, 117, 118, 119, 120, 121, 122, 123, 124, 13, 15, 18, 68, 71, 72, 76, 77, 82, 86, 89, 90, 94, 95, 100, 109, 110, 115<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant72,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 113, 6, 115, 116, 72, 73, 74, 117, 120, 121, 89, 90, 91, 118, 103, 119<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 36, 68, 71, 81, 85, 88, 98, 112, 13, 75, 76, 92, 93, 106, 107<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Object109,Lambda110,Lambda115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 116, 18, 72, 77, 82, 86, 90, 95, 100, 6, 68, 110, 115<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Lambda68,Lambda71,Object75,Lambda76,Lambda81,Lambda85,Lambda88,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112 bucket1
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys82 bucket3
+    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys83 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression32,PgClassExpression33 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.deopt.mermaid
@@ -10,10 +10,25 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant111 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Constant114 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant104 & Constant90 & Constant91 --> Object107
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -21,52 +36,51 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
-    Constant112 --> Lambda15
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
+    Constant115 --> Lambda15
     Lambda15 --> PgValidateParsedCursor17
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda68
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
+    Lambda15 --> Access18
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda68
     Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda71
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant118 --> Lambda82
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant121 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda87
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda87 --> Access88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant119 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant120 --> Lambda113
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant111 & Access18 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect16
+    Object13 & Connection14 & Lambda15 & Constant114 & Access18 & Lambda84 & Access88 & Lambda93 & Lambda98 --> PgSelect16
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda105{{"Lambda[105∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda105 & Lambda110 --> PgSelect62
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda108 & Lambda113 --> PgSelect62
     Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant111 & Constant6 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object104{{"Object[104∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant101 & Constant88 & Constant89 --> Object104
+    Constant114 & Constant6 & Constant6 & Access39 --> Object45
     Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant111 & Constant6 & Access39 --> Object40
-    Lambda15 --> Access18
+    Constant114 & Constant6 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,23 +114,13 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant115 --> Lambda81
-    Constant118 --> Lambda83
-    Constant119 --> Lambda86
-    Object90 --> Lambda91
-    Constant116 --> Lambda96
-    Object104 --> Lambda105
-    Constant117 --> Lambda110
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSelect26[["PgSelect[26∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression25 & Lambda68 & Lambda71 & Lambda76 & Lambda81 --> PgSelect26
+    Object13 & PgClassExpression25 & Lambda68 & Access72 & Lambda77 & Lambda82 --> PgSelect26
     PgCursor21{{"PgCursor[21∈3]"}}:::plan
     List23{{"List[23∈3]<br />ᐸ22ᐳ"}}:::plan
     List23 --> PgCursor21
@@ -138,16 +142,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 72, 73, 74, 87, 88, 89, 101, 111, 112, 113, 114, 115, 116, 117, 118, 119, 13, 15, 68, 71<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 89, 90, 91, 104, 114, 115, 116, 117, 118, 119, 120, 121, 122, 13, 15, 18, 68, 71, 72, 76, 77, 82, 84, 87, 88, 92, 93, 98, 107, 108, 113<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Lambda68,Lambda71,Constant72,Constant73,Constant74,Constant87,Constant88,Constant89,Constant101,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 111, 6, 68, 71, 72, 73, 74, 115, 118, 119, 87, 88, 89, 116, 101, 117<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 18, 36, 75, 81, 83, 86, 96, 104, 110, 76, 90, 91, 105<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda84,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 114, 18, 84, 88, 93, 98, 6, 68, 72, 108, 113, 77, 82<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Object75,Lambda76,Lambda81,Lambda83,Lambda86,Object90,Lambda91,Lambda96,Object104,Lambda105,Lambda110 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 71, 76, 81<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 68, 72, 77, 82<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 71, 76, 81<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 13, 68, 72, 77, 82<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]<br />1: <br />ᐳ: 22, 24, 25, 23, 21<br />2: PgSelect[26]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgClassExpression25,PgSelect26,First30,PgSelectSingle31 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.mermaid
@@ -10,63 +10,77 @@ graph TD
 
     %% plan dependencies
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor17["PgValidateParsedCursor[17∈0] ➊"]:::plan
-    Constant113 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
-    Constant114 --> Lambda15
-    Lambda15 --> PgValidateParsedCursor17
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ15.1ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda15 & Constant113 & Access18 & Lambda71 & Lambda76 & Lambda81 & Lambda85 & Lambda88 & Lambda93 & Lambda98 --> PgSelect16
-    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Lambda68 & Lambda71 & Lambda107 & Lambda112 --> PgSelect62
-    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant113 & Constant6 & Constant6 & Access39 --> Object45
-    Object75{{"Object[75∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant72 & Constant73 & Constant74 --> Object75
-    Object92{{"Object[92∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda85 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda68 & Constant103 & Constant90 & Constant91 --> Object106
-    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant113 & Constant6 & Access39 --> Object40
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant116 & Lambda15 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 & PgValidateParsedCursor17 --> Connection14
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda68 & Constant73 & Constant74 & Constant75 --> Object76
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda68 & Constant106 & Constant92 & Constant93 --> Object109
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ'WyJmMGIyOGM5NGMxIiwiY2E3MGNhNzAtMDAwMC0wMDAwLTAwMDAtY2VjMTEᐳ"}}:::plan
+    Constant117 --> Lambda15
+    Lambda15 --> PgValidateParsedCursor17
+    Access18{{"Access[18∈0] ➊<br />ᐸ15.1ᐳ"}}:::plan
     Lambda15 --> Access18
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda68
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant119 --> Lambda71
+    Access72{{"Access[72∈0] ➊<br />ᐸ71.0ᐳ"}}:::plan
+    Lambda71 --> Access72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant120 --> Lambda82
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant124 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda100
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant122 --> Lambda115
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸmessages+1ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda15 & Constant116 & Access18 & Access72 & Lambda77 & Lambda82 & Lambda86 & Access90 & Lambda95 & Lambda100 --> PgSelect16
+    PgSelect62[["PgSelect[62∈1] ➊<br />ᐸmessages(aggregate)ᐳ"]]:::plan
+    Object13 & Connection14 & Lambda68 & Access72 & Lambda110 & Lambda115 --> PgSelect62
+    Object45{{"Object[45∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
+    Access39{{"Access[39∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
+    Constant116 & Constant6 & Constant6 & Access39 --> Object45
+    Object40{{"Object[40∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
+    Constant116 & Constant6 & Access39 --> Object40
     PgPageInfo36{{"PgPageInfo[36∈1] ➊"}}:::plan
     Connection14 --> PgPageInfo36
     PgSelect16 --> Access39
@@ -100,16 +114,6 @@ graph TD
     First63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    Constant115 --> Lambda68
-    Constant116 --> Lambda71
-    Object75 --> Lambda76
-    Constant117 --> Lambda81
-    Constant120 --> Lambda85
-    Constant121 --> Lambda88
-    Object92 --> Lambda93
-    Constant118 --> Lambda98
-    Object106 --> Lambda107
-    Constant119 --> Lambda112
     __Item19[/"__Item[19∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmessagesᐳ"}}:::plan
@@ -123,9 +127,9 @@ graph TD
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression24
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys82{{"RemapKeys[82∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys82 --> PgSelectSingle31
-    PgSelectSingle20 --> RemapKeys82
+    RemapKeys83{{"RemapKeys[83∈3]<br />ᐸ20:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys83 --> PgSelectSingle31
+    PgSelectSingle20 --> RemapKeys83
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression32
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -134,18 +138,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-before"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 72, 73, 74, 89, 90, 91, 103, 113, 114, 115, 116, 117, 118, 119, 120, 121, 15<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 11, 12, 73, 74, 75, 91, 92, 93, 106, 116, 117, 118, 119, 120, 121, 122, 123, 124, 13, 15, 18, 68, 71, 72, 76, 77, 82, 86, 89, 90, 94, 95, 100, 109, 110, 115<br />2: PgValidateParsedCursor[17]<br />ᐳ: Connection[14]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection14,Lambda15,PgValidateParsedCursor17,Constant72,Constant73,Constant74,Constant89,Constant90,Constant91,Constant103,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 15, 113, 6, 115, 116, 72, 73, 74, 117, 120, 121, 89, 90, 91, 118, 103, 119<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 18, 36, 68, 71, 81, 85, 88, 98, 112, 13, 75, 76, 92, 93, 106, 107<br />2: PgSelect[16], PgSelect[62]<br />ᐳ: 39, 40, 41, 45, 46, 49, 50, 53, 54, 56, 57, 60, 61, 63, 64, 65, 51, 58"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access11,Access12,Object13,Connection14,Lambda15,PgValidateParsedCursor17,Access18,Lambda68,Lambda71,Access72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Object109,Lambda110,Lambda115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 15, 116, 18, 72, 77, 82, 86, 90, 95, 100, 6, 68, 110, 115<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect16,Access18,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65,Lambda68,Lambda71,Object75,Lambda76,Lambda81,Lambda85,Lambda88,Object92,Lambda93,Lambda98,Object106,Lambda107,Lambda112 bucket1
+    class Bucket1,PgSelect16,PgPageInfo36,Access39,Object40,Lambda41,Object45,Lambda46,First49,PgSelectSingle50,PgCursor51,PgClassExpression53,List54,Last56,PgSelectSingle57,PgCursor58,PgClassExpression60,List61,PgSelect62,First63,PgSelectSingle64,PgClassExpression65 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys82 bucket3
+    class Bucket3,PgCursor21,PgClassExpression22,List23,PgClassExpression24,PgSelectSingle31,RemapKeys83 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression32,PgClassExpression33 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.deopt.mermaid
@@ -11,17 +11,32 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant123 & Lambda110 & Lambda112 & Lambda117 & Lambda122 --> PgSelect9
-    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda110 & Constant113 & Constant114 & Constant115 --> Object116
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access116{{"Access[116∈0] ➊<br />ᐸ115.0ᐳ"}}:::plan
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant127 & Lambda113 & Access116 & Lambda121 & Lambda126 --> PgSelect9
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda82 & Constant87 & Constant88 & Constant89 --> Object90
+    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda66 & Constant102 & Constant88 & Constant89 --> Object105
+    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda113 & Constant117 & Constant118 & Constant119 --> Object120
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -29,72 +44,63 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant123 --> Connection23
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant124 --> Lambda66
+    Constant127 --> Connection23
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant128 --> Lambda66
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant125 --> Lambda69
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant130 --> Lambda81
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant132 --> Lambda110
-    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant133 --> Lambda112
-    Object116 --> Lambda117
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant129 --> Lambda122
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant129 --> Lambda69
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda69 --> Access70
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object74 --> Lambda75
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant130 --> Lambda80
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant134 --> Lambda82
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant135 --> Lambda85
+    Access86{{"Access[86∈0] ➊<br />ᐸ85.0ᐳ"}}:::plan
+    Lambda85 --> Access86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object90 --> Lambda91
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant131 --> Lambda96
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object105 --> Lambda106
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant132 --> Lambda111
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant136 --> Lambda113
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant137 --> Lambda115
+    Lambda115 --> Access116
+    Object120 --> Lambda121
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant133 --> Lambda126
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object73{{"Object[73∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant85 & Constant86 & Constant87 --> Object88
-    Object102{{"Object[102∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda66 & Constant99 & Constant86 & Constant87 --> Object102
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object73 --> Lambda74
-    Lambda79{{"Lambda[79∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant126 --> Lambda79
-    Lambda84{{"Lambda[84∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant131 --> Lambda84
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant127 --> Lambda94
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object102 --> Lambda103
-    Lambda108{{"Lambda[108∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant128 --> Lambda108
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
     PgSelect24[["PgSelect[24∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression18 & Connection23 & Constant123 & Lambda81 & Lambda84 & Lambda89 & Lambda94 --> PgSelect24
+    Object12 & PgClassExpression18 & Connection23 & Constant127 & Lambda82 & Access86 & Lambda91 & Lambda96 --> PgSelect24
     PgSelect60[["PgSelect[60∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object12 & PgClassExpression18 & Connection23 & Lambda66 & Lambda69 & Lambda103 & Lambda108 --> PgSelect60
+    Object12 & PgClassExpression18 & Connection23 & Lambda66 & Access70 & Lambda106 & Lambda111 --> PgSelect60
     Object46{{"Object[46∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access41{{"Access[41∈3]<br />ᐸ24.hasMoreᐳ"}}:::plan
-    Constant8 & Constant123 & Constant8 & Access41 --> Object46
+    Constant8 & Constant127 & Constant8 & Access41 --> Object46
     Object42{{"Object[42∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant8 & Constant123 & Access41 --> Object42
+    Constant8 & Constant127 & Access41 --> Object42
     PgSelectSingle14 --> PgClassExpression18
     PgPageInfo38{{"PgPageInfo[38∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo38
@@ -135,7 +141,7 @@ graph TD
     __Item25 --> PgSelectSingle26
     PgSelect29[["PgSelect[29∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression28 & Lambda66 & Lambda69 & Lambda74 & Lambda79 --> PgSelect29
+    Object12 & PgClassExpression28 & Lambda66 & Access70 & Lambda75 & Lambda80 --> PgSelect29
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle26 --> PgClassExpression28
@@ -151,22 +157,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-when-inlined-backwards-nodes-only"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 70, 71, 72, 85, 86, 87, 99, 113, 114, 115, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 12, 23, 66, 69, 81, 110, 112, 116, 117, 122<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 71, 72, 73, 87, 88, 89, 102, 117, 118, 119, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 12, 23, 66, 69, 70, 74, 75, 80, 82, 85, 86, 90, 91, 96, 105, 106, 111, 113, 115, 116, 120, 121, 126<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Lambda66,Lambda69,Constant70,Constant71,Constant72,Lambda81,Constant85,Constant86,Constant87,Constant99,Lambda110,Lambda112,Constant113,Constant114,Constant115,Object116,Lambda117,Lambda122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 66, 70, 71, 72, 126, 131, 81, 85, 86, 87, 127, 99, 128, 12, 23, 123, 8, 69<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Lambda66,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Lambda82,Lambda85,Access86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant102,Object105,Lambda106,Lambda111,Lambda113,Lambda115,Access116,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133,Constant134,Constant135,Constant136,Constant137 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 12, 23, 127, 82, 86, 91, 96, 8, 66, 70, 106, 111, 75, 80<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item13,PgSelectSingle14,Object73,Lambda74,Lambda79,Lambda84,Object88,Lambda89,Lambda94,Object102,Lambda103,Lambda108 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 23, 123, 81, 84, 89, 94, 8, 66, 69, 103, 108, 74, 79<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    class Bucket1,__Item13,PgSelectSingle14 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 23, 127, 82, 86, 91, 96, 8, 66, 70, 106, 111, 75, 80<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 23, 123, 81, 84, 89, 94, 8, 66, 69, 103, 108, 74, 79<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: PgClassExpression[18], PgPageInfo[38]<br />2: PgSelect[24], PgSelect[60]<br />ᐳ: 41, 42, 43, 46, 47, 49, 50, 52, 53, 55, 56, 58, 59, 61, 62, 63, 51, 57"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 23, 127, 82, 86, 91, 96, 8, 66, 70, 106, 111, 75, 80<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: PgClassExpression[18], PgPageInfo[38]<br />2: PgSelect[24], PgSelect[60]<br />ᐳ: 41, 42, 43, 46, 47, 49, 50, 52, 53, 55, 56, 58, 59, 61, 62, 63, 51, 57"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect24,PgPageInfo38,Access41,Object42,Lambda43,Object46,Lambda47,First49,PgSelectSingle50,PgCursor51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,List59,PgSelect60,First61,PgSelectSingle62,PgClassExpression63 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 12, 66, 69, 74, 79<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 12, 66, 70, 75, 80<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 12, 66, 69, 74, 79<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 12, 66, 70, 75, 80<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression27,PgClassExpression28,PgSelect29,First33,PgSelectSingle34 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.mermaid
@@ -11,40 +11,40 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant134 & Lambda69 & Lambda74 & Lambda79 & Lambda86 & Lambda91 & Lambda96 & Lambda69 & Lambda110 & Lambda115 & Lambda121 & Lambda123 & Lambda128 & Lambda133 --> PgSelect9
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access88{{"Access[88∈0] ➊<br />ᐸ87.0ᐳ"}}:::plan
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access127{{"Access[127∈0] ➊<br />ᐸ126.0ᐳ"}}:::plan
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant138 & Access70 & Lambda75 & Lambda80 & Access88 & Lambda93 & Lambda98 & Access70 & Lambda113 & Lambda118 & Lambda124 & Access127 & Lambda132 & Lambda137 --> PgSelect9
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
-    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda66 & Constant106 & Constant88 & Constant89 --> Object109
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda121 & Constant124 & Constant125 & Constant126 --> Object127
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda84 & Constant89 & Constant90 & Constant91 --> Object92
+    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda66 & Constant109 & Constant90 & Constant91 --> Object112
+    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda124 & Constant128 & Constant129 & Constant130 --> Object131
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -52,63 +52,69 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant134 --> Connection23
-    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant135 --> Lambda66
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant136 --> Lambda69
-    Object73 --> Lambda74
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant137 --> Lambda79
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant141 --> Lambda83
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant142 --> Lambda86
-    Object90 --> Lambda91
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant138 --> Lambda96
-    Object109 --> Lambda110
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant139 --> Lambda115
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant143 --> Lambda121
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant144 --> Lambda123
-    Object127 --> Lambda128
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant140 --> Lambda133
+    Constant138 --> Connection23
+    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant139 --> Lambda66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant140 --> Lambda69
+    Lambda69 --> Access70
+    Object74 --> Lambda75
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant141 --> Lambda80
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant145 --> Lambda84
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant146 --> Lambda87
+    Lambda87 --> Access88
+    Object92 --> Lambda93
+    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant142 --> Lambda98
+    Object112 --> Lambda113
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant143 --> Lambda118
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant147 --> Lambda124
+    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant148 --> Lambda126
+    Lambda126 --> Access127
+    Object131 --> Lambda132
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant144 --> Lambda137
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant64{{"Constant[64∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant67{{"Constant[67∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
-    Object100{{"Object[100∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access98{{"Access[98∈3]<br />ᐸ13.1ᐳ"}}:::plan
-    Access98 & Constant64 & Constant134 & Lambda83 & Constant84 --> Object100
-    Object118{{"Object[118∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access116{{"Access[116∈3]<br />ᐸ13.2ᐳ"}}:::plan
-    Access116 & Constant64 & Constant64 & Lambda66 & Constant67 --> Object118
+    Object102{{"Object[102∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access100{{"Access[100∈3]<br />ᐸ13.1ᐳ"}}:::plan
+    Access100 & Constant64 & Constant138 & Lambda84 & Constant85 --> Object102
+    Object121{{"Object[121∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access119{{"Access[119∈3]<br />ᐸ13.2ᐳ"}}:::plan
+    Access119 & Constant64 & Constant64 & Lambda66 & Constant67 --> Object121
     Object46{{"Object[46∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access41{{"Access[41∈3]<br />ᐸ101.hasMoreᐳ"}}:::plan
-    Constant8 & Constant134 & Constant8 & Access41 --> Object46
+    Access41{{"Access[41∈3]<br />ᐸ103.hasMoreᐳ"}}:::plan
+    Constant8 & Constant138 & Constant8 & Access41 --> Object46
     Object42{{"Object[42∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant8 & Constant134 & Access41 --> Object42
+    Constant8 & Constant138 & Access41 --> Object42
     PgPageInfo38{{"PgPageInfo[38∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo38
-    Lambda101{{"Lambda[101∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda101 --> Access41
+    Lambda103{{"Lambda[103∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda103 --> Access41
     Lambda43{{"Lambda[43∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object42 --> Lambda43
     Lambda47{{"Lambda[47∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object46 --> Lambda47
     First49{{"First[49∈3]"}}:::plan
-    Lambda101 --> First49
+    Lambda103 --> First49
     PgSelectSingle50{{"PgSelectSingle[50∈3]<br />ᐸmessagesᐳ"}}:::plan
     First49 --> PgSelectSingle50
     PgCursor51{{"PgCursor[51∈3]"}}:::plan
@@ -118,7 +124,7 @@ graph TD
     PgSelectSingle50 --> PgClassExpression52
     PgClassExpression52 --> List53
     Last55{{"Last[55∈3]"}}:::plan
-    Lambda101 --> Last55
+    Lambda103 --> Last55
     PgSelectSingle56{{"PgSelectSingle[56∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last55 --> PgSelectSingle56
     PgCursor57{{"PgCursor[57∈3]"}}:::plan
@@ -128,26 +134,26 @@ graph TD
     PgSelectSingle56 --> PgClassExpression58
     PgClassExpression58 --> List59
     First61{{"First[61∈3]"}}:::plan
-    Lambda119{{"Lambda[119∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda119 --> First61
+    Lambda122{{"Lambda[122∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda122 --> First61
     PgSelectSingle62{{"PgSelectSingle[62∈3]<br />ᐸmessagesᐳ"}}:::plan
     First61 --> PgSelectSingle62
     PgClassExpression63{{"PgClassExpression[63∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle62 --> PgClassExpression63
-    __Item13 --> Access98
-    Object100 --> Lambda101
-    __Item13 --> Access116
-    Object118 --> Lambda119
-    __Item25[/"__Item[25∈4]<br />ᐸ101ᐳ"\]:::itemplan
-    Lambda101 ==> __Item25
+    __Item13 --> Access100
+    Object102 --> Lambda103
+    __Item13 --> Access119
+    Object121 --> Lambda122
+    __Item25[/"__Item[25∈4]<br />ᐸ103ᐳ"\]:::itemplan
+    Lambda103 ==> __Item25
     PgSelectSingle26{{"PgSelectSingle[26∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item25 --> PgSelectSingle26
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys80{{"RemapKeys[80∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys80 --> PgSelectSingle34
-    PgSelectSingle26 --> RemapKeys80
+    RemapKeys81{{"RemapKeys[81∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys81 --> PgSelectSingle34
+    PgSelectSingle26 --> RemapKeys81
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
     PgClassExpression36{{"PgClassExpression[36∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -156,24 +162,24 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-when-inlined-backwards-nodes-only"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 64, 67, 70, 71, 72, 84, 87, 88, 89, 106, 124, 125, 126, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 12, 23, 66, 69, 73, 74, 79, 83, 86, 90, 91, 96, 109, 110, 115, 121, 123, 127, 128, 133<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 64, 67, 71, 72, 73, 85, 89, 90, 91, 109, 128, 129, 130, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 12, 23, 66, 69, 70, 74, 75, 80, 84, 87, 88, 92, 93, 98, 112, 113, 118, 124, 126, 127, 131, 132, 137<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Constant64,Lambda66,Constant67,Lambda69,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Lambda83,Constant84,Lambda86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant106,Object109,Lambda110,Lambda115,Lambda121,Lambda123,Constant124,Constant125,Constant126,Object127,Lambda128,Lambda133,Constant134,Constant135,Constant136,Constant137,Constant138,Constant139,Constant140,Constant141,Constant142,Constant143,Constant144 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 8, 134, 64, 83, 84, 66, 67<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Constant64,Lambda66,Constant67,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Lambda84,Constant85,Lambda87,Access88,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant109,Object112,Lambda113,Lambda118,Lambda124,Lambda126,Access127,Constant128,Constant129,Constant130,Object131,Lambda132,Lambda137,Constant138,Constant139,Constant140,Constant141,Constant142,Constant143,Constant144,Constant145,Constant146,Constant147,Constant148 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 8, 138, 64, 84, 85, 66, 67<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13,PgSelectSingle14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 23, 8, 134, 13, 64, 83, 84, 66, 67<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 23, 8, 138, 13, 64, 84, 85, 66, 67<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 8, 134, 13, 64, 83, 84, 66, 67<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 8, 138, 13, 64, 84, 85, 66, 67<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo38,Access41,Object42,Lambda43,Object46,Lambda47,First49,PgSelectSingle50,PgCursor51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,List59,First61,PgSelectSingle62,PgClassExpression63,Access98,Object100,Lambda101,Access116,Object118,Lambda119 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ101ᐳ[25]"):::bucket
+    class Bucket3,PgPageInfo38,Access41,Object42,Lambda43,Object46,Lambda47,First49,PgSelectSingle50,PgCursor51,PgClassExpression52,List53,Last55,PgSelectSingle56,PgCursor57,PgClassExpression58,List59,First61,PgSelectSingle62,PgClassExpression63,Access100,Object102,Lambda103,Access119,Object121,Lambda122 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ103ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys80 bucket5
+    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys81 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression35,PgClassExpression36 bucket6

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.deopt.mermaid
@@ -11,17 +11,36 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access146{{"Access[146∈0] ➊<br />ᐸ145.0ᐳ"}}:::plan
     Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant152 & Lambda139 & Lambda141 & Lambda146 & Lambda151 --> PgSelect9
-    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda139 & Constant142 & Constant143 & Constant144 --> Object145
+    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant157 & Lambda143 & Access146 & Lambda151 & Lambda156 --> PgSelect9
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda81 & Constant86 & Constant87 & Constant88 --> Object89
+    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda81 & Constant101 & Constant102 & Constant88 --> Object104
+    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda112 & Constant117 & Constant118 & Constant119 --> Object120
+    Object135{{"Object[135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda81 & Constant132 & Constant118 & Constant119 --> Object135
+    Object150{{"Object[150∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda143 & Constant147 & Constant148 & Constant149 --> Object150
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -29,81 +48,68 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant152 --> Connection23
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant153 --> Lambda81
+    Constant157 --> Connection23
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda81
     Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant154 --> Lambda84
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant160 --> Lambda110
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant162 --> Lambda139
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant159 --> Lambda84
+    Access85{{"Access[85∈0] ➊<br />ᐸ84.0ᐳ"}}:::plan
+    Lambda84 --> Access85
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object89 --> Lambda90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant160 --> Lambda95
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object104 --> Lambda105
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant161 --> Lambda110
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant165 --> Lambda112
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant166 --> Lambda115
+    Access116{{"Access[116∈0] ➊<br />ᐸ115.0ᐳ"}}:::plan
+    Lambda115 --> Access116
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object120 --> Lambda121
+    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant162 --> Lambda126
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object135 --> Lambda136
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
     Constant163 --> Lambda141
-    Object145 --> Lambda146
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant159 --> Lambda151
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant167 --> Lambda143
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant168 --> Lambda145
+    Lambda145 --> Access146
+    Object150 --> Lambda151
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant164 --> Lambda156
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant85 & Constant86 & Constant87 --> Object88
-    Object102{{"Object[102∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant99 & Constant100 & Constant87 --> Object102
-    Object117{{"Object[117∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda110 & Constant114 & Constant115 & Constant116 --> Object117
-    Object131{{"Object[131∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant128 & Constant115 & Constant116 --> Object131
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant155 --> Lambda94
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object102 --> Lambda103
-    Lambda108{{"Lambda[108∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant156 --> Lambda108
-    Lambda113{{"Lambda[113∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant161 --> Lambda113
-    Lambda118{{"Lambda[118∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object117 --> Lambda118
-    Lambda123{{"Lambda[123∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157 --> Lambda123
-    Lambda132{{"Lambda[132∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object131 --> Lambda132
-    Lambda137{{"Lambda[137∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant158 --> Lambda137
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
     PgSelect24[["PgSelect[24∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression18 & Connection23 & Constant152 & Lambda110 & Lambda113 & Lambda118 & Lambda123 --> PgSelect24
+    Object12 & PgClassExpression18 & Connection23 & Constant157 & Lambda112 & Access116 & Lambda121 & Lambda126 --> PgSelect24
     PgSelect75[["PgSelect[75∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object12 & PgClassExpression18 & Connection23 & Lambda81 & Lambda84 & Lambda132 & Lambda137 --> PgSelect75
+    Object12 & PgClassExpression18 & Connection23 & Lambda81 & Access85 & Lambda136 & Lambda141 --> PgSelect75
     Object61{{"Object[61∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access56{{"Access[56∈3]<br />ᐸ24.hasMoreᐳ"}}:::plan
-    Constant8 & Constant152 & Constant8 & Access56 --> Object61
+    Constant8 & Constant157 & Constant8 & Access56 --> Object61
     Object57{{"Object[57∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant8 & Constant152 & Access56 --> Object57
+    Constant8 & Constant157 & Access56 --> Object57
     PgSelectSingle14 --> PgClassExpression18
     PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo53
@@ -144,7 +150,7 @@ graph TD
     __Item25 --> PgSelectSingle26
     PgSelect29[["PgSelect[29∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression28 & Lambda81 & Lambda84 & Lambda89 & Lambda94 --> PgSelect29
+    Object12 & PgClassExpression28 & Lambda81 & Access85 & Lambda90 & Lambda95 --> PgSelect29
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle26 --> PgClassExpression28
@@ -158,7 +164,7 @@ graph TD
     PgSelectSingle34 --> PgClassExpression36
     PgSelect44[["PgSelect[44∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression43{{"PgClassExpression[43∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression43 & Lambda81 & Lambda84 & Lambda103 & Lambda108 --> PgSelect44
+    Object12 & PgClassExpression43 & Lambda81 & Access85 & Lambda105 & Lambda110 --> PgSelect44
     PgCursor39{{"PgCursor[39∈7]"}}:::plan
     List41{{"List[41∈7]<br />ᐸ40ᐳ"}}:::plan
     List41 --> PgCursor39
@@ -180,28 +186,28 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-when-inlined-backwards"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 85, 86, 87, 99, 100, 114, 115, 116, 128, 142, 143, 144, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 12, 23, 81, 84, 110, 139, 141, 145, 146, 151<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 86, 87, 88, 101, 102, 117, 118, 119, 132, 147, 148, 149, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 12, 23, 81, 84, 85, 89, 90, 95, 104, 105, 110, 112, 115, 116, 120, 121, 126, 135, 136, 141, 143, 145, 146, 150, 151, 156<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Lambda81,Lambda84,Constant85,Constant86,Constant87,Constant99,Constant100,Lambda110,Constant114,Constant115,Constant116,Constant128,Lambda139,Lambda141,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 81, 85, 86, 87, 155, 99, 100, 156, 161, 110, 114, 115, 116, 157, 128, 158, 12, 23, 152, 8, 84<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Lambda81,Lambda84,Access85,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant101,Constant102,Object104,Lambda105,Lambda110,Lambda112,Lambda115,Access116,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant132,Object135,Lambda136,Lambda141,Lambda143,Lambda145,Access146,Constant147,Constant148,Constant149,Object150,Lambda151,Lambda156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 12, 23, 157, 112, 116, 121, 126, 8, 81, 85, 136, 141, 90, 95, 105, 110<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item13,PgSelectSingle14,Object88,Lambda89,Lambda94,Object102,Lambda103,Lambda108,Lambda113,Object117,Lambda118,Lambda123,Object131,Lambda132,Lambda137 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 23, 152, 110, 113, 118, 123, 8, 81, 84, 132, 137, 89, 94, 103, 108<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    class Bucket1,__Item13,PgSelectSingle14 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 23, 157, 112, 116, 121, 126, 8, 81, 85, 136, 141, 90, 95, 105, 110<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 23, 152, 110, 113, 118, 123, 8, 81, 84, 132, 137, 89, 94, 103, 108<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: PgClassExpression[18], PgPageInfo[53]<br />2: PgSelect[24], PgSelect[75]<br />ᐳ: 56, 57, 58, 61, 62, 64, 65, 67, 68, 70, 71, 73, 74, 76, 77, 78, 66, 72"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 23, 157, 112, 116, 121, 126, 8, 81, 85, 136, 141, 90, 95, 105, 110<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: PgClassExpression[18], PgPageInfo[53]<br />2: PgSelect[24], PgSelect[75]<br />ᐳ: 56, 57, 58, 61, 62, 64, 65, 67, 68, 70, 71, 73, 74, 76, 77, 78, 66, 72"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect24,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,PgSelect75,First76,PgSelectSingle77,PgClassExpression78 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 12, 81, 84, 89, 94, 103, 108<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 12, 81, 85, 90, 95, 105, 110<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 12, 81, 84, 89, 94<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 12, 81, 85, 90, 95<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression27,PgClassExpression28,PgSelect29,First33,PgSelectSingle34 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression35,PgClassExpression36 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 26, 12, 81, 84, 103, 108<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 26, 12, 81, 85, 105, 110<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgClassExpression43,PgSelect44,First48,PgSelectSingle49 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[49]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.mermaid
@@ -11,46 +11,46 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Access85{{"Access[85∈0] ➊<br />ᐸ84.0ᐳ"}}:::plan
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access120{{"Access[120∈0] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access159{{"Access[159∈0] ➊<br />ᐸ158.0ᐳ"}}:::plan
     Lambda164{{"Lambda[164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant165 & Lambda84 & Lambda89 & Lambda94 & Lambda105 & Lambda110 & Lambda117 & Lambda122 & Lambda127 & Lambda84 & Lambda141 & Lambda146 & Lambda152 & Lambda154 & Lambda159 & Lambda164 --> PgSelect9
-    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant170 & Access85 & Lambda90 & Lambda95 & Lambda107 & Lambda112 & Access120 & Lambda125 & Lambda130 & Access85 & Lambda145 & Lambda150 & Lambda156 & Access159 & Lambda164 & Lambda169 --> PgSelect9
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda81 & Constant85 & Constant86 & Constant87 --> Object88
-    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Lambda81 & Constant101 & Constant102 & Constant87 --> Object104
-    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda114 & Constant118 & Constant119 & Constant120 --> Object121
-    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda81 & Constant137 & Constant119 & Constant120 --> Object140
-    Object158{{"Object[158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda152 & Constant155 & Constant156 & Constant157 --> Object158
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda81 & Constant86 & Constant87 & Constant88 --> Object89
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda81 & Constant103 & Constant104 & Constant88 --> Object106
+    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda116 & Constant121 & Constant122 & Constant123 --> Object124
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda81 & Constant141 & Constant122 & Constant123 --> Object144
+    Object163{{"Object[163∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda156 & Constant160 & Constant161 & Constant162 --> Object163
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -58,66 +58,72 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant165 --> Connection23
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant166 --> Lambda81
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant167 --> Lambda84
-    Object88 --> Lambda89
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant168 --> Lambda94
-    Object104 --> Lambda105
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant169 --> Lambda110
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant173 --> Lambda114
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant174 --> Lambda117
-    Object121 --> Lambda122
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant170 --> Lambda127
-    Object140 --> Lambda141
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant171 --> Lambda146
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant175 --> Lambda152
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant176 --> Lambda154
-    Object158 --> Lambda159
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant172 --> Lambda164
+    Constant170 --> Connection23
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant171 --> Lambda81
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant172 --> Lambda84
+    Lambda84 --> Access85
+    Object89 --> Lambda90
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant173 --> Lambda95
+    Object106 --> Lambda107
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant174 --> Lambda112
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant178 --> Lambda116
+    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant179 --> Lambda119
+    Lambda119 --> Access120
+    Object124 --> Lambda125
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant175 --> Lambda130
+    Object144 --> Lambda145
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant176 --> Lambda150
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant180 --> Lambda156
+    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant181 --> Lambda158
+    Lambda158 --> Access159
+    Object163 --> Lambda164
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant177 --> Lambda169
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant79{{"Constant[79∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant82{{"Constant[82∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
-    Object131{{"Object[131∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access129{{"Access[129∈3]<br />ᐸ13.1ᐳ"}}:::plan
-    Access129 & Constant79 & Constant165 & Lambda114 & Constant115 --> Object131
-    Object149{{"Object[149∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access147{{"Access[147∈3]<br />ᐸ13.2ᐳ"}}:::plan
-    Access147 & Constant79 & Constant79 & Lambda81 & Constant82 --> Object149
+    Object134{{"Object[134∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access132{{"Access[132∈3]<br />ᐸ13.1ᐳ"}}:::plan
+    Access132 & Constant79 & Constant170 & Lambda116 & Constant117 --> Object134
+    Object153{{"Object[153∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access151{{"Access[151∈3]<br />ᐸ13.2ᐳ"}}:::plan
+    Access151 & Constant79 & Constant79 & Lambda81 & Constant82 --> Object153
     Object61{{"Object[61∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access56{{"Access[56∈3]<br />ᐸ132.hasMoreᐳ"}}:::plan
-    Constant8 & Constant165 & Constant8 & Access56 --> Object61
+    Access56{{"Access[56∈3]<br />ᐸ135.hasMoreᐳ"}}:::plan
+    Constant8 & Constant170 & Constant8 & Access56 --> Object61
     Object57{{"Object[57∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant8 & Constant165 & Access56 --> Object57
+    Constant8 & Constant170 & Access56 --> Object57
     PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo53
-    Lambda132{{"Lambda[132∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda132 --> Access56
+    Lambda135{{"Lambda[135∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda135 --> Access56
     Lambda58{{"Lambda[58∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object57 --> Lambda58
     Lambda62{{"Lambda[62∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object61 --> Lambda62
     First64{{"First[64∈3]"}}:::plan
-    Lambda132 --> First64
+    Lambda135 --> First64
     PgSelectSingle65{{"PgSelectSingle[65∈3]<br />ᐸmessagesᐳ"}}:::plan
     First64 --> PgSelectSingle65
     PgCursor66{{"PgCursor[66∈3]"}}:::plan
@@ -127,7 +133,7 @@ graph TD
     PgSelectSingle65 --> PgClassExpression67
     PgClassExpression67 --> List68
     Last70{{"Last[70∈3]"}}:::plan
-    Lambda132 --> Last70
+    Lambda135 --> Last70
     PgSelectSingle71{{"PgSelectSingle[71∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last70 --> PgSelectSingle71
     PgCursor72{{"PgCursor[72∈3]"}}:::plan
@@ -137,26 +143,26 @@ graph TD
     PgSelectSingle71 --> PgClassExpression73
     PgClassExpression73 --> List74
     First76{{"First[76∈3]"}}:::plan
-    Lambda150{{"Lambda[150∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda150 --> First76
+    Lambda154{{"Lambda[154∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda154 --> First76
     PgSelectSingle77{{"PgSelectSingle[77∈3]<br />ᐸmessagesᐳ"}}:::plan
     First76 --> PgSelectSingle77
     PgClassExpression78{{"PgClassExpression[78∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle77 --> PgClassExpression78
-    __Item13 --> Access129
-    Object131 --> Lambda132
-    __Item13 --> Access147
-    Object149 --> Lambda150
-    __Item25[/"__Item[25∈4]<br />ᐸ132ᐳ"\]:::itemplan
-    Lambda132 ==> __Item25
+    __Item13 --> Access132
+    Object134 --> Lambda135
+    __Item13 --> Access151
+    Object153 --> Lambda154
+    __Item25[/"__Item[25∈4]<br />ᐸ135ᐳ"\]:::itemplan
+    Lambda135 ==> __Item25
     PgSelectSingle26{{"PgSelectSingle[26∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item25 --> PgSelectSingle26
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys95{{"RemapKeys[95∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys95 --> PgSelectSingle34
-    PgSelectSingle26 --> RemapKeys95
+    RemapKeys96{{"RemapKeys[96∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys96 --> PgSelectSingle34
+    PgSelectSingle26 --> RemapKeys96
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
     PgClassExpression36{{"PgClassExpression[36∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -170,9 +176,9 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression42
     PgSelectSingle49{{"PgSelectSingle[49∈7]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys111{{"RemapKeys[111∈7]<br />ᐸ26:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys111 --> PgSelectSingle49
-    PgSelectSingle26 --> RemapKeys111
+    RemapKeys113{{"RemapKeys[113∈7]<br />ᐸ26:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys113 --> PgSelectSingle49
+    PgSelectSingle26 --> RemapKeys113
     PgClassExpression50{{"PgClassExpression[50∈8]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression51{{"PgClassExpression[51∈8]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -181,30 +187,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-when-inlined-backwards"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 79, 82, 85, 86, 87, 101, 102, 115, 118, 119, 120, 137, 155, 156, 157, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 12, 23, 81, 84, 88, 89, 94, 104, 105, 110, 114, 117, 121, 122, 127, 140, 141, 146, 152, 154, 158, 159, 164<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 79, 82, 86, 87, 88, 103, 104, 117, 121, 122, 123, 141, 160, 161, 162, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 12, 23, 81, 84, 85, 89, 90, 95, 106, 107, 112, 116, 119, 120, 124, 125, 130, 144, 145, 150, 156, 158, 159, 163, 164, 169<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Constant79,Lambda81,Constant82,Lambda84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant101,Constant102,Object104,Lambda105,Lambda110,Lambda114,Constant115,Lambda117,Constant118,Constant119,Constant120,Object121,Lambda122,Lambda127,Constant137,Object140,Lambda141,Lambda146,Lambda152,Lambda154,Constant155,Constant156,Constant157,Object158,Lambda159,Lambda164,Constant165,Constant166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 8, 165, 79, 114, 115, 81, 82<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Constant79,Lambda81,Constant82,Lambda84,Access85,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant103,Constant104,Object106,Lambda107,Lambda112,Lambda116,Constant117,Lambda119,Access120,Constant121,Constant122,Constant123,Object124,Lambda125,Lambda130,Constant141,Object144,Lambda145,Lambda150,Lambda156,Lambda158,Access159,Constant160,Constant161,Constant162,Object163,Lambda164,Lambda169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 8, 170, 79, 116, 117, 81, 82<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13,PgSelectSingle14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 23, 8, 165, 13, 79, 114, 115, 81, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 23, 8, 170, 13, 79, 116, 117, 81, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 8, 165, 13, 79, 114, 115, 81, 82<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 8, 170, 13, 79, 116, 117, 81, 82<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,First76,PgSelectSingle77,PgClassExpression78,Access129,Object131,Lambda132,Access147,Object149,Lambda150 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ132ᐳ[25]"):::bucket
+    class Bucket3,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,First76,PgSelectSingle77,PgClassExpression78,Access132,Object134,Lambda135,Access151,Object153,Lambda154 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ135ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys95 bucket5
+    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys96 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression35,PgClassExpression36 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys111 bucket7
+    class Bucket7,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys113 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[49]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression50,PgClassExpression51 bucket8

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.deopt.mermaid
@@ -11,17 +11,35 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access146{{"Access[146∈0] ➊<br />ᐸ145.0ᐳ"}}:::plan
     Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant152 & Lambda110 & Lambda141 & Lambda146 & Lambda151 --> PgSelect9
-    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda110 & Constant142 & Constant143 & Constant144 --> Object145
+    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant157 & Lambda112 & Access146 & Lambda151 & Lambda156 --> PgSelect9
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda81 & Constant86 & Constant87 & Constant88 --> Object89
+    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda81 & Constant101 & Constant102 & Constant88 --> Object104
+    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda112 & Constant117 & Constant118 & Constant119 --> Object120
+    Object135{{"Object[135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda81 & Constant132 & Constant118 & Constant119 --> Object135
+    Object150{{"Object[150∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda112 & Constant147 & Constant148 & Constant149 --> Object150
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -29,78 +47,66 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant152 --> Connection23
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant153 --> Lambda81
+    Constant157 --> Connection23
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda81
     Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant154 --> Lambda84
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant160 --> Lambda110
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant162 --> Lambda141
-    Object145 --> Lambda146
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant159 --> Lambda151
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant159 --> Lambda84
+    Access85{{"Access[85∈0] ➊<br />ᐸ84.0ᐳ"}}:::plan
+    Lambda84 --> Access85
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object89 --> Lambda90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant160 --> Lambda95
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object104 --> Lambda105
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant161 --> Lambda110
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant165 --> Lambda112
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant166 --> Lambda115
+    Access116{{"Access[116∈0] ➊<br />ᐸ115.0ᐳ"}}:::plan
+    Lambda115 --> Access116
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object120 --> Lambda121
+    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant162 --> Lambda126
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object135 --> Lambda136
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant163 --> Lambda141
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant167 --> Lambda145
+    Lambda145 --> Access146
+    Object150 --> Lambda151
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant164 --> Lambda156
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant85 & Constant86 & Constant87 --> Object88
-    Object102{{"Object[102∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant99 & Constant100 & Constant87 --> Object102
-    Object117{{"Object[117∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda110 & Constant114 & Constant115 & Constant116 --> Object117
-    Object131{{"Object[131∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda81 & Constant128 & Constant115 & Constant116 --> Object131
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object88 --> Lambda89
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant155 --> Lambda94
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object102 --> Lambda103
-    Lambda108{{"Lambda[108∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant156 --> Lambda108
-    Lambda113{{"Lambda[113∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant161 --> Lambda113
-    Lambda118{{"Lambda[118∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object117 --> Lambda118
-    Lambda123{{"Lambda[123∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157 --> Lambda123
-    Lambda132{{"Lambda[132∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object131 --> Lambda132
-    Lambda137{{"Lambda[137∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant158 --> Lambda137
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
     PgSelect24[["PgSelect[24∈3]<br />ᐸmessages+1ᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression18 & Connection23 & Constant152 & Lambda110 & Lambda113 & Lambda118 & Lambda123 --> PgSelect24
+    Object12 & PgClassExpression18 & Connection23 & Constant157 & Lambda112 & Access116 & Lambda121 & Lambda126 --> PgSelect24
     PgSelect75[["PgSelect[75∈3]<br />ᐸmessages(aggregate)ᐳ"]]:::plan
-    Object12 & PgClassExpression18 & Connection23 & Lambda81 & Lambda84 & Lambda132 & Lambda137 --> PgSelect75
+    Object12 & PgClassExpression18 & Connection23 & Lambda81 & Access85 & Lambda136 & Lambda141 --> PgSelect75
     Object61{{"Object[61∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access56{{"Access[56∈3]<br />ᐸ24.hasMoreᐳ"}}:::plan
-    Constant152 & Constant8 & Constant8 & Access56 --> Object61
+    Constant157 & Constant8 & Constant8 & Access56 --> Object61
     Object57{{"Object[57∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant152 & Constant8 & Access56 --> Object57
+    Constant157 & Constant8 & Access56 --> Object57
     PgSelectSingle14 --> PgClassExpression18
     PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo53
@@ -141,7 +147,7 @@ graph TD
     __Item25 --> PgSelectSingle26
     PgSelect29[["PgSelect[29∈5]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression28 & Lambda81 & Lambda84 & Lambda89 & Lambda94 --> PgSelect29
+    Object12 & PgClassExpression28 & Lambda81 & Access85 & Lambda90 & Lambda95 --> PgSelect29
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle26 --> PgClassExpression28
@@ -155,7 +161,7 @@ graph TD
     PgSelectSingle34 --> PgClassExpression36
     PgSelect44[["PgSelect[44∈7]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression43{{"PgClassExpression[43∈7]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression43 & Lambda81 & Lambda84 & Lambda103 & Lambda108 --> PgSelect44
+    Object12 & PgClassExpression43 & Lambda81 & Access85 & Lambda105 & Lambda110 --> PgSelect44
     PgCursor39{{"PgCursor[39∈7]"}}:::plan
     List41{{"List[41∈7]<br />ᐸ40ᐳ"}}:::plan
     List41 --> PgCursor39
@@ -177,28 +183,28 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-when-inlined"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 85, 86, 87, 99, 100, 114, 115, 116, 128, 142, 143, 144, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 12, 23, 81, 84, 110, 141, 145, 146, 151<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 86, 87, 88, 101, 102, 117, 118, 119, 132, 147, 148, 149, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 12, 23, 81, 84, 85, 89, 90, 95, 104, 105, 110, 112, 115, 116, 120, 121, 126, 135, 136, 141, 145, 146, 150, 151, 156<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Lambda81,Lambda84,Constant85,Constant86,Constant87,Constant99,Constant100,Lambda110,Constant114,Constant115,Constant116,Constant128,Lambda141,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 81, 85, 86, 87, 155, 99, 100, 156, 161, 110, 114, 115, 116, 157, 128, 158, 12, 23, 152, 8, 84<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Lambda81,Lambda84,Access85,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant101,Constant102,Object104,Lambda105,Lambda110,Lambda112,Lambda115,Access116,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant132,Object135,Lambda136,Lambda141,Lambda145,Access146,Constant147,Constant148,Constant149,Object150,Lambda151,Lambda156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 12, 23, 157, 112, 116, 121, 126, 8, 81, 85, 136, 141, 90, 95, 105, 110<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item13,PgSelectSingle14,Object88,Lambda89,Lambda94,Object102,Lambda103,Lambda108,Lambda113,Object117,Lambda118,Lambda123,Object131,Lambda132,Lambda137 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 23, 152, 110, 113, 118, 123, 8, 81, 84, 132, 137, 89, 94, 103, 108<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    class Bucket1,__Item13,PgSelectSingle14 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 12, 23, 157, 112, 116, 121, 126, 8, 81, 85, 136, 141, 90, 95, 105, 110<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 23, 152, 110, 113, 118, 123, 8, 81, 84, 132, 137, 89, 94, 103, 108<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: PgClassExpression[18], PgPageInfo[53]<br />2: PgSelect[24], PgSelect[75]<br />ᐳ: 56, 57, 58, 61, 62, 64, 65, 67, 68, 70, 71, 73, 74, 76, 77, 78, 66, 72"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 23, 157, 112, 116, 121, 126, 8, 81, 85, 136, 141, 90, 95, 105, 110<br /><br />ROOT Connectionᐸ19ᐳ[23]<br />1: <br />ᐳ: PgClassExpression[18], PgPageInfo[53]<br />2: PgSelect[24], PgSelect[75]<br />ᐳ: 56, 57, 58, 61, 62, 64, 65, 67, 68, 70, 71, 73, 74, 76, 77, 78, 66, 72"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect24,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,PgSelect75,First76,PgSelectSingle77,PgClassExpression78 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 12, 81, 84, 89, 94, 103, 108<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 12, 81, 85, 90, 95, 105, 110<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 12, 81, 84, 89, 94<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26, 12, 81, 85, 90, 95<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 27, 28<br />2: PgSelect[29]<br />ᐳ: First[33], PgSelectSingle[34]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression27,PgClassExpression28,PgSelect29,First33,PgSelectSingle34 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression35,PgClassExpression36 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 26, 12, 81, 84, 103, 108<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 26, 12, 81, 85, 105, 110<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]<br />1: <br />ᐳ: 40, 42, 43, 41, 39<br />2: PgSelect[44]<br />ᐳ: First[48], PgSelectSingle[49]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgClassExpression43,PgSelect44,First48,PgSelectSingle49 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[49]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.mermaid
@@ -11,45 +11,45 @@ graph TD
     %% plan dependencies
     PgSelect9[["PgSelect[9∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Access85{{"Access[85∈0] ➊<br />ᐸ84.0ᐳ"}}:::plan
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access120{{"Access[120∈0] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access159{{"Access[159∈0] ➊<br />ᐸ158.0ᐳ"}}:::plan
     Lambda164{{"Lambda[164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant165 & Lambda84 & Lambda89 & Lambda94 & Lambda105 & Lambda110 & Lambda117 & Lambda122 & Lambda127 & Lambda84 & Lambda141 & Lambda146 & Lambda114 & Lambda154 & Lambda159 & Lambda164 --> PgSelect9
-    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant170 & Access85 & Lambda90 & Lambda95 & Lambda107 & Lambda112 & Access120 & Lambda125 & Lambda130 & Access85 & Lambda145 & Lambda150 & Lambda116 & Access159 & Lambda164 & Lambda169 --> PgSelect9
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda81 & Constant85 & Constant86 & Constant87 --> Object88
-    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Lambda81 & Constant101 & Constant102 & Constant87 --> Object104
-    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda114 & Constant118 & Constant119 & Constant120 --> Object121
-    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda81 & Constant137 & Constant119 & Constant120 --> Object140
-    Object158{{"Object[158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda114 & Constant155 & Constant156 & Constant157 --> Object158
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda81 & Constant86 & Constant87 & Constant88 --> Object89
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda81 & Constant103 & Constant104 & Constant88 --> Object106
+    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda116 & Constant121 & Constant122 & Constant123 --> Object124
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda81 & Constant141 & Constant122 & Constant123 --> Object144
+    Object163{{"Object[163∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda116 & Constant160 & Constant161 & Constant162 --> Object163
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -57,64 +57,70 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Connection23{{"Connection[23∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant165 --> Connection23
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant166 --> Lambda81
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant167 --> Lambda84
-    Object88 --> Lambda89
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant168 --> Lambda94
-    Object104 --> Lambda105
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant169 --> Lambda110
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant173 --> Lambda114
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant174 --> Lambda117
-    Object121 --> Lambda122
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant170 --> Lambda127
-    Object140 --> Lambda141
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant171 --> Lambda146
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant175 --> Lambda154
-    Object158 --> Lambda159
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant172 --> Lambda164
+    Constant170 --> Connection23
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant171 --> Lambda81
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant172 --> Lambda84
+    Lambda84 --> Access85
+    Object89 --> Lambda90
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant173 --> Lambda95
+    Object106 --> Lambda107
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant174 --> Lambda112
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant178 --> Lambda116
+    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant179 --> Lambda119
+    Lambda119 --> Access120
+    Object124 --> Lambda125
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant175 --> Lambda130
+    Object144 --> Lambda145
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant176 --> Lambda150
+    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant180 --> Lambda158
+    Lambda158 --> Access159
+    Object163 --> Lambda164
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant177 --> Lambda169
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant79{{"Constant[79∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant82{{"Constant[82∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ9ᐳ"\]:::itemplan
     PgSelect9 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item13 --> PgSelectSingle14
     PgClassExpression15{{"PgClassExpression[15∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
-    Object131{{"Object[131∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access129{{"Access[129∈3]<br />ᐸ13.1ᐳ"}}:::plan
-    Access129 & Constant165 & Constant79 & Lambda114 & Constant115 --> Object131
-    Object149{{"Object[149∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access147{{"Access[147∈3]<br />ᐸ13.2ᐳ"}}:::plan
-    Access147 & Constant79 & Constant79 & Lambda81 & Constant82 --> Object149
+    Object134{{"Object[134∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access132{{"Access[132∈3]<br />ᐸ13.1ᐳ"}}:::plan
+    Access132 & Constant170 & Constant79 & Lambda116 & Constant117 --> Object134
+    Object153{{"Object[153∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access151{{"Access[151∈3]<br />ᐸ13.2ᐳ"}}:::plan
+    Access151 & Constant79 & Constant79 & Lambda81 & Constant82 --> Object153
     Object61{{"Object[61∈3]<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access56{{"Access[56∈3]<br />ᐸ132.hasMoreᐳ"}}:::plan
-    Constant165 & Constant8 & Constant8 & Access56 --> Object61
+    Access56{{"Access[56∈3]<br />ᐸ135.hasMoreᐳ"}}:::plan
+    Constant170 & Constant8 & Constant8 & Access56 --> Object61
     Object57{{"Object[57∈3]<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant165 & Constant8 & Access56 --> Object57
+    Constant170 & Constant8 & Access56 --> Object57
     PgPageInfo53{{"PgPageInfo[53∈3] ➊"}}:::plan
     Connection23 --> PgPageInfo53
-    Lambda132{{"Lambda[132∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda132 --> Access56
+    Lambda135{{"Lambda[135∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda135 --> Access56
     Lambda58{{"Lambda[58∈3]<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object57 --> Lambda58
     Lambda62{{"Lambda[62∈3]<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object61 --> Lambda62
     First64{{"First[64∈3]"}}:::plan
-    Lambda132 --> First64
+    Lambda135 --> First64
     PgSelectSingle65{{"PgSelectSingle[65∈3]<br />ᐸmessagesᐳ"}}:::plan
     First64 --> PgSelectSingle65
     PgCursor66{{"PgCursor[66∈3]"}}:::plan
@@ -124,7 +130,7 @@ graph TD
     PgSelectSingle65 --> PgClassExpression67
     PgClassExpression67 --> List68
     Last70{{"Last[70∈3]"}}:::plan
-    Lambda132 --> Last70
+    Lambda135 --> Last70
     PgSelectSingle71{{"PgSelectSingle[71∈3]<br />ᐸmessagesᐳ"}}:::plan
     Last70 --> PgSelectSingle71
     PgCursor72{{"PgCursor[72∈3]"}}:::plan
@@ -134,26 +140,26 @@ graph TD
     PgSelectSingle71 --> PgClassExpression73
     PgClassExpression73 --> List74
     First76{{"First[76∈3]"}}:::plan
-    Lambda150{{"Lambda[150∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda150 --> First76
+    Lambda154{{"Lambda[154∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda154 --> First76
     PgSelectSingle77{{"PgSelectSingle[77∈3]<br />ᐸmessagesᐳ"}}:::plan
     First76 --> PgSelectSingle77
     PgClassExpression78{{"PgClassExpression[78∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle77 --> PgClassExpression78
-    __Item13 --> Access129
-    Object131 --> Lambda132
-    __Item13 --> Access147
-    Object149 --> Lambda150
-    __Item25[/"__Item[25∈4]<br />ᐸ132ᐳ"\]:::itemplan
-    Lambda132 ==> __Item25
+    __Item13 --> Access132
+    Object134 --> Lambda135
+    __Item13 --> Access151
+    Object153 --> Lambda154
+    __Item25[/"__Item[25∈4]<br />ᐸ135ᐳ"\]:::itemplan
+    Lambda135 ==> __Item25
     PgSelectSingle26{{"PgSelectSingle[26∈4]<br />ᐸmessagesᐳ"}}:::plan
     __Item25 --> PgSelectSingle26
     PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys95{{"RemapKeys[95∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys95 --> PgSelectSingle34
-    PgSelectSingle26 --> RemapKeys95
+    RemapKeys96{{"RemapKeys[96∈5]<br />ᐸ26:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys96 --> PgSelectSingle34
+    PgSelectSingle26 --> RemapKeys96
     PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
     PgClassExpression36{{"PgClassExpression[36∈6]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -167,9 +173,9 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈7]<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression42
     PgSelectSingle49{{"PgSelectSingle[49∈7]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys111{{"RemapKeys[111∈7]<br />ᐸ26:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys111 --> PgSelectSingle49
-    PgSelectSingle26 --> RemapKeys111
+    RemapKeys113{{"RemapKeys[113∈7]<br />ᐸ26:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys113 --> PgSelectSingle49
+    PgSelectSingle26 --> RemapKeys113
     PgClassExpression50{{"PgClassExpression[50∈8]<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression51{{"PgClassExpression[51∈8]<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -178,30 +184,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/connections/pagination-when-inlined"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 79, 82, 85, 86, 87, 101, 102, 115, 118, 119, 120, 137, 155, 156, 157, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 12, 23, 81, 84, 88, 89, 94, 104, 105, 110, 114, 117, 121, 122, 127, 140, 141, 146, 154, 158, 159, 164<br />2: PgSelect[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 10, 11, 79, 82, 86, 87, 88, 103, 104, 117, 121, 122, 123, 141, 160, 161, 162, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 12, 23, 81, 84, 85, 89, 90, 95, 106, 107, 112, 116, 119, 120, 124, 125, 130, 144, 145, 150, 158, 159, 163, 164, 169<br />2: PgSelect[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Constant79,Lambda81,Constant82,Lambda84,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant101,Constant102,Object104,Lambda105,Lambda110,Lambda114,Constant115,Lambda117,Constant118,Constant119,Constant120,Object121,Lambda122,Lambda127,Constant137,Object140,Lambda141,Lambda146,Lambda154,Constant155,Constant156,Constant157,Object158,Lambda159,Lambda164,Constant165,Constant166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 165, 8, 79, 114, 115, 81, 82<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,PgSelect9,Access10,Access11,Object12,Connection23,Constant79,Lambda81,Constant82,Lambda84,Access85,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant103,Constant104,Object106,Lambda107,Lambda112,Lambda116,Constant117,Lambda119,Access120,Constant121,Constant122,Constant123,Object124,Lambda125,Lambda130,Constant141,Object144,Lambda145,Lambda150,Lambda158,Access159,Constant160,Constant161,Constant162,Object163,Lambda164,Lambda169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 170, 8, 79, 116, 117, 81, 82<br /><br />ROOT __Item{1}ᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13,PgSelectSingle14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 23, 165, 8, 13, 79, 114, 115, 81, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 23, 170, 8, 13, 79, 116, 117, 81, 82<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression15 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 165, 8, 13, 79, 114, 115, 81, 82<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 170, 8, 13, 79, 116, 117, 81, 82<br /><br />ROOT Connectionᐸ19ᐳ[23]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,First76,PgSelectSingle77,PgClassExpression78,Access129,Object131,Lambda132,Access147,Object149,Lambda150 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ132ᐳ[25]"):::bucket
+    class Bucket3,PgPageInfo53,Access56,Object57,Lambda58,Object61,Lambda62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,First76,PgSelectSingle77,PgClassExpression78,Access132,Object134,Lambda135,Access151,Object153,Lambda154 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ135ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys95 bucket5
+    class Bucket5,PgClassExpression27,PgSelectSingle34,RemapKeys96 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 34<br /><br />ROOT PgSelectSingle{5}ᐸusersᐳ[34]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression35,PgClassExpression36 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 26<br /><br />ROOT PgSelectSingle{4}ᐸmessagesᐳ[26]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys111 bucket7
+    class Bucket7,PgCursor39,PgClassExpression40,List41,PgClassExpression42,PgSelectSingle49,RemapKeys113 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[49]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression50,PgClassExpression51 bucket8

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-combined.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-combined.deopt.mermaid
@@ -11,17 +11,36 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access50{{"Access[50∈0] ➊<br />ᐸ49.0ᐳ"}}:::plan
     Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant118 & Lambda46 & Lambda49 & Lambda112 & Lambda117 --> PgSelect7
-    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda46 & Constant108 & Constant109 & Constant82 --> Object111
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant123 & Lambda46 & Access50 & Lambda117 & Lambda122 --> PgSelect7
+    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda46 & Constant51 & Constant52 & Constant53 --> Object54
+    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda46 & Constant68 & Constant69 & Constant70 --> Object71
+    Object86{{"Object[86∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸsql.identifier(”users_most_recent_forum”)ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda46 & Constant83 & Constant84 & Constant85 --> Object86
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda46 & Constant98 & Constant99 & Constant100 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Lambda46 & Constant113 & Constant114 & Constant85 --> Object116
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,65 +51,48 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant119 --> Lambda46
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant120 --> Lambda49
-    Object111 --> Lambda112
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant125 --> Lambda117
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant124 --> Lambda46
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant125 --> Lambda49
+    Lambda49 --> Access50
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object54 --> Lambda55
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant126 --> Lambda60
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object71 --> Lambda72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant127 --> Lambda77
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object86 --> Lambda87
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users_ᐳ"}}:::plan
+    Constant128 --> Lambda92
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object101 --> Lambda102
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant129 --> Lambda107
+    Object116 --> Lambda117
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant130 --> Lambda122
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”users_most_recent_forum”)ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users_ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸforums_random_userᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__ᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & PgClassExpression13 & Lambda46 & Lambda49 & Lambda98 & Lambda103 --> PgSelect14
-    Object53{{"Object[53∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda46 & Constant50 & Constant51 & Constant52 --> Object53
-    Object69{{"Object[69∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda46 & Constant66 & Constant67 & Constant68 --> Object69
-    Object83{{"Object[83∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda46 & Constant80 & Constant81 & Constant82 --> Object83
-    Object97{{"Object[97∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda46 & Constant94 & Constant95 & Constant96 --> Object97
+    Object10 & PgClassExpression13 & Lambda46 & Access50 & Lambda102 & Lambda107 --> PgSelect14
     PgSelectSingle12 --> PgClassExpression13
     First18{{"First[18∈1] ➊"}}:::plan
     PgSelect14 --> First18
     PgSelectSingle19{{"PgSelectSingle[19∈1] ➊<br />ᐸusersᐳ"}}:::plan
     First18 --> PgSelectSingle19
-    Lambda54{{"Lambda[54∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object53 --> Lambda54
-    Lambda59{{"Lambda[59∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant121 --> Lambda59
-    Lambda70{{"Lambda[70∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object69 --> Lambda70
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant122 --> Lambda75
-    Lambda84{{"Lambda[84∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object83 --> Lambda84
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant123 --> Lambda89
-    Object97 --> Lambda98
-    Constant124 --> Lambda103
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸusers_most_recent_forumᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈2] ➊<br />ᐸ__forums_random_user__ᐳ"}}:::plan
-    Object10 & PgClassExpression22 & Constant29 & Lambda49 & Lambda54 & Lambda59 & Lambda46 & Lambda49 & Lambda84 & Lambda89 --> PgSelect23
+    Object10 & PgClassExpression22 & Constant29 & Access50 & Lambda55 & Lambda60 & Lambda46 & Access50 & Lambda87 & Lambda92 --> PgSelect23
     PgClassExpression20{{"PgClassExpression[20∈2] ➊<br />ᐸ__forums_r...”username”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression20
     PgClassExpression21{{"PgClassExpression[21∈2] ➊<br />ᐸ__forums_r...vatar_url”ᐳ"}}:::plan
@@ -102,7 +104,7 @@ graph TD
     First27 --> PgSelectSingle28
     PgSelect39[["PgSelect[39∈3] ➊<br />ᐸforums_featured_messagesᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__users_mo...nt_forum__ᐳ"}}:::plan
-    Object10 & PgClassExpression30 & Lambda46 & Lambda49 & Lambda70 & Lambda75 --> PgSelect39
+    Object10 & PgClassExpression30 & Lambda46 & Access50 & Lambda72 & Lambda77 --> PgSelect39
     PgSelectSingle28 --> PgClassExpression30
     PgSelectSingle36{{"PgSelectSingle[36∈3] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
     PgSelectSingle28 --> PgSelectSingle36
@@ -118,16 +120,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-combined"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 50, 51, 52, 66, 67, 68, 80, 81, 82, 94, 95, 96, 108, 109, 118, 119, 120, 121, 122, 123, 124, 125, 10, 46, 49, 111, 112, 117<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 51, 52, 53, 68, 69, 70, 83, 84, 85, 98, 99, 100, 113, 114, 123, 124, 125, 126, 127, 128, 129, 130, 10, 46, 49, 50, 54, 55, 60, 71, 72, 77, 86, 87, 92, 101, 102, 107, 116, 117, 122<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant29,Lambda46,Lambda49,Constant50,Constant51,Constant52,Constant66,Constant67,Constant68,Constant80,Constant81,Constant82,Constant94,Constant95,Constant96,Constant108,Constant109,Object111,Lambda112,Lambda117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 46, 49, 50, 51, 52, 121, 66, 67, 68, 122, 80, 81, 82, 123, 94, 95, 96, 124, 29<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: 13, 53, 59, 69, 75, 83, 89, 97, 103, 54, 70, 84, 98<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant29,Lambda46,Lambda49,Access50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant68,Constant69,Constant70,Object71,Lambda72,Lambda77,Constant83,Constant84,Constant85,Object86,Lambda87,Lambda92,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 46, 50, 102, 107, 29, 55, 60, 87, 92, 72, 77<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: PgClassExpression[13]<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgSelect14,First18,PgSelectSingle19,Object53,Lambda54,Lambda59,Object69,Lambda70,Lambda75,Object83,Lambda84,Lambda89,Object97,Lambda98,Lambda103 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 10, 29, 49, 54, 59, 46, 84, 89, 70, 75<br /><br />ROOT PgSelectSingle{1}ᐸusersᐳ[19]<br />1: <br />ᐳ: 20, 21, 22<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    class Bucket1,PgClassExpression13,PgSelect14,First18,PgSelectSingle19 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 10, 29, 50, 55, 60, 46, 87, 92, 72, 77<br /><br />ROOT PgSelectSingle{1}ᐸusersᐳ[19]<br />1: <br />ᐳ: 20, 21, 22<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 10, 46, 49, 70, 75<br /><br />ROOT PgSelectSingle{2}ᐸusers_most_recent_forumᐳ[28]<br />1: <br />ᐳ: 30, 36, 37<br />2: PgSelect[39]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 10, 46, 50, 72, 77<br /><br />ROOT PgSelectSingle{2}ᐸusers_most_recent_forumᐳ[28]<br />1: <br />ᐳ: 30, 36, 37<br />2: PgSelect[39]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression30,PgSelectSingle36,PgClassExpression37,PgSelect39 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ39ᐳ[41]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-combined.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-combined.mermaid
@@ -11,45 +11,45 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access50{{"Access[50∈0] ➊<br />ᐸ49.0ᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant127 & Constant29 & Lambda49 & Lambda54 & Lambda59 & Lambda70 & Lambda75 & Lambda89 & Lambda94 & Lambda49 & Lambda105 & Lambda110 & Lambda46 & Lambda49 & Lambda121 & Lambda126 --> PgSelect7
-    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda46 & Constant50 & Constant51 & Constant52 --> Object53
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda46 & Constant66 & Constant67 & Constant68 --> Object69
-    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”users_most_recent_forum”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda46 & Constant85 & Constant86 & Constant87 --> Object88
-    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda46 & Constant101 & Constant102 & Constant103 --> Object104
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Lambda46 & Constant117 & Constant118 & Constant87 --> Object120
+    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant132 & Constant29 & Access50 & Lambda55 & Lambda60 & Lambda72 & Lambda77 & Lambda92 & Lambda97 & Access50 & Lambda109 & Lambda114 & Lambda46 & Access50 & Lambda126 & Lambda131 --> PgSelect7
+    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda46 & Constant51 & Constant52 & Constant53 --> Object54
+    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda46 & Constant68 & Constant69 & Constant70 --> Object71
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”users_most_recent_forum”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda46 & Constant88 & Constant89 & Constant90 --> Object91
+    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda46 & Constant105 & Constant106 & Constant107 --> Object108
+    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Lambda46 & Constant122 & Constant123 & Constant90 --> Object125
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -60,25 +60,27 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant128 --> Lambda46
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant129 --> Lambda49
-    Object53 --> Lambda54
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant130 --> Lambda59
-    Object69 --> Lambda70
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant131 --> Lambda75
-    Object88 --> Lambda89
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users_ᐳ"}}:::plan
-    Constant132 --> Lambda94
-    Object104 --> Lambda105
-    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant133 --> Lambda110
-    Object120 --> Lambda121
-    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant134 --> Lambda126
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant133 --> Lambda46
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant134 --> Lambda49
+    Lambda49 --> Access50
+    Object54 --> Lambda55
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant135 --> Lambda60
+    Object71 --> Lambda72
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant136 --> Lambda77
+    Object91 --> Lambda92
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users_ᐳ"}}:::plan
+    Constant137 --> Lambda97
+    Object108 --> Lambda109
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant138 --> Lambda114
+    Object125 --> Lambda126
+    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant139 --> Lambda131
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant44{{"Constant[44∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant47{{"Constant[47∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -89,21 +91,21 @@ graph TD
     PgClassExpression21{{"PgClassExpression[21∈2] ➊<br />ᐸ__forums_r...vatar_url”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression21
     PgSelectSingle28{{"PgSelectSingle[28∈2] ➊<br />ᐸusers_most_recent_forumᐳ"}}:::plan
-    RemapKeys95{{"RemapKeys[95∈2] ➊<br />ᐸ19:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
-    RemapKeys95 --> PgSelectSingle28
-    PgSelectSingle19 --> RemapKeys95
-    Object79{{"Object[79∈3] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access77{{"Access[77∈3] ➊<br />ᐸ95.1ᐳ"}}:::plan
-    Access77 & Constant44 & Constant44 & Lambda46 & Constant47 --> Object79
+    RemapKeys98{{"RemapKeys[98∈2] ➊<br />ᐸ19:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    RemapKeys98 --> PgSelectSingle28
+    PgSelectSingle19 --> RemapKeys98
+    Object81{{"Object[81∈3] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access79{{"Access[79∈3] ➊<br />ᐸ98.1ᐳ"}}:::plan
+    Access79 & Constant44 & Constant44 & Lambda46 & Constant47 --> Object81
     PgSelectSingle36{{"PgSelectSingle[36∈3] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
     PgSelectSingle28 --> PgSelectSingle36
     PgClassExpression37{{"PgClassExpression[37∈3] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle36 --> PgClassExpression37
-    RemapKeys95 --> Access77
-    Lambda80{{"Lambda[80∈3] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object79 --> Lambda80
-    __Item41[/"__Item[41∈4]<br />ᐸ80ᐳ"\]:::itemplan
-    Lambda80 ==> __Item41
+    RemapKeys98 --> Access79
+    Lambda82{{"Lambda[82∈3] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object81 --> Lambda82
+    __Item41[/"__Item[41∈4]<br />ᐸ82ᐳ"\]:::itemplan
+    Lambda82 ==> __Item41
     PgSelectSingle42{{"PgSelectSingle[42∈4]<br />ᐸforums_featured_messagesᐳ"}}:::plan
     __Item41 --> PgSelectSingle42
     PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__forums_f...s__.”body”ᐳ"}}:::plan
@@ -112,19 +114,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-combined"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 44, 47, 50, 51, 52, 66, 67, 68, 85, 86, 87, 101, 102, 103, 117, 118, 127, 128, 129, 130, 131, 132, 133, 134, 10, 46, 49, 53, 54, 59, 69, 70, 75, 88, 89, 94, 104, 105, 110, 120, 121, 126<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 44, 47, 51, 52, 53, 68, 69, 70, 88, 89, 90, 105, 106, 107, 122, 123, 132, 133, 134, 135, 136, 137, 138, 139, 10, 46, 49, 50, 54, 55, 60, 71, 72, 77, 91, 92, 97, 108, 109, 114, 125, 126, 131<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant29,Constant44,Lambda46,Constant47,Lambda49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant66,Constant67,Constant68,Object69,Lambda70,Lambda75,Constant85,Constant86,Constant87,Object88,Lambda89,Lambda94,Constant101,Constant102,Constant103,Object104,Lambda105,Lambda110,Constant117,Constant118,Object120,Lambda121,Lambda126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133,Constant134 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant29,Constant44,Lambda46,Constant47,Lambda49,Access50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant68,Constant69,Constant70,Object71,Lambda72,Lambda77,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant105,Constant106,Constant107,Object108,Lambda109,Lambda114,Constant122,Constant123,Object125,Lambda126,Lambda131,Constant132,Constant133,Constant134,Constant135,Constant136,Constant137,Constant138,Constant139 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 44, 46, 47<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelectSingle19 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 44, 46, 47<br /><br />ROOT PgSelectSingle{1}ᐸusersᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression20,PgClassExpression21,PgSelectSingle28,RemapKeys95 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 95, 44, 46, 47<br /><br />ROOT PgSelectSingle{2}ᐸusers_most_recent_forumᐳ[28]"):::bucket
+    class Bucket2,PgClassExpression20,PgClassExpression21,PgSelectSingle28,RemapKeys98 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 98, 44, 46, 47<br /><br />ROOT PgSelectSingle{2}ᐸusers_most_recent_forumᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelectSingle36,PgClassExpression37,Access77,Object79,Lambda80 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ80ᐳ[41]"):::bucket
+    class Bucket3,PgSelectSingle36,PgClassExpression37,Access79,Object81,Lambda82 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ82ᐳ[41]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item41,PgSelectSingle42 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 42<br /><br />ROOT PgSelectSingle{4}ᐸforums_featured_messagesᐳ[42]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.deopt.mermaid
@@ -12,46 +12,48 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda32 & Lambda35 & Lambda54 & Lambda59 --> PgSelect8
-    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda32 & Constant50 & Constant51 & Constant52 --> Object53
+    Access36{{"Access[36∈0] ➊<br />ᐸ35.0ᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda32 & Access36 & Lambda56 & Lambda61 --> PgSelect8
+    Object40{{"Object[40∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸsql.identifier(”forums_messages_list_set”)ᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda32 & Constant37 & Constant38 & Constant39 --> Object40
+    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda32 & Constant52 & Constant53 & Constant54 --> Object55
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant60 --> Lambda32
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant61 --> Lambda35
-    Object53 --> Lambda54
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant63 --> Lambda59
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant62 --> Lambda32
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant63 --> Lambda35
+    Lambda35 --> Access36
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object40 --> Lambda41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant64 --> Lambda46
+    Object55 --> Lambda56
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant65 --> Lambda61
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸsql.identifier(”forums_messages_list_set”)ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Object39{{"Object[39∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda32 & Constant36 & Constant37 & Constant38 --> Object39
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda40{{"Lambda[40∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object39 --> Lambda40
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant62 --> Lambda45
     PgSelect15[["PgSelect[15∈2]<br />ᐸforums_messages_list_setᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__ᐳ"}}:::plan
-    Object11 & PgClassExpression14 & Lambda32 & Lambda35 & Lambda40 & Lambda45 --> PgSelect15
+    Object11 & PgClassExpression14 & Lambda32 & Access36 & Lambda41 & Lambda46 --> PgSelect15
     PgSelectSingle13 --> PgClassExpression14
     __ListTransform19[["__ListTransform[19∈2]<br />ᐸpartitionByIndex1:15ᐳ"]]:::plan
     PgSelect15 --> __ListTransform19
@@ -75,13 +77,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-forums-messages-list-set"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 36, 37, 38, 50, 51, 52, 60, 61, 62, 63, 11, 32, 35, 53, 54, 59<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 37, 38, 39, 52, 53, 54, 62, 63, 64, 65, 11, 32, 35, 36, 40, 41, 46, 55, 56, 61<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda32,Lambda35,Constant36,Constant37,Constant38,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant60,Constant61,Constant62,Constant63 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 32, 36, 37, 38, 62, 11, 35<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda32,Lambda35,Access36,Constant37,Constant38,Constant39,Object40,Lambda41,Lambda46,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 32, 36, 41, 46<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object39,Lambda40,Lambda45 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 32, 35, 40, 45<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: PgClassExpression[14]<br />2: PgSelect[15]<br />3: __ListTransform[19]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 32, 36, 41, 46<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: PgClassExpression[14]<br />2: PgSelect[15]<br />3: __ListTransform[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgSelect15,__ListTransform19 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgClassExpression{3}ᐸ__forums_m..._set_idx__ᐳ[22]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.mermaid
@@ -11,39 +11,41 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access36{{"Access[36∈0] ➊<br />ᐸ35.0ᐳ"}}:::plan
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda35 & Lambda40 & Lambda45 & Lambda32 & Lambda35 & Lambda59 & Lambda64 --> PgSelect8
-    Object39{{"Object[39∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸsql.identifier(”forums_messages_list_set”)ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda32 & Constant36 & Constant37 & Constant38 --> Object39
-    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda32 & Constant55 & Constant56 & Constant57 --> Object58
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Access36 & Lambda41 & Lambda46 & Lambda32 & Access36 & Lambda61 & Lambda66 --> PgSelect8
+    Object40{{"Object[40∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸsql.identifier(”forums_messages_list_set”)ᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda32 & Constant37 & Constant38 & Constant39 --> Object40
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda32 & Constant57 & Constant58 & Constant59 --> Object60
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant65 --> Lambda32
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant66 --> Lambda35
-    Object39 --> Lambda40
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant67 --> Lambda45
-    Object58 --> Lambda59
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant68 --> Lambda64
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant67 --> Lambda32
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant68 --> Lambda35
+    Lambda35 --> Access36
+    Object40 --> Lambda41
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant69 --> Lambda46
+    Object60 --> Lambda61
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant70 --> Lambda66
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant30{{"Constant[30∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant33{{"Constant[33∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -51,16 +53,16 @@ graph TD
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Object49{{"Object[49∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access47{{"Access[47∈2]<br />ᐸ12.0ᐳ"}}:::plan
-    Access47 & Constant30 & Constant30 & Lambda32 & Constant33 --> Object49
+    Object50{{"Object[50∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access48{{"Access[48∈2]<br />ᐸ12.0ᐳ"}}:::plan
+    Access48 & Constant30 & Constant30 & Lambda32 & Constant33 --> Object50
     __ListTransform19[["__ListTransform[19∈2]<br />ᐸpartitionByIndex1:15ᐳ"]]:::plan
-    Lambda50{{"Lambda[50∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda50 --> __ListTransform19
-    __Item12 --> Access47
-    Object49 --> Lambda50
-    __Item20[/"__Item[20∈3]<br />ᐸ50ᐳ"\]:::itemplan
-    Lambda50 -.-> __Item20
+    Lambda51{{"Lambda[51∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda51 --> __ListTransform19
+    __Item12 --> Access48
+    Object50 --> Lambda51
+    __Item20[/"__Item[20∈3]<br />ᐸ51ᐳ"\]:::itemplan
+    Lambda51 -.-> __Item20
     PgSelectSingle21{{"PgSelectSingle[21∈3]<br />ᐸforums_messages_list_setᐳ"}}:::plan
     __Item20 --> PgSelectSingle21
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__forums_m..._set_idx__ᐳ"}}:::plan
@@ -79,15 +81,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-forums-messages-list-set"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 30, 33, 36, 37, 38, 55, 56, 57, 65, 66, 67, 68, 11, 32, 35, 39, 40, 45, 58, 59, 64<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 30, 33, 37, 38, 39, 57, 58, 59, 67, 68, 69, 70, 11, 32, 35, 36, 40, 41, 46, 60, 61, 66<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Constant30,Lambda32,Constant33,Lambda35,Constant36,Constant37,Constant38,Object39,Lambda40,Lambda45,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant65,Constant66,Constant67,Constant68 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Constant30,Lambda32,Constant33,Lambda35,Access36,Constant37,Constant38,Constant39,Object40,Lambda41,Lambda46,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant67,Constant68,Constant69,Constant70 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 30, 32, 33<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 30, 32, 33, 13<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: Access[47], Object[49], Lambda[50]<br />2: __ListTransform[19]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 30, 32, 33, 13<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]<br />1: <br />ᐳ: Access[48], Object[50], Lambda[51]<br />2: __ListTransform[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__ListTransform19,Access47,Object49,Lambda50 bucket2
+    class Bucket2,__ListTransform19,Access48,Object50,Lambda51 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgClassExpression{3}ᐸ__forums_m..._set_idx__ᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item20,PgSelectSingle21,PgClassExpression22 bucket3

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.deopt.mermaid
@@ -12,49 +12,51 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda50 & Lambda55 --> PgSelect8
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda42 & Constant46 & Constant47 & Constant48 --> Object49
+    Access46{{"Access[46∈0] ➊<br />ᐸ45.0ᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda42 & Access46 & Lambda51 & Lambda56 --> PgSelect8
+    Object50{{"Object[50∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda42 & Constant47 & Constant48 & Constant49 --> Object50
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda42 & Constant62 & Constant63 & Constant64 --> Object65
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda42
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda45
-    Object49 --> Lambda50
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant72 --> Lambda55
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda42
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant73 --> Lambda45
+    Lambda45 --> Access46
+    Object50 --> Lambda51
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant74 --> Lambda56
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object65 --> Lambda66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant75 --> Lambda71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object63{{"Object[63∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda42 & Constant60 & Constant61 & Constant62 --> Object63
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object63 --> Lambda64
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant73 --> Lambda69
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression23
     PgSelect15[["PgSelect[15∈3] ➊<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda64 & Lambda69 --> PgSelect15
+    Object11 & Lambda42 & Access46 & Lambda66 & Lambda71 --> PgSelect15
     __ListTransform19[["__ListTransform[19∈3]<br />ᐸfilter:15ᐳ"]]:::plan
     PgSelect15 & PgSelectSingle13 & PgClassExpression23 --> __ListTransform19
     __ListTransform26[["__ListTransform[26∈3]<br />ᐸgroupBy:19ᐳ"]]:::plan
@@ -91,16 +93,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-forums-messages-with-many-transforms.defer"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 46, 47, 48, 60, 61, 62, 70, 71, 72, 73, 11, 42, 45, 49, 50, 55<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 47, 48, 49, 62, 63, 64, 72, 73, 74, 75, 11, 42, 45, 46, 50, 51, 56, 65, 66, 71<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda42,Lambda45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant60,Constant61,Constant62,Constant70,Constant71,Constant72,Constant73 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 42, 60, 61, 62, 73, 11, 45<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda42,Lambda45,Access46,Constant47,Constant48,Constant49,Object50,Lambda51,Lambda56,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant72,Constant73,Constant74,Constant75 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 42, 46, 66, 71<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object63,Lambda64,Lambda69 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 42, 45, 64, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 42, 46, 66, 71<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression23 bucket2
-    Bucket3("Bucket 3 (defer)<br />Deps: 11, 42, 45, 64, 69, 13, 23<br /><br />1: PgSelect[15]<br />2: __ListTransform[19]<br />3: __ListTransform[26]<br />ᐳ: Lambda[30]"):::bucket
+    Bucket3("Bucket 3 (defer)<br />Deps: 11, 42, 46, 66, 71, 13, 23<br /><br />1: PgSelect[15]<br />2: __ListTransform[19]<br />3: __ListTransform[26]<br />ᐳ: Lambda[30]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgSelect15,__ListTransform19,__ListTransform26,Lambda30 bucket3
     Bucket4("Bucket 4 (subroutine)<br />Deps: 23<br /><br />ROOT Lambda{4}[25]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.mermaid
@@ -12,49 +12,51 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda50 & Lambda55 --> PgSelect8
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda42 & Constant46 & Constant47 & Constant48 --> Object49
+    Access46{{"Access[46∈0] ➊<br />ᐸ45.0ᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda42 & Access46 & Lambda51 & Lambda56 --> PgSelect8
+    Object50{{"Object[50∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda42 & Constant47 & Constant48 & Constant49 --> Object50
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda42 & Constant62 & Constant63 & Constant64 --> Object65
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda42
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda45
-    Object49 --> Lambda50
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant72 --> Lambda55
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda42
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant73 --> Lambda45
+    Lambda45 --> Access46
+    Object50 --> Lambda51
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant74 --> Lambda56
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object65 --> Lambda66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant75 --> Lambda71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object63{{"Object[63∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda42 & Constant60 & Constant61 & Constant62 --> Object63
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
     PgSelectSingle13{{"PgSelectSingle[13∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item12 --> PgSelectSingle13
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object63 --> Lambda64
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant73 --> Lambda69
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression23
     PgSelect15[["PgSelect[15∈3] ➊<br />ᐸmessagesᐳ"]]:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda64 & Lambda69 --> PgSelect15
+    Object11 & Lambda42 & Access46 & Lambda66 & Lambda71 --> PgSelect15
     __ListTransform19[["__ListTransform[19∈3]<br />ᐸfilter:15ᐳ"]]:::plan
     PgSelect15 & PgSelectSingle13 & PgClassExpression23 --> __ListTransform19
     __ListTransform26[["__ListTransform[26∈3]<br />ᐸgroupBy:19ᐳ"]]:::plan
@@ -91,16 +93,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-forums-messages-with-many-transforms.defer"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 46, 47, 48, 60, 61, 62, 70, 71, 72, 73, 11, 42, 45, 49, 50, 55<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 47, 48, 49, 62, 63, 64, 72, 73, 74, 75, 11, 42, 45, 46, 50, 51, 56, 65, 66, 71<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda42,Lambda45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant60,Constant61,Constant62,Constant70,Constant71,Constant72,Constant73 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 42, 60, 61, 62, 73, 11, 45<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda42,Lambda45,Access46,Constant47,Constant48,Constant49,Object50,Lambda51,Lambda56,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant72,Constant73,Constant74,Constant75 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 42, 46, 66, 71<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item12,PgSelectSingle13,Object63,Lambda64,Lambda69 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 42, 45, 64, 69<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
+    class Bucket1,__Item12,PgSelectSingle13 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 11, 42, 46, 66, 71<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression14,PgClassExpression23 bucket2
-    Bucket3("Bucket 3 (defer)<br />Deps: 11, 42, 45, 64, 69, 13, 23<br /><br />1: PgSelect[15]<br />2: __ListTransform[19]<br />3: __ListTransform[26]<br />ᐳ: Lambda[30]"):::bucket
+    Bucket3("Bucket 3 (defer)<br />Deps: 11, 42, 46, 66, 71, 13, 23<br /><br />1: PgSelect[15]<br />2: __ListTransform[19]<br />3: __ListTransform[26]<br />ᐳ: Lambda[30]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgSelect15,__ListTransform19,__ListTransform26,Lambda30 bucket3
     Bucket4("Bucket 4 (subroutine)<br />Deps: 23<br /><br />ROOT Lambda{4}[25]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.deopt.mermaid
@@ -12,40 +12,42 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda50 & Lambda55 --> PgSelect8
+    Access46{{"Access[46∈0] ➊<br />ᐸ45.0ᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda42 & Access46 & Lambda51 & Lambda56 --> PgSelect8
     PgSelect15[["PgSelect[15∈0] ➊<br />ᐸmessagesᐳ"]]:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda64 & Lambda69 --> PgSelect15
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda42 & Constant46 & Constant47 & Constant48 --> Object49
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda42 & Constant60 & Constant61 & Constant62 --> Object63
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda42 & Access46 & Lambda66 & Lambda71 --> PgSelect15
+    Object50{{"Object[50∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda42 & Constant47 & Constant48 & Constant49 --> Object50
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda42 & Constant62 & Constant63 & Constant64 --> Object65
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda42
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda45
-    Object49 --> Lambda50
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant72 --> Lambda55
-    Object63 --> Lambda64
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant73 --> Lambda69
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda42
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant73 --> Lambda45
+    Lambda45 --> Access46
+    Object50 --> Lambda51
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant74 --> Lambda56
+    Object65 --> Lambda66
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant75 --> Lambda71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -91,9 +93,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-forums-messages-with-many-transforms"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 46, 47, 48, 60, 61, 62, 70, 71, 72, 73, 11, 42, 45, 49, 50, 55, 63, 64, 69<br />2: PgSelect[8], PgSelect[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 47, 48, 49, 62, 63, 64, 72, 73, 74, 75, 11, 42, 45, 46, 50, 51, 56, 65, 66, 71<br />2: PgSelect[8], PgSelect[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,PgSelect15,Lambda42,Lambda45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant70,Constant71,Constant72,Constant73 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,PgSelect15,Lambda42,Lambda45,Access46,Constant47,Constant48,Constant49,Object50,Lambda51,Lambda56,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant72,Constant73,Constant74,Constant75 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 15<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.mermaid
@@ -12,40 +12,42 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda50 & Lambda55 --> PgSelect8
+    Access46{{"Access[46∈0] ➊<br />ᐸ45.0ᐳ"}}:::plan
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda42 & Access46 & Lambda51 & Lambda56 --> PgSelect8
     PgSelect15[["PgSelect[15∈0] ➊<br />ᐸmessagesᐳ"]]:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda42 & Lambda45 & Lambda64 & Lambda69 --> PgSelect15
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda42 & Constant46 & Constant47 & Constant48 --> Object49
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda42 & Constant60 & Constant61 & Constant62 --> Object63
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda42 & Access46 & Lambda66 & Lambda71 --> PgSelect15
+    Object50{{"Object[50∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda42 & Constant47 & Constant48 & Constant49 --> Object50
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda42 & Constant62 & Constant63 & Constant64 --> Object65
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda42
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda45
-    Object49 --> Lambda50
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant72 --> Lambda55
-    Object63 --> Lambda64
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant73 --> Lambda69
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda42
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant73 --> Lambda45
+    Lambda45 --> Access46
+    Object50 --> Lambda51
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant74 --> Lambda56
+    Object65 --> Lambda66
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant75 --> Lambda71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -91,9 +93,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-forums-messages-with-many-transforms"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 46, 47, 48, 60, 61, 62, 70, 71, 72, 73, 11, 42, 45, 49, 50, 55, 63, 64, 69<br />2: PgSelect[8], PgSelect[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 47, 48, 49, 62, 63, 64, 72, 73, 74, 75, 11, 42, 45, 46, 50, 51, 56, 65, 66, 71<br />2: PgSelect[8], PgSelect[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,PgSelect15,Lambda42,Lambda45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant70,Constant71,Constant72,Constant73 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,PgSelect15,Lambda42,Lambda45,Access46,Constant47,Constant48,Constant49,Object50,Lambda51,Lambda56,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant72,Constant73,Constant74,Constant75 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 15<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-scalar.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-scalar.deopt.mermaid
@@ -11,39 +11,39 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Constant13{{"Constant[13∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant100 & Constant13 & Lambda41 & Lambda46 & Lambda51 & Constant101 & Lambda41 & Lambda62 & Lambda67 & Constant39 & Lambda41 & Lambda78 & Lambda83 & Lambda38 & Lambda41 & Lambda94 & Lambda99 --> PgSelect7
-    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Lambda38 & Constant58 & Constant59 & Constant44 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Lambda38 & Constant74 & Constant75 & Constant44 --> Object77
-    Object93{{"Object[93∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant90 & Constant91 & Constant92 --> Object93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant104 & Constant13 & Access42 & Lambda47 & Lambda52 & Constant105 & Access42 & Lambda64 & Lambda69 & Constant39 & Access42 & Lambda81 & Lambda86 & Lambda38 & Access42 & Lambda98 & Lambda103 --> PgSelect7
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Lambda38 & Constant60 & Constant61 & Constant45 --> Object63
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Lambda38 & Constant77 & Constant78 & Constant45 --> Object80
+    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant94 & Constant95 & Constant96 --> Object97
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -54,48 +54,50 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant102 --> Lambda38
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant103 --> Lambda41
-    Object45 --> Lambda46
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant104 --> Lambda51
-    Object61 --> Lambda62
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant105 --> Lambda67
-    Object77 --> Lambda78
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant106 --> Lambda83
-    Object93 --> Lambda94
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant107 --> Lambda99
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant106 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant107 --> Lambda41
+    Lambda41 --> Access42
+    Object46 --> Lambda47
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant108 --> Lambda52
+    Object63 --> Lambda64
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant109 --> Lambda69
+    Object80 --> Lambda81
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant110 --> Lambda86
+    Object97 --> Lambda98
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant111 --> Lambda103
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelectSingle20{{"PgSelectSingle[20∈1] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
     PgSelectSingle12 --> PgSelectSingle20
     PgClassExpression21{{"PgClassExpression[21∈1] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression21
     PgSelectSingle27{{"PgSelectSingle[27∈1] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
-    RemapKeys68{{"RemapKeys[68∈1] ➊<br />ᐸ12:{”0”:1}ᐳ"}}:::plan
-    RemapKeys68 --> PgSelectSingle27
+    RemapKeys70{{"RemapKeys[70∈1] ➊<br />ᐸ12:{”0”:1}ᐳ"}}:::plan
+    RemapKeys70 --> PgSelectSingle27
     PgClassExpression28{{"PgClassExpression[28∈1] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle27 --> PgClassExpression28
     PgSelectSingle34{{"PgSelectSingle[34∈1] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
-    RemapKeys84{{"RemapKeys[84∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
-    RemapKeys84 --> PgSelectSingle34
+    RemapKeys87{{"RemapKeys[87∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
+    RemapKeys87 --> PgSelectSingle34
     PgClassExpression35{{"PgClassExpression[35∈1] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
-    PgSelectSingle12 --> RemapKeys68
-    PgSelectSingle12 --> RemapKeys84
+    PgSelectSingle12 --> RemapKeys70
+    PgSelectSingle12 --> RemapKeys87
 
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-scalar"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 39, 42, 43, 44, 58, 59, 74, 75, 90, 91, 92, 100, 101, 102, 103, 104, 105, 106, 107, 10, 38, 41, 45, 46, 51, 61, 62, 67, 77, 78, 83, 93, 94, 99<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 39, 43, 44, 45, 60, 61, 77, 78, 94, 95, 96, 104, 105, 106, 107, 108, 109, 110, 111, 10, 38, 41, 42, 46, 47, 52, 63, 64, 69, 80, 81, 86, 97, 98, 103<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Lambda38,Constant39,Lambda41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Constant58,Constant59,Object61,Lambda62,Lambda67,Constant74,Constant75,Object77,Lambda78,Lambda83,Constant90,Constant91,Constant92,Object93,Lambda94,Lambda99,Constant100,Constant101,Constant102,Constant103,Constant104,Constant105,Constant106,Constant107 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Lambda38,Constant39,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant60,Constant61,Object63,Lambda64,Lambda69,Constant77,Constant78,Object80,Lambda81,Lambda86,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelectSingle20,PgClassExpression21,PgSelectSingle27,PgClassExpression28,PgSelectSingle34,PgClassExpression35,RemapKeys68,RemapKeys84 bucket1
+    class Bucket1,PgSelectSingle20,PgClassExpression21,PgSelectSingle27,PgClassExpression28,PgSelectSingle34,PgClassExpression35,RemapKeys70,RemapKeys87 bucket1
     Bucket0 --> Bucket1
     end

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-scalar.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-scalar.mermaid
@@ -11,39 +11,39 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Constant13{{"Constant[13∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant100 & Constant13 & Lambda41 & Lambda46 & Lambda51 & Constant101 & Lambda41 & Lambda62 & Lambda67 & Constant39 & Lambda41 & Lambda78 & Lambda83 & Lambda38 & Lambda41 & Lambda94 & Lambda99 --> PgSelect7
-    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Lambda38 & Constant58 & Constant59 & Constant44 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
-    Lambda38 & Constant74 & Constant75 & Constant44 --> Object77
-    Object93{{"Object[93∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda38 & Constant90 & Constant91 & Constant92 --> Object93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant104 & Constant13 & Access42 & Lambda47 & Lambda52 & Constant105 & Access42 & Lambda64 & Lambda69 & Constant39 & Access42 & Lambda81 & Lambda86 & Lambda38 & Access42 & Lambda98 & Lambda103 --> PgSelect7
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Lambda38 & Constant60 & Constant61 & Constant45 --> Object63
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”forums_unique_author_count”)ᐳ"}}:::plan
+    Lambda38 & Constant77 & Constant78 & Constant45 --> Object80
+    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda38 & Constant94 & Constant95 & Constant96 --> Object97
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -54,48 +54,50 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant102 --> Lambda38
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant103 --> Lambda41
-    Object45 --> Lambda46
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant104 --> Lambda51
-    Object61 --> Lambda62
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant105 --> Lambda67
-    Object77 --> Lambda78
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant106 --> Lambda83
-    Object93 --> Lambda94
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant107 --> Lambda99
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant106 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant107 --> Lambda41
+    Lambda41 --> Access42
+    Object46 --> Lambda47
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant108 --> Lambda52
+    Object63 --> Lambda64
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant109 --> Lambda69
+    Object80 --> Lambda81
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant110 --> Lambda86
+    Object97 --> Lambda98
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant111 --> Lambda103
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelectSingle20{{"PgSelectSingle[20∈1] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
     PgSelectSingle12 --> PgSelectSingle20
     PgClassExpression21{{"PgClassExpression[21∈1] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression21
     PgSelectSingle27{{"PgSelectSingle[27∈1] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
-    RemapKeys68{{"RemapKeys[68∈1] ➊<br />ᐸ12:{”0”:1}ᐳ"}}:::plan
-    RemapKeys68 --> PgSelectSingle27
+    RemapKeys70{{"RemapKeys[70∈1] ➊<br />ᐸ12:{”0”:1}ᐳ"}}:::plan
+    RemapKeys70 --> PgSelectSingle27
     PgClassExpression28{{"PgClassExpression[28∈1] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle27 --> PgClassExpression28
     PgSelectSingle34{{"PgSelectSingle[34∈1] ➊<br />ᐸforums_unique_author_countᐳ"}}:::plan
-    RemapKeys84{{"RemapKeys[84∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
-    RemapKeys84 --> PgSelectSingle34
+    RemapKeys87{{"RemapKeys[87∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
+    RemapKeys87 --> PgSelectSingle34
     PgClassExpression35{{"PgClassExpression[35∈1] ➊<br />ᐸ__forums_u..._count__.vᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
-    PgSelectSingle12 --> RemapKeys68
-    PgSelectSingle12 --> RemapKeys84
+    PgSelectSingle12 --> RemapKeys70
+    PgSelectSingle12 --> RemapKeys87
 
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-scalar"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 39, 42, 43, 44, 58, 59, 74, 75, 90, 91, 92, 100, 101, 102, 103, 104, 105, 106, 107, 10, 38, 41, 45, 46, 51, 61, 62, 67, 77, 78, 83, 93, 94, 99<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 39, 43, 44, 45, 60, 61, 77, 78, 94, 95, 96, 104, 105, 106, 107, 108, 109, 110, 111, 10, 38, 41, 42, 46, 47, 52, 63, 64, 69, 80, 81, 86, 97, 98, 103<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Lambda38,Constant39,Lambda41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Constant58,Constant59,Object61,Lambda62,Lambda67,Constant74,Constant75,Object77,Lambda78,Lambda83,Constant90,Constant91,Constant92,Object93,Lambda94,Lambda99,Constant100,Constant101,Constant102,Constant103,Constant104,Constant105,Constant106,Constant107 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Lambda38,Constant39,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant60,Constant61,Object63,Lambda64,Lambda69,Constant77,Constant78,Object80,Lambda81,Lambda86,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelectSingle20,PgClassExpression21,PgSelectSingle27,PgClassExpression28,PgSelectSingle34,PgClassExpression35,RemapKeys68,RemapKeys84 bucket1
+    class Bucket1,PgSelectSingle20,PgClassExpression21,PgSelectSingle27,PgClassExpression28,PgSelectSingle34,PgClassExpression35,RemapKeys70,RemapKeys87 bucket1
     Bucket0 --> Bucket1
     end

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-setof-message.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-setof-message.deopt.mermaid
@@ -11,17 +11,22 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant51 & Lambda23 & Lambda26 & Lambda45 & Lambda50 --> PgSelect7
-    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda23 & Constant41 & Constant42 & Constant43 --> Object44
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant53 & Lambda23 & Access27 & Lambda47 & Lambda52 --> PgSelect7
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda23 & Constant43 & Constant44 & Constant45 --> Object46
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,28 +37,25 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant52 --> Lambda23
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant53 --> Lambda26
-    Object44 --> Lambda45
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant55 --> Lambda50
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant54 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant55 --> Lambda26
+    Lambda26 --> Access27
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object31 --> Lambda32
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant56 --> Lambda37
+    Object46 --> Lambda47
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant57 --> Lambda52
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸforums_featured_messagesᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__ᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & PgClassExpression13 & Lambda23 & Lambda26 & Lambda31 & Lambda36 --> PgSelect14
-    Object30{{"Object[30∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
+    Object10 & PgClassExpression13 & Lambda23 & Access27 & Lambda32 & Lambda37 --> PgSelect14
     PgSelectSingle12 --> PgClassExpression13
-    Object30 --> Lambda31
-    Constant54 --> Lambda36
     __Item18[/"__Item[18∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item18
     PgSelectSingle19{{"PgSelectSingle[19∈2]<br />ᐸforums_featured_messagesᐳ"}}:::plan
@@ -64,12 +66,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-setof-message"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 27, 28, 29, 41, 42, 43, 51, 52, 53, 54, 55, 10, 23, 26, 44, 45, 50<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 28, 29, 30, 43, 44, 45, 53, 54, 55, 56, 57, 10, 23, 26, 27, 31, 32, 37, 46, 47, 52<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda23,Lambda26,Constant27,Constant28,Constant29,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Constant51,Constant52,Constant53,Constant54,Constant55 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 23, 26, 27, 28, 29, 54<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: 13, 30, 36, 31<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda23,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant53,Constant54,Constant55,Constant56,Constant57 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 23, 27, 32, 37<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: PgClassExpression[13]<br />2: PgSelect[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgSelect14,Object30,Lambda31,Lambda36 bucket1
+    class Bucket1,PgClassExpression13,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgSelectSingle19 bucket2

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-setof-message.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-setof-message.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant56 & Lambda26 & Lambda31 & Lambda36 & Lambda23 & Lambda26 & Lambda50 & Lambda55 --> PgSelect7
-    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda23 & Constant46 & Constant47 & Constant48 --> Object49
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant58 & Access27 & Lambda32 & Lambda37 & Lambda23 & Access27 & Lambda52 & Lambda57 --> PgSelect7
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums_featured_messages”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
+    Object51{{"Object[51∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda23 & Constant48 & Constant49 & Constant50 --> Object51
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,27 +39,29 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant57 --> Lambda23
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant58 --> Lambda26
-    Object30 --> Lambda31
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant59 --> Lambda36
-    Object49 --> Lambda50
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant60 --> Lambda55
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant59 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant60 --> Lambda26
+    Lambda26 --> Access27
+    Object31 --> Lambda32
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant61 --> Lambda37
+    Object51 --> Lambda52
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant62 --> Lambda57
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant21{{"Constant[21∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant24{{"Constant[24∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Object40{{"Object[40∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access38{{"Access[38∈1] ➊<br />ᐸ11.0ᐳ"}}:::plan
-    Access38 & Constant21 & Constant21 & Lambda23 & Constant24 --> Object40
-    First11 --> Access38
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object40 --> Lambda41
-    __Item18[/"__Item[18∈2]<br />ᐸ41ᐳ"\]:::itemplan
-    Lambda41 ==> __Item18
+    Object41{{"Object[41∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access39{{"Access[39∈1] ➊<br />ᐸ11.0ᐳ"}}:::plan
+    Access39 & Constant21 & Constant21 & Lambda23 & Constant24 --> Object41
+    First11 --> Access39
+    Lambda42{{"Lambda[42∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object41 --> Lambda42
+    __Item18[/"__Item[18∈2]<br />ᐸ42ᐳ"\]:::itemplan
+    Lambda42 ==> __Item18
     PgSelectSingle19{{"PgSelectSingle[19∈2]<br />ᐸforums_featured_messagesᐳ"}}:::plan
     __Item18 --> PgSelectSingle19
     PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__forums_f...s__.”body”ᐳ"}}:::plan
@@ -68,13 +70,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-setof-message"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 24, 27, 28, 29, 46, 47, 48, 56, 57, 58, 59, 60, 10, 23, 26, 30, 31, 36, 49, 50, 55<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 24, 28, 29, 30, 48, 49, 50, 58, 59, 60, 61, 62, 10, 23, 26, 27, 31, 32, 37, 51, 52, 57<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant21,Lambda23,Constant24,Lambda26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant58,Constant59,Constant60 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant21,Lambda23,Constant24,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant48,Constant49,Constant50,Object51,Lambda52,Lambda57,Constant58,Constant59,Constant60,Constant61,Constant62 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 21, 23, 24, 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access38,Object40,Lambda41 bucket1
-    Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ41ᐳ[18]"):::bucket
+    class Bucket1,Access39,Object41,Lambda42 bucket1
+    Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ42ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgSelectSingle19 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19<br /><br />ROOT PgSelectSingle{2}ᐸforums_featured_messagesᐳ[19]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-user.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-user.deopt.mermaid
@@ -11,17 +11,22 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant52 & Lambda24 & Lambda27 & Lambda46 & Lambda51 --> PgSelect7
-    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda24 & Constant42 & Constant43 & Constant44 --> Object45
+    Access28{{"Access[28∈0] ➊<br />ᐸ27.0ᐳ"}}:::plan
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant54 & Lambda24 & Access28 & Lambda48 & Lambda53 --> PgSelect7
+    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda24 & Constant29 & Constant30 & Constant31 --> Object32
+    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda24 & Constant44 & Constant45 & Constant46 --> Object47
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,32 +37,29 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant53 --> Lambda24
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant54 --> Lambda27
-    Object45 --> Lambda46
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant56 --> Lambda51
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant55 --> Lambda24
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant56 --> Lambda27
+    Lambda27 --> Access28
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object32 --> Lambda33
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant57 --> Lambda38
+    Object47 --> Lambda48
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant58 --> Lambda53
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸforums_random_userᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__ᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & PgClassExpression13 & Lambda24 & Lambda27 & Lambda32 & Lambda37 --> PgSelect14
-    Object31{{"Object[31∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda24 & Constant28 & Constant29 & Constant30 --> Object31
+    Object10 & PgClassExpression13 & Lambda24 & Access28 & Lambda33 & Lambda38 --> PgSelect14
     PgSelectSingle12 --> PgClassExpression13
     First18{{"First[18∈1] ➊"}}:::plan
     PgSelect14 --> First18
     PgSelectSingle19{{"PgSelectSingle[19∈1] ➊<br />ᐸusersᐳ"}}:::plan
     First18 --> PgSelectSingle19
-    Object31 --> Lambda32
-    Constant55 --> Lambda37
     PgClassExpression20{{"PgClassExpression[20∈2] ➊<br />ᐸ__forums_r...”username”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression20
     PgClassExpression21{{"PgClassExpression[21∈2] ➊<br />ᐸ__forums_r...vatar_url”ᐳ"}}:::plan
@@ -66,12 +68,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-user"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 28, 29, 30, 42, 43, 44, 52, 53, 54, 55, 56, 10, 24, 27, 45, 46, 51<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 30, 31, 44, 45, 46, 54, 55, 56, 57, 58, 10, 24, 27, 28, 32, 33, 38, 47, 48, 53<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda24,Lambda27,Constant28,Constant29,Constant30,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Constant52,Constant53,Constant54,Constant55,Constant56 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 24, 27, 28, 29, 30, 55<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: 13, 31, 37, 32<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda24,Lambda27,Access28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant54,Constant55,Constant56,Constant57,Constant58 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 24, 28, 33, 38<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: PgClassExpression[13]<br />2: PgSelect[14]<br />ᐳ: First[18], PgSelectSingle[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgSelect14,First18,PgSelectSingle19,Object31,Lambda32,Lambda37 bucket1
+    class Bucket1,PgClassExpression13,PgSelect14,First18,PgSelectSingle19 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19<br /><br />ROOT PgSelectSingle{1}ᐸusersᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression20,PgClassExpression21 bucket2

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-user.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-user.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Access28{{"Access[28∈0] ➊<br />ᐸ27.0ᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant54 & Lambda27 & Lambda32 & Lambda37 & Lambda24 & Lambda27 & Lambda48 & Lambda53 --> PgSelect7
-    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda24 & Constant28 & Constant29 & Constant30 --> Object31
-    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda24 & Constant44 & Constant45 & Constant46 --> Object47
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant56 & Access28 & Lambda33 & Lambda38 & Lambda24 & Access28 & Lambda50 & Lambda55 --> PgSelect7
+    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”forums_random_user”)ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda24 & Constant29 & Constant30 & Constant31 --> Object32
+    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda24 & Constant46 & Constant47 & Constant48 --> Object49
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant55 --> Lambda24
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant56 --> Lambda27
-    Object31 --> Lambda32
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant57 --> Lambda37
-    Object47 --> Lambda48
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant58 --> Lambda53
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant57 --> Lambda24
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant58 --> Lambda27
+    Lambda27 --> Access28
+    Object32 --> Lambda33
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant59 --> Lambda38
+    Object49 --> Lambda50
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant60 --> Lambda55
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelectSingle19{{"PgSelectSingle[19∈1] ➊<br />ᐸusersᐳ"}}:::plan
     PgSelectSingle12 --> PgSelectSingle19
@@ -60,9 +62,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/computed-column-user"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 28, 29, 30, 44, 45, 46, 54, 55, 56, 57, 58, 10, 24, 27, 31, 32, 37, 47, 48, 53<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 30, 31, 46, 47, 48, 56, 57, 58, 59, 60, 10, 24, 27, 28, 32, 33, 38, 49, 50, 55<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda24,Lambda27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant54,Constant55,Constant56,Constant57,Constant58 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda24,Lambda27,Access28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant58,Constant59,Constant60 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelectSingle19 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-array.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-array.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_names_arrayᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”forum_names_array”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forum_names_array”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -33,13 +33,15 @@ graph TD
     First10 --> PgSelectSingle11
     PgClassExpression12{{"PgClassExpression[12∈0] ➊<br />ᐸ__forum_names_array__.vᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ12ᐳ"\]:::itemplan
     PgClassExpression12 ==> __Item13
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names-array"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]<br />ᐳ: 10, 11, 12"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]<br />ᐳ: 10, 11, 12"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,PgClassExpression12,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,PgClassExpression12,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ12ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-array.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-array.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_names_arrayᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”forum_names_array”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forum_names_array”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -33,13 +33,15 @@ graph TD
     First10 --> PgSelectSingle11
     PgClassExpression12{{"PgClassExpression[12∈0] ➊<br />ᐸ__forum_names_array__.vᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ12ᐳ"\]:::itemplan
     PgClassExpression12 ==> __Item13
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names-array"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]<br />ᐳ: 10, 11, 12"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]<br />ᐳ: 10, 11, 12"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,PgClassExpression12,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,PgClassExpression12,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ12ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-cases.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-cases.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_names_casesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”forum_names_cases”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forum_names_cases”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names-cases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11,PgClassExpression12 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-cases.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-cases.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_names_casesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”forum_names_cases”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forum_names_cases”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(text[])ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names-cases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11,PgClassExpression12 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_namesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda20 & Lambda23 & Lambda28 & Lambda33 --> PgSelect6
-    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Lambda20 & Constant24 & Constant25 & Constant26 --> Object27
+    Access24{{"Access[24∈0] ➊<br />ᐸ23.0ᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda20 & Access24 & Lambda29 & Lambda34 --> PgSelect6
+    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda20 & Constant25 & Constant26 & Constant27 --> Object28
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -29,13 +29,15 @@ graph TD
     __Value2 --> Access8
     __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸeach:6ᐳ"]]:::plan
     PgSelect6 --> __ListTransform10
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda20
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda23
-    Object27 --> Lambda28
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant36 --> Lambda33
+    Constant35 --> Lambda20
+    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda23
+    Lambda23 --> Access24
+    Object28 --> Lambda29
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant37 --> Lambda34
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 -.-> __Item11
@@ -55,9 +57,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names-upper"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 24, 25, 26, 34, 35, 36, 9, 20, 23, 27, 28, 33<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 25, 26, 27, 35, 36, 37, 9, 20, 23, 24, 28, 29, 34<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda20,Lambda23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant34,Constant35,Constant36 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda20,Lambda23,Access24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgClassExpression{1}ᐸ__forum_names__.vᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_namesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda20 & Lambda23 & Lambda28 & Lambda33 --> PgSelect6
-    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Lambda20 & Constant24 & Constant25 & Constant26 --> Object27
+    Access24{{"Access[24∈0] ➊<br />ᐸ23.0ᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda20 & Access24 & Lambda29 & Lambda34 --> PgSelect6
+    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda20 & Constant25 & Constant26 & Constant27 --> Object28
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -29,13 +29,15 @@ graph TD
     __Value2 --> Access8
     __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸeach:6ᐳ"]]:::plan
     PgSelect6 --> __ListTransform10
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda20
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda23
-    Object27 --> Lambda28
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant36 --> Lambda33
+    Constant35 --> Lambda20
+    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda23
+    Lambda23 --> Access24
+    Object28 --> Lambda29
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant37 --> Lambda34
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 -.-> __Item11
@@ -55,9 +57,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names-upper"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 24, 25, 26, 34, 35, 36, 9, 20, 23, 27, 28, 33<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 25, 26, 27, 35, 36, 37, 9, 20, 23, 24, 28, 29, 34<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda20,Lambda23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant34,Constant35,Constant36 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda20,Lambda23,Access24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgClassExpression{1}ᐸ__forum_names__.vᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_namesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda15 & Lambda18 & Lambda23 & Lambda28 --> PgSelect6
-    Object22{{"Object[22∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant19{{"Constant[19∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Lambda15 & Constant19 & Constant20 & Constant21 --> Object22
+    Access19{{"Access[19∈0] ➊<br />ᐸ18.0ᐳ"}}:::plan
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda15 & Access19 & Lambda24 & Lambda29 --> PgSelect6
+    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda15 & Constant20 & Constant21 & Constant22 --> Object23
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant29 --> Lambda15
     Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda18
-    Object22 --> Lambda23
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant31 --> Lambda28
+    Constant30 --> Lambda15
+    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant31 --> Lambda18
+    Lambda18 --> Access19
+    Object23 --> Lambda24
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant32 --> Lambda29
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 19, 20, 21, 29, 30, 31, 9, 15, 18, 22, 23, 28<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 15, 18, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Constant19,Constant20,Constant21,Object22,Lambda23,Lambda28,Constant29,Constant30,Constant31 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Access19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11,PgClassExpression12 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_namesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda15 & Lambda18 & Lambda23 & Lambda28 --> PgSelect6
-    Object22{{"Object[22∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant19{{"Constant[19∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
-    Lambda15 & Constant19 & Constant20 & Constant21 --> Object22
+    Access19{{"Access[19∈0] ➊<br />ᐸ18.0ᐳ"}}:::plan
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda15 & Access19 & Lambda24 & Lambda29 --> PgSelect6
+    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”forum_names”)ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸCodec(text)ᐳ"}}:::plan
+    Lambda15 & Constant20 & Constant21 & Constant22 --> Object23
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant29 --> Lambda15
     Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda18
-    Object22 --> Lambda23
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
-    Constant31 --> Lambda28
+    Constant30 --> Lambda15
+    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant31 --> Lambda18
+    Lambda18 --> Access19
+    Object23 --> Lambda24
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forum_ᐳ"}}:::plan
+    Constant32 --> Lambda29
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-forum-names"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 19, 20, 21, 29, 30, 31, 9, 15, 18, 22, 23, 28<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 15, 18, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Constant19,Constant20,Constant21,Object22,Lambda23,Lambda28,Constant29,Constant30,Constant31 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Access19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11,PgClassExpression12 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_user_array_setᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda23 & Lambda26 & Lambda31 & Lambda36 --> PgSelect6
-    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”random_user_array_set”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda23 & Access27 & Lambda32 & Lambda37 --> PgSelect6
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”random_user_array_set”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -29,13 +29,15 @@ graph TD
     __Value2 --> Access8
     __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸpartitionByIndex1:6ᐳ"]]:::plan
     PgSelect6 --> __ListTransform10
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda23
     Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda26
-    Object30 --> Lambda31
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant39 --> Lambda36
+    Constant38 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda26
+    Lambda26 --> Access27
+    Object31 --> Lambda32
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant40 --> Lambda37
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 -.-> __Item11
@@ -57,9 +59,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-random-user-array-set"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 27, 28, 29, 37, 38, 39, 9, 23, 26, 30, 31, 36<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 28, 29, 30, 38, 39, 40, 9, 23, 26, 27, 31, 32, 37<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda23,Lambda26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant37,Constant38,Constant39 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda23,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgClassExpression{1}ᐸ__random_u..._set_idx__ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_user_array_setᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda23 & Lambda26 & Lambda31 & Lambda36 --> PgSelect6
-    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”random_user_array_set”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda23 & Access27 & Lambda32 & Lambda37 --> PgSelect6
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”random_user_array_set”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -29,13 +29,15 @@ graph TD
     __Value2 --> Access8
     __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸpartitionByIndex1:6ᐳ"]]:::plan
     PgSelect6 --> __ListTransform10
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda23
     Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda26
-    Object30 --> Lambda31
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant39 --> Lambda36
+    Constant38 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda26
+    Lambda26 --> Access27
+    Object31 --> Lambda32
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant40 --> Lambda37
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 -.-> __Item11
@@ -57,9 +59,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-random-user-array-set"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 27, 28, 29, 37, 38, 39, 9, 23, 26, 30, 31, 36<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 28, 29, 30, 38, 39, 40, 9, 23, 26, 27, 31, 32, 37<br />2: PgSelect[6]<br />3: __ListTransform[10]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda23,Lambda26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant37,Constant38,Constant39 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,__ListTransform10,Lambda23,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgClassExpression{1}ᐸ__random_u..._set_idx__ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_user_arrayᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”random_user_array”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”random_user_array”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-random-user-array"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_user_arrayᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”random_user_array”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”random_user_array”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-random-user-array"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-scalar.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-scalar.deopt.mermaid
@@ -13,33 +13,33 @@ graph TD
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant6 & Lambda28 & Lambda31 & Lambda36 & Lambda41 --> PgSelect7
+    Access32{{"Access[32∈0] ➊<br />ᐸ31.0ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant6 & Lambda28 & Access32 & Lambda37 & Lambda42 --> PgSelect7
     PgSelect15[["PgSelect[15∈0] ➊<br />ᐸunique_author_countᐳ"]]:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant70 & Lambda28 & Lambda31 & Lambda50 & Lambda55 --> PgSelect15
+    Constant73{{"Constant[73∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant73 & Lambda28 & Access32 & Lambda52 & Lambda57 --> PgSelect15
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸunique_author_countᐳ"]]:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant29 & Lambda28 & Lambda31 & Lambda64 & Lambda69 --> PgSelect21
-    Object35{{"Object[35∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda28 & Constant32 & Constant33 & Constant34 --> Object35
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
-    Lambda28 & Constant46 & Constant47 & Constant34 --> Object49
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
-    Lambda28 & Constant60 & Constant61 & Constant34 --> Object63
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant29 & Lambda28 & Access32 & Lambda67 & Lambda72 --> PgSelect21
+    Object36{{"Object[36∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda28 & Constant33 & Constant34 & Constant35 --> Object36
+    Object51{{"Object[51∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
+    Lambda28 & Constant48 & Constant49 & Constant35 --> Object51
+    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
+    Lambda28 & Constant63 & Constant64 & Constant35 --> Object66
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -64,25 +64,27 @@ graph TD
     First23 --> PgSelectSingle24
     PgClassExpression25{{"PgClassExpression[25∈0] ➊<br />ᐸ__unique_a..._count__.vᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda28
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant72 --> Lambda31
-    Object35 --> Lambda36
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant73 --> Lambda41
-    Object49 --> Lambda50
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant74 --> Lambda55
-    Object63 --> Lambda64
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant75 --> Lambda69
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant74 --> Lambda28
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant75 --> Lambda31
+    Lambda31 --> Access32
+    Object36 --> Lambda37
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant76 --> Lambda42
+    Object51 --> Lambda52
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant77 --> Lambda57
+    Object66 --> Lambda67
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant78 --> Lambda72
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
 
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-scalar"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 8, 9, 29, 32, 33, 34, 46, 47, 60, 61, 70, 71, 72, 73, 74, 75, 10, 28, 31, 35, 36, 41, 49, 50, 55, 63, 64, 69<br />2: PgSelect[7], PgSelect[15], PgSelect[21]<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 8, 9, 29, 33, 34, 35, 48, 49, 63, 64, 73, 74, 75, 76, 77, 78, 10, 28, 31, 32, 36, 37, 42, 51, 52, 57, 66, 67, 72<br />2: PgSelect[7], PgSelect[15], PgSelect[21]<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,Lambda28,Constant29,Lambda31,Constant32,Constant33,Constant34,Object35,Lambda36,Lambda41,Constant46,Constant47,Object49,Lambda50,Lambda55,Constant60,Constant61,Object63,Lambda64,Lambda69,Constant70,Constant71,Constant72,Constant73,Constant74,Constant75 bucket0
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,Lambda28,Constant29,Lambda31,Access32,Constant33,Constant34,Constant35,Object36,Lambda37,Lambda42,Constant48,Constant49,Object51,Lambda52,Lambda57,Constant63,Constant64,Object66,Lambda67,Lambda72,Constant73,Constant74,Constant75,Constant76,Constant77,Constant78 bucket0
     end

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-scalar.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-scalar.mermaid
@@ -13,33 +13,33 @@ graph TD
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant6 & Lambda28 & Lambda31 & Lambda36 & Lambda41 --> PgSelect7
+    Access32{{"Access[32∈0] ➊<br />ᐸ31.0ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant6 & Lambda28 & Access32 & Lambda37 & Lambda42 --> PgSelect7
     PgSelect15[["PgSelect[15∈0] ➊<br />ᐸunique_author_countᐳ"]]:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant70 & Lambda28 & Lambda31 & Lambda50 & Lambda55 --> PgSelect15
+    Constant73{{"Constant[73∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant73 & Lambda28 & Access32 & Lambda52 & Lambda57 --> PgSelect15
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸunique_author_countᐳ"]]:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant29 & Lambda28 & Lambda31 & Lambda64 & Lambda69 --> PgSelect21
-    Object35{{"Object[35∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda28 & Constant32 & Constant33 & Constant34 --> Object35
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
-    Lambda28 & Constant46 & Constant47 & Constant34 --> Object49
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
-    Lambda28 & Constant60 & Constant61 & Constant34 --> Object63
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant29 & Lambda28 & Access32 & Lambda67 & Lambda72 --> PgSelect21
+    Object36{{"Object[36∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda28 & Constant33 & Constant34 & Constant35 --> Object36
+    Object51{{"Object[51∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
+    Lambda28 & Constant48 & Constant49 & Constant35 --> Object51
+    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”unique_author_count”)ᐳ"}}:::plan
+    Lambda28 & Constant63 & Constant64 & Constant35 --> Object66
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -64,25 +64,27 @@ graph TD
     First23 --> PgSelectSingle24
     PgClassExpression25{{"PgClassExpression[25∈0] ➊<br />ᐸ__unique_a..._count__.vᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda28
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant72 --> Lambda31
-    Object35 --> Lambda36
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant73 --> Lambda41
-    Object49 --> Lambda50
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant74 --> Lambda55
-    Object63 --> Lambda64
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant75 --> Lambda69
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant74 --> Lambda28
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant75 --> Lambda31
+    Lambda31 --> Access32
+    Object36 --> Lambda37
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant76 --> Lambda42
+    Object51 --> Lambda52
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant77 --> Lambda57
+    Object66 --> Lambda67
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant78 --> Lambda72
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
 
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-scalar"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 8, 9, 29, 32, 33, 34, 46, 47, 60, 61, 70, 71, 72, 73, 74, 75, 10, 28, 31, 35, 36, 41, 49, 50, 55, 63, 64, 69<br />2: PgSelect[7], PgSelect[15], PgSelect[21]<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 8, 9, 29, 33, 34, 35, 48, 49, 63, 64, 73, 74, 75, 76, 77, 78, 10, 28, 31, 32, 36, 37, 42, 51, 52, 57, 66, 67, 72<br />2: PgSelect[7], PgSelect[15], PgSelect[21]<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,Lambda28,Constant29,Lambda31,Constant32,Constant33,Constant34,Object35,Lambda36,Lambda41,Constant46,Constant47,Object49,Lambda50,Lambda55,Constant60,Constant61,Object63,Lambda64,Lambda69,Constant70,Constant71,Constant72,Constant73,Constant74,Constant75 bucket0
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,Lambda28,Constant29,Lambda31,Access32,Constant33,Constant34,Constant35,Object36,Lambda37,Lambda42,Constant48,Constant49,Object51,Lambda52,Lambda57,Constant63,Constant64,Object66,Lambda67,Lambda72,Constant73,Constant74,Constant75,Constant76,Constant77,Constant78 bucket0
     end

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-setof-message.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-setof-message.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸfeatured_messagesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda15 & Lambda18 & Lambda23 & Lambda28 --> PgSelect6
-    Object22{{"Object[22∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant19{{"Constant[19∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸsql.identifier(”featured_messages”)ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda15 & Constant19 & Constant20 & Constant21 --> Object22
+    Access19{{"Access[19∈0] ➊<br />ᐸ18.0ᐳ"}}:::plan
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda15 & Access19 & Lambda24 & Lambda29 --> PgSelect6
+    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”featured_messages”)ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda15 & Constant20 & Constant21 & Constant22 --> Object23
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant29 --> Lambda15
     Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda18
-    Object22 --> Lambda23
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”featurᐳ"}}:::plan
-    Constant31 --> Lambda28
+    Constant30 --> Lambda15
+    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant31 --> Lambda18
+    Lambda18 --> Access19
+    Object23 --> Lambda24
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”featurᐳ"}}:::plan
+    Constant32 --> Lambda29
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-setof-message"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 19, 20, 21, 29, 30, 31, 9, 15, 18, 22, 23, 28<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 15, 18, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Constant19,Constant20,Constant21,Object22,Lambda23,Lambda28,Constant29,Constant30,Constant31 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Access19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-setof-message.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-setof-message.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸfeatured_messagesᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda15 & Lambda18 & Lambda23 & Lambda28 --> PgSelect6
-    Object22{{"Object[22∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant19{{"Constant[19∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸsql.identifier(”featured_messages”)ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda15 & Constant19 & Constant20 & Constant21 --> Object22
+    Access19{{"Access[19∈0] ➊<br />ᐸ18.0ᐳ"}}:::plan
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda15 & Access19 & Lambda24 & Lambda29 --> PgSelect6
+    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”featured_messages”)ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda15 & Constant20 & Constant21 & Constant22 --> Object23
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant29 --> Lambda15
     Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda18
-    Object22 --> Lambda23
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”featurᐳ"}}:::plan
-    Constant31 --> Lambda28
+    Constant30 --> Lambda15
+    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant31 --> Lambda18
+    Lambda18 --> Access19
+    Object23 --> Lambda24
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”featurᐳ"}}:::plan
+    Constant32 --> Lambda29
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-setof-message"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 19, 20, 21, 29, 30, 31, 9, 15, 18, 22, 23, 28<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 15, 18, 19, 23, 24, 29<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Constant19,Constant20,Constant21,Object22,Lambda23,Lambda28,Constant29,Constant30,Constant31 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda15,Lambda18,Access19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-user.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-user.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,13 +31,15 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-user"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,PgClassExpression13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-user.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-user.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda16 & Lambda19 & Lambda24 & Lambda29 --> PgSelect6
-    Object23{{"Object[23∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant20{{"Constant[20∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda16 & Constant20 & Constant21 & Constant22 --> Object23
+    Access20{{"Access[20∈0] ➊<br />ᐸ19.0ᐳ"}}:::plan
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda16 & Access20 & Lambda25 & Lambda30 --> PgSelect6
+    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda16 & Constant21 & Constant22 & Constant23 --> Object24
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,13 +31,15 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant30 --> Lambda16
     Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda19
-    Object23 --> Lambda24
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant32 --> Lambda29
+    Constant31 --> Lambda16
+    Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant32 --> Lambda19
+    Lambda19 --> Access20
+    Object24 --> Lambda25
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant33 --> Lambda30
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/functions/custom-query-user"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 20, 21, 22, 30, 31, 32, 9, 16, 19, 23, 24, 29<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 21, 22, 23, 31, 32, 33, 9, 16, 19, 20, 24, 25, 30<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda16,Lambda19,Constant20,Constant21,Constant22,Object23,Lambda24,Lambda29,Constant30,Constant31,Constant32 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda16,Lambda19,Access20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,PgClassExpression13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.mermaid
@@ -12,96 +12,98 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda66 & Lambda69 & Lambda158 & Lambda163 --> PgSelect6
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
-    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda66 & Constant84 & Constant85 & Constant86 --> Object87
-    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda66 & Constant98 & Constant99 & Constant100 --> Object101
-    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda66 & Constant112 & Constant113 & Constant114 --> Object115
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda66 & Constant126 & Constant127 & Constant128 --> Object129
-    Object157{{"Object[157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda66 & Constant154 & Constant155 & Constant156 --> Object157
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda66 & Access70 & Lambda165 & Lambda170 --> PgSelect6
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda66 & Constant86 & Constant87 & Constant88 --> Object89
+    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda66 & Constant101 & Constant102 & Constant103 --> Object104
+    Object119{{"Object[119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda66 & Constant116 & Constant117 & Constant118 --> Object119
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda66 & Constant131 & Constant132 & Constant133 --> Object134
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda66 & Constant146 & Constant147 & Constant148 --> Object149
+    Object164{{"Object[164∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda66 & Constant161 & Constant162 & Constant163 --> Object164
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant164 --> Lambda66
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant165 --> Lambda69
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object73 --> Lambda74
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant166 --> Lambda79
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object87 --> Lambda88
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant167 --> Lambda93
-    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object101 --> Lambda102
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant168 --> Lambda107
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object115 --> Lambda116
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant169 --> Lambda121
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object129 --> Lambda130
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant171 --> Lambda66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant172 --> Lambda69
+    Lambda69 --> Access70
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object74 --> Lambda75
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant173 --> Lambda80
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object89 --> Lambda90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant174 --> Lambda95
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object104 --> Lambda105
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant175 --> Lambda110
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object119 --> Lambda120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant176 --> Lambda125
     Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant170 --> Lambda135
-    Object157 --> Lambda158
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant172 --> Lambda163
+    Object134 --> Lambda135
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant177 --> Lambda140
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object149 --> Lambda150
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant178 --> Lambda155
+    Object164 --> Lambda165
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant179 --> Lambda170
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object143{{"Object[143∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda66 & Constant140 & Constant141 & Constant142 --> Object143
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda144{{"Lambda[144∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object143 --> Lambda144
-    Lambda149{{"Lambda[149∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant171 --> Lambda149
     PgSelect14[["PgSelect[14∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda66 & Lambda69 & Lambda144 & Lambda149 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda66 & Access70 & Lambda150 & Lambda155 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -121,15 +123,15 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda74 & Lambda79 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda75 & Lambda80 --> PgSelect26
     PgSelect40[["PgSelect[40∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda88 & Lambda93 --> PgSelect40
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda90 & Lambda95 --> PgSelect40
     PgSelect47[["PgSelect[47∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda102 & Lambda107 --> PgSelect47
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda105 & Lambda110 --> PgSelect47
     PgSelect53[["PgSelect[53∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda116 & Lambda121 --> PgSelect53
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda120 & Lambda125 --> PgSelect53
     PgSelect58[["PgSelect[58∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda130 & Lambda135 --> PgSelect58
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda135 & Lambda140 --> PgSelect58
     PgSelectSingle22 --> PgClassExpression25
     First30{{"First[30∈5]"}}:::plan
     PgSelect26 --> First30
@@ -185,22 +187,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/basics-with-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 70, 71, 72, 84, 85, 86, 98, 99, 100, 112, 113, 114, 126, 127, 128, 140, 141, 142, 154, 155, 156, 164, 165, 166, 167, 168, 169, 170, 171, 172, 9, 66, 69, 73, 74, 79, 87, 88, 93, 101, 102, 107, 115, 116, 121, 129, 130, 135, 157, 158, 163<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 71, 72, 73, 86, 87, 88, 101, 102, 103, 116, 117, 118, 131, 132, 133, 146, 147, 148, 161, 162, 163, 171, 172, 173, 174, 175, 176, 177, 178, 179, 9, 66, 69, 70, 74, 75, 80, 89, 90, 95, 104, 105, 110, 119, 120, 125, 134, 135, 140, 149, 150, 155, 164, 165, 170<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda66,Lambda69,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant112,Constant113,Constant114,Object115,Lambda116,Lambda121,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant140,Constant141,Constant142,Constant154,Constant155,Constant156,Object157,Lambda158,Lambda163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 66, 140, 141, 142, 171, 9, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda66,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant101,Constant102,Constant103,Object104,Lambda105,Lambda110,Constant116,Constant117,Constant118,Object119,Lambda120,Lambda125,Constant131,Constant132,Constant133,Object134,Lambda135,Lambda140,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant161,Constant162,Constant163,Object164,Lambda165,Lambda170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 66, 70, 150, 155, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object143,Lambda144,Lambda149 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 66, 69, 144, 149, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 66, 70, 150, 155, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 66, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 66, 70, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 66, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 40, 47, 53, 58<br />ᐳ: 30, 31, 39, 42, 43, 44, 45, 46, 49, 50, 51, 52, 55, 56, 57, 60, 61, 62, 63"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 66, 70, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 40, 47, 53, 58<br />ᐳ: 30, 31, 39, 42, 43, 44, 45, 46, 49, 50, 51, 52, 55, 56, 57, 60, 61, 62, 63"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgSelect40,First42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgSelect47,First49,PgSelectSingle50,PgClassExpression51,PgClassExpression52,PgSelect53,First55,PgSelectSingle56,PgClassExpression57,PgSelect58,First60,PgSelectSingle61,PgClassExpression62,PgClassExpression63 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.mermaid
@@ -11,89 +11,91 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda69 & Lambda144 & Lambda149 & Lambda66 & Lambda69 & Lambda163 & Lambda168 --> PgSelect6
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
-    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda66 & Constant84 & Constant85 & Constant86 --> Object87
-    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda66 & Constant98 & Constant99 & Constant100 --> Object101
-    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda66 & Constant112 & Constant113 & Constant114 --> Object115
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda66 & Constant126 & Constant127 & Constant128 --> Object129
-    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda66 & Constant140 & Constant141 & Constant142 --> Object143
-    Object162{{"Object[162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda66 & Constant159 & Constant160 & Constant161 --> Object162
+    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access70 & Lambda150 & Lambda155 & Lambda66 & Access70 & Lambda170 & Lambda175 --> PgSelect6
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda66 & Constant86 & Constant87 & Constant88 --> Object89
+    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda66 & Constant101 & Constant102 & Constant103 --> Object104
+    Object119{{"Object[119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda66 & Constant116 & Constant117 & Constant118 --> Object119
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda66 & Constant131 & Constant132 & Constant133 --> Object134
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda66 & Constant146 & Constant147 & Constant148 --> Object149
+    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda66 & Constant166 & Constant167 & Constant168 --> Object169
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant169 --> Lambda66
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant170 --> Lambda69
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object73 --> Lambda74
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant171 --> Lambda79
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object87 --> Lambda88
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant172 --> Lambda93
-    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object101 --> Lambda102
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant173 --> Lambda107
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object115 --> Lambda116
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant174 --> Lambda121
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object129 --> Lambda130
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant176 --> Lambda66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant177 --> Lambda69
+    Lambda69 --> Access70
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object74 --> Lambda75
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant178 --> Lambda80
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object89 --> Lambda90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant179 --> Lambda95
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object104 --> Lambda105
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant180 --> Lambda110
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object119 --> Lambda120
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant181 --> Lambda125
     Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant175 --> Lambda135
-    Object143 --> Lambda144
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant176 --> Lambda149
-    Object162 --> Lambda163
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant177 --> Lambda168
+    Object134 --> Lambda135
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant182 --> Lambda140
+    Object149 --> Lambda150
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant183 --> Lambda155
+    Object169 --> Lambda170
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant184 --> Lambda175
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant64{{"Constant[64∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant67{{"Constant[67∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -101,18 +103,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object153{{"Object[153∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access151{{"Access[151∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access151 & Constant64 & Constant64 & Lambda66 & Constant67 --> Object153
+    Object159{{"Object[159∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access157{{"Access[157∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access157 & Constant64 & Constant64 & Lambda66 & Constant67 --> Object159
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda154{{"Lambda[154∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda154 --> __ListTransform18
-    __Item10 --> Access151
-    Object153 --> Lambda154
-    __Item19[/"__Item[19∈3]<br />ᐸ154ᐳ"\]:::itemplan
-    Lambda154 -.-> __Item19
+    Lambda160{{"Lambda[160∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda160 --> __ListTransform18
+    __Item10 --> Access157
+    Object159 --> Lambda160
+    __Item19[/"__Item[19∈3]<br />ᐸ160ᐳ"\]:::itemplan
+    Lambda160 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgPolymorphic24{{"PgPolymorphic[24∈4]"}}:::plan
@@ -125,15 +127,15 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda74 & Lambda79 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda75 & Lambda80 --> PgSelect26
     PgSelect40[["PgSelect[40∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda88 & Lambda93 --> PgSelect40
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda90 & Lambda95 --> PgSelect40
     PgSelect47[["PgSelect[47∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda102 & Lambda107 --> PgSelect47
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda105 & Lambda110 --> PgSelect47
     PgSelect53[["PgSelect[53∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda116 & Lambda121 --> PgSelect53
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda120 & Lambda125 --> PgSelect53
     PgSelect58[["PgSelect[58∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda66 & Lambda69 & Lambda130 & Lambda135 --> PgSelect58
+    Object9 & PgClassExpression25 & Lambda66 & Access70 & Lambda135 & Lambda140 --> PgSelect58
     PgSelectSingle22 --> PgClassExpression25
     First30{{"First[30∈5]"}}:::plan
     PgSelect26 --> First30
@@ -189,22 +191,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/basics-with-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 64, 67, 70, 71, 72, 84, 85, 86, 98, 99, 100, 112, 113, 114, 126, 127, 128, 140, 141, 142, 159, 160, 161, 169, 170, 171, 172, 173, 174, 175, 176, 177, 9, 66, 69, 73, 74, 79, 87, 88, 93, 101, 102, 107, 115, 116, 121, 129, 130, 135, 143, 144, 149, 162, 163, 168<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 64, 67, 71, 72, 73, 86, 87, 88, 101, 102, 103, 116, 117, 118, 131, 132, 133, 146, 147, 148, 166, 167, 168, 176, 177, 178, 179, 180, 181, 182, 183, 184, 9, 66, 69, 70, 74, 75, 80, 89, 90, 95, 104, 105, 110, 119, 120, 125, 134, 135, 140, 149, 150, 155, 169, 170, 175<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant64,Lambda66,Constant67,Lambda69,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant112,Constant113,Constant114,Object115,Lambda116,Lambda121,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant140,Constant141,Constant142,Object143,Lambda144,Lambda149,Constant159,Constant160,Constant161,Object162,Lambda163,Lambda168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176,Constant177 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 64, 66, 67, 9, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant64,Lambda66,Constant67,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant101,Constant102,Constant103,Object104,Lambda105,Lambda110,Constant116,Constant117,Constant118,Object119,Lambda120,Lambda125,Constant131,Constant132,Constant133,Object134,Lambda135,Lambda140,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 64, 66, 67, 9, 70, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 64, 66, 67, 9, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 151, 153, 154<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 64, 66, 67, 9, 70, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 157, 159, 160<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access151,Object153,Lambda154 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access157,Object159,Lambda160 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 66, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 66, 70, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 66, 69, 74, 79, 88, 93, 102, 107, 116, 121, 130, 135, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 40, 47, 53, 58<br />ᐳ: 30, 31, 39, 42, 43, 44, 45, 46, 49, 50, 51, 52, 55, 56, 57, 60, 61, 62, 63"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 66, 70, 75, 80, 90, 95, 105, 110, 120, 125, 135, 140, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 40, 47, 53, 58<br />ᐳ: 30, 31, 39, 42, 43, 44, 45, 46, 49, 50, 51, 52, 55, 56, 57, 60, 61, 62, 63"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgSelect40,First42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgSelect47,First49,PgSelectSingle50,PgClassExpression51,PgClassExpression52,PgSelect53,First55,PgSelectSingle56,PgClassExpression57,PgSelect58,First60,PgSelectSingle61,PgClassExpression62,PgClassExpression63 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.mermaid
@@ -12,96 +12,98 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda57 & Lambda60 & Lambda149 & Lambda154 --> PgSelect6
-    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda57 & Constant61 & Constant62 & Constant63 --> Object64
-    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda57 & Constant75 & Constant76 & Constant77 --> Object78
-    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda57 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda57 & Constant103 & Constant104 & Constant105 --> Object106
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda57 & Constant117 & Constant118 & Constant119 --> Object120
-    Object148{{"Object[148∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant145{{"Constant[145∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda57 & Constant145 & Constant146 & Constant147 --> Object148
+    Access61{{"Access[61∈0] ➊<br />ᐸ60.0ᐳ"}}:::plan
+    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda57 & Access61 & Lambda156 & Lambda161 --> PgSelect6
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda57 & Constant62 & Constant63 & Constant64 --> Object65
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda57 & Constant77 & Constant78 & Constant79 --> Object80
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda57 & Constant92 & Constant93 & Constant94 --> Object95
+    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda57 & Constant107 & Constant108 & Constant109 --> Object110
+    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda57 & Constant122 & Constant123 & Constant124 --> Object125
+    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda57 & Constant137 & Constant138 & Constant139 --> Object140
+    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda57 & Constant152 & Constant153 & Constant154 --> Object155
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant155 --> Lambda57
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant156 --> Lambda60
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object64 --> Lambda65
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant157 --> Lambda70
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object78 --> Lambda79
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant158 --> Lambda84
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object92 --> Lambda93
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant159 --> Lambda98
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object106 --> Lambda107
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant160 --> Lambda112
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object120 --> Lambda121
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant162 --> Lambda57
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant163 --> Lambda60
+    Lambda60 --> Access61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object65 --> Lambda66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant164 --> Lambda71
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object80 --> Lambda81
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant165 --> Lambda86
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object95 --> Lambda96
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant166 --> Lambda101
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object110 --> Lambda111
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant167 --> Lambda116
     Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant161 --> Lambda126
-    Object148 --> Lambda149
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant163 --> Lambda154
+    Object125 --> Lambda126
+    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant168 --> Lambda131
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object140 --> Lambda141
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant169 --> Lambda146
+    Object155 --> Lambda156
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant170 --> Lambda161
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object134{{"Object[134∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda57 & Constant131 & Constant132 & Constant133 --> Object134
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda135{{"Lambda[135∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object134 --> Lambda135
-    Lambda140{{"Lambda[140∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant162 --> Lambda140
     PgSelect14[["PgSelect[14∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda57 & Lambda60 & Lambda135 & Lambda140 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda57 & Access61 & Lambda141 & Lambda146 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -121,15 +123,15 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda65 & Lambda70 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda66 & Lambda71 --> PgSelect26
     PgSelect39[["PgSelect[39∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda79 & Lambda84 --> PgSelect39
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda81 & Lambda86 --> PgSelect39
     PgSelect43[["PgSelect[43∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda93 & Lambda98 --> PgSelect43
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda96 & Lambda101 --> PgSelect43
     PgSelect47[["PgSelect[47∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda107 & Lambda112 --> PgSelect47
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda111 & Lambda116 --> PgSelect47
     PgSelect51[["PgSelect[51∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda121 & Lambda126 --> PgSelect51
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda126 & Lambda131 --> PgSelect51
     PgSelectSingle22 --> PgClassExpression25
     First30{{"First[30∈5]"}}:::plan
     PgSelect26 --> First30
@@ -167,22 +169,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 61, 62, 63, 75, 76, 77, 89, 90, 91, 103, 104, 105, 117, 118, 119, 131, 132, 133, 145, 146, 147, 155, 156, 157, 158, 159, 160, 161, 162, 163, 9, 57, 60, 64, 65, 70, 78, 79, 84, 92, 93, 98, 106, 107, 112, 120, 121, 126, 148, 149, 154<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 62, 63, 64, 77, 78, 79, 92, 93, 94, 107, 108, 109, 122, 123, 124, 137, 138, 139, 152, 153, 154, 162, 163, 164, 165, 166, 167, 168, 169, 170, 9, 57, 60, 61, 65, 66, 71, 80, 81, 86, 95, 96, 101, 110, 111, 116, 125, 126, 131, 140, 141, 146, 155, 156, 161<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda57,Lambda60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant75,Constant76,Constant77,Object78,Lambda79,Lambda84,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant131,Constant132,Constant133,Constant145,Constant146,Constant147,Object148,Lambda149,Lambda154,Constant155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 57, 131, 132, 133, 162, 9, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda57,Lambda60,Access61,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant77,Constant78,Constant79,Object80,Lambda81,Lambda86,Constant92,Constant93,Constant94,Object95,Lambda96,Lambda101,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Constant122,Constant123,Constant124,Object125,Lambda126,Lambda131,Constant137,Constant138,Constant139,Object140,Lambda141,Lambda146,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169,Constant170 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 57, 61, 141, 146, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object134,Lambda135,Lambda140 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 57, 60, 135, 140, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 57, 61, 141, 146, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 57, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 57, 61, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 57, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 39, 43, 47, 51<br />ᐳ: 30, 31, 41, 42, 45, 46, 49, 50, 53, 54"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 57, 61, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 39, 43, 47, 51<br />ᐳ: 30, 31, 41, 42, 45, 46, 49, 50, 53, 54"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgSelect43,First45,PgSelectSingle46,PgSelect47,First49,PgSelectSingle50,PgSelect51,First53,PgSelectSingle54 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.mermaid
@@ -11,89 +11,91 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access61{{"Access[61∈0] ➊<br />ᐸ60.0ᐳ"}}:::plan
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda60 & Lambda135 & Lambda140 & Lambda57 & Lambda60 & Lambda154 & Lambda159 --> PgSelect6
-    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda57 & Constant61 & Constant62 & Constant63 --> Object64
-    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda57 & Constant75 & Constant76 & Constant77 --> Object78
-    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda57 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda57 & Constant103 & Constant104 & Constant105 --> Object106
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda57 & Constant117 & Constant118 & Constant119 --> Object120
-    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda57 & Constant131 & Constant132 & Constant133 --> Object134
-    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda57 & Constant150 & Constant151 & Constant152 --> Object153
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access61 & Lambda141 & Lambda146 & Lambda57 & Access61 & Lambda161 & Lambda166 --> PgSelect6
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda57 & Constant62 & Constant63 & Constant64 --> Object65
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda57 & Constant77 & Constant78 & Constant79 --> Object80
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda57 & Constant92 & Constant93 & Constant94 --> Object95
+    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda57 & Constant107 & Constant108 & Constant109 --> Object110
+    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda57 & Constant122 & Constant123 & Constant124 --> Object125
+    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda57 & Constant137 & Constant138 & Constant139 --> Object140
+    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda57 & Constant157 & Constant158 & Constant159 --> Object160
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant160 --> Lambda57
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant161 --> Lambda60
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object64 --> Lambda65
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant162 --> Lambda70
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object78 --> Lambda79
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant163 --> Lambda84
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object92 --> Lambda93
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant164 --> Lambda98
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object106 --> Lambda107
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant165 --> Lambda112
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object120 --> Lambda121
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant167 --> Lambda57
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant168 --> Lambda60
+    Lambda60 --> Access61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object65 --> Lambda66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant169 --> Lambda71
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object80 --> Lambda81
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant170 --> Lambda86
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object95 --> Lambda96
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant171 --> Lambda101
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object110 --> Lambda111
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant172 --> Lambda116
     Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant166 --> Lambda126
-    Object134 --> Lambda135
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant167 --> Lambda140
-    Object153 --> Lambda154
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant168 --> Lambda159
+    Object125 --> Lambda126
+    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant173 --> Lambda131
+    Object140 --> Lambda141
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant174 --> Lambda146
+    Object160 --> Lambda161
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant175 --> Lambda166
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant55{{"Constant[55∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant58{{"Constant[58∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -101,18 +103,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object144{{"Object[144∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access142{{"Access[142∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access142 & Constant55 & Constant55 & Lambda57 & Constant58 --> Object144
+    Object150{{"Object[150∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access148{{"Access[148∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access148 & Constant55 & Constant55 & Lambda57 & Constant58 --> Object150
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda145{{"Lambda[145∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda145 --> __ListTransform18
-    __Item10 --> Access142
-    Object144 --> Lambda145
-    __Item19[/"__Item[19∈3]<br />ᐸ145ᐳ"\]:::itemplan
-    Lambda145 -.-> __Item19
+    Lambda151{{"Lambda[151∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda151 --> __ListTransform18
+    __Item10 --> Access148
+    Object150 --> Lambda151
+    __Item19[/"__Item[19∈3]<br />ᐸ151ᐳ"\]:::itemplan
+    Lambda151 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgPolymorphic24{{"PgPolymorphic[24∈4]"}}:::plan
@@ -125,15 +127,15 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda65 & Lambda70 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda66 & Lambda71 --> PgSelect26
     PgSelect39[["PgSelect[39∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda79 & Lambda84 --> PgSelect39
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda81 & Lambda86 --> PgSelect39
     PgSelect43[["PgSelect[43∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda93 & Lambda98 --> PgSelect43
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda96 & Lambda101 --> PgSelect43
     PgSelect47[["PgSelect[47∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda107 & Lambda112 --> PgSelect47
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda111 & Lambda116 --> PgSelect47
     PgSelect51[["PgSelect[51∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda57 & Lambda60 & Lambda121 & Lambda126 --> PgSelect51
+    Object9 & PgClassExpression25 & Lambda57 & Access61 & Lambda126 & Lambda131 --> PgSelect51
     PgSelectSingle22 --> PgClassExpression25
     First30{{"First[30∈5]"}}:::plan
     PgSelect26 --> First30
@@ -171,22 +173,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 55, 58, 61, 62, 63, 75, 76, 77, 89, 90, 91, 103, 104, 105, 117, 118, 119, 131, 132, 133, 150, 151, 152, 160, 161, 162, 163, 164, 165, 166, 167, 168, 9, 57, 60, 64, 65, 70, 78, 79, 84, 92, 93, 98, 106, 107, 112, 120, 121, 126, 134, 135, 140, 153, 154, 159<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 55, 58, 62, 63, 64, 77, 78, 79, 92, 93, 94, 107, 108, 109, 122, 123, 124, 137, 138, 139, 157, 158, 159, 167, 168, 169, 170, 171, 172, 173, 174, 175, 9, 57, 60, 61, 65, 66, 71, 80, 81, 86, 95, 96, 101, 110, 111, 116, 125, 126, 131, 140, 141, 146, 160, 161, 166<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant55,Lambda57,Constant58,Lambda60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant75,Constant76,Constant77,Object78,Lambda79,Lambda84,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Constant131,Constant132,Constant133,Object134,Lambda135,Lambda140,Constant150,Constant151,Constant152,Object153,Lambda154,Lambda159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 55, 57, 58, 9, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant55,Lambda57,Constant58,Lambda60,Access61,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant77,Constant78,Constant79,Object80,Lambda81,Lambda86,Constant92,Constant93,Constant94,Object95,Lambda96,Lambda101,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Constant122,Constant123,Constant124,Object125,Lambda126,Lambda131,Constant137,Constant138,Constant139,Object140,Lambda141,Lambda146,Constant157,Constant158,Constant159,Object160,Lambda161,Lambda166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 55, 57, 58, 9, 61, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 55, 57, 58, 9, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 142, 144, 145<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 55, 57, 58, 9, 61, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 148, 150, 151<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access142,Object144,Lambda145 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access148,Object150,Lambda151 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 57, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 57, 61, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 57, 60, 65, 70, 79, 84, 93, 98, 107, 112, 121, 126, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 39, 43, 47, 51<br />ᐳ: 30, 31, 41, 42, 45, 46, 49, 50, 53, 54"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 57, 61, 66, 71, 81, 86, 96, 101, 111, 116, 126, 131, 24, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 33, 34, 35, 36, 37, 38<br />2: 26, 39, 43, 47, 51<br />ᐳ: 30, 31, 41, 42, 45, 46, 49, 50, 53, 54"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgSelect43,First45,PgSelectSingle46,PgSelect47,First49,PgSelectSingle50,PgSelect51,First53,PgSelectSingle54 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.deopt.mermaid
@@ -11,46 +11,46 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_commentablesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant187 & Lambda174 & Lambda176 & Lambda181 & Lambda186 --> PgSelect7
-    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access183{{"Access[183∈0] ➊<br />ᐸ182.0ᐳ"}}:::plan
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant194 & Lambda180 & Access183 & Lambda188 & Lambda193 --> PgSelect7
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda83 & Constant103 & Constant104 & Constant105 --> Object106
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda83 & Constant117 & Constant118 & Constant89 --> Object120
-    Object136{{"Object[136∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda83 & Constant133 & Constant134 & Constant135 --> Object136
-    Object150{{"Object[150∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda83 & Constant147 & Constant148 & Constant89 --> Object150
-    Object166{{"Object[166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda83 & Constant163 & Constant164 & Constant165 --> Object166
-    Object180{{"Object[180∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
-    Lambda174 & Constant177 & Constant178 & Constant179 --> Object180
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda83 & Constant88 & Constant89 & Constant90 --> Object91
+    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda83 & Constant105 & Constant106 & Constant107 --> Object108
+    Object123{{"Object[123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda83 & Constant120 & Constant121 & Constant90 --> Object123
+    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda83 & Constant137 & Constant138 & Constant139 --> Object140
+    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda83 & Constant152 & Constant153 & Constant90 --> Object155
+    Object172{{"Object[172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda83 & Constant169 & Constant170 & Constant171 --> Object172
+    Object187{{"Object[187∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
+    Lambda180 & Constant184 & Constant185 & Constant186 --> Object187
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -59,48 +59,52 @@ graph TD
     __Value2 --> Access9
     __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
     PgSelect7 --> __ListTransform11
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant188 --> Lambda83
+    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant195 --> Lambda83
     Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant189 --> Lambda86
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object90 --> Lambda91
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant190 --> Lambda96
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object106 --> Lambda107
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant191 --> Lambda112
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object120 --> Lambda121
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant192 --> Lambda126
-    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object136 --> Lambda137
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant193 --> Lambda142
-    Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object150 --> Lambda151
+    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant196 --> Lambda86
+    Access87{{"Access[87∈0] ➊<br />ᐸ86.0ᐳ"}}:::plan
+    Lambda86 --> Access87
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant197 --> Lambda97
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object108 --> Lambda109
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant198 --> Lambda114
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object123 --> Lambda124
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant199{{"Constant[199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant199 --> Lambda129
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object140 --> Lambda141
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant200 --> Lambda146
     Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant194 --> Lambda156
-    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object166 --> Lambda167
-    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant195 --> Lambda172
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant197 --> Lambda174
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant198 --> Lambda176
-    Object180 --> Lambda181
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant196 --> Lambda186
+    Object155 --> Lambda156
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant201 --> Lambda161
+    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object172 --> Lambda173
+    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant202 --> Lambda178
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant204 --> Lambda180
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant205 --> Lambda182
+    Lambda182 --> Access183
+    Object187 --> Lambda188
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant203 --> Lambda193
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 -.-> __Item12
@@ -116,11 +120,11 @@ graph TD
     PgSelectSingle15 --> PgClassExpression16
     PgSelect19[["PgSelect[19∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
-    Object10 & PgClassExpression18 & Lambda86 & Lambda91 & Lambda96 & Lambda83 & Lambda86 & Lambda107 & Lambda112 --> PgSelect19
+    Object10 & PgClassExpression18 & Access87 & Lambda92 & Lambda97 & Lambda83 & Access87 & Lambda109 & Lambda114 --> PgSelect19
     PgSelect41[["PgSelect[41∈3]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression18 & Lambda86 & Lambda121 & Lambda126 & Lambda83 & Lambda86 & Lambda137 & Lambda142 --> PgSelect41
+    Object10 & PgClassExpression18 & Access87 & Lambda124 & Lambda129 & Lambda83 & Access87 & Lambda141 & Lambda146 --> PgSelect41
     PgSelect61[["PgSelect[61∈3]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression18 & Lambda86 & Lambda151 & Lambda156 & Lambda83 & Lambda86 & Lambda167 & Lambda172 --> PgSelect61
+    Object10 & PgClassExpression18 & Access87 & Lambda156 & Lambda161 & Lambda83 & Access87 & Lambda173 & Lambda178 --> PgSelect61
     PgSelectSingle15 --> PgClassExpression18
     First23{{"First[23∈3]"}}:::plan
     PgSelect19 --> First23
@@ -162,16 +166,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/commentables-simple"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 87, 88, 89, 103, 104, 105, 117, 118, 133, 134, 135, 147, 148, 163, 164, 165, 177, 178, 179, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 10, 83, 86, 90, 91, 96, 106, 107, 112, 120, 121, 126, 136, 137, 142, 150, 151, 156, 166, 167, 172, 174, 176, 180, 181, 186<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 88, 89, 90, 105, 106, 107, 120, 121, 137, 138, 139, 152, 153, 169, 170, 171, 184, 185, 186, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 10, 83, 86, 87, 91, 92, 97, 108, 109, 114, 123, 124, 129, 140, 141, 146, 155, 156, 161, 172, 173, 178, 180, 182, 183, 187, 188, 193<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda83,Lambda86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant117,Constant118,Object120,Lambda121,Lambda126,Constant133,Constant134,Constant135,Object136,Lambda137,Lambda142,Constant147,Constant148,Object150,Lambda151,Lambda156,Constant163,Constant164,Constant165,Object166,Lambda167,Lambda172,Lambda174,Lambda176,Constant177,Constant178,Constant179,Object180,Lambda181,Lambda186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193,Constant194,Constant195,Constant196,Constant197,Constant198 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda83,Lambda86,Access87,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant105,Constant106,Constant107,Object108,Lambda109,Lambda114,Constant120,Constant121,Object123,Lambda124,Lambda129,Constant137,Constant138,Constant139,Object140,Lambda141,Lambda146,Constant152,Constant153,Object155,Lambda156,Lambda161,Constant169,Constant170,Constant171,Object172,Lambda173,Lambda178,Lambda180,Lambda182,Access183,Constant184,Constant185,Constant186,Object187,Lambda188,Lambda193,Constant194,Constant195,Constant196,Constant197,Constant198,Constant199,Constant200,Constant201,Constant202,Constant203,Constant204,Constant205 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgSelectSingle{1}ᐸrelational_commentablesᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 86, 91, 96, 83, 107, 112, 121, 126, 137, 142, 151, 156, 167, 172<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 87, 92, 97, 83, 109, 114, 124, 129, 141, 146, 156, 161, 173, 178<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15,PgClassExpression16,PgPolymorphic17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 86, 91, 96, 83, 107, 112, 121, 126, 137, 142, 151, 156, 167, 172, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 41, 61<br />ᐳ: 23, 24, 29, 30, 35, 40, 43, 44, 49, 50, 55, 60, 63, 64, 69, 70, 75, 80"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 87, 92, 97, 83, 109, 114, 124, 129, 141, 146, 156, 161, 173, 178, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 41, 61<br />ᐳ: 23, 24, 29, 30, 35, 40, 43, 44, 49, 50, 55, 60, 63, 64, 69, 70, 75, 80"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect19,First23,PgSelectSingle24,PgSelectSingle29,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgSelect41,First43,PgSelectSingle44,PgSelectSingle49,PgClassExpression50,PgClassExpression55,PgClassExpression60,PgSelect61,First63,PgSelectSingle64,PgSelectSingle69,PgClassExpression70,PgClassExpression75,PgClassExpression80 bucket3
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.mermaid
@@ -11,46 +11,46 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_commentablesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant187 & Lambda174 & Lambda176 & Lambda181 & Lambda186 --> PgSelect7
-    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access183{{"Access[183∈0] ➊<br />ᐸ182.0ᐳ"}}:::plan
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant194 & Lambda180 & Access183 & Lambda188 & Lambda193 --> PgSelect7
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda83 & Constant103 & Constant104 & Constant105 --> Object106
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda83 & Constant117 & Constant118 & Constant89 --> Object120
-    Object136{{"Object[136∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda83 & Constant133 & Constant134 & Constant135 --> Object136
-    Object150{{"Object[150∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda83 & Constant147 & Constant148 & Constant89 --> Object150
-    Object166{{"Object[166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda83 & Constant163 & Constant164 & Constant165 --> Object166
-    Object180{{"Object[180∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
-    Lambda174 & Constant177 & Constant178 & Constant179 --> Object180
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda83 & Constant88 & Constant89 & Constant90 --> Object91
+    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda83 & Constant105 & Constant106 & Constant107 --> Object108
+    Object123{{"Object[123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda83 & Constant120 & Constant121 & Constant90 --> Object123
+    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda83 & Constant137 & Constant138 & Constant139 --> Object140
+    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda83 & Constant152 & Constant153 & Constant90 --> Object155
+    Object172{{"Object[172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda83 & Constant169 & Constant170 & Constant171 --> Object172
+    Object187{{"Object[187∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
+    Lambda180 & Constant184 & Constant185 & Constant186 --> Object187
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -59,48 +59,52 @@ graph TD
     __Value2 --> Access9
     __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
     PgSelect7 --> __ListTransform11
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant188 --> Lambda83
+    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant195 --> Lambda83
     Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant189 --> Lambda86
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object90 --> Lambda91
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant190 --> Lambda96
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object106 --> Lambda107
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant191 --> Lambda112
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object120 --> Lambda121
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant192 --> Lambda126
-    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object136 --> Lambda137
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant193 --> Lambda142
-    Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object150 --> Lambda151
+    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant196 --> Lambda86
+    Access87{{"Access[87∈0] ➊<br />ᐸ86.0ᐳ"}}:::plan
+    Lambda86 --> Access87
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant197 --> Lambda97
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object108 --> Lambda109
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant198 --> Lambda114
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object123 --> Lambda124
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant199{{"Constant[199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant199 --> Lambda129
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object140 --> Lambda141
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant200 --> Lambda146
     Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant194 --> Lambda156
-    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object166 --> Lambda167
-    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant195 --> Lambda172
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant197 --> Lambda174
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant198 --> Lambda176
-    Object180 --> Lambda181
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant196 --> Lambda186
+    Object155 --> Lambda156
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant201 --> Lambda161
+    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object172 --> Lambda173
+    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant202 --> Lambda178
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant204 --> Lambda180
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant205 --> Lambda182
+    Lambda182 --> Access183
+    Object187 --> Lambda188
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant203 --> Lambda193
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 -.-> __Item12
@@ -116,11 +120,11 @@ graph TD
     PgSelectSingle15 --> PgClassExpression16
     PgSelect19[["PgSelect[19∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
-    Object10 & PgClassExpression18 & Lambda86 & Lambda91 & Lambda96 & Lambda83 & Lambda86 & Lambda107 & Lambda112 --> PgSelect19
+    Object10 & PgClassExpression18 & Access87 & Lambda92 & Lambda97 & Lambda83 & Access87 & Lambda109 & Lambda114 --> PgSelect19
     PgSelect41[["PgSelect[41∈3]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression18 & Lambda86 & Lambda121 & Lambda126 & Lambda83 & Lambda86 & Lambda137 & Lambda142 --> PgSelect41
+    Object10 & PgClassExpression18 & Access87 & Lambda124 & Lambda129 & Lambda83 & Access87 & Lambda141 & Lambda146 --> PgSelect41
     PgSelect61[["PgSelect[61∈3]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression18 & Lambda86 & Lambda151 & Lambda156 & Lambda83 & Lambda86 & Lambda167 & Lambda172 --> PgSelect61
+    Object10 & PgClassExpression18 & Access87 & Lambda156 & Lambda161 & Lambda83 & Access87 & Lambda173 & Lambda178 --> PgSelect61
     PgSelectSingle15 --> PgClassExpression18
     First23{{"First[23∈3]"}}:::plan
     PgSelect19 --> First23
@@ -162,16 +166,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/commentables-simple"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 87, 88, 89, 103, 104, 105, 117, 118, 133, 134, 135, 147, 148, 163, 164, 165, 177, 178, 179, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 10, 83, 86, 90, 91, 96, 106, 107, 112, 120, 121, 126, 136, 137, 142, 150, 151, 156, 166, 167, 172, 174, 176, 180, 181, 186<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 88, 89, 90, 105, 106, 107, 120, 121, 137, 138, 139, 152, 153, 169, 170, 171, 184, 185, 186, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 10, 83, 86, 87, 91, 92, 97, 108, 109, 114, 123, 124, 129, 140, 141, 146, 155, 156, 161, 172, 173, 178, 180, 182, 183, 187, 188, 193<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda83,Lambda86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant117,Constant118,Object120,Lambda121,Lambda126,Constant133,Constant134,Constant135,Object136,Lambda137,Lambda142,Constant147,Constant148,Object150,Lambda151,Lambda156,Constant163,Constant164,Constant165,Object166,Lambda167,Lambda172,Lambda174,Lambda176,Constant177,Constant178,Constant179,Object180,Lambda181,Lambda186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193,Constant194,Constant195,Constant196,Constant197,Constant198 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda83,Lambda86,Access87,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant105,Constant106,Constant107,Object108,Lambda109,Lambda114,Constant120,Constant121,Object123,Lambda124,Lambda129,Constant137,Constant138,Constant139,Object140,Lambda141,Lambda146,Constant152,Constant153,Object155,Lambda156,Lambda161,Constant169,Constant170,Constant171,Object172,Lambda173,Lambda178,Lambda180,Lambda182,Access183,Constant184,Constant185,Constant186,Object187,Lambda188,Lambda193,Constant194,Constant195,Constant196,Constant197,Constant198,Constant199,Constant200,Constant201,Constant202,Constant203,Constant204,Constant205 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgSelectSingle{1}ᐸrelational_commentablesᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 86, 91, 96, 83, 107, 112, 121, 126, 137, 142, 151, 156, 167, 172<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 87, 92, 97, 83, 109, 114, 124, 129, 141, 146, 156, 161, 173, 178<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15,PgClassExpression16,PgPolymorphic17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 86, 91, 96, 83, 107, 112, 121, 126, 137, 142, 151, 156, 167, 172, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 41, 61<br />ᐳ: 23, 24, 29, 30, 35, 40, 43, 44, 49, 50, 55, 60, 63, 64, 69, 70, 75, 80"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 87, 92, 97, 83, 109, 114, 124, 129, 141, 146, 156, 161, 173, 178, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 41, 61<br />ᐳ: 23, 24, 29, 30, 35, 40, 43, 44, 49, 50, 55, 60, 63, 64, 69, 70, 75, 80"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect19,First23,PgSelectSingle24,PgSelectSingle29,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgSelect41,First43,PgSelectSingle44,PgSelectSingle49,PgClassExpression50,PgClassExpression55,PgClassExpression60,PgSelect61,First63,PgSelectSingle64,PgSelectSingle69,PgClassExpression70,PgClassExpression75,PgClassExpression80 bucket3
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.mermaid
@@ -12,43 +12,43 @@ graph TD
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_commentablesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda89 & Lambda92 & Lambda187 & Lambda192 --> PgSelect7
-    Object96{{"Object[96∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda89 & Constant93 & Constant94 & Constant95 --> Object96
-    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda89 & Constant109 & Constant110 & Constant111 --> Object112
-    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda89 & Constant123 & Constant124 & Constant95 --> Object126
-    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda89 & Constant139 & Constant140 & Constant141 --> Object142
-    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda89 & Constant153 & Constant154 & Constant95 --> Object156
-    Object172{{"Object[172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda89 & Constant169 & Constant170 & Constant171 --> Object172
-    Object186{{"Object[186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
-    Lambda89 & Constant183 & Constant184 & Constant185 --> Object186
+    Access93{{"Access[93∈0] ➊<br />ᐸ92.0ᐳ"}}:::plan
+    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda199{{"Lambda[199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda89 & Access93 & Lambda194 & Lambda199 --> PgSelect7
+    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda89 & Constant94 & Constant95 & Constant96 --> Object97
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda89 & Constant111 & Constant112 & Constant113 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda89 & Constant126 & Constant127 & Constant96 --> Object129
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda89 & Constant143 & Constant144 & Constant145 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda89 & Constant158 & Constant159 & Constant96 --> Object161
+    Object178{{"Object[178∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda89 & Constant175 & Constant176 & Constant177 --> Object178
+    Object193{{"Object[193∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
+    Lambda89 & Constant190 & Constant191 & Constant192 --> Object193
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -57,43 +57,45 @@ graph TD
     __Value2 --> Access9
     __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
     PgSelect7 --> __ListTransform11
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant193 --> Lambda89
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant194 --> Lambda92
-    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object96 --> Lambda97
-    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant195 --> Lambda102
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object112 --> Lambda113
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant196 --> Lambda118
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object126 --> Lambda127
-    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant197 --> Lambda132
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object142 --> Lambda143
-    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant198 --> Lambda148
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object156 --> Lambda157
+    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant200 --> Lambda89
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant201 --> Lambda92
+    Lambda92 --> Access93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object97 --> Lambda98
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant202 --> Lambda103
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant203 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant204 --> Lambda135
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object146 --> Lambda147
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant205 --> Lambda152
     Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant199{{"Constant[199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant199 --> Lambda162
-    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object172 --> Lambda173
-    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant200 --> Lambda178
-    Object186 --> Lambda187
-    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant201 --> Lambda192
+    Object161 --> Lambda162
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant206 --> Lambda167
+    Lambda179{{"Lambda[179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object178 --> Lambda179
+    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant207 --> Lambda184
+    Object193 --> Lambda194
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant208 --> Lambda199
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 -.-> __Item12
@@ -109,11 +111,11 @@ graph TD
     PgSelectSingle15 --> PgClassExpression16
     PgSelect19[["PgSelect[19∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
-    Object10 & PgClassExpression18 & Lambda92 & Lambda97 & Lambda102 & Lambda89 & Lambda92 & Lambda113 & Lambda118 --> PgSelect19
+    Object10 & PgClassExpression18 & Access93 & Lambda98 & Lambda103 & Lambda89 & Access93 & Lambda115 & Lambda120 --> PgSelect19
     PgSelect44[["PgSelect[44∈3]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression18 & Lambda92 & Lambda127 & Lambda132 & Lambda89 & Lambda92 & Lambda143 & Lambda148 --> PgSelect44
+    Object10 & PgClassExpression18 & Access93 & Lambda130 & Lambda135 & Lambda89 & Access93 & Lambda147 & Lambda152 --> PgSelect44
     PgSelect65[["PgSelect[65∈3]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression18 & Lambda92 & Lambda157 & Lambda162 & Lambda89 & Lambda92 & Lambda173 & Lambda178 --> PgSelect65
+    Object10 & PgClassExpression18 & Access93 & Lambda162 & Lambda167 & Lambda89 & Access93 & Lambda179 & Lambda184 --> PgSelect65
     PgSelectSingle15 --> PgClassExpression18
     First23{{"First[23∈3]"}}:::plan
     PgSelect19 --> First23
@@ -173,16 +175,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/commentables"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 93, 94, 95, 109, 110, 111, 123, 124, 139, 140, 141, 153, 154, 169, 170, 171, 183, 184, 185, 193, 194, 195, 196, 197, 198, 199, 200, 201, 10, 89, 92, 96, 97, 102, 112, 113, 118, 126, 127, 132, 142, 143, 148, 156, 157, 162, 172, 173, 178, 186, 187, 192<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 94, 95, 96, 111, 112, 113, 126, 127, 143, 144, 145, 158, 159, 175, 176, 177, 190, 191, 192, 200, 201, 202, 203, 204, 205, 206, 207, 208, 10, 89, 92, 93, 97, 98, 103, 114, 115, 120, 129, 130, 135, 146, 147, 152, 161, 162, 167, 178, 179, 184, 193, 194, 199<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda89,Lambda92,Constant93,Constant94,Constant95,Object96,Lambda97,Lambda102,Constant109,Constant110,Constant111,Object112,Lambda113,Lambda118,Constant123,Constant124,Object126,Lambda127,Lambda132,Constant139,Constant140,Constant141,Object142,Lambda143,Lambda148,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant169,Constant170,Constant171,Object172,Lambda173,Lambda178,Constant183,Constant184,Constant185,Object186,Lambda187,Lambda192,Constant193,Constant194,Constant195,Constant196,Constant197,Constant198,Constant199,Constant200,Constant201 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda89,Lambda92,Access93,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Constant111,Constant112,Constant113,Object114,Lambda115,Lambda120,Constant126,Constant127,Object129,Lambda130,Lambda135,Constant143,Constant144,Constant145,Object146,Lambda147,Lambda152,Constant158,Constant159,Object161,Lambda162,Lambda167,Constant175,Constant176,Constant177,Object178,Lambda179,Lambda184,Constant190,Constant191,Constant192,Object193,Lambda194,Lambda199,Constant200,Constant201,Constant202,Constant203,Constant204,Constant205,Constant206,Constant207,Constant208 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgSelectSingle{1}ᐸrelational_commentablesᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 92, 97, 102, 89, 113, 118, 127, 132, 143, 148, 157, 162, 173, 178<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 93, 98, 103, 89, 115, 120, 130, 135, 147, 152, 162, 167, 179, 184<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15,PgClassExpression16,PgPolymorphic17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 92, 97, 102, 89, 113, 118, 127, 132, 143, 148, 157, 162, 173, 178, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 44, 65<br />ᐳ: 23, 24, 25, 29, 30, 35, 40, 41, 42, 43, 46, 47, 48, 52, 53, 58, 63, 64, 67, 68, 69, 73, 74, 79, 84, 85, 86"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 93, 98, 103, 89, 115, 120, 130, 135, 147, 152, 162, 167, 179, 184, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 44, 65<br />ᐳ: 23, 24, 25, 29, 30, 35, 40, 41, 42, 43, 46, 47, 48, 52, 53, 58, 63, 64, 67, 68, 69, 73, 74, 79, 84, 85, 86"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect19,First23,PgSelectSingle24,PgClassExpression25,PgSelectSingle29,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgSelect44,First46,PgSelectSingle47,PgClassExpression48,PgSelectSingle52,PgClassExpression53,PgClassExpression58,PgClassExpression63,PgClassExpression64,PgSelect65,First67,PgSelectSingle68,PgClassExpression69,PgSelectSingle73,PgClassExpression74,PgClassExpression79,PgClassExpression84,PgClassExpression85,PgClassExpression86 bucket3
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.mermaid
@@ -12,43 +12,43 @@ graph TD
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_commentablesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda89 & Lambda92 & Lambda187 & Lambda192 --> PgSelect7
-    Object96{{"Object[96∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda89 & Constant93 & Constant94 & Constant95 --> Object96
-    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda89 & Constant109 & Constant110 & Constant111 --> Object112
-    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda89 & Constant123 & Constant124 & Constant95 --> Object126
-    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda89 & Constant139 & Constant140 & Constant141 --> Object142
-    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda89 & Constant153 & Constant154 & Constant95 --> Object156
-    Object172{{"Object[172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda89 & Constant169 & Constant170 & Constant171 --> Object172
-    Object186{{"Object[186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
-    Lambda89 & Constant183 & Constant184 & Constant185 --> Object186
+    Access93{{"Access[93∈0] ➊<br />ᐸ92.0ᐳ"}}:::plan
+    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda199{{"Lambda[199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda89 & Access93 & Lambda194 & Lambda199 --> PgSelect7
+    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda89 & Constant94 & Constant95 & Constant96 --> Object97
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda89 & Constant111 & Constant112 & Constant113 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda89 & Constant126 & Constant127 & Constant96 --> Object129
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda89 & Constant143 & Constant144 & Constant145 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda89 & Constant158 & Constant159 & Constant96 --> Object161
+    Object178{{"Object[178∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda89 & Constant175 & Constant176 & Constant177 --> Object178
+    Object193{{"Object[193∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 198ᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸsql.identifier(”relational_commentables”)ᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸRecordCodec(relational_commentables)ᐳ"}}:::plan
+    Lambda89 & Constant190 & Constant191 & Constant192 --> Object193
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -57,43 +57,45 @@ graph TD
     __Value2 --> Access9
     __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
     PgSelect7 --> __ListTransform11
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant193 --> Lambda89
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant194 --> Lambda92
-    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object96 --> Lambda97
-    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant195 --> Lambda102
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object112 --> Lambda113
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant196 --> Lambda118
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object126 --> Lambda127
-    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant197 --> Lambda132
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object142 --> Lambda143
-    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant198 --> Lambda148
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object156 --> Lambda157
+    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant200 --> Lambda89
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant201 --> Lambda92
+    Lambda92 --> Access93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object97 --> Lambda98
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant202 --> Lambda103
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant203 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant204 --> Lambda135
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object146 --> Lambda147
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant205 --> Lambda152
     Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant199{{"Constant[199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant199 --> Lambda162
-    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object172 --> Lambda173
-    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant200 --> Lambda178
-    Object186 --> Lambda187
-    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant201 --> Lambda192
+    Object161 --> Lambda162
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant206 --> Lambda167
+    Lambda179{{"Lambda[179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object178 --> Lambda179
+    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant207 --> Lambda184
+    Object193 --> Lambda194
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant208 --> Lambda199
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 -.-> __Item12
@@ -109,11 +111,11 @@ graph TD
     PgSelectSingle15 --> PgClassExpression16
     PgSelect19[["PgSelect[19∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
-    Object10 & PgClassExpression18 & Lambda92 & Lambda97 & Lambda102 & Lambda89 & Lambda92 & Lambda113 & Lambda118 --> PgSelect19
+    Object10 & PgClassExpression18 & Access93 & Lambda98 & Lambda103 & Lambda89 & Access93 & Lambda115 & Lambda120 --> PgSelect19
     PgSelect44[["PgSelect[44∈3]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression18 & Lambda92 & Lambda127 & Lambda132 & Lambda89 & Lambda92 & Lambda143 & Lambda148 --> PgSelect44
+    Object10 & PgClassExpression18 & Access93 & Lambda130 & Lambda135 & Lambda89 & Access93 & Lambda147 & Lambda152 --> PgSelect44
     PgSelect65[["PgSelect[65∈3]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression18 & Lambda92 & Lambda157 & Lambda162 & Lambda89 & Lambda92 & Lambda173 & Lambda178 --> PgSelect65
+    Object10 & PgClassExpression18 & Access93 & Lambda162 & Lambda167 & Lambda89 & Access93 & Lambda179 & Lambda184 --> PgSelect65
     PgSelectSingle15 --> PgClassExpression18
     First23{{"First[23∈3]"}}:::plan
     PgSelect19 --> First23
@@ -173,16 +175,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/commentables"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 93, 94, 95, 109, 110, 111, 123, 124, 139, 140, 141, 153, 154, 169, 170, 171, 183, 184, 185, 193, 194, 195, 196, 197, 198, 199, 200, 201, 10, 89, 92, 96, 97, 102, 112, 113, 118, 126, 127, 132, 142, 143, 148, 156, 157, 162, 172, 173, 178, 186, 187, 192<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 94, 95, 96, 111, 112, 113, 126, 127, 143, 144, 145, 158, 159, 175, 176, 177, 190, 191, 192, 200, 201, 202, 203, 204, 205, 206, 207, 208, 10, 89, 92, 93, 97, 98, 103, 114, 115, 120, 129, 130, 135, 146, 147, 152, 161, 162, 167, 178, 179, 184, 193, 194, 199<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda89,Lambda92,Constant93,Constant94,Constant95,Object96,Lambda97,Lambda102,Constant109,Constant110,Constant111,Object112,Lambda113,Lambda118,Constant123,Constant124,Object126,Lambda127,Lambda132,Constant139,Constant140,Constant141,Object142,Lambda143,Lambda148,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant169,Constant170,Constant171,Object172,Lambda173,Lambda178,Constant183,Constant184,Constant185,Object186,Lambda187,Lambda192,Constant193,Constant194,Constant195,Constant196,Constant197,Constant198,Constant199,Constant200,Constant201 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda89,Lambda92,Access93,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Constant111,Constant112,Constant113,Object114,Lambda115,Lambda120,Constant126,Constant127,Object129,Lambda130,Lambda135,Constant143,Constant144,Constant145,Object146,Lambda147,Lambda152,Constant158,Constant159,Object161,Lambda162,Lambda167,Constant175,Constant176,Constant177,Object178,Lambda179,Lambda184,Constant190,Constant191,Constant192,Object193,Lambda194,Lambda199,Constant200,Constant201,Constant202,Constant203,Constant204,Constant205,Constant206,Constant207,Constant208 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgSelectSingle{1}ᐸrelational_commentablesᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 92, 97, 102, 89, 113, 118, 127, 132, 143, 148, 157, 162, 173, 178<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 93, 98, 103, 89, 115, 120, 130, 135, 147, 152, 162, 167, 179, 184<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15,PgClassExpression16,PgPolymorphic17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 92, 97, 102, 89, 113, 118, 127, 132, 143, 148, 157, 162, 173, 178, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 44, 65<br />ᐳ: 23, 24, 25, 29, 30, 35, 40, 41, 42, 43, 46, 47, 48, 52, 53, 58, 63, 64, 67, 68, 69, 73, 74, 79, 84, 85, 86"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 15, 10, 93, 98, 103, 89, 115, 120, 130, 135, 147, 152, 162, 167, 179, 184, 17<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[18]<br />2: 19, 44, 65<br />ᐳ: 23, 24, 25, 29, 30, 35, 40, 41, 42, 43, 46, 47, 48, 52, 53, 58, 63, 64, 67, 68, 69, 73, 74, 79, 84, 85, 86"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect19,First23,PgSelectSingle24,PgClassExpression25,PgSelectSingle29,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgSelect44,First46,PgSelectSingle47,PgClassExpression48,PgSelectSingle52,PgClassExpression53,PgClassExpression58,PgClassExpression63,PgClassExpression64,PgSelect65,First67,PgSelectSingle68,PgClassExpression69,PgSelectSingle73,PgClassExpression74,PgClassExpression79,PgClassExpression84,PgClassExpression85,PgClassExpression86 bucket3
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.mermaid
@@ -12,168 +12,170 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda343{{"Lambda[343∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda544{{"Lambda[544∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda549{{"Lambda[549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda340 & Lambda343 & Lambda544 & Lambda549 --> PgSelect6
-    Object347{{"Object[347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda340 & Constant344 & Constant345 & Constant346 --> Object347
-    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant360{{"Constant[360∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda340 & Constant358 & Constant359 & Constant360 --> Object361
-    Object375{{"Object[375∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda340 & Constant372 & Constant373 & Constant374 --> Object375
-    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda340 & Constant386 & Constant387 & Constant388 --> Object389
-    Object403{{"Object[403∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda340 & Constant400 & Constant401 & Constant402 --> Object403
-    Object417{{"Object[417∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda340 & Constant414 & Constant415 & Constant346 --> Object417
-    Object431{{"Object[431∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda340 & Constant428 & Constant429 & Constant360 --> Object431
-    Object445{{"Object[445∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda340 & Constant442 & Constant443 & Constant374 --> Object445
-    Object459{{"Object[459∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant456{{"Constant[456∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant457{{"Constant[457∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda340 & Constant456 & Constant457 & Constant388 --> Object459
-    Object473{{"Object[473∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda340 & Constant470 & Constant471 & Constant402 --> Object473
-    Object487{{"Object[487∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant484{{"Constant[484∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant485{{"Constant[485∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda340 & Constant484 & Constant485 & Constant486 --> Object487
-    Object501{{"Object[501∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant498{{"Constant[498∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant499{{"Constant[499∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant500{{"Constant[500∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda340 & Constant498 & Constant499 & Constant500 --> Object501
-    Object515{{"Object[515∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant512{{"Constant[512∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant513{{"Constant[513∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda340 & Constant512 & Constant513 & Constant486 --> Object515
+    Access344{{"Access[344∈0] ➊<br />ᐸ343.0ᐳ"}}:::plan
+    Lambda559{{"Lambda[559∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda564{{"Lambda[564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda340 & Access344 & Lambda559 & Lambda564 --> PgSelect6
+    Object348{{"Object[348∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant347{{"Constant[347∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda340 & Constant345 & Constant346 & Constant347 --> Object348
+    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant362{{"Constant[362∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda340 & Constant360 & Constant361 & Constant362 --> Object363
+    Object378{{"Object[378∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant377{{"Constant[377∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda340 & Constant375 & Constant376 & Constant377 --> Object378
+    Object393{{"Object[393∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda340 & Constant390 & Constant391 & Constant392 --> Object393
+    Object408{{"Object[408∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda340 & Constant405 & Constant406 & Constant407 --> Object408
+    Object423{{"Object[423∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda340 & Constant420 & Constant421 & Constant347 --> Object423
+    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda340 & Constant435 & Constant436 & Constant362 --> Object438
+    Object453{{"Object[453∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda340 & Constant450 & Constant451 & Constant377 --> Object453
+    Object468{{"Object[468∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda340 & Constant465 & Constant466 & Constant392 --> Object468
+    Object483{{"Object[483∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda340 & Constant480 & Constant481 & Constant407 --> Object483
+    Object498{{"Object[498∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant495{{"Constant[495∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant496{{"Constant[496∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant497{{"Constant[497∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda340 & Constant495 & Constant496 & Constant497 --> Object498
+    Object513{{"Object[513∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant510{{"Constant[510∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant511{{"Constant[511∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant512{{"Constant[512∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda340 & Constant510 & Constant511 & Constant512 --> Object513
+    Object528{{"Object[528∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant525{{"Constant[525∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant526{{"Constant[526∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda340 & Constant525 & Constant526 & Constant497 --> Object528
     Object543{{"Object[543∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant540{{"Constant[540∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant541{{"Constant[541∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda340 & Constant540 & Constant541 & Constant486 --> Object543
+    Constant540{{"Constant[540∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant541{{"Constant[541∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda340 & Constant540 & Constant541 & Constant512 --> Object543
+    Object558{{"Object[558∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant555{{"Constant[555∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant556{{"Constant[556∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda340 & Constant555 & Constant556 & Constant497 --> Object558
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant550{{"Constant[550∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant550 --> Lambda340
-    Constant551{{"Constant[551∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant551 --> Lambda343
-    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object347 --> Lambda348
-    Lambda353{{"Lambda[353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant552{{"Constant[552∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant552 --> Lambda353
-    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object361 --> Lambda362
-    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant553{{"Constant[553∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant553 --> Lambda367
-    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object375 --> Lambda376
-    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant554{{"Constant[554∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant554 --> Lambda381
-    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object389 --> Lambda390
-    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant555{{"Constant[555∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant555 --> Lambda395
-    Lambda404{{"Lambda[404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object403 --> Lambda404
+    Constant565{{"Constant[565∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant565 --> Lambda340
+    Lambda343{{"Lambda[343∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant566{{"Constant[566∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant566 --> Lambda343
+    Lambda343 --> Access344
+    Lambda349{{"Lambda[349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object348 --> Lambda349
+    Lambda354{{"Lambda[354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant567{{"Constant[567∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant567 --> Lambda354
+    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object363 --> Lambda364
+    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant568{{"Constant[568∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant568 --> Lambda369
+    Lambda379{{"Lambda[379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object378 --> Lambda379
+    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant569{{"Constant[569∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant569 --> Lambda384
+    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object393 --> Lambda394
+    Lambda399{{"Lambda[399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant570{{"Constant[570∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant570 --> Lambda399
     Lambda409{{"Lambda[409∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant556 --> Lambda409
-    Lambda418{{"Lambda[418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object417 --> Lambda418
-    Lambda423{{"Lambda[423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant557 --> Lambda423
-    Lambda432{{"Lambda[432∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object431 --> Lambda432
-    Lambda437{{"Lambda[437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant558{{"Constant[558∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant558 --> Lambda437
-    Lambda446{{"Lambda[446∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object445 --> Lambda446
-    Lambda451{{"Lambda[451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant559{{"Constant[559∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant559 --> Lambda451
-    Lambda460{{"Lambda[460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object459 --> Lambda460
-    Lambda465{{"Lambda[465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant560{{"Constant[560∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant560 --> Lambda465
+    Object408 --> Lambda409
+    Lambda414{{"Lambda[414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant571{{"Constant[571∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant571 --> Lambda414
+    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object423 --> Lambda424
+    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant572{{"Constant[572∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant572 --> Lambda429
+    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object438 --> Lambda439
+    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant573{{"Constant[573∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant573 --> Lambda444
+    Lambda454{{"Lambda[454∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object453 --> Lambda454
+    Lambda459{{"Lambda[459∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant574{{"Constant[574∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant574 --> Lambda459
+    Lambda469{{"Lambda[469∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object468 --> Lambda469
     Lambda474{{"Lambda[474∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object473 --> Lambda474
-    Lambda479{{"Lambda[479∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant561{{"Constant[561∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant561 --> Lambda479
-    Lambda488{{"Lambda[488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object487 --> Lambda488
-    Lambda493{{"Lambda[493∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant562{{"Constant[562∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant562 --> Lambda493
-    Lambda502{{"Lambda[502∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object501 --> Lambda502
-    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant563{{"Constant[563∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant563 --> Lambda507
-    Lambda516{{"Lambda[516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object515 --> Lambda516
-    Lambda521{{"Lambda[521∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant564 --> Lambda521
+    Constant575{{"Constant[575∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant575 --> Lambda474
+    Lambda484{{"Lambda[484∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object483 --> Lambda484
+    Lambda489{{"Lambda[489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant576{{"Constant[576∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant576 --> Lambda489
+    Lambda499{{"Lambda[499∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object498 --> Lambda499
+    Lambda504{{"Lambda[504∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant577{{"Constant[577∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant577 --> Lambda504
+    Lambda514{{"Lambda[514∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object513 --> Lambda514
+    Lambda519{{"Lambda[519∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant578 --> Lambda519
+    Lambda529{{"Lambda[529∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object528 --> Lambda529
+    Lambda534{{"Lambda[534∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant579{{"Constant[579∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant579 --> Lambda534
+    Lambda544{{"Lambda[544∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object543 --> Lambda544
-    Constant566{{"Constant[566∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant566 --> Lambda549
+    Lambda549{{"Lambda[549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant580{{"Constant[580∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant580 --> Lambda549
+    Object558 --> Lambda559
+    Constant581{{"Constant[581∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant581 --> Lambda564
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant526{{"Constant[526∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant527{{"Constant[527∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant565{{"Constant[565∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object529{{"Object[529∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda340 & Constant526 & Constant527 & Constant500 --> Object529
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda530{{"Lambda[530∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object529 --> Lambda530
-    Lambda535{{"Lambda[535∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant565 --> Lambda535
     PgSelect14[["PgSelect[14∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda340 & Lambda343 & Lambda530 & Lambda535 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda340 & Access344 & Lambda544 & Lambda549 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -193,21 +195,21 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda348 & Lambda353 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda349 & Lambda354 --> PgSelect26
     PgSelect33[["PgSelect[33∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression32 & Lambda340 & Lambda343 & Lambda502 & Lambda507 --> PgSelect33
+    Object9 & PgClassExpression32 & Lambda340 & Access344 & Lambda514 & Lambda519 --> PgSelect33
     PgSelect103[["PgSelect[103∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression102{{"PgClassExpression[102∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression102 & Lambda340 & Lambda343 & Lambda516 & Lambda521 --> PgSelect103
+    Object9 & PgClassExpression102 & Lambda340 & Access344 & Lambda529 & Lambda534 --> PgSelect103
     PgSelect114[["PgSelect[114∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda362 & Lambda367 --> PgSelect114
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda364 & Lambda369 --> PgSelect114
     PgSelect171[["PgSelect[171∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda376 & Lambda381 --> PgSelect171
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda379 & Lambda384 --> PgSelect171
     PgSelect227[["PgSelect[227∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda390 & Lambda395 --> PgSelect227
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda394 & Lambda399 --> PgSelect227
     PgSelect282[["PgSelect[282∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda404 & Lambda409 --> PgSelect282
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda409 & Lambda414 --> PgSelect282
     PgPolymorphic38{{"PgPolymorphic[38∈5]<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -275,18 +277,18 @@ graph TD
     PgSelectSingle285 --> PgClassExpression337
     PgSelect40[["PgSelect[40∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda418 & Lambda423 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda424 & Lambda429 --> PgSelect40
     PgSelect49[["PgSelect[49∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     PgClassExpression48{{"PgClassExpression[48∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression48 & Lambda340 & Lambda343 & Lambda488 & Lambda493 --> PgSelect49
+    Object9 & PgClassExpression48 & Lambda340 & Access344 & Lambda499 & Lambda504 --> PgSelect49
     PgSelect60[["PgSelect[60∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda432 & Lambda437 --> PgSelect60
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda439 & Lambda444 --> PgSelect60
     PgSelect71[["PgSelect[71∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda446 & Lambda451 --> PgSelect71
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda454 & Lambda459 --> PgSelect71
     PgSelect81[["PgSelect[81∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda460 & Lambda465 --> PgSelect81
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda469 & Lambda474 --> PgSelect81
     PgSelect90[["PgSelect[90∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda474 & Lambda479 --> PgSelect90
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda484 & Lambda489 --> PgSelect90
     PgSelectSingle36 --> PgClassExpression39
     First44{{"First[44∈6]"}}:::plan
     PgSelect40 --> First44
@@ -351,25 +353,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/nested-more-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 344, 345, 346, 358, 359, 360, 372, 373, 374, 386, 387, 388, 400, 401, 402, 414, 415, 428, 429, 442, 443, 456, 457, 470, 471, 484, 485, 486, 498, 499, 500, 512, 513, 526, 527, 540, 541, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 9, 340, 343, 347, 348, 353, 361, 362, 367, 375, 376, 381, 389, 390, 395, 403, 404, 409, 417, 418, 423, 431, 432, 437, 445, 446, 451, 459, 460, 465, 473, 474, 479, 487, 488, 493, 501, 502, 507, 515, 516, 521, 543, 544, 549<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 345, 346, 347, 360, 361, 362, 375, 376, 377, 390, 391, 392, 405, 406, 407, 420, 421, 435, 436, 450, 451, 465, 466, 480, 481, 495, 496, 497, 510, 511, 512, 525, 526, 540, 541, 555, 556, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 9, 340, 343, 344, 348, 349, 354, 363, 364, 369, 378, 379, 384, 393, 394, 399, 408, 409, 414, 423, 424, 429, 438, 439, 444, 453, 454, 459, 468, 469, 474, 483, 484, 489, 498, 499, 504, 513, 514, 519, 528, 529, 534, 543, 544, 549, 558, 559, 564<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda340,Lambda343,Constant344,Constant345,Constant346,Object347,Lambda348,Lambda353,Constant358,Constant359,Constant360,Object361,Lambda362,Lambda367,Constant372,Constant373,Constant374,Object375,Lambda376,Lambda381,Constant386,Constant387,Constant388,Object389,Lambda390,Lambda395,Constant400,Constant401,Constant402,Object403,Lambda404,Lambda409,Constant414,Constant415,Object417,Lambda418,Lambda423,Constant428,Constant429,Object431,Lambda432,Lambda437,Constant442,Constant443,Object445,Lambda446,Lambda451,Constant456,Constant457,Object459,Lambda460,Lambda465,Constant470,Constant471,Object473,Lambda474,Lambda479,Constant484,Constant485,Constant486,Object487,Lambda488,Lambda493,Constant498,Constant499,Constant500,Object501,Lambda502,Lambda507,Constant512,Constant513,Object515,Lambda516,Lambda521,Constant526,Constant527,Constant540,Constant541,Object543,Lambda544,Lambda549,Constant550,Constant551,Constant552,Constant553,Constant554,Constant555,Constant556,Constant557,Constant558,Constant559,Constant560,Constant561,Constant562,Constant563,Constant564,Constant565,Constant566 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 340, 526, 527, 500, 565, 9, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda340,Lambda343,Access344,Constant345,Constant346,Constant347,Object348,Lambda349,Lambda354,Constant360,Constant361,Constant362,Object363,Lambda364,Lambda369,Constant375,Constant376,Constant377,Object378,Lambda379,Lambda384,Constant390,Constant391,Constant392,Object393,Lambda394,Lambda399,Constant405,Constant406,Constant407,Object408,Lambda409,Lambda414,Constant420,Constant421,Object423,Lambda424,Lambda429,Constant435,Constant436,Object438,Lambda439,Lambda444,Constant450,Constant451,Object453,Lambda454,Lambda459,Constant465,Constant466,Object468,Lambda469,Lambda474,Constant480,Constant481,Object483,Lambda484,Lambda489,Constant495,Constant496,Constant497,Object498,Lambda499,Lambda504,Constant510,Constant511,Constant512,Object513,Lambda514,Lambda519,Constant525,Constant526,Object528,Lambda529,Lambda534,Constant540,Constant541,Object543,Lambda544,Lambda549,Constant555,Constant556,Object558,Lambda559,Lambda564,Constant565,Constant566,Constant567,Constant568,Constant569,Constant570,Constant571,Constant572,Constant573,Constant574,Constant575,Constant576,Constant577,Constant578,Constant579,Constant580,Constant581 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 340, 344, 544, 549, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object529,Lambda530,Lambda535 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 340, 343, 530, 535, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 340, 344, 544, 549, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 340, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 340, 344, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 340, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 24, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 101, 102, 108, 109, 110, 111, 112<br />2: 26, 33, 103, 114, 171, 227, 282<br />ᐳ: 30, 31, 35, 36, 37, 38, 105, 106, 113, 116, 117, 168, 169, 170, 173, 174, 225, 226, 229, 230, 281, 284, 285, 336, 337"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 340, 344, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 24, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 101, 102, 108, 109, 110, 111, 112<br />2: 26, 33, 103, 114, 171, 227, 282<br />ᐳ: 30, 31, 35, 36, 37, 38, 105, 106, 113, 116, 117, 168, 169, 170, 173, 174, 225, 226, 229, 230, 281, 284, 285, 336, 337"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression32,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,PgPolymorphic38,PgClassExpression101,PgClassExpression102,PgSelect103,First105,PgSelectSingle106,PgClassExpression108,PgClassExpression109,PgClassExpression110,PgClassExpression111,PgClassExpression112,PgClassExpression113,PgSelect114,First116,PgSelectSingle117,PgClassExpression168,PgClassExpression169,PgClassExpression170,PgSelect171,First173,PgSelectSingle174,PgClassExpression225,PgClassExpression226,PgSelect227,First229,PgSelectSingle230,PgClassExpression281,PgSelect282,First284,PgSelectSingle285,PgClassExpression336,PgClassExpression337 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 340, 343, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 60, 71, 81, 90<br />ᐳ: 44, 45, 51, 52, 59, 62, 63, 68, 69, 70, 73, 74, 79, 80, 83, 84, 89, 92, 93, 98, 99"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 340, 344, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 60, 71, 81, 90<br />ᐳ: 44, 45, 51, 52, 59, 62, 63, 68, 69, 70, 73, 74, 79, 80, 83, 84, 89, 92, 93, 98, 99"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectSingle52,PgClassExpression54,PgClassExpression55,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgSelect60,First62,PgSelectSingle63,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgSelect71,First73,PgSelectSingle74,PgClassExpression79,PgClassExpression80,PgSelect81,First83,PgSelectSingle84,PgClassExpression89,PgSelect90,First92,PgSelectSingle93,PgClassExpression98,PgClassExpression99 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 52<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[52]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.mermaid
@@ -11,161 +11,163 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda343{{"Lambda[343∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda530{{"Lambda[530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda535{{"Lambda[535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access344{{"Access[344∈0] ➊<br />ᐸ343.0ᐳ"}}:::plan
+    Lambda544{{"Lambda[544∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda549{{"Lambda[549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda554{{"Lambda[554∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda343 & Lambda530 & Lambda535 & Lambda340 & Lambda343 & Lambda549 & Lambda554 --> PgSelect6
-    Object347{{"Object[347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda340 & Constant344 & Constant345 & Constant346 --> Object347
-    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant360{{"Constant[360∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda340 & Constant358 & Constant359 & Constant360 --> Object361
-    Object375{{"Object[375∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda340 & Constant372 & Constant373 & Constant374 --> Object375
-    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda340 & Constant386 & Constant387 & Constant388 --> Object389
-    Object403{{"Object[403∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda340 & Constant400 & Constant401 & Constant402 --> Object403
-    Object417{{"Object[417∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda340 & Constant414 & Constant415 & Constant346 --> Object417
-    Object431{{"Object[431∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda340 & Constant428 & Constant429 & Constant360 --> Object431
-    Object445{{"Object[445∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda340 & Constant442 & Constant443 & Constant374 --> Object445
-    Object459{{"Object[459∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant456{{"Constant[456∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant457{{"Constant[457∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda340 & Constant456 & Constant457 & Constant388 --> Object459
-    Object473{{"Object[473∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda340 & Constant470 & Constant471 & Constant402 --> Object473
-    Object487{{"Object[487∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant484{{"Constant[484∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant485{{"Constant[485∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda340 & Constant484 & Constant485 & Constant486 --> Object487
-    Object501{{"Object[501∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant498{{"Constant[498∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant499{{"Constant[499∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant500{{"Constant[500∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda340 & Constant498 & Constant499 & Constant500 --> Object501
-    Object515{{"Object[515∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant512{{"Constant[512∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant513{{"Constant[513∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda340 & Constant512 & Constant513 & Constant486 --> Object515
-    Object529{{"Object[529∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant526{{"Constant[526∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant527{{"Constant[527∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda340 & Constant526 & Constant527 & Constant500 --> Object529
-    Object548{{"Object[548∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant545{{"Constant[545∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant546{{"Constant[546∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda340 & Constant545 & Constant546 & Constant486 --> Object548
+    Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda564{{"Lambda[564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda569{{"Lambda[569∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access344 & Lambda544 & Lambda549 & Lambda340 & Access344 & Lambda564 & Lambda569 --> PgSelect6
+    Object348{{"Object[348∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant347{{"Constant[347∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda340 & Constant345 & Constant346 & Constant347 --> Object348
+    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant362{{"Constant[362∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda340 & Constant360 & Constant361 & Constant362 --> Object363
+    Object378{{"Object[378∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant377{{"Constant[377∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda340 & Constant375 & Constant376 & Constant377 --> Object378
+    Object393{{"Object[393∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda340 & Constant390 & Constant391 & Constant392 --> Object393
+    Object408{{"Object[408∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda340 & Constant405 & Constant406 & Constant407 --> Object408
+    Object423{{"Object[423∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda340 & Constant420 & Constant421 & Constant347 --> Object423
+    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda340 & Constant435 & Constant436 & Constant362 --> Object438
+    Object453{{"Object[453∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda340 & Constant450 & Constant451 & Constant377 --> Object453
+    Object468{{"Object[468∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda340 & Constant465 & Constant466 & Constant392 --> Object468
+    Object483{{"Object[483∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda340 & Constant480 & Constant481 & Constant407 --> Object483
+    Object498{{"Object[498∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant495{{"Constant[495∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant496{{"Constant[496∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant497{{"Constant[497∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda340 & Constant495 & Constant496 & Constant497 --> Object498
+    Object513{{"Object[513∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant510{{"Constant[510∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant511{{"Constant[511∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant512{{"Constant[512∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda340 & Constant510 & Constant511 & Constant512 --> Object513
+    Object528{{"Object[528∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant525{{"Constant[525∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant526{{"Constant[526∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda340 & Constant525 & Constant526 & Constant497 --> Object528
+    Object543{{"Object[543∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant540{{"Constant[540∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant541{{"Constant[541∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda340 & Constant540 & Constant541 & Constant512 --> Object543
+    Object563{{"Object[563∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant560{{"Constant[560∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant561{{"Constant[561∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda340 & Constant560 & Constant561 & Constant497 --> Object563
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant555{{"Constant[555∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant555 --> Lambda340
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant556 --> Lambda343
-    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object347 --> Lambda348
-    Lambda353{{"Lambda[353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant557 --> Lambda353
-    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object361 --> Lambda362
-    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant558{{"Constant[558∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant558 --> Lambda367
-    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object375 --> Lambda376
-    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant559{{"Constant[559∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant559 --> Lambda381
-    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object389 --> Lambda390
-    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant560{{"Constant[560∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant560 --> Lambda395
-    Lambda404{{"Lambda[404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object403 --> Lambda404
+    Constant570{{"Constant[570∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant570 --> Lambda340
+    Lambda343{{"Lambda[343∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant571{{"Constant[571∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant571 --> Lambda343
+    Lambda343 --> Access344
+    Lambda349{{"Lambda[349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object348 --> Lambda349
+    Lambda354{{"Lambda[354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant572{{"Constant[572∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant572 --> Lambda354
+    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object363 --> Lambda364
+    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant573{{"Constant[573∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant573 --> Lambda369
+    Lambda379{{"Lambda[379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object378 --> Lambda379
+    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant574{{"Constant[574∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant574 --> Lambda384
+    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object393 --> Lambda394
+    Lambda399{{"Lambda[399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant575{{"Constant[575∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant575 --> Lambda399
     Lambda409{{"Lambda[409∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant561{{"Constant[561∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant561 --> Lambda409
-    Lambda418{{"Lambda[418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object417 --> Lambda418
-    Lambda423{{"Lambda[423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant562{{"Constant[562∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant562 --> Lambda423
-    Lambda432{{"Lambda[432∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object431 --> Lambda432
-    Lambda437{{"Lambda[437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant563{{"Constant[563∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant563 --> Lambda437
-    Lambda446{{"Lambda[446∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object445 --> Lambda446
-    Lambda451{{"Lambda[451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant564 --> Lambda451
-    Lambda460{{"Lambda[460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object459 --> Lambda460
-    Lambda465{{"Lambda[465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant565{{"Constant[565∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant565 --> Lambda465
+    Object408 --> Lambda409
+    Lambda414{{"Lambda[414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant576{{"Constant[576∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant576 --> Lambda414
+    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object423 --> Lambda424
+    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant577{{"Constant[577∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant577 --> Lambda429
+    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object438 --> Lambda439
+    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant578 --> Lambda444
+    Lambda454{{"Lambda[454∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object453 --> Lambda454
+    Lambda459{{"Lambda[459∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant579{{"Constant[579∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant579 --> Lambda459
+    Lambda469{{"Lambda[469∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object468 --> Lambda469
     Lambda474{{"Lambda[474∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object473 --> Lambda474
-    Lambda479{{"Lambda[479∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant566{{"Constant[566∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant566 --> Lambda479
-    Lambda488{{"Lambda[488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object487 --> Lambda488
-    Lambda493{{"Lambda[493∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant567{{"Constant[567∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant567 --> Lambda493
-    Lambda502{{"Lambda[502∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object501 --> Lambda502
-    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant568{{"Constant[568∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant568 --> Lambda507
-    Lambda516{{"Lambda[516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object515 --> Lambda516
-    Lambda521{{"Lambda[521∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant569{{"Constant[569∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant569 --> Lambda521
-    Object529 --> Lambda530
-    Constant570{{"Constant[570∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant570 --> Lambda535
-    Object548 --> Lambda549
-    Constant571{{"Constant[571∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant571 --> Lambda554
+    Constant580{{"Constant[580∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant580 --> Lambda474
+    Lambda484{{"Lambda[484∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object483 --> Lambda484
+    Lambda489{{"Lambda[489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant581{{"Constant[581∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant581 --> Lambda489
+    Lambda499{{"Lambda[499∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object498 --> Lambda499
+    Lambda504{{"Lambda[504∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant582{{"Constant[582∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant582 --> Lambda504
+    Lambda514{{"Lambda[514∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object513 --> Lambda514
+    Lambda519{{"Lambda[519∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant583{{"Constant[583∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant583 --> Lambda519
+    Lambda529{{"Lambda[529∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object528 --> Lambda529
+    Lambda534{{"Lambda[534∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant584{{"Constant[584∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant584 --> Lambda534
+    Object543 --> Lambda544
+    Constant585{{"Constant[585∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant585 --> Lambda549
+    Object563 --> Lambda564
+    Constant586{{"Constant[586∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant586 --> Lambda569
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant338{{"Constant[338∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant341{{"Constant[341∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -173,18 +175,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object539{{"Object[539∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access537{{"Access[537∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access537 & Constant338 & Constant338 & Lambda340 & Constant341 --> Object539
+    Object553{{"Object[553∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access551{{"Access[551∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access551 & Constant338 & Constant338 & Lambda340 & Constant341 --> Object553
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda540{{"Lambda[540∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda540 --> __ListTransform18
-    __Item10 --> Access537
-    Object539 --> Lambda540
-    __Item19[/"__Item[19∈3]<br />ᐸ540ᐳ"\]:::itemplan
-    Lambda540 -.-> __Item19
+    Lambda554{{"Lambda[554∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda554 --> __ListTransform18
+    __Item10 --> Access551
+    Object553 --> Lambda554
+    __Item19[/"__Item[19∈3]<br />ᐸ554ᐳ"\]:::itemplan
+    Lambda554 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgPolymorphic24{{"PgPolymorphic[24∈4]"}}:::plan
@@ -197,21 +199,21 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda348 & Lambda353 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda349 & Lambda354 --> PgSelect26
     PgSelect33[["PgSelect[33∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression32 & Lambda340 & Lambda343 & Lambda502 & Lambda507 --> PgSelect33
+    Object9 & PgClassExpression32 & Lambda340 & Access344 & Lambda514 & Lambda519 --> PgSelect33
     PgSelect103[["PgSelect[103∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression102{{"PgClassExpression[102∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression102 & Lambda340 & Lambda343 & Lambda516 & Lambda521 --> PgSelect103
+    Object9 & PgClassExpression102 & Lambda340 & Access344 & Lambda529 & Lambda534 --> PgSelect103
     PgSelect114[["PgSelect[114∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda362 & Lambda367 --> PgSelect114
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda364 & Lambda369 --> PgSelect114
     PgSelect171[["PgSelect[171∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda376 & Lambda381 --> PgSelect171
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda379 & Lambda384 --> PgSelect171
     PgSelect227[["PgSelect[227∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda390 & Lambda395 --> PgSelect227
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda394 & Lambda399 --> PgSelect227
     PgSelect282[["PgSelect[282∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda340 & Lambda343 & Lambda404 & Lambda409 --> PgSelect282
+    Object9 & PgClassExpression25 & Lambda340 & Access344 & Lambda409 & Lambda414 --> PgSelect282
     PgPolymorphic38{{"PgPolymorphic[38∈5]<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -279,18 +281,18 @@ graph TD
     PgSelectSingle285 --> PgClassExpression337
     PgSelect40[["PgSelect[40∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda418 & Lambda423 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda424 & Lambda429 --> PgSelect40
     PgSelect49[["PgSelect[49∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     PgClassExpression48{{"PgClassExpression[48∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression48 & Lambda340 & Lambda343 & Lambda488 & Lambda493 --> PgSelect49
+    Object9 & PgClassExpression48 & Lambda340 & Access344 & Lambda499 & Lambda504 --> PgSelect49
     PgSelect60[["PgSelect[60∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda432 & Lambda437 --> PgSelect60
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda439 & Lambda444 --> PgSelect60
     PgSelect71[["PgSelect[71∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda446 & Lambda451 --> PgSelect71
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda454 & Lambda459 --> PgSelect71
     PgSelect81[["PgSelect[81∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda460 & Lambda465 --> PgSelect81
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda469 & Lambda474 --> PgSelect81
     PgSelect90[["PgSelect[90∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression39 & Lambda340 & Lambda343 & Lambda474 & Lambda479 --> PgSelect90
+    Object9 & PgClassExpression39 & Lambda340 & Access344 & Lambda484 & Lambda489 --> PgSelect90
     PgSelectSingle36 --> PgClassExpression39
     First44{{"First[44∈6]"}}:::plan
     PgSelect40 --> First44
@@ -355,25 +357,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/nested-more-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 338, 341, 344, 345, 346, 358, 359, 360, 372, 373, 374, 386, 387, 388, 400, 401, 402, 414, 415, 428, 429, 442, 443, 456, 457, 470, 471, 484, 485, 486, 498, 499, 500, 512, 513, 526, 527, 545, 546, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 9, 340, 343, 347, 348, 353, 361, 362, 367, 375, 376, 381, 389, 390, 395, 403, 404, 409, 417, 418, 423, 431, 432, 437, 445, 446, 451, 459, 460, 465, 473, 474, 479, 487, 488, 493, 501, 502, 507, 515, 516, 521, 529, 530, 535, 548, 549, 554<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 338, 341, 345, 346, 347, 360, 361, 362, 375, 376, 377, 390, 391, 392, 405, 406, 407, 420, 421, 435, 436, 450, 451, 465, 466, 480, 481, 495, 496, 497, 510, 511, 512, 525, 526, 540, 541, 560, 561, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 9, 340, 343, 344, 348, 349, 354, 363, 364, 369, 378, 379, 384, 393, 394, 399, 408, 409, 414, 423, 424, 429, 438, 439, 444, 453, 454, 459, 468, 469, 474, 483, 484, 489, 498, 499, 504, 513, 514, 519, 528, 529, 534, 543, 544, 549, 563, 564, 569<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant338,Lambda340,Constant341,Lambda343,Constant344,Constant345,Constant346,Object347,Lambda348,Lambda353,Constant358,Constant359,Constant360,Object361,Lambda362,Lambda367,Constant372,Constant373,Constant374,Object375,Lambda376,Lambda381,Constant386,Constant387,Constant388,Object389,Lambda390,Lambda395,Constant400,Constant401,Constant402,Object403,Lambda404,Lambda409,Constant414,Constant415,Object417,Lambda418,Lambda423,Constant428,Constant429,Object431,Lambda432,Lambda437,Constant442,Constant443,Object445,Lambda446,Lambda451,Constant456,Constant457,Object459,Lambda460,Lambda465,Constant470,Constant471,Object473,Lambda474,Lambda479,Constant484,Constant485,Constant486,Object487,Lambda488,Lambda493,Constant498,Constant499,Constant500,Object501,Lambda502,Lambda507,Constant512,Constant513,Object515,Lambda516,Lambda521,Constant526,Constant527,Object529,Lambda530,Lambda535,Constant545,Constant546,Object548,Lambda549,Lambda554,Constant555,Constant556,Constant557,Constant558,Constant559,Constant560,Constant561,Constant562,Constant563,Constant564,Constant565,Constant566,Constant567,Constant568,Constant569,Constant570,Constant571 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 338, 340, 341, 9, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant338,Lambda340,Constant341,Lambda343,Access344,Constant345,Constant346,Constant347,Object348,Lambda349,Lambda354,Constant360,Constant361,Constant362,Object363,Lambda364,Lambda369,Constant375,Constant376,Constant377,Object378,Lambda379,Lambda384,Constant390,Constant391,Constant392,Object393,Lambda394,Lambda399,Constant405,Constant406,Constant407,Object408,Lambda409,Lambda414,Constant420,Constant421,Object423,Lambda424,Lambda429,Constant435,Constant436,Object438,Lambda439,Lambda444,Constant450,Constant451,Object453,Lambda454,Lambda459,Constant465,Constant466,Object468,Lambda469,Lambda474,Constant480,Constant481,Object483,Lambda484,Lambda489,Constant495,Constant496,Constant497,Object498,Lambda499,Lambda504,Constant510,Constant511,Constant512,Object513,Lambda514,Lambda519,Constant525,Constant526,Object528,Lambda529,Lambda534,Constant540,Constant541,Object543,Lambda544,Lambda549,Constant560,Constant561,Object563,Lambda564,Lambda569,Constant570,Constant571,Constant572,Constant573,Constant574,Constant575,Constant576,Constant577,Constant578,Constant579,Constant580,Constant581,Constant582,Constant583,Constant584,Constant585,Constant586 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 338, 340, 341, 9, 344, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 338, 340, 341, 9, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 537, 539, 540<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 338, 340, 341, 9, 344, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 551, 553, 554<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access537,Object539,Lambda540 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access551,Object553,Lambda554 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 340, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 340, 344, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 340, 343, 348, 353, 502, 507, 516, 521, 362, 367, 376, 381, 390, 395, 404, 409, 24, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 101, 102, 108, 109, 110, 111, 112<br />2: 26, 33, 103, 114, 171, 227, 282<br />ᐳ: 30, 31, 35, 36, 37, 38, 105, 106, 113, 116, 117, 168, 169, 170, 173, 174, 225, 226, 229, 230, 281, 284, 285, 336, 337"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 340, 344, 349, 354, 514, 519, 529, 534, 364, 369, 379, 384, 394, 399, 409, 414, 24, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 101, 102, 108, 109, 110, 111, 112<br />2: 26, 33, 103, 114, 171, 227, 282<br />ᐳ: 30, 31, 35, 36, 37, 38, 105, 106, 113, 116, 117, 168, 169, 170, 173, 174, 225, 226, 229, 230, 281, 284, 285, 336, 337"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression32,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,PgPolymorphic38,PgClassExpression101,PgClassExpression102,PgSelect103,First105,PgSelectSingle106,PgClassExpression108,PgClassExpression109,PgClassExpression110,PgClassExpression111,PgClassExpression112,PgClassExpression113,PgSelect114,First116,PgSelectSingle117,PgClassExpression168,PgClassExpression169,PgClassExpression170,PgSelect171,First173,PgSelectSingle174,PgClassExpression225,PgClassExpression226,PgSelect227,First229,PgSelectSingle230,PgClassExpression281,PgSelect282,First284,PgSelectSingle285,PgClassExpression336,PgClassExpression337 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 340, 343, 418, 423, 488, 493, 432, 437, 446, 451, 460, 465, 474, 479, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 60, 71, 81, 90<br />ᐳ: 44, 45, 51, 52, 59, 62, 63, 68, 69, 70, 73, 74, 79, 80, 83, 84, 89, 92, 93, 98, 99"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 340, 344, 424, 429, 499, 504, 439, 444, 454, 459, 469, 474, 484, 489, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 60, 71, 81, 90<br />ᐳ: 44, 45, 51, 52, 59, 62, 63, 68, 69, 70, 73, 74, 79, 80, 83, 84, 89, 92, 93, 98, 99"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectSingle52,PgClassExpression54,PgClassExpression55,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgSelect60,First62,PgSelectSingle63,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgSelect71,First73,PgSelectSingle74,PgClassExpression79,PgClassExpression80,PgSelect81,First83,PgSelectSingle84,PgClassExpression89,PgSelect90,First92,PgSelectSingle93,PgClassExpression98,PgClassExpression99 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 52<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[52]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.mermaid
@@ -12,168 +12,170 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda526{{"Lambda[526∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda531{{"Lambda[531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda322 & Lambda325 & Lambda526 & Lambda531 --> PgSelect6
-    Object329{{"Object[329∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant326{{"Constant[326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant327{{"Constant[327∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant328{{"Constant[328∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda322 & Constant326 & Constant327 & Constant328 --> Object329
-    Object343{{"Object[343∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant340{{"Constant[340∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant341{{"Constant[341∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant342{{"Constant[342∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda322 & Constant340 & Constant341 & Constant342 --> Object343
-    Object357{{"Object[357∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant354{{"Constant[354∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant355{{"Constant[355∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant356{{"Constant[356∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda322 & Constant354 & Constant355 & Constant356 --> Object357
-    Object371{{"Object[371∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant368{{"Constant[368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant369{{"Constant[369∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant370{{"Constant[370∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda322 & Constant368 & Constant369 & Constant370 --> Object371
-    Object385{{"Object[385∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda322 & Constant382 & Constant383 & Constant384 --> Object385
-    Object399{{"Object[399∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant396{{"Constant[396∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant397{{"Constant[397∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda322 & Constant396 & Constant397 & Constant328 --> Object399
-    Object413{{"Object[413∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda322 & Constant410 & Constant411 & Constant342 --> Object413
-    Object427{{"Object[427∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda322 & Constant424 & Constant425 & Constant356 --> Object427
-    Object441{{"Object[441∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda322 & Constant438 & Constant439 & Constant370 --> Object441
-    Object455{{"Object[455∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant452{{"Constant[452∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant453{{"Constant[453∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda322 & Constant452 & Constant453 & Constant384 --> Object455
-    Object469{{"Object[469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda322 & Constant466 & Constant467 & Constant468 --> Object469
-    Object483{{"Object[483∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant480{{"Constant[480∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant482{{"Constant[482∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda322 & Constant480 & Constant481 & Constant482 --> Object483
-    Object497{{"Object[497∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant494{{"Constant[494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant495{{"Constant[495∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda322 & Constant494 & Constant495 & Constant468 --> Object497
+    Access326{{"Access[326∈0] ➊<br />ᐸ325.0ᐳ"}}:::plan
+    Lambda541{{"Lambda[541∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda546{{"Lambda[546∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda322 & Access326 & Lambda541 & Lambda546 --> PgSelect6
+    Object330{{"Object[330∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant327{{"Constant[327∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant329{{"Constant[329∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda322 & Constant327 & Constant328 & Constant329 --> Object330
+    Object345{{"Object[345∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant342{{"Constant[342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant344{{"Constant[344∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda322 & Constant342 & Constant343 & Constant344 --> Object345
+    Object360{{"Object[360∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant358{{"Constant[358∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda322 & Constant357 & Constant358 & Constant359 --> Object360
+    Object375{{"Object[375∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant374{{"Constant[374∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda322 & Constant372 & Constant373 & Constant374 --> Object375
+    Object390{{"Object[390∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant388{{"Constant[388∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda322 & Constant387 & Constant388 & Constant389 --> Object390
+    Object405{{"Object[405∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda322 & Constant402 & Constant403 & Constant329 --> Object405
+    Object420{{"Object[420∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda322 & Constant417 & Constant418 & Constant344 --> Object420
+    Object435{{"Object[435∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda322 & Constant432 & Constant433 & Constant359 --> Object435
+    Object450{{"Object[450∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda322 & Constant447 & Constant448 & Constant374 --> Object450
+    Object465{{"Object[465∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda322 & Constant462 & Constant463 & Constant389 --> Object465
+    Object480{{"Object[480∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda322 & Constant477 & Constant478 & Constant479 --> Object480
+    Object495{{"Object[495∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant492{{"Constant[492∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant493{{"Constant[493∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda322 & Constant492 & Constant493 & Constant494 --> Object495
+    Object510{{"Object[510∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant507{{"Constant[507∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant508{{"Constant[508∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda322 & Constant507 & Constant508 & Constant479 --> Object510
     Object525{{"Object[525∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant522{{"Constant[522∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant523{{"Constant[523∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda322 & Constant522 & Constant523 & Constant468 --> Object525
+    Constant522{{"Constant[522∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant523{{"Constant[523∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda322 & Constant522 & Constant523 & Constant494 --> Object525
+    Object540{{"Object[540∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant537{{"Constant[537∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant538{{"Constant[538∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda322 & Constant537 & Constant538 & Constant479 --> Object540
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant532{{"Constant[532∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant532 --> Lambda322
-    Constant533{{"Constant[533∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant533 --> Lambda325
-    Lambda330{{"Lambda[330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object329 --> Lambda330
-    Lambda335{{"Lambda[335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant534{{"Constant[534∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant534 --> Lambda335
-    Lambda344{{"Lambda[344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object343 --> Lambda344
-    Lambda349{{"Lambda[349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant535{{"Constant[535∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant535 --> Lambda349
-    Lambda358{{"Lambda[358∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object357 --> Lambda358
-    Lambda363{{"Lambda[363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant536{{"Constant[536∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant536 --> Lambda363
-    Lambda372{{"Lambda[372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object371 --> Lambda372
-    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant537{{"Constant[537∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant537 --> Lambda377
-    Lambda386{{"Lambda[386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object385 --> Lambda386
+    Constant547{{"Constant[547∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant547 --> Lambda322
+    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant548{{"Constant[548∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant548 --> Lambda325
+    Lambda325 --> Access326
+    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object330 --> Lambda331
+    Lambda336{{"Lambda[336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant549{{"Constant[549∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant549 --> Lambda336
+    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object345 --> Lambda346
+    Lambda351{{"Lambda[351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant550{{"Constant[550∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant550 --> Lambda351
+    Lambda361{{"Lambda[361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object360 --> Lambda361
+    Lambda366{{"Lambda[366∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant551{{"Constant[551∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant551 --> Lambda366
+    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object375 --> Lambda376
+    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant552{{"Constant[552∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant552 --> Lambda381
     Lambda391{{"Lambda[391∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant538{{"Constant[538∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant538 --> Lambda391
-    Lambda400{{"Lambda[400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object399 --> Lambda400
-    Lambda405{{"Lambda[405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant539{{"Constant[539∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant539 --> Lambda405
-    Lambda414{{"Lambda[414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object413 --> Lambda414
-    Lambda419{{"Lambda[419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant540{{"Constant[540∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant540 --> Lambda419
-    Lambda428{{"Lambda[428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object427 --> Lambda428
-    Lambda433{{"Lambda[433∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant541{{"Constant[541∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant541 --> Lambda433
-    Lambda442{{"Lambda[442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object441 --> Lambda442
-    Lambda447{{"Lambda[447∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant542{{"Constant[542∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant542 --> Lambda447
+    Object390 --> Lambda391
+    Lambda396{{"Lambda[396∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant553{{"Constant[553∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant553 --> Lambda396
+    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object405 --> Lambda406
+    Lambda411{{"Lambda[411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant554{{"Constant[554∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant554 --> Lambda411
+    Lambda421{{"Lambda[421∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object420 --> Lambda421
+    Lambda426{{"Lambda[426∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant555{{"Constant[555∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant555 --> Lambda426
+    Lambda436{{"Lambda[436∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object435 --> Lambda436
+    Lambda441{{"Lambda[441∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant556{{"Constant[556∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant556 --> Lambda441
+    Lambda451{{"Lambda[451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object450 --> Lambda451
     Lambda456{{"Lambda[456∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object455 --> Lambda456
-    Lambda461{{"Lambda[461∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant543 --> Lambda461
-    Lambda470{{"Lambda[470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object469 --> Lambda470
-    Lambda475{{"Lambda[475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant544{{"Constant[544∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant544 --> Lambda475
-    Lambda484{{"Lambda[484∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object483 --> Lambda484
-    Lambda489{{"Lambda[489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant545{{"Constant[545∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant545 --> Lambda489
-    Lambda498{{"Lambda[498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object497 --> Lambda498
-    Lambda503{{"Lambda[503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant546{{"Constant[546∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant546 --> Lambda503
+    Constant557{{"Constant[557∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant557 --> Lambda456
+    Lambda466{{"Lambda[466∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object465 --> Lambda466
+    Lambda471{{"Lambda[471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant558{{"Constant[558∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant558 --> Lambda471
+    Lambda481{{"Lambda[481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object480 --> Lambda481
+    Lambda486{{"Lambda[486∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant559{{"Constant[559∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant559 --> Lambda486
+    Lambda496{{"Lambda[496∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object495 --> Lambda496
+    Lambda501{{"Lambda[501∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant560{{"Constant[560∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant560 --> Lambda501
+    Lambda511{{"Lambda[511∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object510 --> Lambda511
+    Lambda516{{"Lambda[516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant561{{"Constant[561∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant561 --> Lambda516
+    Lambda526{{"Lambda[526∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object525 --> Lambda526
-    Constant548{{"Constant[548∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant548 --> Lambda531
+    Lambda531{{"Lambda[531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant562{{"Constant[562∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant562 --> Lambda531
+    Object540 --> Lambda541
+    Constant563{{"Constant[563∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant563 --> Lambda546
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant508{{"Constant[508∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant509{{"Constant[509∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant547{{"Constant[547∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object511{{"Object[511∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda322 & Constant508 & Constant509 & Constant482 --> Object511
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda512{{"Lambda[512∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object511 --> Lambda512
-    Lambda517{{"Lambda[517∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant547 --> Lambda517
     PgSelect14[["PgSelect[14∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda322 & Lambda325 & Lambda512 & Lambda517 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda322 & Access326 & Lambda526 & Lambda531 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -193,21 +195,21 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda330 & Lambda335 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda331 & Lambda336 --> PgSelect26
     PgSelect33[["PgSelect[33∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression32 & Lambda322 & Lambda325 & Lambda484 & Lambda489 --> PgSelect33
+    Object9 & PgClassExpression32 & Lambda322 & Access326 & Lambda496 & Lambda501 --> PgSelect33
     PgSelect94[["PgSelect[94∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression93{{"PgClassExpression[93∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression93 & Lambda322 & Lambda325 & Lambda498 & Lambda503 --> PgSelect94
+    Object9 & PgClassExpression93 & Lambda322 & Access326 & Lambda511 & Lambda516 --> PgSelect94
     PgSelect104[["PgSelect[104∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda344 & Lambda349 --> PgSelect104
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda346 & Lambda351 --> PgSelect104
     PgSelect158[["PgSelect[158∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda358 & Lambda363 --> PgSelect158
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda361 & Lambda366 --> PgSelect158
     PgSelect212[["PgSelect[212∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda372 & Lambda377 --> PgSelect212
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda376 & Lambda381 --> PgSelect212
     PgSelect266[["PgSelect[266∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda386 & Lambda391 --> PgSelect266
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda391 & Lambda396 --> PgSelect266
     PgPolymorphic38{{"PgPolymorphic[38∈5]<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -257,18 +259,18 @@ graph TD
     First268 --> PgSelectSingle269
     PgSelect40[["PgSelect[40∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda400 & Lambda405 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda406 & Lambda411 --> PgSelect40
     PgSelect49[["PgSelect[49∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     PgClassExpression48{{"PgClassExpression[48∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression48 & Lambda322 & Lambda325 & Lambda470 & Lambda475 --> PgSelect49
+    Object9 & PgClassExpression48 & Lambda322 & Access326 & Lambda481 & Lambda486 --> PgSelect49
     PgSelect59[["PgSelect[59∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda414 & Lambda419 --> PgSelect59
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda421 & Lambda426 --> PgSelect59
     PgSelect67[["PgSelect[67∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda428 & Lambda433 --> PgSelect67
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda436 & Lambda441 --> PgSelect67
     PgSelect75[["PgSelect[75∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda442 & Lambda447 --> PgSelect75
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda451 & Lambda456 --> PgSelect75
     PgSelect83[["PgSelect[83∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda456 & Lambda461 --> PgSelect83
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda466 & Lambda471 --> PgSelect83
     PgSelectSingle36 --> PgClassExpression39
     First44{{"First[44∈6]"}}:::plan
     PgSelect40 --> First44
@@ -315,25 +317,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/nested-more"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 326, 327, 328, 340, 341, 342, 354, 355, 356, 368, 369, 370, 382, 383, 384, 396, 397, 410, 411, 424, 425, 438, 439, 452, 453, 466, 467, 468, 480, 481, 482, 494, 495, 508, 509, 522, 523, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 9, 322, 325, 329, 330, 335, 343, 344, 349, 357, 358, 363, 371, 372, 377, 385, 386, 391, 399, 400, 405, 413, 414, 419, 427, 428, 433, 441, 442, 447, 455, 456, 461, 469, 470, 475, 483, 484, 489, 497, 498, 503, 525, 526, 531<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 327, 328, 329, 342, 343, 344, 357, 358, 359, 372, 373, 374, 387, 388, 389, 402, 403, 417, 418, 432, 433, 447, 448, 462, 463, 477, 478, 479, 492, 493, 494, 507, 508, 522, 523, 537, 538, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 9, 322, 325, 326, 330, 331, 336, 345, 346, 351, 360, 361, 366, 375, 376, 381, 390, 391, 396, 405, 406, 411, 420, 421, 426, 435, 436, 441, 450, 451, 456, 465, 466, 471, 480, 481, 486, 495, 496, 501, 510, 511, 516, 525, 526, 531, 540, 541, 546<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda322,Lambda325,Constant326,Constant327,Constant328,Object329,Lambda330,Lambda335,Constant340,Constant341,Constant342,Object343,Lambda344,Lambda349,Constant354,Constant355,Constant356,Object357,Lambda358,Lambda363,Constant368,Constant369,Constant370,Object371,Lambda372,Lambda377,Constant382,Constant383,Constant384,Object385,Lambda386,Lambda391,Constant396,Constant397,Object399,Lambda400,Lambda405,Constant410,Constant411,Object413,Lambda414,Lambda419,Constant424,Constant425,Object427,Lambda428,Lambda433,Constant438,Constant439,Object441,Lambda442,Lambda447,Constant452,Constant453,Object455,Lambda456,Lambda461,Constant466,Constant467,Constant468,Object469,Lambda470,Lambda475,Constant480,Constant481,Constant482,Object483,Lambda484,Lambda489,Constant494,Constant495,Object497,Lambda498,Lambda503,Constant508,Constant509,Constant522,Constant523,Object525,Lambda526,Lambda531,Constant532,Constant533,Constant534,Constant535,Constant536,Constant537,Constant538,Constant539,Constant540,Constant541,Constant542,Constant543,Constant544,Constant545,Constant546,Constant547,Constant548 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 322, 508, 509, 482, 547, 9, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda322,Lambda325,Access326,Constant327,Constant328,Constant329,Object330,Lambda331,Lambda336,Constant342,Constant343,Constant344,Object345,Lambda346,Lambda351,Constant357,Constant358,Constant359,Object360,Lambda361,Lambda366,Constant372,Constant373,Constant374,Object375,Lambda376,Lambda381,Constant387,Constant388,Constant389,Object390,Lambda391,Lambda396,Constant402,Constant403,Object405,Lambda406,Lambda411,Constant417,Constant418,Object420,Lambda421,Lambda426,Constant432,Constant433,Object435,Lambda436,Lambda441,Constant447,Constant448,Object450,Lambda451,Lambda456,Constant462,Constant463,Object465,Lambda466,Lambda471,Constant477,Constant478,Constant479,Object480,Lambda481,Lambda486,Constant492,Constant493,Constant494,Object495,Lambda496,Lambda501,Constant507,Constant508,Object510,Lambda511,Lambda516,Constant522,Constant523,Object525,Lambda526,Lambda531,Constant537,Constant538,Object540,Lambda541,Lambda546,Constant547,Constant548,Constant549,Constant550,Constant551,Constant552,Constant553,Constant554,Constant555,Constant556,Constant557,Constant558,Constant559,Constant560,Constant561,Constant562,Constant563 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 322, 326, 526, 531, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object511,Lambda512,Lambda517 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 322, 325, 512, 517, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 322, 326, 526, 531, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 322, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 322, 326, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 322, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 24, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 92, 93, 99, 100, 101, 102, 103<br />2: 26, 33, 94, 104, 158, 212, 266<br />ᐳ: 30, 31, 35, 36, 37, 38, 96, 97, 106, 107, 160, 161, 214, 215, 268, 269"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 322, 326, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 24, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 92, 93, 99, 100, 101, 102, 103<br />2: 26, 33, 94, 104, 158, 212, 266<br />ᐳ: 30, 31, 35, 36, 37, 38, 96, 97, 106, 107, 160, 161, 214, 215, 268, 269"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression32,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,PgPolymorphic38,PgClassExpression92,PgClassExpression93,PgSelect94,First96,PgSelectSingle97,PgClassExpression99,PgClassExpression100,PgClassExpression101,PgClassExpression102,PgClassExpression103,PgSelect104,First106,PgSelectSingle107,PgSelect158,First160,PgSelectSingle161,PgSelect212,First214,PgSelectSingle215,PgSelect266,First268,PgSelectSingle269 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 322, 325, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 59, 67, 75, 83<br />ᐳ: 44, 45, 51, 52, 61, 62, 69, 70, 77, 78, 85, 86"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 322, 326, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 59, 67, 75, 83<br />ᐳ: 44, 45, 51, 52, 61, 62, 69, 70, 77, 78, 85, 86"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectSingle52,PgClassExpression54,PgClassExpression55,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgSelect59,First61,PgSelectSingle62,PgSelect67,First69,PgSelectSingle70,PgSelect75,First77,PgSelectSingle78,PgSelect83,First85,PgSelectSingle86 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 52<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[52]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.mermaid
@@ -11,161 +11,163 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda512{{"Lambda[512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda517{{"Lambda[517∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access326{{"Access[326∈0] ➊<br />ᐸ325.0ᐳ"}}:::plan
+    Lambda526{{"Lambda[526∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda531{{"Lambda[531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda536{{"Lambda[536∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda325 & Lambda512 & Lambda517 & Lambda322 & Lambda325 & Lambda531 & Lambda536 --> PgSelect6
-    Object329{{"Object[329∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant326{{"Constant[326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant327{{"Constant[327∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant328{{"Constant[328∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda322 & Constant326 & Constant327 & Constant328 --> Object329
-    Object343{{"Object[343∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant340{{"Constant[340∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant341{{"Constant[341∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant342{{"Constant[342∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda322 & Constant340 & Constant341 & Constant342 --> Object343
-    Object357{{"Object[357∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant354{{"Constant[354∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant355{{"Constant[355∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant356{{"Constant[356∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda322 & Constant354 & Constant355 & Constant356 --> Object357
-    Object371{{"Object[371∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant368{{"Constant[368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant369{{"Constant[369∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant370{{"Constant[370∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda322 & Constant368 & Constant369 & Constant370 --> Object371
-    Object385{{"Object[385∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda322 & Constant382 & Constant383 & Constant384 --> Object385
-    Object399{{"Object[399∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant396{{"Constant[396∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant397{{"Constant[397∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda322 & Constant396 & Constant397 & Constant328 --> Object399
-    Object413{{"Object[413∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda322 & Constant410 & Constant411 & Constant342 --> Object413
-    Object427{{"Object[427∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda322 & Constant424 & Constant425 & Constant356 --> Object427
-    Object441{{"Object[441∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda322 & Constant438 & Constant439 & Constant370 --> Object441
-    Object455{{"Object[455∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant452{{"Constant[452∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant453{{"Constant[453∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda322 & Constant452 & Constant453 & Constant384 --> Object455
-    Object469{{"Object[469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda322 & Constant466 & Constant467 & Constant468 --> Object469
-    Object483{{"Object[483∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant480{{"Constant[480∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant482{{"Constant[482∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda322 & Constant480 & Constant481 & Constant482 --> Object483
-    Object497{{"Object[497∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant494{{"Constant[494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant495{{"Constant[495∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda322 & Constant494 & Constant495 & Constant468 --> Object497
-    Object511{{"Object[511∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant508{{"Constant[508∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant509{{"Constant[509∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda322 & Constant508 & Constant509 & Constant482 --> Object511
-    Object530{{"Object[530∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant527{{"Constant[527∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant528{{"Constant[528∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda322 & Constant527 & Constant528 & Constant468 --> Object530
+    Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda546{{"Lambda[546∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda551{{"Lambda[551∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access326 & Lambda526 & Lambda531 & Lambda322 & Access326 & Lambda546 & Lambda551 --> PgSelect6
+    Object330{{"Object[330∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant327{{"Constant[327∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant329{{"Constant[329∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda322 & Constant327 & Constant328 & Constant329 --> Object330
+    Object345{{"Object[345∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant342{{"Constant[342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant344{{"Constant[344∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda322 & Constant342 & Constant343 & Constant344 --> Object345
+    Object360{{"Object[360∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant358{{"Constant[358∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda322 & Constant357 & Constant358 & Constant359 --> Object360
+    Object375{{"Object[375∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant372{{"Constant[372∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant373{{"Constant[373∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant374{{"Constant[374∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda322 & Constant372 & Constant373 & Constant374 --> Object375
+    Object390{{"Object[390∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant388{{"Constant[388∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda322 & Constant387 & Constant388 & Constant389 --> Object390
+    Object405{{"Object[405∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda322 & Constant402 & Constant403 & Constant329 --> Object405
+    Object420{{"Object[420∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda322 & Constant417 & Constant418 & Constant344 --> Object420
+    Object435{{"Object[435∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda322 & Constant432 & Constant433 & Constant359 --> Object435
+    Object450{{"Object[450∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda322 & Constant447 & Constant448 & Constant374 --> Object450
+    Object465{{"Object[465∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda322 & Constant462 & Constant463 & Constant389 --> Object465
+    Object480{{"Object[480∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda322 & Constant477 & Constant478 & Constant479 --> Object480
+    Object495{{"Object[495∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant492{{"Constant[492∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant493{{"Constant[493∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda322 & Constant492 & Constant493 & Constant494 --> Object495
+    Object510{{"Object[510∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant507{{"Constant[507∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant508{{"Constant[508∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda322 & Constant507 & Constant508 & Constant479 --> Object510
+    Object525{{"Object[525∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant522{{"Constant[522∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant523{{"Constant[523∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda322 & Constant522 & Constant523 & Constant494 --> Object525
+    Object545{{"Object[545∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant542{{"Constant[542∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant543{{"Constant[543∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda322 & Constant542 & Constant543 & Constant479 --> Object545
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant537{{"Constant[537∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant537 --> Lambda322
-    Constant538{{"Constant[538∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant538 --> Lambda325
-    Lambda330{{"Lambda[330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object329 --> Lambda330
-    Lambda335{{"Lambda[335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant539{{"Constant[539∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant539 --> Lambda335
-    Lambda344{{"Lambda[344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object343 --> Lambda344
-    Lambda349{{"Lambda[349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant540{{"Constant[540∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant540 --> Lambda349
-    Lambda358{{"Lambda[358∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object357 --> Lambda358
-    Lambda363{{"Lambda[363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant541{{"Constant[541∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant541 --> Lambda363
-    Lambda372{{"Lambda[372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object371 --> Lambda372
-    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant542{{"Constant[542∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant542 --> Lambda377
-    Lambda386{{"Lambda[386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object385 --> Lambda386
+    Constant552{{"Constant[552∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant552 --> Lambda322
+    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant553{{"Constant[553∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant553 --> Lambda325
+    Lambda325 --> Access326
+    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object330 --> Lambda331
+    Lambda336{{"Lambda[336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant554{{"Constant[554∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant554 --> Lambda336
+    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object345 --> Lambda346
+    Lambda351{{"Lambda[351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant555{{"Constant[555∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant555 --> Lambda351
+    Lambda361{{"Lambda[361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object360 --> Lambda361
+    Lambda366{{"Lambda[366∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant556{{"Constant[556∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant556 --> Lambda366
+    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object375 --> Lambda376
+    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant557{{"Constant[557∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant557 --> Lambda381
     Lambda391{{"Lambda[391∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant543 --> Lambda391
-    Lambda400{{"Lambda[400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object399 --> Lambda400
-    Lambda405{{"Lambda[405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant544{{"Constant[544∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant544 --> Lambda405
-    Lambda414{{"Lambda[414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object413 --> Lambda414
-    Lambda419{{"Lambda[419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant545{{"Constant[545∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant545 --> Lambda419
-    Lambda428{{"Lambda[428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object427 --> Lambda428
-    Lambda433{{"Lambda[433∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant546{{"Constant[546∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant546 --> Lambda433
-    Lambda442{{"Lambda[442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object441 --> Lambda442
-    Lambda447{{"Lambda[447∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant547{{"Constant[547∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant547 --> Lambda447
+    Object390 --> Lambda391
+    Lambda396{{"Lambda[396∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant558{{"Constant[558∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant558 --> Lambda396
+    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object405 --> Lambda406
+    Lambda411{{"Lambda[411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant559{{"Constant[559∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant559 --> Lambda411
+    Lambda421{{"Lambda[421∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object420 --> Lambda421
+    Lambda426{{"Lambda[426∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant560{{"Constant[560∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant560 --> Lambda426
+    Lambda436{{"Lambda[436∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object435 --> Lambda436
+    Lambda441{{"Lambda[441∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant561{{"Constant[561∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant561 --> Lambda441
+    Lambda451{{"Lambda[451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object450 --> Lambda451
     Lambda456{{"Lambda[456∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object455 --> Lambda456
-    Lambda461{{"Lambda[461∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant548{{"Constant[548∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant548 --> Lambda461
-    Lambda470{{"Lambda[470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object469 --> Lambda470
-    Lambda475{{"Lambda[475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant549{{"Constant[549∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant549 --> Lambda475
-    Lambda484{{"Lambda[484∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object483 --> Lambda484
-    Lambda489{{"Lambda[489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant550{{"Constant[550∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant550 --> Lambda489
-    Lambda498{{"Lambda[498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object497 --> Lambda498
-    Lambda503{{"Lambda[503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant551{{"Constant[551∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant551 --> Lambda503
-    Object511 --> Lambda512
-    Constant552{{"Constant[552∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant552 --> Lambda517
-    Object530 --> Lambda531
-    Constant553{{"Constant[553∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant553 --> Lambda536
+    Constant562{{"Constant[562∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant562 --> Lambda456
+    Lambda466{{"Lambda[466∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object465 --> Lambda466
+    Lambda471{{"Lambda[471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant563{{"Constant[563∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant563 --> Lambda471
+    Lambda481{{"Lambda[481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object480 --> Lambda481
+    Lambda486{{"Lambda[486∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant564{{"Constant[564∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant564 --> Lambda486
+    Lambda496{{"Lambda[496∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object495 --> Lambda496
+    Lambda501{{"Lambda[501∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant565{{"Constant[565∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant565 --> Lambda501
+    Lambda511{{"Lambda[511∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object510 --> Lambda511
+    Lambda516{{"Lambda[516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant566{{"Constant[566∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant566 --> Lambda516
+    Object525 --> Lambda526
+    Constant567{{"Constant[567∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant567 --> Lambda531
+    Object545 --> Lambda546
+    Constant568{{"Constant[568∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant568 --> Lambda551
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant320{{"Constant[320∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant323{{"Constant[323∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -173,18 +175,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object521{{"Object[521∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access519{{"Access[519∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access519 & Constant320 & Constant320 & Lambda322 & Constant323 --> Object521
+    Object535{{"Object[535∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access533{{"Access[533∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access533 & Constant320 & Constant320 & Lambda322 & Constant323 --> Object535
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda522{{"Lambda[522∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda522 --> __ListTransform18
-    __Item10 --> Access519
-    Object521 --> Lambda522
-    __Item19[/"__Item[19∈3]<br />ᐸ522ᐳ"\]:::itemplan
-    Lambda522 -.-> __Item19
+    Lambda536{{"Lambda[536∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda536 --> __ListTransform18
+    __Item10 --> Access533
+    Object535 --> Lambda536
+    __Item19[/"__Item[19∈3]<br />ᐸ536ᐳ"\]:::itemplan
+    Lambda536 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgPolymorphic24{{"PgPolymorphic[24∈4]"}}:::plan
@@ -197,21 +199,21 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda330 & Lambda335 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda331 & Lambda336 --> PgSelect26
     PgSelect33[["PgSelect[33∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression32 & Lambda322 & Lambda325 & Lambda484 & Lambda489 --> PgSelect33
+    Object9 & PgClassExpression32 & Lambda322 & Access326 & Lambda496 & Lambda501 --> PgSelect33
     PgSelect94[["PgSelect[94∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression93{{"PgClassExpression[93∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression93 & Lambda322 & Lambda325 & Lambda498 & Lambda503 --> PgSelect94
+    Object9 & PgClassExpression93 & Lambda322 & Access326 & Lambda511 & Lambda516 --> PgSelect94
     PgSelect104[["PgSelect[104∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda344 & Lambda349 --> PgSelect104
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda346 & Lambda351 --> PgSelect104
     PgSelect158[["PgSelect[158∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda358 & Lambda363 --> PgSelect158
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda361 & Lambda366 --> PgSelect158
     PgSelect212[["PgSelect[212∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda372 & Lambda377 --> PgSelect212
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda376 & Lambda381 --> PgSelect212
     PgSelect266[["PgSelect[266∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda322 & Lambda325 & Lambda386 & Lambda391 --> PgSelect266
+    Object9 & PgClassExpression25 & Lambda322 & Access326 & Lambda391 & Lambda396 --> PgSelect266
     PgPolymorphic38{{"PgPolymorphic[38∈5]<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -261,18 +263,18 @@ graph TD
     First268 --> PgSelectSingle269
     PgSelect40[["PgSelect[40∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda400 & Lambda405 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda406 & Lambda411 --> PgSelect40
     PgSelect49[["PgSelect[49∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     PgClassExpression48{{"PgClassExpression[48∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression48 & Lambda322 & Lambda325 & Lambda470 & Lambda475 --> PgSelect49
+    Object9 & PgClassExpression48 & Lambda322 & Access326 & Lambda481 & Lambda486 --> PgSelect49
     PgSelect59[["PgSelect[59∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda414 & Lambda419 --> PgSelect59
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda421 & Lambda426 --> PgSelect59
     PgSelect67[["PgSelect[67∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda428 & Lambda433 --> PgSelect67
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda436 & Lambda441 --> PgSelect67
     PgSelect75[["PgSelect[75∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda442 & Lambda447 --> PgSelect75
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda451 & Lambda456 --> PgSelect75
     PgSelect83[["PgSelect[83∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression39 & Lambda322 & Lambda325 & Lambda456 & Lambda461 --> PgSelect83
+    Object9 & PgClassExpression39 & Lambda322 & Access326 & Lambda466 & Lambda471 --> PgSelect83
     PgSelectSingle36 --> PgClassExpression39
     First44{{"First[44∈6]"}}:::plan
     PgSelect40 --> First44
@@ -319,25 +321,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/nested-more"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 320, 323, 326, 327, 328, 340, 341, 342, 354, 355, 356, 368, 369, 370, 382, 383, 384, 396, 397, 410, 411, 424, 425, 438, 439, 452, 453, 466, 467, 468, 480, 481, 482, 494, 495, 508, 509, 527, 528, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 9, 322, 325, 329, 330, 335, 343, 344, 349, 357, 358, 363, 371, 372, 377, 385, 386, 391, 399, 400, 405, 413, 414, 419, 427, 428, 433, 441, 442, 447, 455, 456, 461, 469, 470, 475, 483, 484, 489, 497, 498, 503, 511, 512, 517, 530, 531, 536<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 320, 323, 327, 328, 329, 342, 343, 344, 357, 358, 359, 372, 373, 374, 387, 388, 389, 402, 403, 417, 418, 432, 433, 447, 448, 462, 463, 477, 478, 479, 492, 493, 494, 507, 508, 522, 523, 542, 543, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 9, 322, 325, 326, 330, 331, 336, 345, 346, 351, 360, 361, 366, 375, 376, 381, 390, 391, 396, 405, 406, 411, 420, 421, 426, 435, 436, 441, 450, 451, 456, 465, 466, 471, 480, 481, 486, 495, 496, 501, 510, 511, 516, 525, 526, 531, 545, 546, 551<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant320,Lambda322,Constant323,Lambda325,Constant326,Constant327,Constant328,Object329,Lambda330,Lambda335,Constant340,Constant341,Constant342,Object343,Lambda344,Lambda349,Constant354,Constant355,Constant356,Object357,Lambda358,Lambda363,Constant368,Constant369,Constant370,Object371,Lambda372,Lambda377,Constant382,Constant383,Constant384,Object385,Lambda386,Lambda391,Constant396,Constant397,Object399,Lambda400,Lambda405,Constant410,Constant411,Object413,Lambda414,Lambda419,Constant424,Constant425,Object427,Lambda428,Lambda433,Constant438,Constant439,Object441,Lambda442,Lambda447,Constant452,Constant453,Object455,Lambda456,Lambda461,Constant466,Constant467,Constant468,Object469,Lambda470,Lambda475,Constant480,Constant481,Constant482,Object483,Lambda484,Lambda489,Constant494,Constant495,Object497,Lambda498,Lambda503,Constant508,Constant509,Object511,Lambda512,Lambda517,Constant527,Constant528,Object530,Lambda531,Lambda536,Constant537,Constant538,Constant539,Constant540,Constant541,Constant542,Constant543,Constant544,Constant545,Constant546,Constant547,Constant548,Constant549,Constant550,Constant551,Constant552,Constant553 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 320, 322, 323, 9, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant320,Lambda322,Constant323,Lambda325,Access326,Constant327,Constant328,Constant329,Object330,Lambda331,Lambda336,Constant342,Constant343,Constant344,Object345,Lambda346,Lambda351,Constant357,Constant358,Constant359,Object360,Lambda361,Lambda366,Constant372,Constant373,Constant374,Object375,Lambda376,Lambda381,Constant387,Constant388,Constant389,Object390,Lambda391,Lambda396,Constant402,Constant403,Object405,Lambda406,Lambda411,Constant417,Constant418,Object420,Lambda421,Lambda426,Constant432,Constant433,Object435,Lambda436,Lambda441,Constant447,Constant448,Object450,Lambda451,Lambda456,Constant462,Constant463,Object465,Lambda466,Lambda471,Constant477,Constant478,Constant479,Object480,Lambda481,Lambda486,Constant492,Constant493,Constant494,Object495,Lambda496,Lambda501,Constant507,Constant508,Object510,Lambda511,Lambda516,Constant522,Constant523,Object525,Lambda526,Lambda531,Constant542,Constant543,Object545,Lambda546,Lambda551,Constant552,Constant553,Constant554,Constant555,Constant556,Constant557,Constant558,Constant559,Constant560,Constant561,Constant562,Constant563,Constant564,Constant565,Constant566,Constant567,Constant568 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 320, 322, 323, 9, 326, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 320, 322, 323, 9, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 519, 521, 522<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 320, 322, 323, 9, 326, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 533, 535, 536<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access519,Object521,Lambda522 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access533,Object535,Lambda536 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 322, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 322, 326, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 322, 325, 330, 335, 484, 489, 498, 503, 344, 349, 358, 363, 372, 377, 386, 391, 24, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 92, 93, 99, 100, 101, 102, 103<br />2: 26, 33, 94, 104, 158, 212, 266<br />ᐳ: 30, 31, 35, 36, 37, 38, 96, 97, 106, 107, 160, 161, 214, 215, 268, 269"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 322, 326, 331, 336, 496, 501, 511, 516, 346, 351, 361, 366, 376, 381, 391, 396, 24, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 92, 93, 99, 100, 101, 102, 103<br />2: 26, 33, 94, 104, 158, 212, 266<br />ᐳ: 30, 31, 35, 36, 37, 38, 96, 97, 106, 107, 160, 161, 214, 215, 268, 269"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression32,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,PgPolymorphic38,PgClassExpression92,PgClassExpression93,PgSelect94,First96,PgSelectSingle97,PgClassExpression99,PgClassExpression100,PgClassExpression101,PgClassExpression102,PgClassExpression103,PgSelect104,First106,PgSelectSingle107,PgSelect158,First160,PgSelectSingle161,PgSelect212,First214,PgSelectSingle215,PgSelect266,First268,PgSelectSingle269 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 322, 325, 400, 405, 470, 475, 414, 419, 428, 433, 442, 447, 456, 461, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 59, 67, 75, 83<br />ᐳ: 44, 45, 51, 52, 61, 62, 69, 70, 77, 78, 85, 86"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 322, 326, 406, 411, 481, 486, 421, 426, 436, 441, 451, 456, 466, 471, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47, 48, 54, 55, 56, 57, 58<br />2: 40, 49, 59, 67, 75, 83<br />ᐳ: 44, 45, 51, 52, 61, 62, 69, 70, 77, 78, 85, 86"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectSingle52,PgClassExpression54,PgClassExpression55,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgSelect59,First61,PgSelectSingle62,PgSelect67,First69,PgSelectSingle70,PgSelect75,First77,PgSelectSingle78,PgSelect83,First85,PgSelectSingle86 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 52<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[52]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.mermaid
@@ -12,150 +12,152 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda188 & Lambda191 & Lambda364 & Lambda369 --> PgSelect6
-    Object195{{"Object[195∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda188 & Constant192 & Constant193 & Constant194 --> Object195
-    Object209{{"Object[209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda188 & Constant206 & Constant207 & Constant208 --> Object209
-    Object223{{"Object[223∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda188 & Constant220 & Constant221 & Constant222 --> Object223
-    Object237{{"Object[237∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant235{{"Constant[235∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda188 & Constant234 & Constant235 & Constant236 --> Object237
-    Object251{{"Object[251∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant249{{"Constant[249∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda188 & Constant248 & Constant249 & Constant250 --> Object251
-    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda188 & Constant262 & Constant263 & Constant194 --> Object265
-    Object279{{"Object[279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant276{{"Constant[276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant277{{"Constant[277∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda188 & Constant276 & Constant277 & Constant208 --> Object279
-    Object293{{"Object[293∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant290{{"Constant[290∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant291{{"Constant[291∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda188 & Constant290 & Constant291 & Constant222 --> Object293
-    Object307{{"Object[307∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda188 & Constant304 & Constant305 & Constant236 --> Object307
-    Object321{{"Object[321∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant318{{"Constant[318∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant319{{"Constant[319∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda188 & Constant318 & Constant319 & Constant250 --> Object321
-    Object335{{"Object[335∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant332{{"Constant[332∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant333{{"Constant[333∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant334{{"Constant[334∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda188 & Constant332 & Constant333 & Constant334 --> Object335
-    Object363{{"Object[363∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant360{{"Constant[360∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant361{{"Constant[361∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant362{{"Constant[362∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda188 & Constant360 & Constant361 & Constant362 --> Object363
+    Access192{{"Access[192∈0] ➊<br />ᐸ191.0ᐳ"}}:::plan
+    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda382{{"Lambda[382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda188 & Access192 & Lambda377 & Lambda382 --> PgSelect6
+    Object196{{"Object[196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda188 & Constant193 & Constant194 & Constant195 --> Object196
+    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda188 & Constant208 & Constant209 & Constant210 --> Object211
+    Object226{{"Object[226∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda188 & Constant223 & Constant224 & Constant225 --> Object226
+    Object241{{"Object[241∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda188 & Constant238 & Constant239 & Constant240 --> Object241
+    Object256{{"Object[256∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant253{{"Constant[253∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant254{{"Constant[254∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda188 & Constant253 & Constant254 & Constant255 --> Object256
+    Object271{{"Object[271∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant268{{"Constant[268∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant269{{"Constant[269∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda188 & Constant268 & Constant269 & Constant195 --> Object271
+    Object286{{"Object[286∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant283 & Constant284 & Constant210 --> Object286
+    Object301{{"Object[301∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant298{{"Constant[298∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant299{{"Constant[299∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda188 & Constant298 & Constant299 & Constant225 --> Object301
+    Object316{{"Object[316∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant313{{"Constant[313∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant314{{"Constant[314∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda188 & Constant313 & Constant314 & Constant240 --> Object316
+    Object331{{"Object[331∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant329{{"Constant[329∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda188 & Constant328 & Constant329 & Constant255 --> Object331
+    Object346{{"Object[346∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant344{{"Constant[344∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda188 & Constant343 & Constant344 & Constant345 --> Object346
+    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant358{{"Constant[358∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant358 & Constant359 & Constant345 --> Object361
+    Object376{{"Object[376∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant373{{"Constant[373∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant374{{"Constant[374∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda188 & Constant373 & Constant374 & Constant375 --> Object376
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant370{{"Constant[370∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant370 --> Lambda188
-    Constant371{{"Constant[371∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant371 --> Lambda191
-    Lambda196{{"Lambda[196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object195 --> Lambda196
-    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant372 --> Lambda201
-    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object209 --> Lambda210
-    Lambda215{{"Lambda[215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant373 --> Lambda215
-    Lambda224{{"Lambda[224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object223 --> Lambda224
-    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant374 --> Lambda229
-    Lambda238{{"Lambda[238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object237 --> Lambda238
-    Lambda243{{"Lambda[243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant375 --> Lambda243
-    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object251 --> Lambda252
+    Constant383{{"Constant[383∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant383 --> Lambda188
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant384{{"Constant[384∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant384 --> Lambda191
+    Lambda191 --> Access192
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object196 --> Lambda197
+    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant385{{"Constant[385∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant385 --> Lambda202
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object211 --> Lambda212
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant386 --> Lambda217
+    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object226 --> Lambda227
+    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant387 --> Lambda232
+    Lambda242{{"Lambda[242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object241 --> Lambda242
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant388{{"Constant[388∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant388 --> Lambda247
     Lambda257{{"Lambda[257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant376{{"Constant[376∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant376 --> Lambda257
-    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object265 --> Lambda266
-    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant377{{"Constant[377∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant377 --> Lambda271
-    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object279 --> Lambda280
-    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant378 --> Lambda285
-    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object293 --> Lambda294
-    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant379 --> Lambda299
-    Lambda308{{"Lambda[308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object307 --> Lambda308
-    Lambda313{{"Lambda[313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant380 --> Lambda313
+    Object256 --> Lambda257
+    Lambda262{{"Lambda[262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant389 --> Lambda262
+    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object271 --> Lambda272
+    Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant390 --> Lambda277
+    Lambda287{{"Lambda[287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object286 --> Lambda287
+    Lambda292{{"Lambda[292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant391 --> Lambda292
+    Lambda302{{"Lambda[302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object301 --> Lambda302
+    Lambda307{{"Lambda[307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant392 --> Lambda307
+    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object316 --> Lambda317
     Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object321 --> Lambda322
-    Lambda327{{"Lambda[327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant381 --> Lambda327
-    Lambda336{{"Lambda[336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object335 --> Lambda336
-    Lambda341{{"Lambda[341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant382 --> Lambda341
-    Object363 --> Lambda364
-    Constant384{{"Constant[384∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant384 --> Lambda369
+    Constant393{{"Constant[393∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant393 --> Lambda322
+    Lambda332{{"Lambda[332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object331 --> Lambda332
+    Lambda337{{"Lambda[337∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant394{{"Constant[394∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant394 --> Lambda337
+    Lambda347{{"Lambda[347∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object346 --> Lambda347
+    Lambda352{{"Lambda[352∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant395{{"Constant[395∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant395 --> Lambda352
+    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object361 --> Lambda362
+    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant396{{"Constant[396∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant396 --> Lambda367
+    Object376 --> Lambda377
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant397 --> Lambda382
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object349{{"Object[349∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda188 & Constant346 & Constant347 & Constant334 --> Object349
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda350{{"Lambda[350∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object349 --> Lambda350
-    Lambda355{{"Lambda[355∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant383 --> Lambda355
     PgSelect14[["PgSelect[14∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda188 & Lambda191 & Lambda350 & Lambda355 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda188 & Access192 & Lambda362 & Lambda367 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -175,18 +177,18 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda196 & Lambda201 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda197 & Lambda202 --> PgSelect26
     PgSelect33[["PgSelect[33∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression32 & Lambda188 & Lambda191 & Lambda336 & Lambda341 --> PgSelect33
+    Object9 & PgClassExpression32 & Lambda188 & Access192 & Lambda347 & Lambda352 --> PgSelect33
     PgSelect66[["PgSelect[66∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda210 & Lambda215 --> PgSelect66
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda212 & Lambda217 --> PgSelect66
     PgSelect96[["PgSelect[96∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda224 & Lambda229 --> PgSelect96
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda227 & Lambda232 --> PgSelect96
     PgSelect126[["PgSelect[126∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda238 & Lambda243 --> PgSelect126
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda242 & Lambda247 --> PgSelect126
     PgSelect156[["PgSelect[156∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda252 & Lambda257 --> PgSelect156
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda257 & Lambda262 --> PgSelect156
     PgPolymorphic38{{"PgPolymorphic[38∈5]<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -221,15 +223,15 @@ graph TD
     First158 --> PgSelectSingle159
     PgSelect40[["PgSelect[40∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda266 & Lambda271 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda272 & Lambda277 --> PgSelect40
     PgSelect48[["PgSelect[48∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda280 & Lambda285 --> PgSelect48
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda287 & Lambda292 --> PgSelect48
     PgSelect52[["PgSelect[52∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda294 & Lambda299 --> PgSelect52
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda302 & Lambda307 --> PgSelect52
     PgSelect56[["PgSelect[56∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda308 & Lambda313 --> PgSelect56
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda317 & Lambda322 --> PgSelect56
     PgSelect60[["PgSelect[60∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda322 & Lambda327 --> PgSelect60
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda332 & Lambda337 --> PgSelect60
     PgSelectSingle36 --> PgClassExpression39
     First44{{"First[44∈6]"}}:::plan
     PgSelect40 --> First44
@@ -257,25 +259,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/nested"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 192, 193, 194, 206, 207, 208, 220, 221, 222, 234, 235, 236, 248, 249, 250, 262, 263, 276, 277, 290, 291, 304, 305, 318, 319, 332, 333, 334, 346, 347, 360, 361, 362, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 9, 188, 191, 195, 196, 201, 209, 210, 215, 223, 224, 229, 237, 238, 243, 251, 252, 257, 265, 266, 271, 279, 280, 285, 293, 294, 299, 307, 308, 313, 321, 322, 327, 335, 336, 341, 363, 364, 369<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 193, 194, 195, 208, 209, 210, 223, 224, 225, 238, 239, 240, 253, 254, 255, 268, 269, 283, 284, 298, 299, 313, 314, 328, 329, 343, 344, 345, 358, 359, 373, 374, 375, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 9, 188, 191, 192, 196, 197, 202, 211, 212, 217, 226, 227, 232, 241, 242, 247, 256, 257, 262, 271, 272, 277, 286, 287, 292, 301, 302, 307, 316, 317, 322, 331, 332, 337, 346, 347, 352, 361, 362, 367, 376, 377, 382<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda188,Lambda191,Constant192,Constant193,Constant194,Object195,Lambda196,Lambda201,Constant206,Constant207,Constant208,Object209,Lambda210,Lambda215,Constant220,Constant221,Constant222,Object223,Lambda224,Lambda229,Constant234,Constant235,Constant236,Object237,Lambda238,Lambda243,Constant248,Constant249,Constant250,Object251,Lambda252,Lambda257,Constant262,Constant263,Object265,Lambda266,Lambda271,Constant276,Constant277,Object279,Lambda280,Lambda285,Constant290,Constant291,Object293,Lambda294,Lambda299,Constant304,Constant305,Object307,Lambda308,Lambda313,Constant318,Constant319,Object321,Lambda322,Lambda327,Constant332,Constant333,Constant334,Object335,Lambda336,Lambda341,Constant346,Constant347,Constant360,Constant361,Constant362,Object363,Lambda364,Lambda369,Constant370,Constant371,Constant372,Constant373,Constant374,Constant375,Constant376,Constant377,Constant378,Constant379,Constant380,Constant381,Constant382,Constant383,Constant384 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 188, 346, 347, 334, 383, 9, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda188,Lambda191,Access192,Constant193,Constant194,Constant195,Object196,Lambda197,Lambda202,Constant208,Constant209,Constant210,Object211,Lambda212,Lambda217,Constant223,Constant224,Constant225,Object226,Lambda227,Lambda232,Constant238,Constant239,Constant240,Object241,Lambda242,Lambda247,Constant253,Constant254,Constant255,Object256,Lambda257,Lambda262,Constant268,Constant269,Object271,Lambda272,Lambda277,Constant283,Constant284,Object286,Lambda287,Lambda292,Constant298,Constant299,Object301,Lambda302,Lambda307,Constant313,Constant314,Object316,Lambda317,Lambda322,Constant328,Constant329,Object331,Lambda332,Lambda337,Constant343,Constant344,Constant345,Object346,Lambda347,Lambda352,Constant358,Constant359,Object361,Lambda362,Lambda367,Constant373,Constant374,Constant375,Object376,Lambda377,Lambda382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 188, 192, 362, 367, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object349,Lambda350,Lambda355 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 188, 191, 350, 355, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 188, 192, 362, 367, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 188, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 188, 192, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 188, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 24, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 65<br />2: 26, 33, 66, 96, 126, 156<br />ᐳ: 30, 31, 35, 36, 37, 38, 68, 69, 98, 99, 128, 129, 158, 159"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 188, 192, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 24, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 65<br />2: 26, 33, 66, 96, 126, 156<br />ᐳ: 30, 31, 35, 36, 37, 38, 68, 69, 98, 99, 128, 129, 158, 159"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression32,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,PgPolymorphic38,PgClassExpression65,PgSelect66,First68,PgSelectSingle69,PgSelect96,First98,PgSelectSingle99,PgSelect126,First128,PgSelectSingle129,PgSelect156,First158,PgSelectSingle159 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 188, 191, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47<br />2: 40, 48, 52, 56, 60<br />ᐳ: 44, 45, 50, 51, 54, 55, 58, 59, 62, 63"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 188, 192, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47<br />2: 40, 48, 52, 56, 60<br />ᐳ: 44, 45, 50, 51, 54, 55, 58, 59, 62, 63"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgSelect48,First50,PgSelectSingle51,PgSelect52,First54,PgSelectSingle55,PgSelect56,First58,PgSelectSingle59,PgSelect60,First62,PgSelectSingle63 bucket6
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.mermaid
@@ -11,143 +11,145 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda355{{"Lambda[355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access192{{"Access[192∈0] ➊<br />ᐸ191.0ᐳ"}}:::plan
+    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda374{{"Lambda[374∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda191 & Lambda350 & Lambda355 & Lambda188 & Lambda191 & Lambda369 & Lambda374 --> PgSelect6
-    Object195{{"Object[195∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda188 & Constant192 & Constant193 & Constant194 --> Object195
-    Object209{{"Object[209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda188 & Constant206 & Constant207 & Constant208 --> Object209
-    Object223{{"Object[223∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda188 & Constant220 & Constant221 & Constant222 --> Object223
-    Object237{{"Object[237∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant235{{"Constant[235∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda188 & Constant234 & Constant235 & Constant236 --> Object237
-    Object251{{"Object[251∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant249{{"Constant[249∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda188 & Constant248 & Constant249 & Constant250 --> Object251
-    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda188 & Constant262 & Constant263 & Constant194 --> Object265
-    Object279{{"Object[279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant276{{"Constant[276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant277{{"Constant[277∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda188 & Constant276 & Constant277 & Constant208 --> Object279
-    Object293{{"Object[293∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant290{{"Constant[290∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant291{{"Constant[291∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda188 & Constant290 & Constant291 & Constant222 --> Object293
-    Object307{{"Object[307∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda188 & Constant304 & Constant305 & Constant236 --> Object307
-    Object321{{"Object[321∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant318{{"Constant[318∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant319{{"Constant[319∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda188 & Constant318 & Constant319 & Constant250 --> Object321
-    Object335{{"Object[335∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant332{{"Constant[332∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant333{{"Constant[333∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant334{{"Constant[334∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda188 & Constant332 & Constant333 & Constant334 --> Object335
-    Object349{{"Object[349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda188 & Constant346 & Constant347 & Constant334 --> Object349
-    Object368{{"Object[368∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant366{{"Constant[366∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda188 & Constant365 & Constant366 & Constant367 --> Object368
+    Lambda382{{"Lambda[382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access192 & Lambda362 & Lambda367 & Lambda188 & Access192 & Lambda382 & Lambda387 --> PgSelect6
+    Object196{{"Object[196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda188 & Constant193 & Constant194 & Constant195 --> Object196
+    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda188 & Constant208 & Constant209 & Constant210 --> Object211
+    Object226{{"Object[226∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda188 & Constant223 & Constant224 & Constant225 --> Object226
+    Object241{{"Object[241∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda188 & Constant238 & Constant239 & Constant240 --> Object241
+    Object256{{"Object[256∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant253{{"Constant[253∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant254{{"Constant[254∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda188 & Constant253 & Constant254 & Constant255 --> Object256
+    Object271{{"Object[271∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant268{{"Constant[268∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant269{{"Constant[269∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda188 & Constant268 & Constant269 & Constant195 --> Object271
+    Object286{{"Object[286∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda188 & Constant283 & Constant284 & Constant210 --> Object286
+    Object301{{"Object[301∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant298{{"Constant[298∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant299{{"Constant[299∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda188 & Constant298 & Constant299 & Constant225 --> Object301
+    Object316{{"Object[316∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant313{{"Constant[313∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant314{{"Constant[314∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda188 & Constant313 & Constant314 & Constant240 --> Object316
+    Object331{{"Object[331∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant329{{"Constant[329∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda188 & Constant328 & Constant329 & Constant255 --> Object331
+    Object346{{"Object[346∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant344{{"Constant[344∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda188 & Constant343 & Constant344 & Constant345 --> Object346
+    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant358{{"Constant[358∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda188 & Constant358 & Constant359 & Constant345 --> Object361
+    Object381{{"Object[381∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant378{{"Constant[378∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant379{{"Constant[379∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant380{{"Constant[380∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda188 & Constant378 & Constant379 & Constant380 --> Object381
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant375{{"Constant[375∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant375 --> Lambda188
-    Constant376{{"Constant[376∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant376 --> Lambda191
-    Lambda196{{"Lambda[196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object195 --> Lambda196
-    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant377{{"Constant[377∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant377 --> Lambda201
-    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object209 --> Lambda210
-    Lambda215{{"Lambda[215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant378 --> Lambda215
-    Lambda224{{"Lambda[224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object223 --> Lambda224
-    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant379 --> Lambda229
-    Lambda238{{"Lambda[238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object237 --> Lambda238
-    Lambda243{{"Lambda[243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant380 --> Lambda243
-    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object251 --> Lambda252
+    Constant388{{"Constant[388∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant388 --> Lambda188
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant389 --> Lambda191
+    Lambda191 --> Access192
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object196 --> Lambda197
+    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant390 --> Lambda202
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object211 --> Lambda212
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant391 --> Lambda217
+    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object226 --> Lambda227
+    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant392 --> Lambda232
+    Lambda242{{"Lambda[242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object241 --> Lambda242
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant393{{"Constant[393∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant393 --> Lambda247
     Lambda257{{"Lambda[257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant381 --> Lambda257
-    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object265 --> Lambda266
-    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant382 --> Lambda271
-    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object279 --> Lambda280
-    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant383 --> Lambda285
-    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object293 --> Lambda294
-    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant384 --> Lambda299
-    Lambda308{{"Lambda[308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object307 --> Lambda308
-    Lambda313{{"Lambda[313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant385{{"Constant[385∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant385 --> Lambda313
+    Object256 --> Lambda257
+    Lambda262{{"Lambda[262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant394{{"Constant[394∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant394 --> Lambda262
+    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object271 --> Lambda272
+    Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant395{{"Constant[395∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant395 --> Lambda277
+    Lambda287{{"Lambda[287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object286 --> Lambda287
+    Lambda292{{"Lambda[292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant396{{"Constant[396∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant396 --> Lambda292
+    Lambda302{{"Lambda[302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object301 --> Lambda302
+    Lambda307{{"Lambda[307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant397 --> Lambda307
+    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object316 --> Lambda317
     Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object321 --> Lambda322
-    Lambda327{{"Lambda[327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant386 --> Lambda327
-    Lambda336{{"Lambda[336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object335 --> Lambda336
-    Lambda341{{"Lambda[341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant387 --> Lambda341
-    Object349 --> Lambda350
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant388 --> Lambda355
-    Object368 --> Lambda369
-    Constant389{{"Constant[389∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant389 --> Lambda374
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant398 --> Lambda322
+    Lambda332{{"Lambda[332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object331 --> Lambda332
+    Lambda337{{"Lambda[337∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant399 --> Lambda337
+    Lambda347{{"Lambda[347∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object346 --> Lambda347
+    Lambda352{{"Lambda[352∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant400{{"Constant[400∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant400 --> Lambda352
+    Object361 --> Lambda362
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant401 --> Lambda367
+    Object381 --> Lambda382
+    Constant402{{"Constant[402∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant402 --> Lambda387
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant186{{"Constant[186∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant189{{"Constant[189∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -155,18 +157,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object359{{"Object[359∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access357{{"Access[357∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access357 & Constant186 & Constant186 & Lambda188 & Constant189 --> Object359
+    Object371{{"Object[371∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access369{{"Access[369∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access369 & Constant186 & Constant186 & Lambda188 & Constant189 --> Object371
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda360{{"Lambda[360∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda360 --> __ListTransform18
-    __Item10 --> Access357
-    Object359 --> Lambda360
-    __Item19[/"__Item[19∈3]<br />ᐸ360ᐳ"\]:::itemplan
-    Lambda360 -.-> __Item19
+    Lambda372{{"Lambda[372∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda372 --> __ListTransform18
+    __Item10 --> Access369
+    Object371 --> Lambda372
+    __Item19[/"__Item[19∈3]<br />ᐸ372ᐳ"\]:::itemplan
+    Lambda372 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgPolymorphic24{{"PgPolymorphic[24∈4]"}}:::plan
@@ -179,18 +181,18 @@ graph TD
     PgSelectSingle22 --> PgClassExpression23
     PgSelect26[["PgSelect[26∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression25{{"PgClassExpression[25∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda196 & Lambda201 --> PgSelect26
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda197 & Lambda202 --> PgSelect26
     PgSelect33[["PgSelect[33∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression32 & Lambda188 & Lambda191 & Lambda336 & Lambda341 --> PgSelect33
+    Object9 & PgClassExpression32 & Lambda188 & Access192 & Lambda347 & Lambda352 --> PgSelect33
     PgSelect66[["PgSelect[66∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda210 & Lambda215 --> PgSelect66
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda212 & Lambda217 --> PgSelect66
     PgSelect96[["PgSelect[96∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda224 & Lambda229 --> PgSelect96
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda227 & Lambda232 --> PgSelect96
     PgSelect126[["PgSelect[126∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda238 & Lambda243 --> PgSelect126
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda242 & Lambda247 --> PgSelect126
     PgSelect156[["PgSelect[156∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression25 & Lambda188 & Lambda191 & Lambda252 & Lambda257 --> PgSelect156
+    Object9 & PgClassExpression25 & Lambda188 & Access192 & Lambda257 & Lambda262 --> PgSelect156
     PgPolymorphic38{{"PgPolymorphic[38∈5]<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle36{{"PgSelectSingle[36∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -225,15 +227,15 @@ graph TD
     First158 --> PgSelectSingle159
     PgSelect40[["PgSelect[40∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda266 & Lambda271 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda272 & Lambda277 --> PgSelect40
     PgSelect48[["PgSelect[48∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda280 & Lambda285 --> PgSelect48
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda287 & Lambda292 --> PgSelect48
     PgSelect52[["PgSelect[52∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda294 & Lambda299 --> PgSelect52
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda302 & Lambda307 --> PgSelect52
     PgSelect56[["PgSelect[56∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda308 & Lambda313 --> PgSelect56
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda317 & Lambda322 --> PgSelect56
     PgSelect60[["PgSelect[60∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object9 & PgClassExpression39 & Lambda188 & Lambda191 & Lambda322 & Lambda327 --> PgSelect60
+    Object9 & PgClassExpression39 & Lambda188 & Access192 & Lambda332 & Lambda337 --> PgSelect60
     PgSelectSingle36 --> PgClassExpression39
     First44{{"First[44∈6]"}}:::plan
     PgSelect40 --> First44
@@ -261,25 +263,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/nested"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 186, 189, 192, 193, 194, 206, 207, 208, 220, 221, 222, 234, 235, 236, 248, 249, 250, 262, 263, 276, 277, 290, 291, 304, 305, 318, 319, 332, 333, 334, 346, 347, 365, 366, 367, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 9, 188, 191, 195, 196, 201, 209, 210, 215, 223, 224, 229, 237, 238, 243, 251, 252, 257, 265, 266, 271, 279, 280, 285, 293, 294, 299, 307, 308, 313, 321, 322, 327, 335, 336, 341, 349, 350, 355, 368, 369, 374<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 186, 189, 193, 194, 195, 208, 209, 210, 223, 224, 225, 238, 239, 240, 253, 254, 255, 268, 269, 283, 284, 298, 299, 313, 314, 328, 329, 343, 344, 345, 358, 359, 378, 379, 380, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 9, 188, 191, 192, 196, 197, 202, 211, 212, 217, 226, 227, 232, 241, 242, 247, 256, 257, 262, 271, 272, 277, 286, 287, 292, 301, 302, 307, 316, 317, 322, 331, 332, 337, 346, 347, 352, 361, 362, 367, 381, 382, 387<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant186,Lambda188,Constant189,Lambda191,Constant192,Constant193,Constant194,Object195,Lambda196,Lambda201,Constant206,Constant207,Constant208,Object209,Lambda210,Lambda215,Constant220,Constant221,Constant222,Object223,Lambda224,Lambda229,Constant234,Constant235,Constant236,Object237,Lambda238,Lambda243,Constant248,Constant249,Constant250,Object251,Lambda252,Lambda257,Constant262,Constant263,Object265,Lambda266,Lambda271,Constant276,Constant277,Object279,Lambda280,Lambda285,Constant290,Constant291,Object293,Lambda294,Lambda299,Constant304,Constant305,Object307,Lambda308,Lambda313,Constant318,Constant319,Object321,Lambda322,Lambda327,Constant332,Constant333,Constant334,Object335,Lambda336,Lambda341,Constant346,Constant347,Object349,Lambda350,Lambda355,Constant365,Constant366,Constant367,Object368,Lambda369,Lambda374,Constant375,Constant376,Constant377,Constant378,Constant379,Constant380,Constant381,Constant382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 186, 188, 189, 9, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant186,Lambda188,Constant189,Lambda191,Access192,Constant193,Constant194,Constant195,Object196,Lambda197,Lambda202,Constant208,Constant209,Constant210,Object211,Lambda212,Lambda217,Constant223,Constant224,Constant225,Object226,Lambda227,Lambda232,Constant238,Constant239,Constant240,Object241,Lambda242,Lambda247,Constant253,Constant254,Constant255,Object256,Lambda257,Lambda262,Constant268,Constant269,Object271,Lambda272,Lambda277,Constant283,Constant284,Object286,Lambda287,Lambda292,Constant298,Constant299,Object301,Lambda302,Lambda307,Constant313,Constant314,Object316,Lambda317,Lambda322,Constant328,Constant329,Object331,Lambda332,Lambda337,Constant343,Constant344,Constant345,Object346,Lambda347,Lambda352,Constant358,Constant359,Object361,Lambda362,Lambda367,Constant378,Constant379,Constant380,Object381,Lambda382,Lambda387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397,Constant398,Constant399,Constant400,Constant401,Constant402 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 186, 188, 189, 9, 192, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 186, 188, 189, 9, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 357, 359, 360<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 186, 188, 189, 9, 192, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 369, 371, 372<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access357,Object359,Lambda360 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access369,Object371,Lambda372 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸrelational_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 188, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 188, 192, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,PgPolymorphic24 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 188, 191, 196, 201, 336, 341, 210, 215, 224, 229, 238, 243, 252, 257, 24, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 65<br />2: 26, 33, 66, 96, 126, 156<br />ᐳ: 30, 31, 35, 36, 37, 38, 68, 69, 98, 99, 128, 129, 158, 159"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 22, 9, 188, 192, 197, 202, 347, 352, 212, 217, 227, 232, 242, 247, 257, 262, 24, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337, 23<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 25, 32, 65<br />2: 26, 33, 66, 96, 126, 156<br />ᐳ: 30, 31, 35, 36, 37, 38, 68, 69, 98, 99, 128, 129, 158, 159"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression25,PgSelect26,First30,PgSelectSingle31,PgClassExpression32,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,PgPolymorphic38,PgClassExpression65,PgSelect66,First68,PgSelectSingle69,PgSelect96,First98,PgSelectSingle99,PgSelect126,First128,PgSelectSingle129,PgSelect156,First158,PgSelectSingle159 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 188, 191, 266, 271, 280, 285, 294, 299, 308, 313, 322, 327, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47<br />2: 40, 48, 52, 56, 60<br />ᐳ: 44, 45, 50, 51, 54, 55, 58, 59, 62, 63"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 36, 9, 188, 192, 272, 277, 287, 292, 302, 307, 317, 322, 332, 337, 38, 37<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 39, 47<br />2: 40, 48, 52, 56, 60<br />ᐳ: 44, 45, 50, 51, 54, 55, 58, 59, 62, 63"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgSelect48,First50,PgSelectSingle51,PgSelect52,First54,PgSelectSingle55,PgSelect56,First58,PgSelectSingle59,PgSelect60,First62,PgSelectSingle63 bucket6
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.deopt.mermaid
@@ -11,71 +11,71 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant458{{"Constant[458∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant471{{"Constant[471∈0] ➊<br />ᐸ15ᐳ"}}:::plan
     Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda452{{"Lambda[452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda457{{"Lambda[457∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant458 & Lambda276 & Lambda279 & Lambda452 & Lambda457 --> PgSelect7
-    Object283{{"Object[283∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant280{{"Constant[280∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant281{{"Constant[281∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda276 & Constant280 & Constant281 & Constant282 --> Object283
-    Object297{{"Object[297∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant294{{"Constant[294∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant295{{"Constant[295∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant296{{"Constant[296∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda276 & Constant294 & Constant295 & Constant296 --> Object297
-    Object311{{"Object[311∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant308{{"Constant[308∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant309{{"Constant[309∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda276 & Constant308 & Constant309 & Constant310 --> Object311
-    Object325{{"Object[325∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant322{{"Constant[322∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant323{{"Constant[323∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant324{{"Constant[324∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda276 & Constant322 & Constant323 & Constant324 --> Object325
-    Object339{{"Object[339∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant336{{"Constant[336∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant337{{"Constant[337∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant338{{"Constant[338∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda276 & Constant336 & Constant337 & Constant338 --> Object339
-    Object353{{"Object[353∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant350{{"Constant[350∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant351{{"Constant[351∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda276 & Constant350 & Constant351 & Constant282 --> Object353
-    Object367{{"Object[367∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant364{{"Constant[364∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda276 & Constant364 & Constant365 & Constant296 --> Object367
-    Object381{{"Object[381∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda276 & Constant378 & Constant379 & Constant310 --> Object381
-    Object395{{"Object[395∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant392{{"Constant[392∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant393{{"Constant[393∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda276 & Constant392 & Constant393 & Constant324 --> Object395
-    Object409{{"Object[409∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda276 & Constant406 & Constant407 & Constant338 --> Object409
-    Object423{{"Object[423∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant420{{"Constant[420∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant421{{"Constant[421∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda276 & Constant420 & Constant421 & Constant422 --> Object423
-    Object437{{"Object[437∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda276 & Constant434 & Constant435 & Constant436 --> Object437
-    Object451{{"Object[451∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda276 & Constant448 & Constant449 & Constant436 --> Object451
+    Access280{{"Access[280∈0] ➊<br />ᐸ279.0ᐳ"}}:::plan
+    Lambda465{{"Lambda[465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda470{{"Lambda[470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant471 & Lambda276 & Access280 & Lambda465 & Lambda470 --> PgSelect7
+    Object284{{"Object[284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda276 & Constant281 & Constant282 & Constant283 --> Object284
+    Object299{{"Object[299∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant296{{"Constant[296∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant297{{"Constant[297∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant298{{"Constant[298∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda276 & Constant296 & Constant297 & Constant298 --> Object299
+    Object314{{"Object[314∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant311{{"Constant[311∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant312{{"Constant[312∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant313{{"Constant[313∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda276 & Constant311 & Constant312 & Constant313 --> Object314
+    Object329{{"Object[329∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant326{{"Constant[326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant327{{"Constant[327∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda276 & Constant326 & Constant327 & Constant328 --> Object329
+    Object344{{"Object[344∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant341{{"Constant[341∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant342{{"Constant[342∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda276 & Constant341 & Constant342 & Constant343 --> Object344
+    Object359{{"Object[359∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant356{{"Constant[356∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda276 & Constant356 & Constant357 & Constant283 --> Object359
+    Object374{{"Object[374∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant371{{"Constant[371∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant372{{"Constant[372∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda276 & Constant371 & Constant372 & Constant298 --> Object374
+    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda276 & Constant386 & Constant387 & Constant313 --> Object389
+    Object404{{"Object[404∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda276 & Constant401 & Constant402 & Constant328 --> Object404
+    Object419{{"Object[419∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant416{{"Constant[416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda276 & Constant416 & Constant417 & Constant343 --> Object419
+    Object434{{"Object[434∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda276 & Constant431 & Constant432 & Constant433 --> Object434
+    Object449{{"Object[449∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda276 & Constant446 & Constant447 & Constant448 --> Object449
+    Object464{{"Object[464∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda276 & Constant461 & Constant462 & Constant448 --> Object464
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -90,88 +90,90 @@ graph TD
     PgSelect7 --> First11
     First11 --> PgSelectSingle12
     PgSelectSingle12 --> PgClassExpression13
-    Constant459{{"Constant[459∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant459 --> Lambda276
-    Constant460{{"Constant[460∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant460 --> Lambda279
-    Lambda284{{"Lambda[284∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object283 --> Lambda284
-    Lambda289{{"Lambda[289∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant461{{"Constant[461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant461 --> Lambda289
-    Lambda298{{"Lambda[298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object297 --> Lambda298
-    Lambda303{{"Lambda[303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant462{{"Constant[462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant462 --> Lambda303
-    Lambda312{{"Lambda[312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object311 --> Lambda312
-    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant463{{"Constant[463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant463 --> Lambda317
-    Lambda326{{"Lambda[326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object325 --> Lambda326
-    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant464 --> Lambda331
-    Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object339 --> Lambda340
+    Constant472{{"Constant[472∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant472 --> Lambda276
+    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant473 --> Lambda279
+    Lambda279 --> Access280
+    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object284 --> Lambda285
+    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant474 --> Lambda290
+    Lambda300{{"Lambda[300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object299 --> Lambda300
+    Lambda305{{"Lambda[305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant475{{"Constant[475∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant475 --> Lambda305
+    Lambda315{{"Lambda[315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object314 --> Lambda315
+    Lambda320{{"Lambda[320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant476{{"Constant[476∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant476 --> Lambda320
+    Lambda330{{"Lambda[330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object329 --> Lambda330
+    Lambda335{{"Lambda[335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant477 --> Lambda335
     Lambda345{{"Lambda[345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant465 --> Lambda345
-    Lambda354{{"Lambda[354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object353 --> Lambda354
-    Lambda359{{"Lambda[359∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant466 --> Lambda359
-    Lambda368{{"Lambda[368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object367 --> Lambda368
-    Lambda373{{"Lambda[373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant467 --> Lambda373
-    Lambda382{{"Lambda[382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object381 --> Lambda382
-    Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant468 --> Lambda387
-    Lambda396{{"Lambda[396∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object395 --> Lambda396
-    Lambda401{{"Lambda[401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant469 --> Lambda401
+    Object344 --> Lambda345
+    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant478 --> Lambda350
+    Lambda360{{"Lambda[360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object359 --> Lambda360
+    Lambda365{{"Lambda[365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant479 --> Lambda365
+    Lambda375{{"Lambda[375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object374 --> Lambda375
+    Lambda380{{"Lambda[380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant480 --> Lambda380
+    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object389 --> Lambda390
+    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant481 --> Lambda395
+    Lambda405{{"Lambda[405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object404 --> Lambda405
     Lambda410{{"Lambda[410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object409 --> Lambda410
-    Lambda415{{"Lambda[415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant470 --> Lambda415
-    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object423 --> Lambda424
-    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant471 --> Lambda429
-    Lambda438{{"Lambda[438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object437 --> Lambda438
-    Lambda443{{"Lambda[443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant472 --> Lambda443
-    Object451 --> Lambda452
-    Constant473{{"Constant[473∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant473 --> Lambda457
+    Constant482{{"Constant[482∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant482 --> Lambda410
+    Lambda420{{"Lambda[420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object419 --> Lambda420
+    Lambda425{{"Lambda[425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant483{{"Constant[483∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant483 --> Lambda425
+    Lambda435{{"Lambda[435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object434 --> Lambda435
+    Lambda440{{"Lambda[440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant484{{"Constant[484∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant484 --> Lambda440
+    Lambda450{{"Lambda[450∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object449 --> Lambda450
+    Lambda455{{"Lambda[455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant485{{"Constant[485∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant485 --> Lambda455
+    Object464 --> Lambda465
+    Constant486{{"Constant[486∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant486 --> Lambda470
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda284 & Lambda289 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda285 & Lambda290 --> PgSelect16
     PgSelect23[["PgSelect[23∈1] ➊<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈1] ➊<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression22 & Lambda276 & Lambda279 & Lambda438 & Lambda443 --> PgSelect23
+    Object10 & PgClassExpression22 & Lambda276 & Access280 & Lambda450 & Lambda455 --> PgSelect23
     PgSelect74[["PgSelect[74∈1] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda298 & Lambda303 --> PgSelect74
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda300 & Lambda305 --> PgSelect74
     PgSelect124[["PgSelect[124∈1] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda312 & Lambda317 --> PgSelect124
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda315 & Lambda320 --> PgSelect124
     PgSelect174[["PgSelect[174∈1] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda326 & Lambda331 --> PgSelect174
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda330 & Lambda335 --> PgSelect174
     PgSelect224[["PgSelect[224∈1] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda340 & Lambda345 --> PgSelect224
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda345 & Lambda350 --> PgSelect224
     PgPolymorphic28{{"PgPolymorphic[28∈1] ➊<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle26{{"PgSelectSingle[26∈1] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression27{{"PgClassExpression[27∈1] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -204,18 +206,18 @@ graph TD
     First226 --> PgSelectSingle227
     PgSelect30[["PgSelect[30∈2] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression29{{"PgClassExpression[29∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda354 & Lambda359 --> PgSelect30
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda360 & Lambda365 --> PgSelect30
     PgSelect37[["PgSelect[37∈2] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈2] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression36 & Lambda276 & Lambda279 & Lambda424 & Lambda429 --> PgSelect37
+    Object10 & PgClassExpression36 & Lambda276 & Access280 & Lambda435 & Lambda440 --> PgSelect37
     PgSelect42[["PgSelect[42∈2] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda368 & Lambda373 --> PgSelect42
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda375 & Lambda380 --> PgSelect42
     PgSelect50[["PgSelect[50∈2] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda382 & Lambda387 --> PgSelect50
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda390 & Lambda395 --> PgSelect50
     PgSelect58[["PgSelect[58∈2] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda396 & Lambda401 --> PgSelect58
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda405 & Lambda410 --> PgSelect58
     PgSelect66[["PgSelect[66∈2] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda410 & Lambda415 --> PgSelect66
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda420 & Lambda425 --> PgSelect66
     PgSelectSingle26 --> PgClassExpression29
     First34{{"First[34∈2] ➊"}}:::plan
     PgSelect30 --> First34
@@ -248,13 +250,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 280, 281, 282, 294, 295, 296, 308, 309, 310, 322, 323, 324, 336, 337, 338, 350, 351, 364, 365, 378, 379, 392, 393, 406, 407, 420, 421, 422, 434, 435, 436, 448, 449, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 10, 276, 279, 283, 284, 289, 297, 298, 303, 311, 312, 317, 325, 326, 331, 339, 340, 345, 353, 354, 359, 367, 368, 373, 381, 382, 387, 395, 396, 401, 409, 410, 415, 423, 424, 429, 437, 438, 443, 451, 452, 457<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 281, 282, 283, 296, 297, 298, 311, 312, 313, 326, 327, 328, 341, 342, 343, 356, 357, 371, 372, 386, 387, 401, 402, 416, 417, 431, 432, 433, 446, 447, 448, 461, 462, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 10, 276, 279, 280, 284, 285, 290, 299, 300, 305, 314, 315, 320, 329, 330, 335, 344, 345, 350, 359, 360, 365, 374, 375, 380, 389, 390, 395, 404, 405, 410, 419, 420, 425, 434, 435, 440, 449, 450, 455, 464, 465, 470<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda276,Lambda279,Constant280,Constant281,Constant282,Object283,Lambda284,Lambda289,Constant294,Constant295,Constant296,Object297,Lambda298,Lambda303,Constant308,Constant309,Constant310,Object311,Lambda312,Lambda317,Constant322,Constant323,Constant324,Object325,Lambda326,Lambda331,Constant336,Constant337,Constant338,Object339,Lambda340,Lambda345,Constant350,Constant351,Object353,Lambda354,Lambda359,Constant364,Constant365,Object367,Lambda368,Lambda373,Constant378,Constant379,Object381,Lambda382,Lambda387,Constant392,Constant393,Object395,Lambda396,Lambda401,Constant406,Constant407,Object409,Lambda410,Lambda415,Constant420,Constant421,Constant422,Object423,Lambda424,Lambda429,Constant434,Constant435,Constant436,Object437,Lambda438,Lambda443,Constant448,Constant449,Object451,Lambda452,Lambda457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 10, 276, 279, 284, 289, 438, 443, 298, 303, 312, 317, 326, 331, 340, 345, 14, 354, 359, 424, 429, 368, 373, 382, 387, 396, 401, 410, 415<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 15, 22<br />2: 16, 23, 74, 124, 174, 224<br />ᐳ: 20, 21, 25, 26, 27, 28, 76, 77, 126, 127, 176, 177, 226, 227"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda276,Lambda279,Access280,Constant281,Constant282,Constant283,Object284,Lambda285,Lambda290,Constant296,Constant297,Constant298,Object299,Lambda300,Lambda305,Constant311,Constant312,Constant313,Object314,Lambda315,Lambda320,Constant326,Constant327,Constant328,Object329,Lambda330,Lambda335,Constant341,Constant342,Constant343,Object344,Lambda345,Lambda350,Constant356,Constant357,Object359,Lambda360,Lambda365,Constant371,Constant372,Object374,Lambda375,Lambda380,Constant386,Constant387,Object389,Lambda390,Lambda395,Constant401,Constant402,Object404,Lambda405,Lambda410,Constant416,Constant417,Object419,Lambda420,Lambda425,Constant431,Constant432,Constant433,Object434,Lambda435,Lambda440,Constant446,Constant447,Constant448,Object449,Lambda450,Lambda455,Constant461,Constant462,Object464,Lambda465,Lambda470,Constant471,Constant472,Constant473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483,Constant484,Constant485,Constant486 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 10, 276, 280, 285, 290, 450, 455, 300, 305, 315, 320, 330, 335, 345, 350, 14, 360, 365, 435, 440, 375, 380, 390, 395, 405, 410, 420, 425<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 15, 22<br />2: 16, 23, 74, 124, 174, 224<br />ᐳ: 20, 21, 25, 26, 27, 28, 76, 77, 126, 127, 176, 177, 226, 227"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgSelect23,First25,PgSelectSingle26,PgClassExpression27,PgPolymorphic28,PgSelect74,First76,PgSelectSingle77,PgSelect124,First126,PgSelectSingle127,PgSelect174,First176,PgSelectSingle177,PgSelect224,First226,PgSelectSingle227 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 26, 10, 276, 279, 354, 359, 424, 429, 368, 373, 382, 387, 396, 401, 410, 415, 28<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 29, 36<br />2: 30, 37, 42, 50, 58, 66<br />ᐳ: 34, 35, 39, 40, 44, 45, 52, 53, 60, 61, 68, 69"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 26, 10, 276, 280, 360, 365, 435, 440, 375, 380, 390, 395, 405, 410, 420, 425, 28<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 29, 36<br />2: 30, 37, 42, 50, 58, 66<br />ᐳ: 34, 35, 39, 40, 44, 45, 52, 53, 60, 61, 68, 69"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression29,PgSelect30,First34,PgSelectSingle35,PgClassExpression36,PgSelect37,First39,PgSelectSingle40,PgSelect42,First44,PgSelectSingle45,PgSelect50,First52,PgSelectSingle53,PgSelect58,First60,PgSelectSingle61,PgSelect66,First68,PgSelectSingle69 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 40<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[40]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.mermaid
@@ -11,71 +11,71 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant458{{"Constant[458∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant471{{"Constant[471∈0] ➊<br />ᐸ15ᐳ"}}:::plan
     Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda452{{"Lambda[452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda457{{"Lambda[457∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant458 & Lambda276 & Lambda279 & Lambda452 & Lambda457 --> PgSelect7
-    Object283{{"Object[283∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant280{{"Constant[280∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant281{{"Constant[281∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda276 & Constant280 & Constant281 & Constant282 --> Object283
-    Object297{{"Object[297∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant294{{"Constant[294∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant295{{"Constant[295∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant296{{"Constant[296∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
-    Lambda276 & Constant294 & Constant295 & Constant296 --> Object297
-    Object311{{"Object[311∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant308{{"Constant[308∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant309{{"Constant[309∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
-    Lambda276 & Constant308 & Constant309 & Constant310 --> Object311
-    Object325{{"Object[325∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant322{{"Constant[322∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant323{{"Constant[323∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant324{{"Constant[324∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
-    Lambda276 & Constant322 & Constant323 & Constant324 --> Object325
-    Object339{{"Object[339∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant336{{"Constant[336∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant337{{"Constant[337∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant338{{"Constant[338∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
-    Lambda276 & Constant336 & Constant337 & Constant338 --> Object339
-    Object353{{"Object[353∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant350{{"Constant[350∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant351{{"Constant[351∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda276 & Constant350 & Constant351 & Constant282 --> Object353
-    Object367{{"Object[367∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant364{{"Constant[364∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda276 & Constant364 & Constant365 & Constant296 --> Object367
-    Object381{{"Object[381∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda276 & Constant378 & Constant379 & Constant310 --> Object381
-    Object395{{"Object[395∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant392{{"Constant[392∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant393{{"Constant[393∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda276 & Constant392 & Constant393 & Constant324 --> Object395
-    Object409{{"Object[409∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda276 & Constant406 & Constant407 & Constant338 --> Object409
-    Object423{{"Object[423∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant420{{"Constant[420∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant421{{"Constant[421∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda276 & Constant420 & Constant421 & Constant422 --> Object423
-    Object437{{"Object[437∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda276 & Constant434 & Constant435 & Constant436 --> Object437
-    Object451{{"Object[451∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda276 & Constant448 & Constant449 & Constant436 --> Object451
+    Access280{{"Access[280∈0] ➊<br />ᐸ279.0ᐳ"}}:::plan
+    Lambda465{{"Lambda[465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda470{{"Lambda[470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant471 & Lambda276 & Access280 & Lambda465 & Lambda470 --> PgSelect7
+    Object284{{"Object[284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda276 & Constant281 & Constant282 & Constant283 --> Object284
+    Object299{{"Object[299∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant296{{"Constant[296∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant297{{"Constant[297∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant298{{"Constant[298∈0] ➊<br />ᐸRecordCodec(relational_posts)ᐳ"}}:::plan
+    Lambda276 & Constant296 & Constant297 & Constant298 --> Object299
+    Object314{{"Object[314∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant311{{"Constant[311∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant312{{"Constant[312∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant313{{"Constant[313∈0] ➊<br />ᐸRecordCodec(relational_dividers)ᐳ"}}:::plan
+    Lambda276 & Constant311 & Constant312 & Constant313 --> Object314
+    Object329{{"Object[329∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant326{{"Constant[326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant327{{"Constant[327∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸRecordCodec(relational_checklists)ᐳ"}}:::plan
+    Lambda276 & Constant326 & Constant327 & Constant328 --> Object329
+    Object344{{"Object[344∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant341{{"Constant[341∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant342{{"Constant[342∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸRecordCodec(relational_checklist_items)ᐳ"}}:::plan
+    Lambda276 & Constant341 & Constant342 & Constant343 --> Object344
+    Object359{{"Object[359∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant356{{"Constant[356∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda276 & Constant356 & Constant357 & Constant283 --> Object359
+    Object374{{"Object[374∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant371{{"Constant[371∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant372{{"Constant[372∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda276 & Constant371 & Constant372 & Constant298 --> Object374
+    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda276 & Constant386 & Constant387 & Constant313 --> Object389
+    Object404{{"Object[404∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda276 & Constant401 & Constant402 & Constant328 --> Object404
+    Object419{{"Object[419∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant416{{"Constant[416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda276 & Constant416 & Constant417 & Constant343 --> Object419
+    Object434{{"Object[434∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda276 & Constant431 & Constant432 & Constant433 --> Object434
+    Object449{{"Object[449∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda276 & Constant446 & Constant447 & Constant448 --> Object449
+    Object464{{"Object[464∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda276 & Constant461 & Constant462 & Constant448 --> Object464
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -90,88 +90,90 @@ graph TD
     PgSelect7 --> First11
     First11 --> PgSelectSingle12
     PgSelectSingle12 --> PgClassExpression13
-    Constant459{{"Constant[459∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant459 --> Lambda276
-    Constant460{{"Constant[460∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant460 --> Lambda279
-    Lambda284{{"Lambda[284∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object283 --> Lambda284
-    Lambda289{{"Lambda[289∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant461{{"Constant[461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant461 --> Lambda289
-    Lambda298{{"Lambda[298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object297 --> Lambda298
-    Lambda303{{"Lambda[303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant462{{"Constant[462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant462 --> Lambda303
-    Lambda312{{"Lambda[312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object311 --> Lambda312
-    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant463{{"Constant[463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant463 --> Lambda317
-    Lambda326{{"Lambda[326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object325 --> Lambda326
-    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant464 --> Lambda331
-    Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object339 --> Lambda340
+    Constant472{{"Constant[472∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant472 --> Lambda276
+    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant473 --> Lambda279
+    Lambda279 --> Access280
+    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object284 --> Lambda285
+    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant474 --> Lambda290
+    Lambda300{{"Lambda[300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object299 --> Lambda300
+    Lambda305{{"Lambda[305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant475{{"Constant[475∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant475 --> Lambda305
+    Lambda315{{"Lambda[315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object314 --> Lambda315
+    Lambda320{{"Lambda[320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant476{{"Constant[476∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant476 --> Lambda320
+    Lambda330{{"Lambda[330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object329 --> Lambda330
+    Lambda335{{"Lambda[335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant477 --> Lambda335
     Lambda345{{"Lambda[345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant465 --> Lambda345
-    Lambda354{{"Lambda[354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object353 --> Lambda354
-    Lambda359{{"Lambda[359∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant466 --> Lambda359
-    Lambda368{{"Lambda[368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object367 --> Lambda368
-    Lambda373{{"Lambda[373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant467 --> Lambda373
-    Lambda382{{"Lambda[382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object381 --> Lambda382
-    Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant468 --> Lambda387
-    Lambda396{{"Lambda[396∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object395 --> Lambda396
-    Lambda401{{"Lambda[401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant469 --> Lambda401
+    Object344 --> Lambda345
+    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant478 --> Lambda350
+    Lambda360{{"Lambda[360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object359 --> Lambda360
+    Lambda365{{"Lambda[365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant479 --> Lambda365
+    Lambda375{{"Lambda[375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object374 --> Lambda375
+    Lambda380{{"Lambda[380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant480 --> Lambda380
+    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object389 --> Lambda390
+    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant481 --> Lambda395
+    Lambda405{{"Lambda[405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object404 --> Lambda405
     Lambda410{{"Lambda[410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object409 --> Lambda410
-    Lambda415{{"Lambda[415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant470 --> Lambda415
-    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object423 --> Lambda424
-    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant471 --> Lambda429
-    Lambda438{{"Lambda[438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object437 --> Lambda438
-    Lambda443{{"Lambda[443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant472 --> Lambda443
-    Object451 --> Lambda452
-    Constant473{{"Constant[473∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant473 --> Lambda457
+    Constant482{{"Constant[482∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant482 --> Lambda410
+    Lambda420{{"Lambda[420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object419 --> Lambda420
+    Lambda425{{"Lambda[425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant483{{"Constant[483∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant483 --> Lambda425
+    Lambda435{{"Lambda[435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object434 --> Lambda435
+    Lambda440{{"Lambda[440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant484{{"Constant[484∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant484 --> Lambda440
+    Lambda450{{"Lambda[450∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object449 --> Lambda450
+    Lambda455{{"Lambda[455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant485{{"Constant[485∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant485 --> Lambda455
+    Object464 --> Lambda465
+    Constant486{{"Constant[486∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant486 --> Lambda470
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda284 & Lambda289 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda285 & Lambda290 --> PgSelect16
     PgSelect23[["PgSelect[23∈1] ➊<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈1] ➊<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression22 & Lambda276 & Lambda279 & Lambda438 & Lambda443 --> PgSelect23
+    Object10 & PgClassExpression22 & Lambda276 & Access280 & Lambda450 & Lambda455 --> PgSelect23
     PgSelect74[["PgSelect[74∈1] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda298 & Lambda303 --> PgSelect74
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda300 & Lambda305 --> PgSelect74
     PgSelect124[["PgSelect[124∈1] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda312 & Lambda317 --> PgSelect124
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda315 & Lambda320 --> PgSelect124
     PgSelect174[["PgSelect[174∈1] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda326 & Lambda331 --> PgSelect174
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda330 & Lambda335 --> PgSelect174
     PgSelect224[["PgSelect[224∈1] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda276 & Lambda279 & Lambda340 & Lambda345 --> PgSelect224
+    Object10 & PgClassExpression15 & Lambda276 & Access280 & Lambda345 & Lambda350 --> PgSelect224
     PgPolymorphic28{{"PgPolymorphic[28∈1] ➊<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle26{{"PgSelectSingle[26∈1] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression27{{"PgClassExpression[27∈1] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
@@ -204,18 +206,18 @@ graph TD
     First226 --> PgSelectSingle227
     PgSelect30[["PgSelect[30∈2] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression29{{"PgClassExpression[29∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda354 & Lambda359 --> PgSelect30
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda360 & Lambda365 --> PgSelect30
     PgSelect37[["PgSelect[37∈2] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈2] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression36 & Lambda276 & Lambda279 & Lambda424 & Lambda429 --> PgSelect37
+    Object10 & PgClassExpression36 & Lambda276 & Access280 & Lambda435 & Lambda440 --> PgSelect37
     PgSelect42[["PgSelect[42∈2] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda368 & Lambda373 --> PgSelect42
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda375 & Lambda380 --> PgSelect42
     PgSelect50[["PgSelect[50∈2] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda382 & Lambda387 --> PgSelect50
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda390 & Lambda395 --> PgSelect50
     PgSelect58[["PgSelect[58∈2] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda396 & Lambda401 --> PgSelect58
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda405 & Lambda410 --> PgSelect58
     PgSelect66[["PgSelect[66∈2] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object10 & PgClassExpression29 & Lambda276 & Lambda279 & Lambda410 & Lambda415 --> PgSelect66
+    Object10 & PgClassExpression29 & Lambda276 & Access280 & Lambda420 & Lambda425 --> PgSelect66
     PgSelectSingle26 --> PgClassExpression29
     First34{{"First[34∈2] ➊"}}:::plan
     PgSelect30 --> First34
@@ -248,13 +250,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 280, 281, 282, 294, 295, 296, 308, 309, 310, 322, 323, 324, 336, 337, 338, 350, 351, 364, 365, 378, 379, 392, 393, 406, 407, 420, 421, 422, 434, 435, 436, 448, 449, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 10, 276, 279, 283, 284, 289, 297, 298, 303, 311, 312, 317, 325, 326, 331, 339, 340, 345, 353, 354, 359, 367, 368, 373, 381, 382, 387, 395, 396, 401, 409, 410, 415, 423, 424, 429, 437, 438, 443, 451, 452, 457<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 281, 282, 283, 296, 297, 298, 311, 312, 313, 326, 327, 328, 341, 342, 343, 356, 357, 371, 372, 386, 387, 401, 402, 416, 417, 431, 432, 433, 446, 447, 448, 461, 462, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 10, 276, 279, 280, 284, 285, 290, 299, 300, 305, 314, 315, 320, 329, 330, 335, 344, 345, 350, 359, 360, 365, 374, 375, 380, 389, 390, 395, 404, 405, 410, 419, 420, 425, 434, 435, 440, 449, 450, 455, 464, 465, 470<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda276,Lambda279,Constant280,Constant281,Constant282,Object283,Lambda284,Lambda289,Constant294,Constant295,Constant296,Object297,Lambda298,Lambda303,Constant308,Constant309,Constant310,Object311,Lambda312,Lambda317,Constant322,Constant323,Constant324,Object325,Lambda326,Lambda331,Constant336,Constant337,Constant338,Object339,Lambda340,Lambda345,Constant350,Constant351,Object353,Lambda354,Lambda359,Constant364,Constant365,Object367,Lambda368,Lambda373,Constant378,Constant379,Object381,Lambda382,Lambda387,Constant392,Constant393,Object395,Lambda396,Lambda401,Constant406,Constant407,Object409,Lambda410,Lambda415,Constant420,Constant421,Constant422,Object423,Lambda424,Lambda429,Constant434,Constant435,Constant436,Object437,Lambda438,Lambda443,Constant448,Constant449,Object451,Lambda452,Lambda457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 10, 276, 279, 284, 289, 438, 443, 298, 303, 312, 317, 326, 331, 340, 345, 14, 354, 359, 424, 429, 368, 373, 382, 387, 396, 401, 410, 415<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 15, 22<br />2: 16, 23, 74, 124, 174, 224<br />ᐳ: 20, 21, 25, 26, 27, 28, 76, 77, 126, 127, 176, 177, 226, 227"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda276,Lambda279,Access280,Constant281,Constant282,Constant283,Object284,Lambda285,Lambda290,Constant296,Constant297,Constant298,Object299,Lambda300,Lambda305,Constant311,Constant312,Constant313,Object314,Lambda315,Lambda320,Constant326,Constant327,Constant328,Object329,Lambda330,Lambda335,Constant341,Constant342,Constant343,Object344,Lambda345,Lambda350,Constant356,Constant357,Object359,Lambda360,Lambda365,Constant371,Constant372,Object374,Lambda375,Lambda380,Constant386,Constant387,Object389,Lambda390,Lambda395,Constant401,Constant402,Object404,Lambda405,Lambda410,Constant416,Constant417,Object419,Lambda420,Lambda425,Constant431,Constant432,Constant433,Object434,Lambda435,Lambda440,Constant446,Constant447,Constant448,Object449,Lambda450,Lambda455,Constant461,Constant462,Object464,Lambda465,Lambda470,Constant471,Constant472,Constant473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483,Constant484,Constant485,Constant486 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 10, 276, 280, 285, 290, 450, 455, 300, 305, 315, 320, 330, 335, 345, 350, 14, 360, 365, 435, 440, 375, 380, 390, 395, 405, 410, 420, 425<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 15, 22<br />2: 16, 23, 74, 124, 174, 224<br />ᐳ: 20, 21, 25, 26, 27, 28, 76, 77, 126, 127, 176, 177, 226, 227"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgSelect23,First25,PgSelectSingle26,PgClassExpression27,PgPolymorphic28,PgSelect74,First76,PgSelectSingle77,PgSelect124,First126,PgSelectSingle127,PgSelect174,First176,PgSelectSingle177,PgSelect224,First226,PgSelectSingle227 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 26, 10, 276, 279, 354, 359, 424, 429, 368, 373, 382, 387, 396, 401, 410, 415, 28<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 29, 36<br />2: 30, 37, 42, 50, 58, 66<br />ᐳ: 34, 35, 39, 40, 44, 45, 52, 53, 60, 61, 68, 69"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 26, 10, 276, 280, 360, 365, 435, 440, 375, 380, 390, 395, 405, 410, 420, 425, 28<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 29, 36<br />2: 30, 37, 42, 50, 58, 66<br />ᐳ: 34, 35, 39, 40, 44, 45, 52, 53, 60, 61, 68, 69"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression29,PgSelect30,First34,PgSelectSingle35,PgClassExpression36,PgSelect37,First39,PgSelectSingle40,PgSelect42,First44,PgSelectSingle45,PgSelect50,First52,PgSelectSingle53,PgSelect58,First60,PgSelectSingle61,PgSelect66,First68,PgSelectSingle69 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 40<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[40]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-as-item.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-as-item.deopt.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_topicsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant84 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant86 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda54
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda57
-    Object61 --> Lambda62
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant87 --> Lambda67
-    Object77 --> Lambda78
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant88 --> Lambda83
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant89 --> Lambda68
+    Object79 --> Lambda80
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant90 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__relation...ics__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -74,9 +76,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/single-topic-as-item"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 74, 75, 76, 84, 85, 86, 87, 88, 10, 54, 57, 61, 62, 67, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 76, 77, 78, 86, 87, 88, 89, 90, 10, 54, 57, 58, 62, 63, 68, 79, 80, 85<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrelational_topicsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression20,PgClassExpression25,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression45,PgClassExpression50,PgClassExpression51 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-as-item.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-as-item.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_topicsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant84 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant86 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda54
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda57
-    Object61 --> Lambda62
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant87 --> Lambda67
-    Object77 --> Lambda78
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant88 --> Lambda83
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant89 --> Lambda68
+    Object79 --> Lambda80
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant90 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__relation...ics__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -74,9 +76,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/single-topic-as-item"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 74, 75, 76, 84, 85, 86, 87, 88, 10, 54, 57, 61, 62, 67, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 76, 77, 78, 86, 87, 88, 89, 90, 10, 54, 57, 58, 62, 63, 68, 79, 80, 85<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrelational_topicsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression20,PgClassExpression25,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression45,PgClassExpression50,PgClassExpression51 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-not-topic.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-not-topic.deopt.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_topicsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant84 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant86 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda54
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda57
-    Object61 --> Lambda62
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant87 --> Lambda67
-    Object77 --> Lambda78
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant88 --> Lambda83
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant89 --> Lambda68
+    Object79 --> Lambda80
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant90 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__relation...ics__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -74,9 +76,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/single-topic-not-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 74, 75, 76, 84, 85, 86, 87, 88, 10, 54, 57, 61, 62, 67, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 76, 77, 78, 86, 87, 88, 89, 90, 10, 54, 57, 58, 62, 63, 68, 79, 80, 85<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrelational_topicsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression20,PgClassExpression25,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression45,PgClassExpression50,PgClassExpression51 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-not-topic.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic-not-topic.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_topicsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant84 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant86 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda54
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda57
-    Object61 --> Lambda62
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant87 --> Lambda67
-    Object77 --> Lambda78
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant88 --> Lambda83
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant89 --> Lambda68
+    Object79 --> Lambda80
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant90 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__relation...ics__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -74,9 +76,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/single-topic-not-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 74, 75, 76, 84, 85, 86, 87, 88, 10, 54, 57, 61, 62, 67, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 76, 77, 78, 86, 87, 88, 89, 90, 10, 54, 57, 58, 62, 63, 68, 79, 80, 85<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrelational_topicsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression20,PgClassExpression25,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression45,PgClassExpression50,PgClassExpression51 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic.deopt.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_topicsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant84 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant86 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda54
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda57
-    Object61 --> Lambda62
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant87 --> Lambda67
-    Object77 --> Lambda78
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant88 --> Lambda83
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant89 --> Lambda68
+    Object79 --> Lambda80
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant90 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__relation...ics__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -74,9 +76,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/single-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 74, 75, 76, 84, 85, 86, 87, 88, 10, 54, 57, 61, 62, 67, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 76, 77, 78, 86, 87, 88, 89, 90, 10, 54, 57, 58, 62, 63, 68, 79, 80, 85<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrelational_topicsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression20,PgClassExpression25,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression45,PgClassExpression50,PgClassExpression51 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/single-topic.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_topicsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant84 & Lambda57 & Lambda62 & Lambda67 & Lambda54 & Lambda57 & Lambda78 & Lambda83 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
-    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant86 & Access58 & Lambda63 & Lambda68 & Lambda54 & Access58 & Lambda80 & Lambda85 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(relational_items)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(relational_topics)ᐳ"}}:::plan
+    Lambda54 & Constant76 & Constant77 & Constant78 --> Object79
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,16 +39,18 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant85 --> Lambda54
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda57
-    Object61 --> Lambda62
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant87 --> Lambda67
-    Object77 --> Lambda78
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant88 --> Lambda83
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant87 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant88 --> Lambda57
+    Lambda57 --> Access58
+    Object62 --> Lambda63
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant89 --> Lambda68
+    Object79 --> Lambda80
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant90 --> Lambda85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__relation...ics__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -74,9 +76,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/single-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 74, 75, 76, 84, 85, 86, 87, 88, 10, 54, 57, 61, 62, 67, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 76, 77, 78, 86, 87, 88, 89, 90, 10, 54, 57, 58, 62, 63, 68, 79, 80, 85<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant86,Constant87,Constant88,Constant89,Constant90 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrelational_topicsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression20,PgClassExpression25,PgClassExpression30,PgClassExpression35,PgClassExpression40,PgClassExpression45,PgClassExpression50,PgClassExpression51 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.mermaid
@@ -12,46 +12,48 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda40 & Lambda43 & Lambda62 & Lambda67 --> PgSelect6
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda40 & Constant58 & Constant59 & Constant60 --> Object61
+    Access44{{"Access[44∈0] ➊<br />ᐸ43.0ᐳ"}}:::plan
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda40 & Access44 & Lambda64 & Lambda69 --> PgSelect6
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda40 & Constant45 & Constant46 & Constant47 --> Object48
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda40 & Constant60 & Constant61 & Constant62 --> Object63
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant68 --> Lambda40
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69 --> Lambda43
-    Object61 --> Lambda62
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant71 --> Lambda67
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant70 --> Lambda40
+    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant71 --> Lambda43
+    Lambda43 --> Access44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object48 --> Lambda49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant72 --> Lambda54
+    Object63 --> Lambda64
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant73 --> Lambda69
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object47{{"Object[47∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda40 & Constant44 & Constant45 & Constant46 --> Object47
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda48{{"Lambda[48∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object47 --> Lambda48
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant70 --> Lambda53
     PgSelect14[["PgSelect[14∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda40 & Lambda43 & Lambda48 & Lambda53 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda40 & Access44 & Lambda49 & Lambda54 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -97,13 +99,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/basics-with-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 44, 45, 46, 58, 59, 60, 68, 69, 70, 71, 9, 40, 43, 61, 62, 67<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 45, 46, 47, 60, 61, 62, 70, 71, 72, 73, 9, 40, 43, 44, 48, 49, 54, 63, 64, 69<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda40,Lambda43,Constant44,Constant45,Constant46,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 40, 44, 45, 46, 70, 9, 43<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda40,Lambda43,Access44,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant70,Constant71,Constant72,Constant73 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 40, 44, 49, 54<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object47,Lambda48,Lambda53 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 40, 43, 48, 53<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 40, 44, 49, 54<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.mermaid
@@ -11,39 +11,41 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access44{{"Access[44∈0] ➊<br />ᐸ43.0ᐳ"}}:::plan
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda43 & Lambda48 & Lambda53 & Lambda40 & Lambda43 & Lambda67 & Lambda72 --> PgSelect6
-    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda40 & Constant44 & Constant45 & Constant46 --> Object47
-    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda40 & Constant63 & Constant64 & Constant65 --> Object66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access44 & Lambda49 & Lambda54 & Lambda40 & Access44 & Lambda69 & Lambda74 --> PgSelect6
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda40 & Constant45 & Constant46 & Constant47 --> Object48
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda40 & Constant65 & Constant66 & Constant67 --> Object68
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant73 --> Lambda40
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant74 --> Lambda43
-    Object47 --> Lambda48
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant75 --> Lambda53
-    Object66 --> Lambda67
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant76 --> Lambda72
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant75 --> Lambda40
+    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant76 --> Lambda43
+    Lambda43 --> Access44
+    Object48 --> Lambda49
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant77 --> Lambda54
+    Object68 --> Lambda69
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant78 --> Lambda74
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant38{{"Constant[38∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant41{{"Constant[41∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -51,18 +53,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object57{{"Object[57∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access55{{"Access[55∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access55 & Constant38 & Constant38 & Lambda40 & Constant41 --> Object57
+    Object58{{"Object[58∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access56{{"Access[56∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access56 & Constant38 & Constant38 & Lambda40 & Constant41 --> Object58
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda58{{"Lambda[58∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda58 --> __ListTransform18
-    __Item10 --> Access55
-    Object57 --> Lambda58
-    __Item19[/"__Item[19∈3]<br />ᐸ58ᐳ"\]:::itemplan
-    Lambda58 -.-> __Item19
+    Lambda59{{"Lambda[59∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda59 --> __ListTransform18
+    __Item10 --> Access56
+    Object58 --> Lambda59
+    __Item19[/"__Item[19∈3]<br />ᐸ59ᐳ"\]:::itemplan
+    Lambda59 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈4]"]:::plan
@@ -101,15 +103,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/basics-with-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 38, 41, 44, 45, 46, 63, 64, 65, 73, 74, 75, 76, 9, 40, 43, 47, 48, 53, 66, 67, 72<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 38, 41, 45, 46, 47, 65, 66, 67, 75, 76, 77, 78, 9, 40, 43, 44, 48, 49, 54, 68, 69, 74<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant38,Lambda40,Constant41,Lambda43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant63,Constant64,Constant65,Object66,Lambda67,Lambda72,Constant73,Constant74,Constant75,Constant76 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant38,Lambda40,Constant41,Lambda43,Access44,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant75,Constant76,Constant77,Constant78 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 38, 40, 41<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 38, 40, 41<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 55, 57, 58<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 38, 40, 41<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 56, 58, 59<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access55,Object57,Lambda58 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access56,Object58,Lambda59 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.mermaid
@@ -12,46 +12,48 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda36 & Lambda39 & Lambda58 & Lambda63 --> PgSelect6
-    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda36 & Constant54 & Constant55 & Constant56 --> Object57
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda36 & Access40 & Lambda60 & Lambda65 --> PgSelect6
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object59{{"Object[59∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda36 & Constant56 & Constant57 & Constant58 --> Object59
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant64 --> Lambda36
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant65 --> Lambda39
-    Object57 --> Lambda58
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant67 --> Lambda63
+    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant66 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant67 --> Lambda39
+    Lambda39 --> Access40
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object44 --> Lambda45
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant68 --> Lambda50
+    Object59 --> Lambda60
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant69 --> Lambda65
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object43{{"Object[43∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda44{{"Lambda[44∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object43 --> Lambda44
-    Lambda49{{"Lambda[49∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant66 --> Lambda49
     PgSelect14[["PgSelect[14∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda36 & Lambda39 & Lambda44 & Lambda49 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda36 & Access40 & Lambda45 & Lambda50 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -89,13 +91,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 40, 41, 42, 54, 55, 56, 64, 65, 66, 67, 9, 36, 39, 57, 58, 63<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 41, 42, 43, 56, 57, 58, 66, 67, 68, 69, 9, 36, 39, 40, 44, 45, 50, 59, 60, 65<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda36,Lambda39,Constant40,Constant41,Constant42,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant64,Constant65,Constant66,Constant67 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 36, 40, 41, 42, 66, 9, 39<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda36,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Constant56,Constant57,Constant58,Object59,Lambda60,Lambda65,Constant66,Constant67,Constant68,Constant69 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 36, 40, 45, 50<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object43,Lambda44,Lambda49 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 36, 39, 44, 49<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 36, 40, 45, 50<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.mermaid
@@ -11,39 +11,41 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda39 & Lambda44 & Lambda49 & Lambda36 & Lambda39 & Lambda63 & Lambda68 --> PgSelect6
-    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
-    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda36 & Constant59 & Constant60 & Constant61 --> Object62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access40 & Lambda45 & Lambda50 & Lambda36 & Access40 & Lambda65 & Lambda70 --> PgSelect6
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda36 & Constant61 & Constant62 & Constant63 --> Object64
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69 --> Lambda36
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda39
-    Object43 --> Lambda44
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant71 --> Lambda49
-    Object62 --> Lambda63
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant72 --> Lambda68
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant71 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda39
+    Lambda39 --> Access40
+    Object44 --> Lambda45
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant73 --> Lambda50
+    Object64 --> Lambda65
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant74 --> Lambda70
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant34{{"Constant[34∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant37{{"Constant[37∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -51,18 +53,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object53{{"Object[53∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access51{{"Access[51∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access51 & Constant34 & Constant34 & Lambda36 & Constant37 --> Object53
+    Object54{{"Object[54∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access52{{"Access[52∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access52 & Constant34 & Constant34 & Lambda36 & Constant37 --> Object54
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda54{{"Lambda[54∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda54 --> __ListTransform18
-    __Item10 --> Access51
-    Object53 --> Lambda54
-    __Item19[/"__Item[19∈3]<br />ᐸ54ᐳ"\]:::itemplan
-    Lambda54 -.-> __Item19
+    Lambda55{{"Lambda[55∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda55 --> __ListTransform18
+    __Item10 --> Access52
+    Object54 --> Lambda55
+    __Item19[/"__Item[19∈3]<br />ᐸ55ᐳ"\]:::itemplan
+    Lambda55 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈4]"]:::plan
@@ -93,15 +95,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 34, 37, 40, 41, 42, 59, 60, 61, 69, 70, 71, 72, 9, 36, 39, 43, 44, 49, 62, 63, 68<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 34, 37, 41, 42, 43, 61, 62, 63, 71, 72, 73, 74, 9, 36, 39, 40, 44, 45, 50, 64, 65, 70<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant34,Lambda36,Constant37,Lambda39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant69,Constant70,Constant71,Constant72 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant34,Lambda36,Constant37,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant71,Constant72,Constant73,Constant74 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 34, 36, 37<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 34, 36, 37<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 51, 53, 54<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 34, 36, 37<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 52, 54, 55<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access51,Object53,Lambda54 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access52,Object54,Lambda55 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.mermaid
@@ -12,73 +12,75 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access220{{"Access[220∈0] ➊<br />ᐸ219.0ᐳ"}}:::plan
     Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda216 & Lambda219 & Lambda280 & Lambda285 --> PgSelect6
-    Object223{{"Object[223∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda216 & Constant220 & Constant221 & Constant222 --> Object223
-    Object237{{"Object[237∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant235{{"Constant[235∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda216 & Constant234 & Constant235 & Constant236 --> Object237
-    Object251{{"Object[251∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant249{{"Constant[249∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda216 & Constant248 & Constant249 & Constant222 --> Object251
-    Object279{{"Object[279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant276{{"Constant[276∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant277{{"Constant[277∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda216 & Constant276 & Constant277 & Constant222 --> Object279
+    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda216 & Access220 & Lambda285 & Lambda290 --> PgSelect6
+    Object224{{"Object[224∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda216 & Constant221 & Constant222 & Constant223 --> Object224
+    Object239{{"Object[239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant236{{"Constant[236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant237{{"Constant[237∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda216 & Constant236 & Constant237 & Constant238 --> Object239
+    Object254{{"Object[254∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant251{{"Constant[251∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant252{{"Constant[252∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda216 & Constant251 & Constant252 & Constant223 --> Object254
+    Object269{{"Object[269∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant266{{"Constant[266∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant267{{"Constant[267∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda216 & Constant266 & Constant267 & Constant238 --> Object269
+    Object284{{"Object[284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda216 & Constant281 & Constant282 & Constant223 --> Object284
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant286 --> Lambda216
-    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant287 --> Lambda219
-    Lambda224{{"Lambda[224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object223 --> Lambda224
-    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant288 --> Lambda229
-    Lambda238{{"Lambda[238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object237 --> Lambda238
-    Lambda243{{"Lambda[243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant289 --> Lambda243
-    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object251 --> Lambda252
-    Lambda257{{"Lambda[257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant290 --> Lambda257
-    Object279 --> Lambda280
-    Constant292{{"Constant[292∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant292 --> Lambda285
+    Constant291{{"Constant[291∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant291 --> Lambda216
+    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant292{{"Constant[292∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant292 --> Lambda219
+    Lambda219 --> Access220
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object224 --> Lambda225
+    Lambda230{{"Lambda[230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant293 --> Lambda230
+    Lambda240{{"Lambda[240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object239 --> Lambda240
+    Lambda245{{"Lambda[245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant294{{"Constant[294∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant294 --> Lambda245
+    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object254 --> Lambda255
+    Lambda260{{"Lambda[260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant295{{"Constant[295∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant295 --> Lambda260
+    Lambda270{{"Lambda[270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object269 --> Lambda270
+    Lambda275{{"Lambda[275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant296{{"Constant[296∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant296 --> Lambda275
+    Object284 --> Lambda285
+    Constant297{{"Constant[297∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant297 --> Lambda290
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant291{{"Constant[291∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object265{{"Object[265∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda216 & Constant262 & Constant263 & Constant236 --> Object265
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda266{{"Lambda[266∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object265 --> Lambda266
-    Lambda271{{"Lambda[271∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant291 --> Lambda271
     PgSelect14[["PgSelect[14∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda216 & Lambda219 & Lambda266 & Lambda271 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda216 & Access220 & Lambda270 & Lambda275 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -100,10 +102,10 @@ graph TD
     PgClassExpression23 --> Lambda24
     PgSelect27[["PgSelect[27∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression26 & Lambda216 & Lambda219 & Lambda238 & Lambda243 --> PgSelect27
+    Object9 & PgClassExpression26 & Lambda216 & Access220 & Lambda240 & Lambda245 --> PgSelect27
     PgSelect76[["PgSelect[76∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression75{{"PgClassExpression[75∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression75 & Lambda216 & Lambda219 & Lambda252 & Lambda257 --> PgSelect76
+    Object9 & PgClassExpression75 & Lambda216 & Access220 & Lambda255 & Lambda260 --> PgSelect76
     PgSingleTablePolymorphic35["PgSingleTablePolymorphic[35∈5]<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda34{{"Lambda[34∈5]"}}:::plan
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -144,7 +146,7 @@ graph TD
     PgSelectSingle22 --> PgClassExpression151
     PgSelect40[["PgSelect[40∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda216 & Lambda219 & Lambda224 & Lambda229 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda216 & Access220 & Lambda225 & Lambda230 --> PgSelect40
     PgClassExpression38{{"PgClassExpression[38∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     PgSelectSingle32 --> PgClassExpression38
     PgSelectSingle32 --> PgClassExpression39
@@ -178,25 +180,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/nested-more-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 220, 221, 222, 234, 235, 236, 248, 249, 262, 263, 276, 277, 286, 287, 288, 289, 290, 291, 292, 9, 216, 219, 223, 224, 229, 237, 238, 243, 251, 252, 257, 279, 280, 285<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 221, 222, 223, 236, 237, 238, 251, 252, 266, 267, 281, 282, 291, 292, 293, 294, 295, 296, 297, 9, 216, 219, 220, 224, 225, 230, 239, 240, 245, 254, 255, 260, 269, 270, 275, 284, 285, 290<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda216,Lambda219,Constant220,Constant221,Constant222,Object223,Lambda224,Lambda229,Constant234,Constant235,Constant236,Object237,Lambda238,Lambda243,Constant248,Constant249,Object251,Lambda252,Lambda257,Constant262,Constant263,Constant276,Constant277,Object279,Lambda280,Lambda285,Constant286,Constant287,Constant288,Constant289,Constant290,Constant291,Constant292 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 216, 262, 263, 236, 291, 9, 219, 238, 243, 252, 257, 224, 229<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda216,Lambda219,Access220,Constant221,Constant222,Constant223,Object224,Lambda225,Lambda230,Constant236,Constant237,Constant238,Object239,Lambda240,Lambda245,Constant251,Constant252,Object254,Lambda255,Lambda260,Constant266,Constant267,Object269,Lambda270,Lambda275,Constant281,Constant282,Object284,Lambda285,Lambda290,Constant291,Constant292,Constant293,Constant294,Constant295,Constant296,Constant297 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 216, 220, 270, 275, 240, 245, 255, 260, 225, 230<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object265,Lambda266,Lambda271 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 216, 219, 266, 271, 238, 243, 252, 257, 224, 229<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 216, 220, 270, 275, 240, 245, 255, 260, 225, 230<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 216, 219, 238, 243, 252, 257, 224, 229<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 216, 220, 240, 245, 255, 260, 225, 230<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 216, 219, 238, 243, 252, 257, 25, 224, 229, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 72, 74, 75, 81, 82, 83, 84, 85, 86, 118, 119, 151<br />2: PgSelect[27], PgSelect[76]<br />ᐳ: 31, 32, 33, 34, 78, 79<br />3: PgSingleTablePolymorphic[35]"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 216, 220, 240, 245, 255, 260, 25, 225, 230, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 72, 74, 75, 81, 82, 83, 84, 85, 86, 118, 119, 151<br />2: PgSelect[27], PgSelect[76]<br />ᐳ: 31, 32, 33, 34, 78, 79<br />3: PgSingleTablePolymorphic[35]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression33,Lambda34,PgSingleTablePolymorphic35,PgClassExpression72,PgClassExpression74,PgClassExpression75,PgSelect76,First78,PgSelectSingle79,PgClassExpression81,PgClassExpression82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,PgClassExpression118,PgClassExpression119,PgClassExpression151 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 216, 219, 224, 229, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51, 52, 57, 58, 63<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 216, 220, 225, 230, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51, 52, 57, 58, 63<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression38,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression57,PgClassExpression58,PgClassExpression63 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[45]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.mermaid
@@ -11,66 +11,68 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access220{{"Access[220∈0] ➊<br />ᐸ219.0ᐳ"}}:::plan
+    Lambda270{{"Lambda[270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda275{{"Lambda[275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda219 & Lambda266 & Lambda271 & Lambda216 & Lambda219 & Lambda285 & Lambda290 --> PgSelect6
-    Object223{{"Object[223∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda216 & Constant220 & Constant221 & Constant222 --> Object223
-    Object237{{"Object[237∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant235{{"Constant[235∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda216 & Constant234 & Constant235 & Constant236 --> Object237
-    Object251{{"Object[251∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant249{{"Constant[249∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda216 & Constant248 & Constant249 & Constant222 --> Object251
-    Object265{{"Object[265∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda216 & Constant262 & Constant263 & Constant236 --> Object265
-    Object284{{"Object[284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant281{{"Constant[281∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda216 & Constant281 & Constant282 & Constant222 --> Object284
+    Lambda295{{"Lambda[295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access220 & Lambda270 & Lambda275 & Lambda216 & Access220 & Lambda290 & Lambda295 --> PgSelect6
+    Object224{{"Object[224∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda216 & Constant221 & Constant222 & Constant223 --> Object224
+    Object239{{"Object[239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant236{{"Constant[236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant237{{"Constant[237∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda216 & Constant236 & Constant237 & Constant238 --> Object239
+    Object254{{"Object[254∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant251{{"Constant[251∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant252{{"Constant[252∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda216 & Constant251 & Constant252 & Constant223 --> Object254
+    Object269{{"Object[269∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant266{{"Constant[266∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant267{{"Constant[267∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda216 & Constant266 & Constant267 & Constant238 --> Object269
+    Object289{{"Object[289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda216 & Constant286 & Constant287 & Constant223 --> Object289
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant291{{"Constant[291∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant291 --> Lambda216
-    Constant292{{"Constant[292∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant292 --> Lambda219
-    Lambda224{{"Lambda[224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object223 --> Lambda224
-    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant293{{"Constant[293∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant293 --> Lambda229
-    Lambda238{{"Lambda[238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object237 --> Lambda238
-    Lambda243{{"Lambda[243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant294{{"Constant[294∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant294 --> Lambda243
-    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object251 --> Lambda252
-    Lambda257{{"Lambda[257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant295{{"Constant[295∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant295 --> Lambda257
-    Object265 --> Lambda266
-    Constant296{{"Constant[296∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant296 --> Lambda271
-    Object284 --> Lambda285
-    Constant297{{"Constant[297∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant297 --> Lambda290
+    Constant296{{"Constant[296∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant296 --> Lambda216
+    Lambda219{{"Lambda[219∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant297{{"Constant[297∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant297 --> Lambda219
+    Lambda219 --> Access220
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object224 --> Lambda225
+    Lambda230{{"Lambda[230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant298{{"Constant[298∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant298 --> Lambda230
+    Lambda240{{"Lambda[240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object239 --> Lambda240
+    Lambda245{{"Lambda[245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant299{{"Constant[299∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant299 --> Lambda245
+    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object254 --> Lambda255
+    Lambda260{{"Lambda[260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant300{{"Constant[300∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant300 --> Lambda260
+    Object269 --> Lambda270
+    Constant301{{"Constant[301∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant301 --> Lambda275
+    Object289 --> Lambda290
+    Constant302{{"Constant[302∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant302 --> Lambda295
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant214{{"Constant[214∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant217{{"Constant[217∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -78,18 +80,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object275{{"Object[275∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access273{{"Access[273∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access273 & Constant214 & Constant214 & Lambda216 & Constant217 --> Object275
+    Object279{{"Object[279∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access277{{"Access[277∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access277 & Constant214 & Constant214 & Lambda216 & Constant217 --> Object279
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda276{{"Lambda[276∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda276 --> __ListTransform18
-    __Item10 --> Access273
-    Object275 --> Lambda276
-    __Item19[/"__Item[19∈3]<br />ᐸ276ᐳ"\]:::itemplan
-    Lambda276 -.-> __Item19
+    Lambda280{{"Lambda[280∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda280 --> __ListTransform18
+    __Item10 --> Access277
+    Object279 --> Lambda280
+    __Item19[/"__Item[19∈3]<br />ᐸ280ᐳ"\]:::itemplan
+    Lambda280 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈4]"]:::plan
@@ -104,10 +106,10 @@ graph TD
     PgClassExpression23 --> Lambda24
     PgSelect27[["PgSelect[27∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression26 & Lambda216 & Lambda219 & Lambda238 & Lambda243 --> PgSelect27
+    Object9 & PgClassExpression26 & Lambda216 & Access220 & Lambda240 & Lambda245 --> PgSelect27
     PgSelect76[["PgSelect[76∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression75{{"PgClassExpression[75∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression75 & Lambda216 & Lambda219 & Lambda252 & Lambda257 --> PgSelect76
+    Object9 & PgClassExpression75 & Lambda216 & Access220 & Lambda255 & Lambda260 --> PgSelect76
     PgSingleTablePolymorphic35["PgSingleTablePolymorphic[35∈5]<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda34{{"Lambda[34∈5]"}}:::plan
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -148,7 +150,7 @@ graph TD
     PgSelectSingle22 --> PgClassExpression151
     PgSelect40[["PgSelect[40∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda216 & Lambda219 & Lambda224 & Lambda229 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda216 & Access220 & Lambda225 & Lambda230 --> PgSelect40
     PgClassExpression38{{"PgClassExpression[38∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     PgSelectSingle32 --> PgClassExpression38
     PgSelectSingle32 --> PgClassExpression39
@@ -182,25 +184,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/nested-more-fragments"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 214, 217, 220, 221, 222, 234, 235, 236, 248, 249, 262, 263, 281, 282, 291, 292, 293, 294, 295, 296, 297, 9, 216, 219, 223, 224, 229, 237, 238, 243, 251, 252, 257, 265, 266, 271, 284, 285, 290<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 214, 217, 221, 222, 223, 236, 237, 238, 251, 252, 266, 267, 286, 287, 296, 297, 298, 299, 300, 301, 302, 9, 216, 219, 220, 224, 225, 230, 239, 240, 245, 254, 255, 260, 269, 270, 275, 289, 290, 295<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant214,Lambda216,Constant217,Lambda219,Constant220,Constant221,Constant222,Object223,Lambda224,Lambda229,Constant234,Constant235,Constant236,Object237,Lambda238,Lambda243,Constant248,Constant249,Object251,Lambda252,Lambda257,Constant262,Constant263,Object265,Lambda266,Lambda271,Constant281,Constant282,Object284,Lambda285,Lambda290,Constant291,Constant292,Constant293,Constant294,Constant295,Constant296,Constant297 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 214, 216, 217, 9, 219, 238, 243, 252, 257, 224, 229<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant214,Lambda216,Constant217,Lambda219,Access220,Constant221,Constant222,Constant223,Object224,Lambda225,Lambda230,Constant236,Constant237,Constant238,Object239,Lambda240,Lambda245,Constant251,Constant252,Object254,Lambda255,Lambda260,Constant266,Constant267,Object269,Lambda270,Lambda275,Constant286,Constant287,Object289,Lambda290,Lambda295,Constant296,Constant297,Constant298,Constant299,Constant300,Constant301,Constant302 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 214, 216, 217, 9, 220, 240, 245, 255, 260, 225, 230<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 214, 216, 217, 9, 219, 238, 243, 252, 257, 224, 229<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 273, 275, 276<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 214, 216, 217, 9, 220, 240, 245, 255, 260, 225, 230<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 277, 279, 280<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access273,Object275,Lambda276 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access277,Object279,Lambda280 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 216, 219, 238, 243, 252, 257, 224, 229<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 216, 220, 240, 245, 255, 260, 225, 230<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 216, 219, 238, 243, 252, 257, 25, 224, 229, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 72, 74, 75, 81, 82, 83, 84, 85, 86, 118, 119, 151<br />2: PgSelect[27], PgSelect[76]<br />ᐳ: 31, 32, 33, 34, 78, 79<br />3: PgSingleTablePolymorphic[35]"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 216, 220, 240, 245, 255, 260, 25, 225, 230, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 72, 74, 75, 81, 82, 83, 84, 85, 86, 118, 119, 151<br />2: PgSelect[27], PgSelect[76]<br />ᐳ: 31, 32, 33, 34, 78, 79<br />3: PgSingleTablePolymorphic[35]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression33,Lambda34,PgSingleTablePolymorphic35,PgClassExpression72,PgClassExpression74,PgClassExpression75,PgSelect76,First78,PgSelectSingle79,PgClassExpression81,PgClassExpression82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,PgClassExpression118,PgClassExpression119,PgClassExpression151 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 216, 219, 224, 229, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51, 52, 57, 58, 63<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 216, 220, 225, 230, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51, 52, 57, 58, 63<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression38,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression57,PgClassExpression58,PgClassExpression63 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[45]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.mermaid
@@ -12,73 +12,75 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access212{{"Access[212∈0] ➊<br />ᐸ211.0ᐳ"}}:::plan
     Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda208 & Lambda211 & Lambda272 & Lambda277 --> PgSelect6
-    Object215{{"Object[215∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda208 & Constant212 & Constant213 & Constant214 --> Object215
-    Object229{{"Object[229∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda208 & Constant226 & Constant227 & Constant228 --> Object229
-    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda208 & Constant240 & Constant241 & Constant214 --> Object243
-    Object271{{"Object[271∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda208 & Constant268 & Constant269 & Constant214 --> Object271
+    Lambda282{{"Lambda[282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda208 & Access212 & Lambda277 & Lambda282 --> PgSelect6
+    Object216{{"Object[216∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant215{{"Constant[215∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda208 & Constant213 & Constant214 & Constant215 --> Object216
+    Object231{{"Object[231∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant230{{"Constant[230∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda208 & Constant228 & Constant229 & Constant230 --> Object231
+    Object246{{"Object[246∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda208 & Constant243 & Constant244 & Constant215 --> Object246
+    Object261{{"Object[261∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant258{{"Constant[258∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant259{{"Constant[259∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda208 & Constant258 & Constant259 & Constant230 --> Object261
+    Object276{{"Object[276∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant273{{"Constant[273∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant274{{"Constant[274∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda208 & Constant273 & Constant274 & Constant215 --> Object276
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant278{{"Constant[278∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant278 --> Lambda208
-    Constant279{{"Constant[279∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant279 --> Lambda211
-    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object215 --> Lambda216
-    Lambda221{{"Lambda[221∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant280{{"Constant[280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant280 --> Lambda221
-    Lambda230{{"Lambda[230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object229 --> Lambda230
-    Lambda235{{"Lambda[235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant281{{"Constant[281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant281 --> Lambda235
-    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object243 --> Lambda244
-    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant282 --> Lambda249
-    Object271 --> Lambda272
-    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant284 --> Lambda277
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant283 --> Lambda208
+    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant284 --> Lambda211
+    Lambda211 --> Access212
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object216 --> Lambda217
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant285 --> Lambda222
+    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object231 --> Lambda232
+    Lambda237{{"Lambda[237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant286 --> Lambda237
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object246 --> Lambda247
+    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant287 --> Lambda252
+    Lambda262{{"Lambda[262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object261 --> Lambda262
+    Lambda267{{"Lambda[267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant288 --> Lambda267
+    Object276 --> Lambda277
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant289 --> Lambda282
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant254{{"Constant[254∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant255{{"Constant[255∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object257{{"Object[257∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda208 & Constant254 & Constant255 & Constant228 --> Object257
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda258{{"Lambda[258∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object257 --> Lambda258
-    Lambda263{{"Lambda[263∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant283 --> Lambda263
     PgSelect14[["PgSelect[14∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda208 & Lambda211 & Lambda258 & Lambda263 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda208 & Access212 & Lambda262 & Lambda267 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -100,10 +102,10 @@ graph TD
     PgClassExpression23 --> Lambda24
     PgSelect27[["PgSelect[27∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression26 & Lambda208 & Lambda211 & Lambda230 & Lambda235 --> PgSelect27
+    Object9 & PgClassExpression26 & Lambda208 & Access212 & Lambda232 & Lambda237 --> PgSelect27
     PgSelect72[["PgSelect[72∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression71{{"PgClassExpression[71∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression71 & Lambda208 & Lambda211 & Lambda244 & Lambda249 --> PgSelect72
+    Object9 & PgClassExpression71 & Lambda208 & Access212 & Lambda247 & Lambda252 --> PgSelect72
     PgSingleTablePolymorphic35["PgSingleTablePolymorphic[35∈5]<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda34{{"Lambda[34∈5]"}}:::plan
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -136,7 +138,7 @@ graph TD
     PgSelectSingle22 --> PgClassExpression81
     PgSelect40[["PgSelect[40∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda208 & Lambda211 & Lambda216 & Lambda221 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda208 & Access212 & Lambda217 & Lambda222 --> PgSelect40
     PgClassExpression38{{"PgClassExpression[38∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     PgSelectSingle32 --> PgClassExpression38
     PgSelectSingle32 --> PgClassExpression39
@@ -162,25 +164,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/nested-more"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 212, 213, 214, 226, 227, 228, 240, 241, 254, 255, 268, 269, 278, 279, 280, 281, 282, 283, 284, 9, 208, 211, 215, 216, 221, 229, 230, 235, 243, 244, 249, 271, 272, 277<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 213, 214, 215, 228, 229, 230, 243, 244, 258, 259, 273, 274, 283, 284, 285, 286, 287, 288, 289, 9, 208, 211, 212, 216, 217, 222, 231, 232, 237, 246, 247, 252, 261, 262, 267, 276, 277, 282<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda208,Lambda211,Constant212,Constant213,Constant214,Object215,Lambda216,Lambda221,Constant226,Constant227,Constant228,Object229,Lambda230,Lambda235,Constant240,Constant241,Object243,Lambda244,Lambda249,Constant254,Constant255,Constant268,Constant269,Object271,Lambda272,Lambda277,Constant278,Constant279,Constant280,Constant281,Constant282,Constant283,Constant284 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 208, 254, 255, 228, 283, 9, 211, 230, 235, 244, 249, 216, 221<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda208,Lambda211,Access212,Constant213,Constant214,Constant215,Object216,Lambda217,Lambda222,Constant228,Constant229,Constant230,Object231,Lambda232,Lambda237,Constant243,Constant244,Object246,Lambda247,Lambda252,Constant258,Constant259,Object261,Lambda262,Lambda267,Constant273,Constant274,Object276,Lambda277,Lambda282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 208, 212, 262, 267, 232, 237, 247, 252, 217, 222<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object257,Lambda258,Lambda263 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 208, 211, 258, 263, 230, 235, 244, 249, 216, 221<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 208, 212, 262, 267, 232, 237, 247, 252, 217, 222<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 208, 211, 230, 235, 244, 249, 216, 221<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 208, 212, 232, 237, 247, 252, 217, 222<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 208, 211, 230, 235, 244, 249, 25, 216, 221, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 68, 70, 71, 77, 78, 79, 80, 81<br />2: PgSelect[27], PgSelect[72]<br />ᐳ: 31, 32, 33, 34, 74, 75<br />3: PgSingleTablePolymorphic[35]"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 208, 212, 232, 237, 247, 252, 25, 217, 222, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 68, 70, 71, 77, 78, 79, 80, 81<br />2: PgSelect[27], PgSelect[72]<br />ᐳ: 31, 32, 33, 34, 74, 75<br />3: PgSingleTablePolymorphic[35]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression33,Lambda34,PgSingleTablePolymorphic35,PgClassExpression68,PgClassExpression70,PgClassExpression71,PgSelect72,First74,PgSelectSingle75,PgClassExpression77,PgClassExpression78,PgClassExpression79,PgClassExpression80,PgClassExpression81 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 208, 211, 216, 221, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 208, 212, 217, 222, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression38,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[45]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.mermaid
@@ -11,66 +11,68 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda263{{"Lambda[263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access212{{"Access[212∈0] ➊<br />ᐸ211.0ᐳ"}}:::plan
+    Lambda262{{"Lambda[262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda267{{"Lambda[267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda282{{"Lambda[282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda211 & Lambda258 & Lambda263 & Lambda208 & Lambda211 & Lambda277 & Lambda282 --> PgSelect6
-    Object215{{"Object[215∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda208 & Constant212 & Constant213 & Constant214 --> Object215
-    Object229{{"Object[229∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda208 & Constant226 & Constant227 & Constant228 --> Object229
-    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda208 & Constant240 & Constant241 & Constant214 --> Object243
-    Object257{{"Object[257∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant254{{"Constant[254∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant255{{"Constant[255∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda208 & Constant254 & Constant255 & Constant228 --> Object257
-    Object276{{"Object[276∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant274{{"Constant[274∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda208 & Constant273 & Constant274 & Constant214 --> Object276
+    Lambda287{{"Lambda[287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access212 & Lambda262 & Lambda267 & Lambda208 & Access212 & Lambda282 & Lambda287 --> PgSelect6
+    Object216{{"Object[216∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant215{{"Constant[215∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda208 & Constant213 & Constant214 & Constant215 --> Object216
+    Object231{{"Object[231∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant230{{"Constant[230∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda208 & Constant228 & Constant229 & Constant230 --> Object231
+    Object246{{"Object[246∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda208 & Constant243 & Constant244 & Constant215 --> Object246
+    Object261{{"Object[261∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant258{{"Constant[258∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant259{{"Constant[259∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda208 & Constant258 & Constant259 & Constant230 --> Object261
+    Object281{{"Object[281∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda208 & Constant278 & Constant279 & Constant215 --> Object281
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant283 --> Lambda208
-    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant284 --> Lambda211
-    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object215 --> Lambda216
-    Lambda221{{"Lambda[221∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant285 --> Lambda221
-    Lambda230{{"Lambda[230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object229 --> Lambda230
-    Lambda235{{"Lambda[235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant286 --> Lambda235
-    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object243 --> Lambda244
-    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant287 --> Lambda249
-    Object257 --> Lambda258
-    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant288 --> Lambda263
-    Object276 --> Lambda277
-    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant289 --> Lambda282
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant288 --> Lambda208
+    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant289 --> Lambda211
+    Lambda211 --> Access212
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object216 --> Lambda217
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant290 --> Lambda222
+    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object231 --> Lambda232
+    Lambda237{{"Lambda[237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant291{{"Constant[291∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant291 --> Lambda237
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object246 --> Lambda247
+    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant292{{"Constant[292∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant292 --> Lambda252
+    Object261 --> Lambda262
+    Constant293{{"Constant[293∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant293 --> Lambda267
+    Object281 --> Lambda282
+    Constant294{{"Constant[294∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant294 --> Lambda287
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant206{{"Constant[206∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant209{{"Constant[209∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -78,18 +80,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object267{{"Object[267∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access265{{"Access[265∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access265 & Constant206 & Constant206 & Lambda208 & Constant209 --> Object267
+    Object271{{"Object[271∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access269{{"Access[269∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access269 & Constant206 & Constant206 & Lambda208 & Constant209 --> Object271
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda268{{"Lambda[268∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda268 --> __ListTransform18
-    __Item10 --> Access265
-    Object267 --> Lambda268
-    __Item19[/"__Item[19∈3]<br />ᐸ268ᐳ"\]:::itemplan
-    Lambda268 -.-> __Item19
+    Lambda272{{"Lambda[272∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda272 --> __ListTransform18
+    __Item10 --> Access269
+    Object271 --> Lambda272
+    __Item19[/"__Item[19∈3]<br />ᐸ272ᐳ"\]:::itemplan
+    Lambda272 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈4]"]:::plan
@@ -104,10 +106,10 @@ graph TD
     PgClassExpression23 --> Lambda24
     PgSelect27[["PgSelect[27∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression26 & Lambda208 & Lambda211 & Lambda230 & Lambda235 --> PgSelect27
+    Object9 & PgClassExpression26 & Lambda208 & Access212 & Lambda232 & Lambda237 --> PgSelect27
     PgSelect72[["PgSelect[72∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression71{{"PgClassExpression[71∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression71 & Lambda208 & Lambda211 & Lambda244 & Lambda249 --> PgSelect72
+    Object9 & PgClassExpression71 & Lambda208 & Access212 & Lambda247 & Lambda252 --> PgSelect72
     PgSingleTablePolymorphic35["PgSingleTablePolymorphic[35∈5]<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda34{{"Lambda[34∈5]"}}:::plan
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -140,7 +142,7 @@ graph TD
     PgSelectSingle22 --> PgClassExpression81
     PgSelect40[["PgSelect[40∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression39{{"PgClassExpression[39∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression39 & Lambda208 & Lambda211 & Lambda216 & Lambda221 --> PgSelect40
+    Object9 & PgClassExpression39 & Lambda208 & Access212 & Lambda217 & Lambda222 --> PgSelect40
     PgClassExpression38{{"PgClassExpression[38∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     PgSelectSingle32 --> PgClassExpression38
     PgSelectSingle32 --> PgClassExpression39
@@ -166,25 +168,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/nested-more"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 206, 209, 212, 213, 214, 226, 227, 228, 240, 241, 254, 255, 273, 274, 283, 284, 285, 286, 287, 288, 289, 9, 208, 211, 215, 216, 221, 229, 230, 235, 243, 244, 249, 257, 258, 263, 276, 277, 282<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 206, 209, 213, 214, 215, 228, 229, 230, 243, 244, 258, 259, 278, 279, 288, 289, 290, 291, 292, 293, 294, 9, 208, 211, 212, 216, 217, 222, 231, 232, 237, 246, 247, 252, 261, 262, 267, 281, 282, 287<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant206,Lambda208,Constant209,Lambda211,Constant212,Constant213,Constant214,Object215,Lambda216,Lambda221,Constant226,Constant227,Constant228,Object229,Lambda230,Lambda235,Constant240,Constant241,Object243,Lambda244,Lambda249,Constant254,Constant255,Object257,Lambda258,Lambda263,Constant273,Constant274,Object276,Lambda277,Lambda282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 206, 208, 209, 9, 211, 230, 235, 244, 249, 216, 221<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant206,Lambda208,Constant209,Lambda211,Access212,Constant213,Constant214,Constant215,Object216,Lambda217,Lambda222,Constant228,Constant229,Constant230,Object231,Lambda232,Lambda237,Constant243,Constant244,Object246,Lambda247,Lambda252,Constant258,Constant259,Object261,Lambda262,Lambda267,Constant278,Constant279,Object281,Lambda282,Lambda287,Constant288,Constant289,Constant290,Constant291,Constant292,Constant293,Constant294 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 206, 208, 209, 9, 212, 232, 237, 247, 252, 217, 222<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 206, 208, 209, 9, 211, 230, 235, 244, 249, 216, 221<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 265, 267, 268<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 206, 208, 209, 9, 212, 232, 237, 247, 252, 217, 222<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 269, 271, 272<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access265,Object267,Lambda268 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access269,Object271,Lambda272 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 208, 211, 230, 235, 244, 249, 216, 221<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 208, 212, 232, 237, 247, 252, 217, 222<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 208, 211, 230, 235, 244, 249, 25, 216, 221, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 68, 70, 71, 77, 78, 79, 80, 81<br />2: PgSelect[27], PgSelect[72]<br />ᐳ: 31, 32, 33, 34, 74, 75<br />3: PgSingleTablePolymorphic[35]"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 208, 212, 232, 237, 247, 252, 25, 217, 222, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 68, 70, 71, 77, 78, 79, 80, 81<br />2: PgSelect[27], PgSelect[72]<br />ᐳ: 31, 32, 33, 34, 74, 75<br />3: PgSingleTablePolymorphic[35]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression33,Lambda34,PgSingleTablePolymorphic35,PgClassExpression68,PgClassExpression70,PgClassExpression71,PgSelect72,First74,PgSelectSingle75,PgClassExpression77,PgClassExpression78,PgClassExpression79,PgClassExpression80,PgClassExpression81 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 208, 211, 216, 221, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 9, 208, 212, 217, 222, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 38, 39, 47, 48, 49, 50, 51<br />2: PgSelect[40]<br />ᐳ: First[44], PgSelectSingle[45]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression38,PgClassExpression39,PgSelect40,First44,PgSelectSingle45,PgClassExpression47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[45]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.mermaid
@@ -12,55 +12,57 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda72 & Lambda75 & Lambda108 & Lambda113 --> PgSelect6
-    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda72 & Constant76 & Constant77 & Constant78 --> Object79
-    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda72 & Constant104 & Constant105 & Constant106 --> Object107
+    Access76{{"Access[76∈0] ➊<br />ᐸ75.0ᐳ"}}:::plan
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda72 & Access76 & Lambda111 & Lambda116 --> PgSelect6
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda72 & Constant77 & Constant78 & Constant79 --> Object80
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda72 & Constant92 & Constant93 & Constant79 --> Object95
+    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda72 & Constant107 & Constant108 & Constant109 --> Object110
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant114 --> Lambda72
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant115 --> Lambda75
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object79 --> Lambda80
-    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant116 --> Lambda85
-    Object107 --> Lambda108
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant118 --> Lambda113
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda72
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda75
+    Lambda75 --> Access76
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object80 --> Lambda81
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant119 --> Lambda86
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object95 --> Lambda96
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant120 --> Lambda101
+    Object110 --> Lambda111
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant121 --> Lambda116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object93{{"Object[93∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda72 & Constant90 & Constant91 & Constant78 --> Object93
     __Item10[/"__Item[10∈1]<br />ᐸ6ᐳ"\]:::itemplan
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object93 --> Lambda94
-    Lambda99{{"Lambda[99∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant117 --> Lambda99
     PgSelect14[["PgSelect[14∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object9 & PgClassExpression13 & Lambda72 & Lambda75 & Lambda94 & Lambda99 --> PgSelect14
+    Object9 & PgClassExpression13 & Lambda72 & Access76 & Lambda96 & Lambda101 --> PgSelect14
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgSelectSingle11 --> PgClassExpression13
@@ -82,7 +84,7 @@ graph TD
     PgClassExpression23 --> Lambda24
     PgSelect27[["PgSelect[27∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression26 & Lambda72 & Lambda75 & Lambda80 & Lambda85 --> PgSelect27
+    Object9 & PgClassExpression26 & Lambda72 & Access76 & Lambda81 & Lambda86 --> PgSelect27
     PgSingleTablePolymorphic35["PgSingleTablePolymorphic[35∈5]<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda34{{"Lambda[34∈5]"}}:::plan
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -104,22 +106,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/nested"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 76, 77, 78, 90, 91, 104, 105, 106, 114, 115, 116, 117, 118, 9, 72, 75, 79, 80, 85, 107, 108, 113<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 77, 78, 79, 92, 93, 107, 108, 109, 117, 118, 119, 120, 121, 9, 72, 75, 76, 80, 81, 86, 95, 96, 101, 110, 111, 116<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda72,Lambda75,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant90,Constant91,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 72, 90, 91, 78, 117, 9, 75, 80, 85<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Lambda72,Lambda75,Access76,Constant77,Constant78,Constant79,Object80,Lambda81,Lambda86,Constant92,Constant93,Object95,Lambda96,Lambda101,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 9, 72, 76, 96, 101, 81, 86<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,PgSelectSingle11,Object93,Lambda94,Lambda99 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 72, 75, 94, 99, 80, 85<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
+    class Bucket1,__Item10,PgSelectSingle11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 9, 72, 76, 96, 101, 81, 86<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 13<br />2: PgSelect[14]<br />3: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression12,PgClassExpression13,PgSelect14,__ListTransform18 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 72, 75, 80, 85<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 72, 76, 81, 86<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 72, 75, 80, 85, 25, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 39, 41<br />2: PgSelect[27]<br />ᐳ: 31, 32, 33, 34<br />3: PgSingleTablePolymorphic[35]"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 72, 76, 81, 86, 25, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 39, 41<br />2: PgSelect[27]<br />ᐳ: 31, 32, 33, 34<br />3: PgSingleTablePolymorphic[35]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression33,Lambda34,PgSingleTablePolymorphic35,PgClassExpression39,PgClassExpression41 bucket5
     Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.mermaid
@@ -11,48 +11,50 @@ graph TD
     %% plan dependencies
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access76{{"Access[76∈0] ➊<br />ᐸ75.0ᐳ"}}:::plan
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda75 & Lambda94 & Lambda99 & Lambda72 & Lambda75 & Lambda113 & Lambda118 --> PgSelect6
-    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda72 & Constant76 & Constant77 & Constant78 --> Object79
-    Object93{{"Object[93∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda72 & Constant90 & Constant91 & Constant78 --> Object93
-    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda72 & Constant109 & Constant110 & Constant111 --> Object112
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Access76 & Lambda96 & Lambda101 & Lambda72 & Access76 & Lambda116 & Lambda121 --> PgSelect6
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda72 & Constant77 & Constant78 & Constant79 --> Object80
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda72 & Constant92 & Constant93 & Constant79 --> Object95
+    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1024, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda72 & Constant112 & Constant113 & Constant114 --> Object115
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant119 --> Lambda72
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant120 --> Lambda75
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object79 --> Lambda80
-    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant121 --> Lambda85
-    Object93 --> Lambda94
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant122 --> Lambda99
-    Object112 --> Lambda113
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant123 --> Lambda118
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant122 --> Lambda72
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant123 --> Lambda75
+    Lambda75 --> Access76
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object80 --> Lambda81
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant124 --> Lambda86
+    Object95 --> Lambda96
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant125 --> Lambda101
+    Object115 --> Lambda116
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant126 --> Lambda121
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant70{{"Constant[70∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant73{{"Constant[73∈0] ➊<br />ᐸfalseᐳ"}}:::plan
@@ -60,18 +62,18 @@ graph TD
     PgSelect6 ==> __Item10
     PgSelectSingle11{{"PgSelectSingle[11∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item10 --> PgSelectSingle11
-    Object103{{"Object[103∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access101{{"Access[101∈2]<br />ᐸ10.1ᐳ"}}:::plan
-    Access101 & Constant70 & Constant70 & Lambda72 & Constant73 --> Object103
+    Object105{{"Object[105∈2]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access103{{"Access[103∈2]<br />ᐸ10.1ᐳ"}}:::plan
+    Access103 & Constant70 & Constant70 & Lambda72 & Constant73 --> Object105
     PgClassExpression12{{"PgClassExpression[12∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     __ListTransform18[["__ListTransform[18∈2]<br />ᐸeach:14ᐳ"]]:::plan
-    Lambda104{{"Lambda[104∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda104 --> __ListTransform18
-    __Item10 --> Access101
-    Object103 --> Lambda104
-    __Item19[/"__Item[19∈3]<br />ᐸ104ᐳ"\]:::itemplan
-    Lambda104 -.-> __Item19
+    Lambda106{{"Lambda[106∈2]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda106 --> __ListTransform18
+    __Item10 --> Access103
+    Object105 --> Lambda106
+    __Item19[/"__Item[19∈3]<br />ᐸ106ᐳ"\]:::itemplan
+    Lambda106 -.-> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈4]"]:::plan
@@ -86,7 +88,7 @@ graph TD
     PgClassExpression23 --> Lambda24
     PgSelect27[["PgSelect[27∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object9 & PgClassExpression26 & Lambda72 & Lambda75 & Lambda80 & Lambda85 --> PgSelect27
+    Object9 & PgClassExpression26 & Lambda72 & Access76 & Lambda81 & Lambda86 --> PgSelect27
     PgSingleTablePolymorphic35["PgSingleTablePolymorphic[35∈5]<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda34{{"Lambda[34∈5]"}}:::plan
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -108,22 +110,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/nested"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 70, 73, 76, 77, 78, 90, 91, 109, 110, 111, 119, 120, 121, 122, 123, 9, 72, 75, 79, 80, 85, 93, 94, 99, 112, 113, 118<br />2: PgSelect[6]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 70, 73, 77, 78, 79, 92, 93, 112, 113, 114, 122, 123, 124, 125, 126, 9, 72, 75, 76, 80, 81, 86, 95, 96, 101, 115, 116, 121<br />2: PgSelect[6]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant70,Lambda72,Constant73,Lambda75,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Constant90,Constant91,Object93,Lambda94,Lambda99,Constant109,Constant110,Constant111,Object112,Lambda113,Lambda118,Constant119,Constant120,Constant121,Constant122,Constant123 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 70, 72, 73, 9, 75, 80, 85<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,Constant70,Lambda72,Constant73,Lambda75,Access76,Constant77,Constant78,Constant79,Object80,Lambda81,Lambda86,Constant92,Constant93,Object95,Lambda96,Lambda101,Constant112,Constant113,Constant114,Object115,Lambda116,Lambda121,Constant122,Constant123,Constant124,Constant125,Constant126 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 70, 72, 73, 9, 76, 81, 86<br /><br />ROOT __Item{1}ᐸ6ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item10,PgSelectSingle11 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 70, 72, 73, 9, 75, 80, 85<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 101, 103, 104<br />2: __ListTransform[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 10, 70, 72, 73, 9, 76, 81, 86<br /><br />ROOT PgSelectSingle{1}ᐸpeopleᐳ[11]<br />1: <br />ᐳ: 12, 103, 105, 106<br />2: __ListTransform[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression12,__ListTransform18,Access101,Object103,Lambda104 bucket2
+    class Bucket2,PgClassExpression12,__ListTransform18,Access103,Object105,Lambda106 bucket2
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item19,PgSelectSingle20 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 72, 75, 80, 85<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9, 72, 76, 81, 86<br /><br />ROOT __Item{4}ᐸ18ᐳ[21]<br />1: <br />ᐳ: 22, 23, 24<br />2: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 72, 75, 80, 85, 25, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 39, 41<br />2: PgSelect[27]<br />ᐳ: 31, 32, 33, 34<br />3: PgSingleTablePolymorphic[35]"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 9, 72, 76, 81, 86, 25, 23<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 26, 39, 41<br />2: PgSelect[27]<br />ᐳ: 31, 32, 33, 34<br />3: PgSingleTablePolymorphic[35]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression33,Lambda34,PgSingleTablePolymorphic35,PgClassExpression39,PgClassExpression41 bucket5
     Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 32, 35, 26, 33<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.deopt.mermaid
@@ -11,26 +11,26 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ15ᐳ"}}:::plan
     Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant204 & Lambda162 & Lambda165 & Lambda198 & Lambda203 --> PgSelect7
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda162 & Constant166 & Constant167 & Constant168 --> Object169
-    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda162 & Constant180 & Constant181 & Constant182 --> Object183
-    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda162 & Constant194 & Constant195 & Constant182 --> Object197
+    Access166{{"Access[166∈0] ➊<br />ᐸ165.0ᐳ"}}:::plan
+    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant207 & Lambda162 & Access166 & Lambda201 & Lambda206 --> PgSelect7
+    Object170{{"Object[170∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda162 & Constant167 & Constant168 & Constant169 --> Object170
+    Object185{{"Object[185∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda162 & Constant182 & Constant183 & Constant184 --> Object185
+    Object200{{"Object[200∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant197{{"Constant[197∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda162 & Constant197 & Constant198 & Constant184 --> Object200
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -47,27 +47,29 @@ graph TD
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression13 --> Lambda14
-    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant205 --> Lambda162
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant206 --> Lambda165
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object169 --> Lambda170
-    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant207 --> Lambda175
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object183 --> Lambda184
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant208 --> Lambda189
-    Object197 --> Lambda198
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant209 --> Lambda203
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant208 --> Lambda162
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant209 --> Lambda165
+    Lambda165 --> Access166
+    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object170 --> Lambda171
+    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant210 --> Lambda176
+    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object185 --> Lambda186
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant211 --> Lambda191
+    Object200 --> Lambda201
+    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant212 --> Lambda206
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object10 & PgClassExpression16 & Lambda162 & Lambda165 & Lambda184 & Lambda189 --> PgSelect17
+    Object10 & PgClassExpression16 & Lambda162 & Access166 & Lambda186 & Lambda191 --> PgSelect17
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈1] ➊<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda24{{"Lambda[24∈1] ➊"}}:::plan
     PgSelectSingle22{{"PgSelectSingle[22∈1] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -83,7 +85,7 @@ graph TD
     PgSelectSingle12 --> PgClassExpression51
     PgSelect28[["PgSelect[28∈2] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈2] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    Object10 & PgClassExpression27 & Lambda162 & Lambda165 & Lambda170 & Lambda175 --> PgSelect28
+    Object10 & PgClassExpression27 & Lambda162 & Access166 & Lambda171 & Lambda176 --> PgSelect28
     PgSelectSingle22 --> PgClassExpression27
     First32{{"First[32∈2] ➊"}}:::plan
     PgSelect28 --> First32
@@ -95,13 +97,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 166, 167, 168, 180, 181, 182, 194, 195, 204, 205, 206, 207, 208, 209, 10, 162, 165, 169, 170, 175, 183, 184, 189, 197, 198, 203<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14<br />3: PgSingleTablePolymorphic[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 167, 168, 169, 182, 183, 184, 197, 198, 207, 208, 209, 210, 211, 212, 10, 162, 165, 166, 170, 171, 176, 185, 186, 191, 200, 201, 206<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14<br />3: PgSingleTablePolymorphic[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,Lambda14,PgSingleTablePolymorphic15,Lambda162,Lambda165,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant194,Constant195,Object197,Lambda198,Lambda203,Constant204,Constant205,Constant206,Constant207,Constant208,Constant209 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 12, 10, 162, 165, 184, 189, 15, 170, 175<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 16, 51<br />2: PgSelect[17]<br />ᐳ: 21, 22, 23, 24<br />3: PgSingleTablePolymorphic[25]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,Lambda14,PgSingleTablePolymorphic15,Lambda162,Lambda165,Access166,Constant167,Constant168,Constant169,Object170,Lambda171,Lambda176,Constant182,Constant183,Constant184,Object185,Lambda186,Lambda191,Constant197,Constant198,Object200,Lambda201,Lambda206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 12, 10, 162, 166, 186, 191, 15, 171, 176<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 16, 51<br />2: PgSelect[17]<br />ᐳ: 21, 22, 23, 24<br />3: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25,PgClassExpression51 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 10, 162, 165, 170, 175, 25, 16<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 10, 162, 166, 171, 176, 25, 16<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[33]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.mermaid
@@ -11,26 +11,26 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ15ᐳ"}}:::plan
     Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant204 & Lambda162 & Lambda165 & Lambda198 & Lambda203 --> PgSelect7
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda162 & Constant166 & Constant167 & Constant168 --> Object169
-    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda162 & Constant180 & Constant181 & Constant182 --> Object183
-    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda162 & Constant194 & Constant195 & Constant182 --> Object197
+    Access166{{"Access[166∈0] ➊<br />ᐸ165.0ᐳ"}}:::plan
+    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant207 & Lambda162 & Access166 & Lambda201 & Lambda206 --> PgSelect7
+    Object170{{"Object[170∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda162 & Constant167 & Constant168 & Constant169 --> Object170
+    Object185{{"Object[185∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda162 & Constant182 & Constant183 & Constant184 --> Object185
+    Object200{{"Object[200∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant197{{"Constant[197∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda162 & Constant197 & Constant198 & Constant184 --> Object200
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -47,27 +47,29 @@ graph TD
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression13 --> Lambda14
-    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant205 --> Lambda162
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant206 --> Lambda165
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object169 --> Lambda170
-    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant207 --> Lambda175
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object183 --> Lambda184
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant208 --> Lambda189
-    Object197 --> Lambda198
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant209 --> Lambda203
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant208 --> Lambda162
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant209 --> Lambda165
+    Lambda165 --> Access166
+    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object170 --> Lambda171
+    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant210 --> Lambda176
+    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object185 --> Lambda186
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant211 --> Lambda191
+    Object200 --> Lambda201
+    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant212 --> Lambda206
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object10 & PgClassExpression16 & Lambda162 & Lambda165 & Lambda184 & Lambda189 --> PgSelect17
+    Object10 & PgClassExpression16 & Lambda162 & Access166 & Lambda186 & Lambda191 --> PgSelect17
     PgSingleTablePolymorphic25["PgSingleTablePolymorphic[25∈1] ➊<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]:::plan
     Lambda24{{"Lambda[24∈1] ➊"}}:::plan
     PgSelectSingle22{{"PgSelectSingle[22∈1] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
@@ -83,7 +85,7 @@ graph TD
     PgSelectSingle12 --> PgClassExpression51
     PgSelect28[["PgSelect[28∈2] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈2] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    Object10 & PgClassExpression27 & Lambda162 & Lambda165 & Lambda170 & Lambda175 --> PgSelect28
+    Object10 & PgClassExpression27 & Lambda162 & Access166 & Lambda171 & Lambda176 --> PgSelect28
     PgSelectSingle22 --> PgClassExpression27
     First32{{"First[32∈2] ➊"}}:::plan
     PgSelect28 --> First32
@@ -95,13 +97,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 166, 167, 168, 180, 181, 182, 194, 195, 204, 205, 206, 207, 208, 209, 10, 162, 165, 169, 170, 175, 183, 184, 189, 197, 198, 203<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14<br />3: PgSingleTablePolymorphic[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 167, 168, 169, 182, 183, 184, 197, 198, 207, 208, 209, 210, 211, 212, 10, 162, 165, 166, 170, 171, 176, 185, 186, 191, 200, 201, 206<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14<br />3: PgSingleTablePolymorphic[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,Lambda14,PgSingleTablePolymorphic15,Lambda162,Lambda165,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant194,Constant195,Object197,Lambda198,Lambda203,Constant204,Constant205,Constant206,Constant207,Constant208,Constant209 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 12, 10, 162, 165, 184, 189, 15, 170, 175<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 16, 51<br />2: PgSelect[17]<br />ᐳ: 21, 22, 23, 24<br />3: PgSingleTablePolymorphic[25]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,Lambda14,PgSingleTablePolymorphic15,Lambda162,Lambda165,Access166,Constant167,Constant168,Constant169,Object170,Lambda171,Lambda176,Constant182,Constant183,Constant184,Object185,Lambda186,Lambda191,Constant197,Constant198,Object200,Lambda201,Lambda206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 12, 10, 162, 166, 186, 191, 15, 171, 176<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 16, 51<br />2: PgSelect[17]<br />ᐳ: 21, 22, 23, 24<br />3: PgSingleTablePolymorphic[25]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectSingle22,PgClassExpression23,Lambda24,PgSingleTablePolymorphic25,PgClassExpression51 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 10, 162, 165, 170, 175, 25, 16<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 22, 10, 162, 166, 171, 176, 25, 16<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[27]<br />2: PgSelect[28]<br />ᐳ: First[32], PgSelectSingle[33]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression27,PgSelect28,First32,PgSelectSingle33 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 33<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[33]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-as-item.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-as-item.deopt.mermaid
@@ -11,18 +11,18 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ10ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'TOPIC'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Constant7 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect8
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant40 & Constant7 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect8
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -33,13 +33,15 @@ graph TD
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈0] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First12 --> PgSelectSingle13
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40 --> Lambda25
     Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant41 --> Lambda28
-    Object32 --> Lambda33
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant42 --> Lambda38
+    Constant41 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant42 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant43 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
@@ -63,9 +65,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/single-topic-as-item"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 29, 30, 31, 39, 40, 41, 42, 11, 25, 28, 32, 33, 38<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 30, 31, 32, 40, 41, 42, 43, 11, 25, 28, 29, 33, 34, 39<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,PgClassExpression15,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-as-item.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-as-item.mermaid
@@ -11,18 +11,18 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ10ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'TOPIC'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Constant7 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect8
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant40 & Constant7 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect8
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -33,13 +33,15 @@ graph TD
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈0] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First12 --> PgSelectSingle13
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40 --> Lambda25
     Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant41 --> Lambda28
-    Object32 --> Lambda33
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant42 --> Lambda38
+    Constant41 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant42 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant43 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
@@ -63,9 +65,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/single-topic-as-item"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 29, 30, 31, 39, 40, 41, 42, 11, 25, 28, 32, 33, 38<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 30, 31, 32, 40, 41, 42, 43, 11, 25, 28, 29, 33, 34, 39<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,PgClassExpression15,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-not-topic.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-not-topic.deopt.mermaid
@@ -11,18 +11,18 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ12ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'TOPIC'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Constant7 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect8
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant40 & Constant7 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect8
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -33,13 +33,15 @@ graph TD
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈0] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First12 --> PgSelectSingle13
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40 --> Lambda25
     Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant41 --> Lambda28
-    Object32 --> Lambda33
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant42 --> Lambda38
+    Constant41 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant42 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant43 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
@@ -63,9 +65,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/single-topic-not-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 29, 30, 31, 39, 40, 41, 42, 11, 25, 28, 32, 33, 38<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 30, 31, 32, 40, 41, 42, 43, 11, 25, 28, 29, 33, 34, 39<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,PgClassExpression15,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-not-topic.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic-not-topic.mermaid
@@ -11,18 +11,18 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ12ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'TOPIC'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Constant7 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect8
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant40 & Constant7 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect8
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -33,13 +33,15 @@ graph TD
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈0] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First12 --> PgSelectSingle13
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40 --> Lambda25
     Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant41 --> Lambda28
-    Object32 --> Lambda33
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant42 --> Lambda38
+    Constant41 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant42 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant43 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
@@ -63,9 +65,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/single-topic-not-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 29, 30, 31, 39, 40, 41, 42, 11, 25, 28, 32, 33, 38<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 30, 31, 32, 40, 41, 42, 43, 11, 25, 28, 29, 33, 34, 39<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,PgClassExpression15,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic.deopt.mermaid
@@ -11,18 +11,18 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ10ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'TOPIC'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Constant7 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect8
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant40 & Constant7 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect8
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -33,13 +33,15 @@ graph TD
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈0] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First12 --> PgSelectSingle13
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40 --> Lambda25
     Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant41 --> Lambda28
-    Object32 --> Lambda33
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant42 --> Lambda38
+    Constant41 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant42 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant43 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
@@ -63,9 +65,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/single-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 29, 30, 31, 39, 40, 41, 42, 11, 25, 28, 32, 33, 38<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 30, 31, 32, 40, 41, 42, 43, 11, 25, 28, 29, 33, 34, 39<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,PgClassExpression15,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/single-topic.mermaid
@@ -11,18 +11,18 @@ graph TD
     %% plan dependencies
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ10ᐳ"}}:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸ'TOPIC'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant39 & Constant7 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect8
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant40 & Constant7 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect8
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(single_table_items)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -33,13 +33,15 @@ graph TD
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈0] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First12 --> PgSelectSingle13
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40 --> Lambda25
     Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant41 --> Lambda28
-    Object32 --> Lambda33
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant42 --> Lambda38
+    Constant41 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant42 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant43 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
@@ -63,9 +65,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/single-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 29, 30, 31, 39, 40, 41, 42, 11, 25, 28, 32, 33, 38<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 9, 10, 30, 31, 32, 40, 41, 42, 43, 11, 25, 28, 29, 33, 34, 39<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    class Bucket0,__Value2,__Value4,Constant7,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,PgClassExpression15,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.deopt.mermaid
@@ -9,42 +9,56 @@ graph TD
 
 
     %% plan dependencies
-    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda40 & Constant44 & Constant45 & Constant46 --> Object47
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda40 & Constant58 & Constant59 & Constant60 --> Object61
     PgUnionAll8[["PgUnionAll[8∈0] ➊"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant12{{"Constant[12∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Object11 & Constant12 --> PgUnionAll8
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access74{{"Access[74∈0] ➊<br />ᐸ73.0ᐳ"}}:::plan
+    Access75{{"Access[75∈0] ➊<br />ᐸ73.1ᐳ"}}:::plan
+    Object11 & Constant12 & Constant76 & Constant77 & Lambda71 & Access74 & Access75 --> PgUnionAll8
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda40 & Constant45 & Constant46 & Constant47 --> Object48
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda40 & Constant60 & Constant61 & Constant62 --> Object63
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant68 --> Lambda40
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant78 --> Lambda40
     Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69 --> Lambda43
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object47 --> Lambda48
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant70 --> Lambda53
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant71 --> Lambda67
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant79 --> Lambda43
+    Access44{{"Access[44∈0] ➊<br />ᐸ43.0ᐳ"}}:::plan
+    Lambda43 --> Access44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object48 --> Lambda49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant80 --> Lambda54
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object63 --> Lambda64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant81 --> Lambda69
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant82 --> Lambda71
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant83 --> Lambda73
+    Lambda73 --> Access74
+    Lambda73 --> Access75
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgUnionAll8 ==> __Item13
@@ -52,10 +66,10 @@ graph TD
     __Item13 --> PgUnionAllSingle14
     PgSelect18[["PgSelect[18∈2]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access17{{"Access[17∈2]<br />ᐸ16.0ᐳ"}}:::plan
-    Object11 & Access17 & Lambda40 & Lambda43 & Lambda48 & Lambda53 --> PgSelect18
+    Object11 & Access17 & Lambda40 & Access44 & Lambda49 & Lambda54 --> PgSelect18
     PgSelect30[["PgSelect[30∈2]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access29{{"Access[29∈2]<br />ᐸ28.0ᐳ"}}:::plan
-    Object11 & Access29 & Lambda40 & Lambda43 & Lambda62 & Lambda67 --> PgSelect30
+    Object11 & Access29 & Lambda40 & Access44 & Lambda64 & Lambda69 --> PgSelect30
     Access15{{"Access[15∈2]<br />ᐸ14.2ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle14 --> Access15
     JSONParse16[["JSONParse[16∈2]<br />ᐸ15ᐳ"]]:::plan
@@ -92,13 +106,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilities"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 12, 44, 45, 46, 58, 59, 60, 68, 69, 70, 71, 11, 40, 43, 47, 48, 53, 61, 62, 67<br />2: PgUnionAll[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 12, 45, 46, 47, 60, 61, 62, 76, 77, 78, 79, 80, 81, 82, 83, 11, 40, 43, 44, 48, 49, 54, 63, 64, 69, 71, 73, 74, 75<br />2: PgUnionAll[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgUnionAll8,Access9,Access10,Object11,Constant12,Lambda40,Lambda43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 40, 43, 48, 53, 62, 67<br /><br />ROOT __Item{1}ᐸ8ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,PgUnionAll8,Access9,Access10,Object11,Constant12,Lambda40,Lambda43,Access44,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Lambda71,Lambda73,Access74,Access75,Constant76,Constant77,Constant78,Constant79,Constant80,Constant81,Constant82,Constant83 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 40, 44, 49, 54, 64, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13,PgUnionAllSingle14 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 14, 11, 40, 43, 48, 53, 62, 67<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[15]<br />2: JSONParse[16], JSONParse[28]<br />ᐳ: Access[17], Access[29]<br />3: PgSelect[18], PgSelect[30]<br />ᐳ: 22, 23, 24, 25, 26, 27, 32, 33, 34, 35, 36, 37"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 14, 11, 40, 44, 49, 54, 64, 69<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[15]<br />2: JSONParse[16], JSONParse[28]<br />ᐳ: Access[17], Access[29]<br />3: PgSelect[18], PgSelect[30]<br />ᐳ: 22, 23, 24, 25, 26, 27, 32, 33, 34, 35, 36, 37"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access15,JSONParse16,Access17,PgSelect18,First22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgClassExpression27,JSONParse28,Access29,PgSelect30,First32,PgSelectSingle33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37 bucket2
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.mermaid
@@ -9,42 +9,56 @@ graph TD
 
 
     %% plan dependencies
-    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda40 & Constant44 & Constant45 & Constant46 --> Object47
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda40 & Constant58 & Constant59 & Constant60 --> Object61
     PgUnionAll8[["PgUnionAll[8∈0] ➊"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant12{{"Constant[12∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Object11 & Constant12 --> PgUnionAll8
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access74{{"Access[74∈0] ➊<br />ᐸ73.0ᐳ"}}:::plan
+    Access75{{"Access[75∈0] ➊<br />ᐸ73.1ᐳ"}}:::plan
+    Object11 & Constant12 & Constant76 & Constant77 & Lambda71 & Access74 & Access75 --> PgUnionAll8
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda40 & Constant45 & Constant46 & Constant47 --> Object48
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda40 & Constant60 & Constant61 & Constant62 --> Object63
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant68 --> Lambda40
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant78 --> Lambda40
     Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69 --> Lambda43
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object47 --> Lambda48
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant70 --> Lambda53
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant71 --> Lambda67
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant79 --> Lambda43
+    Access44{{"Access[44∈0] ➊<br />ᐸ43.0ᐳ"}}:::plan
+    Lambda43 --> Access44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object48 --> Lambda49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant80 --> Lambda54
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object63 --> Lambda64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant81 --> Lambda69
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant82 --> Lambda71
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant83 --> Lambda73
+    Lambda73 --> Access74
+    Lambda73 --> Access75
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgUnionAll8 ==> __Item13
@@ -52,10 +66,10 @@ graph TD
     __Item13 --> PgUnionAllSingle14
     PgSelect18[["PgSelect[18∈2]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access17{{"Access[17∈2]<br />ᐸ16.0ᐳ"}}:::plan
-    Object11 & Access17 & Lambda40 & Lambda43 & Lambda48 & Lambda53 --> PgSelect18
+    Object11 & Access17 & Lambda40 & Access44 & Lambda49 & Lambda54 --> PgSelect18
     PgSelect30[["PgSelect[30∈2]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access29{{"Access[29∈2]<br />ᐸ28.0ᐳ"}}:::plan
-    Object11 & Access29 & Lambda40 & Lambda43 & Lambda62 & Lambda67 --> PgSelect30
+    Object11 & Access29 & Lambda40 & Access44 & Lambda64 & Lambda69 --> PgSelect30
     Access15{{"Access[15∈2]<br />ᐸ14.2ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle14 --> Access15
     JSONParse16[["JSONParse[16∈2]<br />ᐸ15ᐳ"]]:::plan
@@ -92,13 +106,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilities"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 12, 44, 45, 46, 58, 59, 60, 68, 69, 70, 71, 11, 40, 43, 47, 48, 53, 61, 62, 67<br />2: PgUnionAll[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 12, 45, 46, 47, 60, 61, 62, 76, 77, 78, 79, 80, 81, 82, 83, 11, 40, 43, 44, 48, 49, 54, 63, 64, 69, 71, 73, 74, 75<br />2: PgUnionAll[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgUnionAll8,Access9,Access10,Object11,Constant12,Lambda40,Lambda43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 40, 43, 48, 53, 62, 67<br /><br />ROOT __Item{1}ᐸ8ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,PgUnionAll8,Access9,Access10,Object11,Constant12,Lambda40,Lambda43,Access44,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Lambda71,Lambda73,Access74,Access75,Constant76,Constant77,Constant78,Constant79,Constant80,Constant81,Constant82,Constant83 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 11, 40, 44, 49, 54, 64, 69<br /><br />ROOT __Item{1}ᐸ8ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item13,PgUnionAllSingle14 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 14, 11, 40, 43, 48, 53, 62, 67<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[15]<br />2: JSONParse[16], JSONParse[28]<br />ᐳ: Access[17], Access[29]<br />3: PgSelect[18], PgSelect[30]<br />ᐳ: 22, 23, 24, 25, 26, 27, 32, 33, 34, 35, 36, 37"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 14, 11, 40, 44, 49, 54, 64, 69<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[15]<br />2: JSONParse[16], JSONParse[28]<br />ᐳ: Access[17], Access[29]<br />3: PgSelect[18], PgSelect[30]<br />ᐳ: 22, 23, 24, 25, 26, 27, 32, 33, 34, 35, 36, 37"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access15,JSONParse16,Access17,PgSelect18,First22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgClassExpression27,JSONParse28,Access29,PgSelect30,First32,PgSelectSingle33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37 bucket2
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.deopt.mermaid
@@ -9,22 +9,22 @@ graph TD
 
 
     %% plan dependencies
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant60 & Constant61 & Constant62 --> Object63
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant74 & Constant75 & Constant76 --> Object77
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant61 & Constant62 & Constant63 --> Object64
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant76 & Constant77 & Constant78 --> Object79
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor21["PgValidateParsedCursor[21∈0] ➊"]:::plan
-    Constant84 & Lambda16 & PgValidateParsedCursor21 --> Connection15
+    Constant92 & Lambda16 & PgValidateParsedCursor21 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -32,37 +32,49 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiRmlyc3RQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
-    Constant85 --> Lambda16
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiRmlyc3RQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
+    Constant93 --> Lambda16
     Lambda16 --> PgValidateParsedCursor21
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda56
+    Access22{{"Access[22∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access22
+    ToPg23{{"ToPg[23∈0] ➊"}}:::plan
+    Access22 --> ToPg23
+    Access24{{"Access[24∈0] ➊<br />ᐸ16.2ᐳ"}}:::plan
+    Lambda16 --> Access24
+    ToPg25{{"ToPg[25∈0] ➊"}}:::plan
+    Access24 --> ToPg25
+    Access26{{"Access[26∈0] ➊<br />ᐸ16.3ᐳ"}}:::plan
+    Lambda16 --> Access26
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda56
     Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda59
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object63 --> Lambda64
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant88 --> Lambda69
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object77 --> Lambda78
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant89 --> Lambda83
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda59
+    Access60{{"Access[60∈0] ➊<br />ᐸ59.0ᐳ"}}:::plan
+    Lambda59 --> Access60
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object64 --> Lambda65
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant96 --> Lambda70
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object79 --> Lambda80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant97 --> Lambda85
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant98 --> Lambda87
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant99 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Access91{{"Access[91∈0] ➊<br />ᐸ89.1ᐳ"}}:::plan
+    Lambda89 --> Access91
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgUnionAll17[["PgUnionAll[17∈1] ➊"]]:::plan
-    ToPg23{{"ToPg[23∈1] ➊"}}:::plan
-    ToPg25{{"ToPg[25∈1] ➊"}}:::plan
-    Access26{{"Access[26∈1] ➊<br />ᐸ16.3ᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll17
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda16 --> Access22
-    Access22 --> ToPg23
-    Access24{{"Access[24∈1] ➊<br />ᐸ16.2ᐳ"}}:::plan
-    Lambda16 --> Access24
-    Access24 --> ToPg25
-    Lambda16 --> Access26
+    Object14 & Connection15 & Lambda16 & Constant92 & ToPg23 & ToPg25 & Access26 & Lambda87 & Access90 & Access91 --> PgUnionAll17
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgUnionAll17 ==> __Item18
     PgUnionAllSingle19["PgUnionAllSingle[19∈2]"]:::plan
@@ -79,10 +91,10 @@ graph TD
     PgUnionAllSingle19 --> Access29
     PgSelect34[["PgSelect[34∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access33{{"Access[33∈4]<br />ᐸ32.0ᐳ"}}:::plan
-    Object14 & Access33 & Lambda56 & Lambda59 & Lambda64 & Lambda69 --> PgSelect34
+    Object14 & Access33 & Lambda56 & Access60 & Lambda65 & Lambda70 --> PgSelect34
     PgSelect46[["PgSelect[46∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access45{{"Access[45∈4]<br />ᐸ44.0ᐳ"}}:::plan
-    Object14 & Access45 & Lambda56 & Lambda59 & Lambda78 & Lambda83 --> PgSelect46
+    Object14 & Access45 & Lambda56 & Access60 & Lambda80 & Lambda85 --> PgSelect46
     JSONParse32[["JSONParse[32∈4]<br />ᐸ29ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access29 --> JSONParse32
     JSONParse32 --> Access33
@@ -117,19 +129,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilitiesConnection.after1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 60, 61, 62, 74, 75, 76, 84, 85, 86, 87, 88, 89, 14, 16, 56, 59, 63, 64, 69, 77, 78, 83<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 61, 62, 63, 76, 77, 78, 92, 93, 94, 95, 96, 97, 98, 99, 14, 16, 22, 23, 24, 25, 26, 56, 59, 60, 64, 65, 70, 79, 80, 85, 87, 89, 90, 91<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Lambda56,Lambda59,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 56, 59, 64, 69, 78, 83<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 22, 24, 26, 23, 25<br />2: PgUnionAll[17]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Access22,ToPg23,Access24,ToPg25,Access26,Lambda56,Lambda59,Access60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Lambda87,Lambda89,Access90,Access91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 92, 23, 25, 26, 87, 90, 91, 56, 60, 65, 70, 80, 85<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll17,Access22,ToPg23,Access24,ToPg25,Access26 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
+    class Bucket1,PgUnionAll17 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgUnionAllSingle19 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor20,Access27,Access28,Access29,List30 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 59, 64, 69, 78, 83, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 60, 65, 70, 80, 85, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse32,Access33,PgSelect34,First38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43,JSONParse44,Access45,PgSelect46,First48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression53 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.mermaid
@@ -9,22 +9,22 @@ graph TD
 
 
     %% plan dependencies
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant60 & Constant61 & Constant62 --> Object63
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant74 & Constant75 & Constant76 --> Object77
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant61 & Constant62 & Constant63 --> Object64
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant76 & Constant77 & Constant78 --> Object79
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor21["PgValidateParsedCursor[21∈0] ➊"]:::plan
-    Constant84 & Lambda16 & PgValidateParsedCursor21 --> Connection15
+    Constant92 & Lambda16 & PgValidateParsedCursor21 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -32,37 +32,49 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiRmlyc3RQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
-    Constant85 --> Lambda16
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiRmlyc3RQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
+    Constant93 --> Lambda16
     Lambda16 --> PgValidateParsedCursor21
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda56
+    Access22{{"Access[22∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access22
+    ToPg23{{"ToPg[23∈0] ➊"}}:::plan
+    Access22 --> ToPg23
+    Access24{{"Access[24∈0] ➊<br />ᐸ16.2ᐳ"}}:::plan
+    Lambda16 --> Access24
+    ToPg25{{"ToPg[25∈0] ➊"}}:::plan
+    Access24 --> ToPg25
+    Access26{{"Access[26∈0] ➊<br />ᐸ16.3ᐳ"}}:::plan
+    Lambda16 --> Access26
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda56
     Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda59
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object63 --> Lambda64
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant88 --> Lambda69
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object77 --> Lambda78
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant89 --> Lambda83
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda59
+    Access60{{"Access[60∈0] ➊<br />ᐸ59.0ᐳ"}}:::plan
+    Lambda59 --> Access60
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object64 --> Lambda65
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant96 --> Lambda70
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object79 --> Lambda80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant97 --> Lambda85
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant98 --> Lambda87
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant99 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Access91{{"Access[91∈0] ➊<br />ᐸ89.1ᐳ"}}:::plan
+    Lambda89 --> Access91
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgUnionAll17[["PgUnionAll[17∈1] ➊"]]:::plan
-    ToPg23{{"ToPg[23∈1] ➊"}}:::plan
-    ToPg25{{"ToPg[25∈1] ➊"}}:::plan
-    Access26{{"Access[26∈1] ➊<br />ᐸ16.3ᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll17
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda16 --> Access22
-    Access22 --> ToPg23
-    Access24{{"Access[24∈1] ➊<br />ᐸ16.2ᐳ"}}:::plan
-    Lambda16 --> Access24
-    Access24 --> ToPg25
-    Lambda16 --> Access26
+    Object14 & Connection15 & Lambda16 & Constant92 & ToPg23 & ToPg25 & Access26 & Lambda87 & Access90 & Access91 --> PgUnionAll17
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgUnionAll17 ==> __Item18
     PgUnionAllSingle19["PgUnionAllSingle[19∈2]"]:::plan
@@ -79,10 +91,10 @@ graph TD
     PgUnionAllSingle19 --> Access29
     PgSelect34[["PgSelect[34∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access33{{"Access[33∈4]<br />ᐸ32.0ᐳ"}}:::plan
-    Object14 & Access33 & Lambda56 & Lambda59 & Lambda64 & Lambda69 --> PgSelect34
+    Object14 & Access33 & Lambda56 & Access60 & Lambda65 & Lambda70 --> PgSelect34
     PgSelect46[["PgSelect[46∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access45{{"Access[45∈4]<br />ᐸ44.0ᐳ"}}:::plan
-    Object14 & Access45 & Lambda56 & Lambda59 & Lambda78 & Lambda83 --> PgSelect46
+    Object14 & Access45 & Lambda56 & Access60 & Lambda80 & Lambda85 --> PgSelect46
     JSONParse32[["JSONParse[32∈4]<br />ᐸ29ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access29 --> JSONParse32
     JSONParse32 --> Access33
@@ -117,19 +129,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilitiesConnection.after1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 60, 61, 62, 74, 75, 76, 84, 85, 86, 87, 88, 89, 14, 16, 56, 59, 63, 64, 69, 77, 78, 83<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 61, 62, 63, 76, 77, 78, 92, 93, 94, 95, 96, 97, 98, 99, 14, 16, 22, 23, 24, 25, 26, 56, 59, 60, 64, 65, 70, 79, 80, 85, 87, 89, 90, 91<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Lambda56,Lambda59,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 56, 59, 64, 69, 78, 83<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 22, 24, 26, 23, 25<br />2: PgUnionAll[17]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Access22,ToPg23,Access24,ToPg25,Access26,Lambda56,Lambda59,Access60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Lambda87,Lambda89,Access90,Access91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 92, 23, 25, 26, 87, 90, 91, 56, 60, 65, 70, 80, 85<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll17,Access22,ToPg23,Access24,ToPg25,Access26 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
+    class Bucket1,PgUnionAll17 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgUnionAllSingle19 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor20,Access27,Access28,Access29,List30 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 59, 64, 69, 78, 83, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 60, 65, 70, 80, 85, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse32,Access33,PgSelect34,First38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43,JSONParse44,Access45,PgSelect46,First48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression53 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.deopt.mermaid
@@ -9,22 +9,22 @@ graph TD
 
 
     %% plan dependencies
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant60 & Constant61 & Constant62 --> Object63
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant74 & Constant75 & Constant76 --> Object77
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant61 & Constant62 & Constant63 --> Object64
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant76 & Constant77 & Constant78 --> Object79
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor21["PgValidateParsedCursor[21∈0] ➊"]:::plan
-    Constant84 & Lambda16 & PgValidateParsedCursor21 --> Connection15
+    Constant92 & Lambda16 & PgValidateParsedCursor21 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -32,37 +32,49 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiVGhpcmRQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
-    Constant85 --> Lambda16
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiVGhpcmRQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
+    Constant93 --> Lambda16
     Lambda16 --> PgValidateParsedCursor21
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda56
+    Access22{{"Access[22∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access22
+    ToPg23{{"ToPg[23∈0] ➊"}}:::plan
+    Access22 --> ToPg23
+    Access24{{"Access[24∈0] ➊<br />ᐸ16.2ᐳ"}}:::plan
+    Lambda16 --> Access24
+    ToPg25{{"ToPg[25∈0] ➊"}}:::plan
+    Access24 --> ToPg25
+    Access26{{"Access[26∈0] ➊<br />ᐸ16.3ᐳ"}}:::plan
+    Lambda16 --> Access26
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda56
     Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda59
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object63 --> Lambda64
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant88 --> Lambda69
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object77 --> Lambda78
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant89 --> Lambda83
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda59
+    Access60{{"Access[60∈0] ➊<br />ᐸ59.0ᐳ"}}:::plan
+    Lambda59 --> Access60
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object64 --> Lambda65
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant96 --> Lambda70
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object79 --> Lambda80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant97 --> Lambda85
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant98 --> Lambda87
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant99 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Access91{{"Access[91∈0] ➊<br />ᐸ89.1ᐳ"}}:::plan
+    Lambda89 --> Access91
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgUnionAll17[["PgUnionAll[17∈1] ➊"]]:::plan
-    ToPg23{{"ToPg[23∈1] ➊"}}:::plan
-    ToPg25{{"ToPg[25∈1] ➊"}}:::plan
-    Access26{{"Access[26∈1] ➊<br />ᐸ16.3ᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll17
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda16 --> Access22
-    Access22 --> ToPg23
-    Access24{{"Access[24∈1] ➊<br />ᐸ16.2ᐳ"}}:::plan
-    Lambda16 --> Access24
-    Access24 --> ToPg25
-    Lambda16 --> Access26
+    Object14 & Connection15 & Lambda16 & Constant92 & ToPg23 & ToPg25 & Access26 & Lambda87 & Access90 & Access91 --> PgUnionAll17
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgUnionAll17 ==> __Item18
     PgUnionAllSingle19["PgUnionAllSingle[19∈2]"]:::plan
@@ -79,10 +91,10 @@ graph TD
     PgUnionAllSingle19 --> Access29
     PgSelect34[["PgSelect[34∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access33{{"Access[33∈4]<br />ᐸ32.0ᐳ"}}:::plan
-    Object14 & Access33 & Lambda56 & Lambda59 & Lambda64 & Lambda69 --> PgSelect34
+    Object14 & Access33 & Lambda56 & Access60 & Lambda65 & Lambda70 --> PgSelect34
     PgSelect46[["PgSelect[46∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access45{{"Access[45∈4]<br />ᐸ44.0ᐳ"}}:::plan
-    Object14 & Access45 & Lambda56 & Lambda59 & Lambda78 & Lambda83 --> PgSelect46
+    Object14 & Access45 & Lambda56 & Access60 & Lambda80 & Lambda85 --> PgSelect46
     JSONParse32[["JSONParse[32∈4]<br />ᐸ29ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access29 --> JSONParse32
     JSONParse32 --> Access33
@@ -117,19 +129,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilitiesConnection.before1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 60, 61, 62, 74, 75, 76, 84, 85, 86, 87, 88, 89, 14, 16, 56, 59, 63, 64, 69, 77, 78, 83<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 61, 62, 63, 76, 77, 78, 92, 93, 94, 95, 96, 97, 98, 99, 14, 16, 22, 23, 24, 25, 26, 56, 59, 60, 64, 65, 70, 79, 80, 85, 87, 89, 90, 91<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Lambda56,Lambda59,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 56, 59, 64, 69, 78, 83<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 22, 24, 26, 23, 25<br />2: PgUnionAll[17]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Access22,ToPg23,Access24,ToPg25,Access26,Lambda56,Lambda59,Access60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Lambda87,Lambda89,Access90,Access91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 92, 23, 25, 26, 87, 90, 91, 56, 60, 65, 70, 80, 85<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll17,Access22,ToPg23,Access24,ToPg25,Access26 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
+    class Bucket1,PgUnionAll17 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgUnionAllSingle19 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor20,Access27,Access28,Access29,List30 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 59, 64, 69, 78, 83, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 60, 65, 70, 80, 85, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse32,Access33,PgSelect34,First38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43,JSONParse44,Access45,PgSelect46,First48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression53 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.mermaid
@@ -9,22 +9,22 @@ graph TD
 
 
     %% plan dependencies
-    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object64{{"Object[64∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant60 & Constant61 & Constant62 --> Object63
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda56 & Constant74 & Constant75 & Constant76 --> Object77
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant61 & Constant62 & Constant63 --> Object64
+    Object79{{"Object[79∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda56 & Constant76 & Constant77 & Constant78 --> Object79
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor21["PgValidateParsedCursor[21∈0] ➊"]:::plan
-    Constant84 & Lambda16 & PgValidateParsedCursor21 --> Connection15
+    Constant92 & Lambda16 & PgValidateParsedCursor21 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -32,37 +32,49 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiVGhpcmRQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
-    Constant85 --> Lambda16
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ'WyI2Y2M3ZmU5NDM2IiwiNy4yIiwiVGhpcmRQYXJ0eVZ1bG5lcmFiaWxpdHkᐳ"}}:::plan
+    Constant93 --> Lambda16
     Lambda16 --> PgValidateParsedCursor21
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant86 --> Lambda56
+    Access22{{"Access[22∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access22
+    ToPg23{{"ToPg[23∈0] ➊"}}:::plan
+    Access22 --> ToPg23
+    Access24{{"Access[24∈0] ➊<br />ᐸ16.2ᐳ"}}:::plan
+    Lambda16 --> Access24
+    ToPg25{{"ToPg[25∈0] ➊"}}:::plan
+    Access24 --> ToPg25
+    Access26{{"Access[26∈0] ➊<br />ᐸ16.3ᐳ"}}:::plan
+    Lambda16 --> Access26
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda56
     Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda59
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object63 --> Lambda64
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant88 --> Lambda69
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object77 --> Lambda78
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant89 --> Lambda83
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda59
+    Access60{{"Access[60∈0] ➊<br />ᐸ59.0ᐳ"}}:::plan
+    Lambda59 --> Access60
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object64 --> Lambda65
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant96 --> Lambda70
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object79 --> Lambda80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant97 --> Lambda85
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant98 --> Lambda87
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant99 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Access91{{"Access[91∈0] ➊<br />ᐸ89.1ᐳ"}}:::plan
+    Lambda89 --> Access91
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgUnionAll17[["PgUnionAll[17∈1] ➊"]]:::plan
-    ToPg23{{"ToPg[23∈1] ➊"}}:::plan
-    ToPg25{{"ToPg[25∈1] ➊"}}:::plan
-    Access26{{"Access[26∈1] ➊<br />ᐸ16.3ᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll17
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda16 --> Access22
-    Access22 --> ToPg23
-    Access24{{"Access[24∈1] ➊<br />ᐸ16.2ᐳ"}}:::plan
-    Lambda16 --> Access24
-    Access24 --> ToPg25
-    Lambda16 --> Access26
+    Object14 & Connection15 & Lambda16 & Constant92 & ToPg23 & ToPg25 & Access26 & Lambda87 & Access90 & Access91 --> PgUnionAll17
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgUnionAll17 ==> __Item18
     PgUnionAllSingle19["PgUnionAllSingle[19∈2]"]:::plan
@@ -79,10 +91,10 @@ graph TD
     PgUnionAllSingle19 --> Access29
     PgSelect34[["PgSelect[34∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access33{{"Access[33∈4]<br />ᐸ32.0ᐳ"}}:::plan
-    Object14 & Access33 & Lambda56 & Lambda59 & Lambda64 & Lambda69 --> PgSelect34
+    Object14 & Access33 & Lambda56 & Access60 & Lambda65 & Lambda70 --> PgSelect34
     PgSelect46[["PgSelect[46∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access45{{"Access[45∈4]<br />ᐸ44.0ᐳ"}}:::plan
-    Object14 & Access45 & Lambda56 & Lambda59 & Lambda78 & Lambda83 --> PgSelect46
+    Object14 & Access45 & Lambda56 & Access60 & Lambda80 & Lambda85 --> PgSelect46
     JSONParse32[["JSONParse[32∈4]<br />ᐸ29ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access29 --> JSONParse32
     JSONParse32 --> Access33
@@ -117,19 +129,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilitiesConnection.before1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 60, 61, 62, 74, 75, 76, 84, 85, 86, 87, 88, 89, 14, 16, 56, 59, 63, 64, 69, 77, 78, 83<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 61, 62, 63, 76, 77, 78, 92, 93, 94, 95, 96, 97, 98, 99, 14, 16, 22, 23, 24, 25, 26, 56, 59, 60, 64, 65, 70, 79, 80, 85, 87, 89, 90, 91<br />2: PgValidateParsedCursor[21]<br />ᐳ: Connection[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Lambda56,Lambda59,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 56, 59, 64, 69, 78, 83<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 22, 24, 26, 23, 25<br />2: PgUnionAll[17]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Access22,ToPg23,Access24,ToPg25,Access26,Lambda56,Lambda59,Access60,Constant61,Constant62,Constant63,Object64,Lambda65,Lambda70,Constant76,Constant77,Constant78,Object79,Lambda80,Lambda85,Lambda87,Lambda89,Access90,Access91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 92, 23, 25, 26, 87, 90, 91, 56, 60, 65, 70, 80, 85<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll17,Access22,ToPg23,Access24,ToPg25,Access26 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
+    class Bucket1,PgUnionAll17 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgUnionAllSingle19 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 59, 64, 69, 78, 83<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 56, 60, 65, 70, 80, 85<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor20,Access27,Access28,Access29,List30 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 59, 64, 69, 78, 83, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 56, 60, 65, 70, 80, 85, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[44]<br />ᐳ: Access[33], Access[45]<br />2: PgSelect[34], PgSelect[46]<br />ᐳ: 38, 39, 40, 41, 42, 43, 48, 49, 50, 51, 52, 53"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse32,Access33,PgSelect34,First38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43,JSONParse44,Access45,PgSelect46,First48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression53 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.deopt.mermaid
@@ -9,17 +9,17 @@ graph TD
 
 
     %% plan dependencies
-    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda47 & Constant51 & Constant52 & Constant53 --> Object54
-    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda47 & Constant65 & Constant66 & Constant67 --> Object68
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda47 & Constant52 & Constant53 & Constant54 --> Object55
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda47 & Constant67 & Constant68 & Constant69 --> Object70
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -27,25 +27,29 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant75 --> Lambda47
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda47
     Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant76 --> Lambda50
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object54 --> Lambda55
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant77 --> Lambda60
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object68 --> Lambda69
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant78 --> Lambda74
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda50
+    Access51{{"Access[51∈0] ➊<br />ᐸ50.0ᐳ"}}:::plan
+    Lambda50 --> Access51
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object55 --> Lambda56
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant85 --> Lambda61
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant86 --> Lambda76
+    Access82{{"Access[82∈0] ➊<br />ᐸ50.1ᐳ"}}:::plan
+    Lambda50 --> Access82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     PgUnionAll14[["PgUnionAll[14∈1] ➊"]]:::plan
-    Object12 & Connection13 --> PgUnionAll14
+    Object12 & Connection13 & Lambda47 & Access51 & Access82 --> PgUnionAll14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgUnionAll14 ==> __Item15
     PgUnionAllSingle16["PgUnionAllSingle[16∈2]"]:::plan
@@ -62,10 +66,10 @@ graph TD
     PgUnionAllSingle16 --> Access20
     PgSelect25[["PgSelect[25∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access24{{"Access[24∈4]<br />ᐸ23.0ᐳ"}}:::plan
-    Object12 & Access24 & Lambda47 & Lambda50 & Lambda55 & Lambda60 --> PgSelect25
+    Object12 & Access24 & Lambda47 & Access51 & Lambda56 & Lambda61 --> PgSelect25
     PgSelect37[["PgSelect[37∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access36{{"Access[36∈4]<br />ᐸ35.0ᐳ"}}:::plan
-    Object12 & Access36 & Lambda47 & Lambda50 & Lambda69 & Lambda74 --> PgSelect37
+    Object12 & Access36 & Lambda47 & Access51 & Lambda71 & Lambda76 --> PgSelect37
     JSONParse23[["JSONParse[23∈4]<br />ᐸ20ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access20 --> JSONParse23
     JSONParse23 --> Access24
@@ -102,17 +106,17 @@ graph TD
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilitiesConnection"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda47,Lambda50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant75,Constant76,Constant77,Constant78 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 47, 50, 55, 60, 69, 74<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda47,Lambda50,Access51,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Access82,Constant83,Constant84,Constant85,Constant86 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 47, 51, 82, 56, 61, 71, 76<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUnionAll14 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 47, 50, 55, 60, 69, 74<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 47, 51, 56, 61, 71, 76<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgUnionAllSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 47, 50, 55, 60, 69, 74<br /><br />ROOT PgUnionAllSingle{2}[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 47, 51, 56, 61, 71, 76<br /><br />ROOT PgUnionAllSingle{2}[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor17,Access18,Access19,Access20,List21 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 12, 47, 50, 55, 60, 69, 74, 16<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[23], JSONParse[35]<br />ᐳ: Access[24], Access[36]<br />2: PgSelect[25], PgSelect[37]<br />ᐳ: 29, 30, 31, 32, 33, 34, 39, 40, 41, 42, 43, 44"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 12, 47, 51, 56, 61, 71, 76, 16<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[23], JSONParse[35]<br />ᐳ: Access[24], Access[36]<br />2: PgSelect[25], PgSelect[37]<br />ᐳ: 29, 30, 31, 32, 33, 34, 39, 40, 41, 42, 43, 44"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse23,Access24,PgSelect25,First29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,JSONParse35,Access36,PgSelect37,First39,PgSelectSingle40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.mermaid
@@ -9,17 +9,17 @@ graph TD
 
 
     %% plan dependencies
-    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda47 & Constant51 & Constant52 & Constant53 --> Object54
-    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
-    Lambda47 & Constant65 & Constant66 & Constant67 --> Object68
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(first_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda47 & Constant52 & Constant53 & Constant54 --> Object55
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(third_party_vulnerabilities)ᐳ"}}:::plan
+    Lambda47 & Constant67 & Constant68 & Constant69 --> Object70
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -27,25 +27,29 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant75 --> Lambda47
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda47
     Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant76 --> Lambda50
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object54 --> Lambda55
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant77 --> Lambda60
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object68 --> Lambda69
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant78 --> Lambda74
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda50
+    Access51{{"Access[51∈0] ➊<br />ᐸ50.0ᐳ"}}:::plan
+    Lambda50 --> Access51
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object55 --> Lambda56
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant85 --> Lambda61
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant86 --> Lambda76
+    Access82{{"Access[82∈0] ➊<br />ᐸ50.1ᐳ"}}:::plan
+    Lambda50 --> Access82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     PgUnionAll14[["PgUnionAll[14∈1] ➊"]]:::plan
-    Object12 & Connection13 --> PgUnionAll14
+    Object12 & Connection13 & Lambda47 & Access51 & Access82 --> PgUnionAll14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgUnionAll14 ==> __Item15
     PgUnionAllSingle16["PgUnionAllSingle[16∈2]"]:::plan
@@ -62,10 +66,10 @@ graph TD
     PgUnionAllSingle16 --> Access20
     PgSelect25[["PgSelect[25∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access24{{"Access[24∈4]<br />ᐸ23.0ᐳ"}}:::plan
-    Object12 & Access24 & Lambda47 & Lambda50 & Lambda55 & Lambda60 --> PgSelect25
+    Object12 & Access24 & Lambda47 & Access51 & Lambda56 & Lambda61 --> PgSelect25
     PgSelect37[["PgSelect[37∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access36{{"Access[36∈4]<br />ᐸ35.0ᐳ"}}:::plan
-    Object12 & Access36 & Lambda47 & Lambda50 & Lambda69 & Lambda74 --> PgSelect37
+    Object12 & Access36 & Lambda47 & Access51 & Lambda71 & Lambda76 --> PgSelect37
     JSONParse23[["JSONParse[23∈4]<br />ᐸ20ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access20 --> JSONParse23
     JSONParse23 --> Access24
@@ -102,17 +106,17 @@ graph TD
     subgraph "Buckets for queries/interfaces-via-union-all/vulnerabilitiesConnection"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda47,Lambda50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant75,Constant76,Constant77,Constant78 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 47, 50, 55, 60, 69, 74<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda47,Lambda50,Access51,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Access82,Constant83,Constant84,Constant85,Constant86 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 47, 51, 82, 56, 61, 71, 76<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUnionAll14 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 47, 50, 55, 60, 69, 74<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 47, 51, 56, 61, 71, 76<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgUnionAllSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 47, 50, 55, 60, 69, 74<br /><br />ROOT PgUnionAllSingle{2}[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 47, 51, 56, 61, 71, 76<br /><br />ROOT PgUnionAllSingle{2}[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor17,Access18,Access19,Access20,List21 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 12, 47, 50, 55, 60, 69, 74, 16<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[23], JSONParse[35]<br />ᐳ: Access[24], Access[36]<br />2: PgSelect[25], PgSelect[37]<br />ᐳ: 29, 30, 31, 32, 33, 34, 39, 40, 41, 42, 43, 44"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 12, 47, 51, 56, 61, 71, 76, 16<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[23], JSONParse[35]<br />ᐳ: Access[24], Access[36]<br />2: PgSelect[25], PgSelect[37]<br />ᐳ: 29, 30, 31, 32, 33, 34, 39, 40, 41, 42, 43, 44"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse23,Access24,PgSelect25,First29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,JSONParse35,Access36,PgSelect37,First39,PgSelectSingle40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/relations/basics-no-join-if-identical.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/relations/basics-no-join-if-identical.deopt.mermaid
@@ -11,17 +11,22 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸmessagesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant53 & Lambda25 & Lambda28 & Lambda47 & Lambda52 --> PgSelect7
-    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda25 & Constant43 & Constant44 & Constant45 --> Object46
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant55 & Lambda25 & Access29 & Lambda49 & Lambda54 --> PgSelect7
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda25 & Constant45 & Constant46 & Constant47 --> Object48
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,25 +37,24 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸmessagesᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant54 --> Lambda25
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant55 --> Lambda28
-    Object46 --> Lambda47
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant57 --> Lambda52
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant56 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant57 --> Lambda28
+    Lambda28 --> Access29
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object33 --> Lambda34
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant58 --> Lambda39
+    Object48 --> Lambda49
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant59 --> Lambda54
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸforumsᐳ"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & PgClassExpression15 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect16
-    Object32{{"Object[32∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Object10 & PgClassExpression15 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect16
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__messages__.”body”ᐳ"}}:::plan
@@ -60,18 +64,16 @@ graph TD
     PgSelect16 --> First20
     PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸforumsᐳ"}}:::plan
     First20 --> PgSelectSingle21
-    Object32 --> Lambda33
-    Constant56 --> Lambda38
 
     %% define steps
 
     subgraph "Buckets for queries/relations/basics-no-join-if-identical"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 30, 31, 43, 44, 45, 53, 54, 55, 56, 57, 10, 25, 28, 46, 47, 52<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 30, 31, 32, 45, 46, 47, 55, 56, 57, 58, 59, 10, 25, 28, 29, 33, 34, 39, 48, 49, 54<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda25,Lambda28,Constant29,Constant30,Constant31,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant53,Constant54,Constant55,Constant56,Constant57 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 25, 28, 29, 30, 31, 56<br /><br />ROOT PgSelectSingleᐸmessagesᐳ[12]<br />1: <br />ᐳ: 13, 14, 15, 32, 38, 33<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant55,Constant56,Constant57,Constant58,Constant59 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 25, 29, 34, 39<br /><br />ROOT PgSelectSingleᐸmessagesᐳ[12]<br />1: <br />ᐳ: 13, 14, 15<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,Object32,Lambda33,Lambda38 bucket1
+    class Bucket1,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelect16,First20,PgSelectSingle21 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 15<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2

--- a/grafast/dataplan-pg/__tests__/queries/relations/basics-no-join-if-identical.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/relations/basics-no-join-if-identical.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸmessagesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant55 & Lambda28 & Lambda33 & Lambda38 & Lambda25 & Lambda28 & Lambda49 & Lambda54 --> PgSelect7
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
-    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda25 & Constant45 & Constant46 & Constant47 --> Object48
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant57 & Access29 & Lambda34 & Lambda39 & Lambda25 & Access29 & Lambda51 & Lambda56 --> PgSelect7
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
+    Object50{{"Object[50∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda25 & Constant47 & Constant48 & Constant49 --> Object50
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,40 +39,42 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸmessagesᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant56 --> Lambda25
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant57 --> Lambda28
-    Object32 --> Lambda33
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant58 --> Lambda38
-    Object48 --> Lambda49
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant59 --> Lambda54
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant58 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant59 --> Lambda28
+    Lambda28 --> Access29
+    Object33 --> Lambda34
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant60 --> Lambda39
+    Object50 --> Lambda51
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant61 --> Lambda56
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression14
-    PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸforumsᐳ"}}:::plan
-    RemapKeys39{{"RemapKeys[39∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
-    RemapKeys39 --> PgSelectSingle21
-    PgSelectSingle12 --> RemapKeys39
-    PgClassExpression15{{"PgClassExpression[15∈2] ➊<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
+    PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression15
+    PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸforumsᐳ"}}:::plan
+    RemapKeys40{{"RemapKeys[40∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
+    RemapKeys40 --> PgSelectSingle21
+    PgSelectSingle12 --> RemapKeys40
 
     %% define steps
 
     subgraph "Buckets for queries/relations/basics-no-join-if-identical"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 30, 31, 45, 46, 47, 55, 56, 57, 58, 59, 10, 25, 28, 32, 33, 38, 48, 49, 54<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 30, 31, 32, 47, 48, 49, 57, 58, 59, 60, 61, 10, 25, 28, 29, 33, 34, 39, 50, 51, 56<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant55,Constant56,Constant57,Constant58,Constant59 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant47,Constant48,Constant49,Object50,Lambda51,Lambda56,Constant57,Constant58,Constant59,Constant60,Constant61 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸmessagesᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgClassExpression14,PgSelectSingle21,RemapKeys39 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 21<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[21]"):::bucket
+    class Bucket1,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelectSingle21,RemapKeys40 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 15<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression15 bucket2
+    class Bucket2 bucket2
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/relations/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/relations/basics.deopt.mermaid
@@ -11,17 +11,22 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸmessagesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
     Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant54 & Lambda26 & Lambda29 & Lambda48 & Lambda53 --> PgSelect7
-    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda26 & Constant44 & Constant45 & Constant46 --> Object47
+    Access30{{"Access[30∈0] ➊<br />ᐸ29.0ᐳ"}}:::plan
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant56 & Lambda26 & Access30 & Lambda50 & Lambda55 --> PgSelect7
+    Object34{{"Object[34∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda26 & Constant31 & Constant32 & Constant33 --> Object34
+    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda26 & Constant46 & Constant47 & Constant48 --> Object49
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,25 +37,24 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸmessagesᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant55 --> Lambda26
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant56 --> Lambda29
-    Object47 --> Lambda48
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant58 --> Lambda53
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant57 --> Lambda26
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant58 --> Lambda29
+    Lambda29 --> Access30
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object34 --> Lambda35
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant59 --> Lambda40
+    Object49 --> Lambda50
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant60 --> Lambda55
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸforumsᐳ"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
-    Lambda34{{"Lambda[34∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & PgClassExpression15 & Lambda26 & Lambda29 & Lambda34 & Lambda39 --> PgSelect16
-    Object33{{"Object[33∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda26 & Constant30 & Constant31 & Constant32 --> Object33
+    Object10 & PgClassExpression15 & Lambda26 & Access30 & Lambda35 & Lambda40 --> PgSelect16
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__messages__.”body”ᐳ"}}:::plan
@@ -60,20 +64,18 @@ graph TD
     PgSelect16 --> First20
     PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸforumsᐳ"}}:::plan
     First20 --> PgSelectSingle21
-    Object33 --> Lambda34
-    Constant57 --> Lambda39
     PgClassExpression23{{"PgClassExpression[23∈2] ➊<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression23
 
     %% define steps
 
     subgraph "Buckets for queries/relations/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 30, 31, 32, 44, 45, 46, 54, 55, 56, 57, 58, 10, 26, 29, 47, 48, 53<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 31, 32, 33, 46, 47, 48, 56, 57, 58, 59, 60, 10, 26, 29, 30, 34, 35, 40, 49, 50, 55<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda26,Lambda29,Constant30,Constant31,Constant32,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant54,Constant55,Constant56,Constant57,Constant58 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 26, 29, 30, 31, 32, 57<br /><br />ROOT PgSelectSingleᐸmessagesᐳ[12]<br />1: <br />ᐳ: 13, 14, 15, 33, 39, 34<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda26,Lambda29,Access30,Constant31,Constant32,Constant33,Object34,Lambda35,Lambda40,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant58,Constant59,Constant60 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 26, 30, 35, 40<br /><br />ROOT PgSelectSingleᐸmessagesᐳ[12]<br />1: <br />ᐳ: 13, 14, 15<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,Object33,Lambda34,Lambda39 bucket1
+    class Bucket1,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelect16,First20,PgSelectSingle21 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 15<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression23 bucket2

--- a/grafast/dataplan-pg/__tests__/queries/relations/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/relations/basics.mermaid
@@ -11,24 +11,24 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸmessagesᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ'ca70ca70-0000-0000-0000-cec111a0ca70'ᐳ"}}:::plan
+    Access30{{"Access[30∈0] ➊<br />ᐸ29.0ᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant56 & Lambda29 & Lambda34 & Lambda39 & Lambda26 & Lambda29 & Lambda50 & Lambda55 --> PgSelect7
-    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda26 & Constant30 & Constant31 & Constant32 --> Object33
-    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda26 & Constant46 & Constant47 & Constant48 --> Object49
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant58 & Access30 & Lambda35 & Lambda40 & Lambda26 & Access30 & Lambda52 & Lambda57 --> PgSelect7
+    Object34{{"Object[34∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda26 & Constant31 & Constant32 & Constant33 --> Object34
+    Object51{{"Object[51∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda26 & Constant48 & Constant49 & Constant50 --> Object51
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -39,42 +39,44 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸmessagesᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant57 --> Lambda26
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant58 --> Lambda29
-    Object33 --> Lambda34
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant59 --> Lambda39
-    Object49 --> Lambda50
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant60 --> Lambda55
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant59 --> Lambda26
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant60 --> Lambda29
+    Lambda29 --> Access30
+    Object34 --> Lambda35
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant61 --> Lambda40
+    Object51 --> Lambda52
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant62 --> Lambda57
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression14
-    PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸforumsᐳ"}}:::plan
-    RemapKeys40{{"RemapKeys[40∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
-    RemapKeys40 --> PgSelectSingle21
-    PgSelectSingle12 --> RemapKeys40
-    PgClassExpression15{{"PgClassExpression[15∈2] ➊<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
+    PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression15
+    PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸforumsᐳ"}}:::plan
+    RemapKeys41{{"RemapKeys[41∈1] ➊<br />ᐸ12:{”0”:2}ᐳ"}}:::plan
+    RemapKeys41 --> PgSelectSingle21
+    PgSelectSingle12 --> RemapKeys41
     PgClassExpression23{{"PgClassExpression[23∈2] ➊<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression23
 
     %% define steps
 
     subgraph "Buckets for queries/relations/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 30, 31, 32, 46, 47, 48, 56, 57, 58, 59, 60, 10, 26, 29, 33, 34, 39, 49, 50, 55<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 31, 32, 33, 48, 49, 50, 58, 59, 60, 61, 62, 10, 26, 29, 30, 34, 35, 40, 51, 52, 57<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda26,Lambda29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant58,Constant59,Constant60 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda26,Lambda29,Access30,Constant31,Constant32,Constant33,Object34,Lambda35,Lambda40,Constant48,Constant49,Constant50,Object51,Lambda52,Lambda57,Constant58,Constant59,Constant60,Constant61,Constant62 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸmessagesᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgClassExpression14,PgSelectSingle21,RemapKeys40 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 21<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[21]"):::bucket
+    class Bucket1,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelectSingle21,RemapKeys41 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 15<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression15,PgClassExpression23 bucket2
+    class Bucket2,PgClassExpression23 bucket2
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda47 & Lambda50 & Lambda55 & Lambda60 --> PgSelect6
-    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda47 & Constant51 & Constant52 & Constant53 --> Object54
+    Access51{{"Access[51∈0] ➊<br />ᐸ50.0ᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda47 & Access51 & Lambda56 & Lambda61 --> PgSelect6
+    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda47 & Constant52 & Constant53 & Constant54 --> Object55
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,70 +31,72 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda47
     Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant63 --> Lambda50
-    Object54 --> Lambda55
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant64 --> Lambda60
+    Constant63 --> Lambda47
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda50
+    Lambda50 --> Access51
+    Object55 --> Lambda56
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant65 --> Lambda61
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
-    PgClassExpression12 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
+    PgClassExpression12 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
     PgSelectSingle11 --> PgClassExpression12
     GraphQLResolver16[["GraphQLResolver[16∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     GraphQLResolver18[["GraphQLResolver[18∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
     GraphQLResolver20[["GraphQLResolver[20∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
     GraphQLResolver44[["GraphQLResolver[44∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver44
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver44
     GraphQLResolver22[["GraphQLResolver[22∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
     GraphQLResolver30[["GraphQLResolver[30∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
     GraphQLResolver38[["GraphQLResolver[38∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver38
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver38
     GraphQLResolver40[["GraphQLResolver[40∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver40
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver40
     GraphQLResolver42[["GraphQLResolver[42∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver42
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver42
     GraphQLResolver24[["GraphQLResolver[24∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
+    GraphQLResolver22 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
     GraphQLResolver26[["GraphQLResolver[26∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
+    GraphQLResolver22 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
     GraphQLResolver28[["GraphQLResolver[28∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
+    GraphQLResolver22 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
     GraphQLResolver32[["GraphQLResolver[32∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver30 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
+    GraphQLResolver30 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
     GraphQLResolver34[["GraphQLResolver[34∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver30 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver34
+    GraphQLResolver30 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver34
     GraphQLResolver36[["GraphQLResolver[36∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver30 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver36
+    GraphQLResolver30 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver36
 
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics-object-errors"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 51, 52, 53, 61, 62, 63, 64, 9, 47, 50, 54, 55, 60<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 52, 53, 54, 62, 63, 64, 65, 9, 47, 50, 51, 55, 56, 61<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda47,Lambda50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant61,Constant62,Constant63,Constant64 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 61, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda47,Lambda50,Access51,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 62, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,GraphQLResolver14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,GraphQLResolver16,GraphQLResolver18,GraphQLResolver20,GraphQLResolver44 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,GraphQLResolver22,GraphQLResolver30,GraphQLResolver38,GraphQLResolver40,GraphQLResolver42 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver24,GraphQLResolver26,GraphQLResolver28 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[30]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[30]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,GraphQLResolver32,GraphQLResolver34,GraphQLResolver36 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda47 & Lambda50 & Lambda55 & Lambda60 --> PgSelect6
-    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda47 & Constant51 & Constant52 & Constant53 --> Object54
+    Access51{{"Access[51∈0] ➊<br />ᐸ50.0ᐳ"}}:::plan
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda47 & Access51 & Lambda56 & Lambda61 --> PgSelect6
+    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda47 & Constant52 & Constant53 & Constant54 --> Object55
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,70 +31,72 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda47
     Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant63 --> Lambda50
-    Object54 --> Lambda55
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant64 --> Lambda60
+    Constant63 --> Lambda47
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda50
+    Lambda50 --> Access51
+    Object55 --> Lambda56
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant65 --> Lambda61
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
-    PgClassExpression12 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
+    PgClassExpression12 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
     PgSelectSingle11 --> PgClassExpression12
     GraphQLResolver16[["GraphQLResolver[16∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     GraphQLResolver18[["GraphQLResolver[18∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
     GraphQLResolver20[["GraphQLResolver[20∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
     GraphQLResolver44[["GraphQLResolver[44∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver44
+    GraphQLResolver14 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver44
     GraphQLResolver22[["GraphQLResolver[22∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
     GraphQLResolver30[["GraphQLResolver[30∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
     GraphQLResolver38[["GraphQLResolver[38∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver38
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver38
     GraphQLResolver40[["GraphQLResolver[40∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver40
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver40
     GraphQLResolver42[["GraphQLResolver[42∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver42
+    GraphQLResolver20 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver42
     GraphQLResolver24[["GraphQLResolver[24∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
+    GraphQLResolver22 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
     GraphQLResolver26[["GraphQLResolver[26∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
+    GraphQLResolver22 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
     GraphQLResolver28[["GraphQLResolver[28∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
+    GraphQLResolver22 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
     GraphQLResolver32[["GraphQLResolver[32∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver30 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
+    GraphQLResolver30 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
     GraphQLResolver34[["GraphQLResolver[34∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver30 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver34
+    GraphQLResolver30 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver34
     GraphQLResolver36[["GraphQLResolver[36∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver30 & Constant61 & __Value2 & __Value0 & __Value4 --> GraphQLResolver36
+    GraphQLResolver30 & Constant62 & __Value2 & __Value0 & __Value4 --> GraphQLResolver36
 
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics-object-errors"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 51, 52, 53, 61, 62, 63, 64, 9, 47, 50, 54, 55, 60<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 52, 53, 54, 62, 63, 64, 65, 9, 47, 50, 51, 55, 56, 61<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda47,Lambda50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Constant61,Constant62,Constant63,Constant64 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 61, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda47,Lambda50,Access51,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 62, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,GraphQLResolver14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,GraphQLResolver16,GraphQLResolver18,GraphQLResolver20,GraphQLResolver44 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,GraphQLResolver22,GraphQLResolver30,GraphQLResolver38,GraphQLResolver40,GraphQLResolver42 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver24,GraphQLResolver26,GraphQLResolver28 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 61, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[30]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 62, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[30]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,GraphQLResolver32,GraphQLResolver34,GraphQLResolver36 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect6
-    Object42{{"Object[42∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect6
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,55 +31,57 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant50 --> Lambda35
     Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant51 --> Lambda38
-    Object42 --> Lambda43
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant52 --> Lambda48
+    Constant51 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant52 --> Lambda38
+    Lambda38 --> Access39
+    Object43 --> Lambda44
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant53 --> Lambda49
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
-    PgClassExpression12 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
+    PgClassExpression12 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
     PgSelectSingle11 --> PgClassExpression12
     GraphQLResolver16[["GraphQLResolver[16∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    GraphQLResolver14 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     GraphQLResolver18[["GraphQLResolver[18∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
+    GraphQLResolver14 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
     GraphQLResolver20[["GraphQLResolver[20∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
+    GraphQLResolver14 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
     GraphQLResolver22[["GraphQLResolver[22∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
     GraphQLResolver28[["GraphQLResolver[28∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
     GraphQLResolver30[["GraphQLResolver[30∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
     GraphQLResolver32[["GraphQLResolver[32∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
     GraphQLResolver24[["GraphQLResolver[24∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
+    GraphQLResolver22 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
     GraphQLResolver26[["GraphQLResolver[26∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
+    GraphQLResolver22 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
 
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics-object-recursive"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 39, 40, 41, 49, 50, 51, 52, 9, 35, 38, 42, 43, 48<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 40, 41, 42, 50, 51, 52, 53, 9, 35, 38, 39, 43, 44, 49<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda35,Lambda38,Constant39,Constant40,Constant41,Object42,Lambda43,Lambda48,Constant49,Constant50,Constant51,Constant52 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 49, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant50,Constant51,Constant52,Constant53 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 50, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,GraphQLResolver14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 49, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 50, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,GraphQLResolver16,GraphQLResolver18,GraphQLResolver20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 49, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 50, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,GraphQLResolver22,GraphQLResolver28,GraphQLResolver30,GraphQLResolver32 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 49, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 50, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver24,GraphQLResolver26 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect6
-    Object42{{"Object[42∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect6
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,55 +31,57 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant50 --> Lambda35
     Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant51 --> Lambda38
-    Object42 --> Lambda43
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant52 --> Lambda48
+    Constant51 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant52 --> Lambda38
+    Lambda38 --> Access39
+    Object43 --> Lambda44
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant53 --> Lambda49
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
-    PgClassExpression12 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
+    PgClassExpression12 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
     PgSelectSingle11 --> PgClassExpression12
     GraphQLResolver16[["GraphQLResolver[16∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    GraphQLResolver14 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     GraphQLResolver18[["GraphQLResolver[18∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
+    GraphQLResolver14 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
     GraphQLResolver20[["GraphQLResolver[20∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
+    GraphQLResolver14 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver20
     GraphQLResolver22[["GraphQLResolver[22∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver22
     GraphQLResolver28[["GraphQLResolver[28∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver28
     GraphQLResolver30[["GraphQLResolver[30∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver30
     GraphQLResolver32[["GraphQLResolver[32∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver20 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
+    GraphQLResolver20 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver32
     GraphQLResolver24[["GraphQLResolver[24∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
+    GraphQLResolver22 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver24
     GraphQLResolver26[["GraphQLResolver[26∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver22 & Constant49 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
+    GraphQLResolver22 & Constant50 & __Value2 & __Value0 & __Value4 --> GraphQLResolver26
 
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics-object-recursive"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 39, 40, 41, 49, 50, 51, 52, 9, 35, 38, 42, 43, 48<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 40, 41, 42, 50, 51, 52, 53, 9, 35, 38, 39, 43, 44, 49<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda35,Lambda38,Constant39,Constant40,Constant41,Object42,Lambda43,Lambda48,Constant49,Constant50,Constant51,Constant52 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 49, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant50,Constant51,Constant52,Constant53 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 50, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,GraphQLResolver14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 49, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 50, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,GraphQLResolver16,GraphQLResolver18,GraphQLResolver20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 49, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 50, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,GraphQLResolver22,GraphQLResolver28,GraphQLResolver30,GraphQLResolver32 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 49, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 22, 50, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[22]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver24,GraphQLResolver26 bucket4
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda21 & Lambda24 & Lambda29 & Lambda34 --> PgSelect6
-    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda21 & Constant25 & Constant26 & Constant27 --> Object28
+    Access25{{"Access[25∈0] ➊<br />ᐸ24.0ᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda21 & Access25 & Lambda30 & Lambda35 --> PgSelect6
+    Object29{{"Object[29∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda21 & Constant26 & Constant27 & Constant28 --> Object29
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,35 +31,37 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant36 --> Lambda21
     Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda24
-    Object28 --> Lambda29
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant38 --> Lambda34
+    Constant37 --> Lambda21
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant38 --> Lambda24
+    Lambda24 --> Access25
+    Object29 --> Lambda30
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant39 --> Lambda35
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
-    PgClassExpression12 & Constant35 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
+    PgClassExpression12 & Constant36 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
     PgSelectSingle11 --> PgClassExpression12
     GraphQLResolver16[["GraphQLResolver[16∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant35 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    GraphQLResolver14 & Constant36 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     GraphQLResolver18[["GraphQLResolver[18∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant35 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
+    GraphQLResolver14 & Constant36 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
 
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics-object"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 25, 26, 27, 35, 36, 37, 38, 9, 21, 24, 28, 29, 34<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 26, 27, 28, 36, 37, 38, 39, 9, 21, 24, 25, 29, 30, 35<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda21,Lambda24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37,Constant38 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 35, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda21,Lambda24,Access25,Constant26,Constant27,Constant28,Object29,Lambda30,Lambda35,Constant36,Constant37,Constant38,Constant39 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 36, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,GraphQLResolver14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 35, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 36, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,GraphQLResolver16,GraphQLResolver18 bucket2
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda21 & Lambda24 & Lambda29 & Lambda34 --> PgSelect6
-    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda21 & Constant25 & Constant26 & Constant27 --> Object28
+    Access25{{"Access[25∈0] ➊<br />ᐸ24.0ᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda21 & Access25 & Lambda30 & Lambda35 --> PgSelect6
+    Object29{{"Object[29∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda21 & Constant26 & Constant27 & Constant28 --> Object29
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,35 +31,37 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant36 --> Lambda21
     Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda24
-    Object28 --> Lambda29
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant38 --> Lambda34
+    Constant37 --> Lambda21
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant38 --> Lambda24
+    Lambda24 --> Access25
+    Object29 --> Lambda30
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant39 --> Lambda35
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
-    PgClassExpression12 & Constant35 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
+    PgClassExpression12 & Constant36 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14
     PgSelectSingle11 --> PgClassExpression12
     GraphQLResolver16[["GraphQLResolver[16∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant35 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    GraphQLResolver14 & Constant36 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     GraphQLResolver18[["GraphQLResolver[18∈2] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver14 & Constant35 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
+    GraphQLResolver14 & Constant36 & __Value2 & __Value0 & __Value4 --> GraphQLResolver18
 
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics-object"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 25, 26, 27, 35, 36, 37, 38, 9, 21, 24, 28, 29, 34<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 26, 27, 28, 36, 37, 38, 39, 9, 21, 24, 25, 29, 30, 35<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda21,Lambda24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37,Constant38 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 35, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda21,Lambda24,Access25,Constant26,Constant27,Constant28,Object29,Lambda30,Lambda35,Constant36,Constant37,Constant38,Constant39 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 36, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12]<br />2: GraphQLResolver[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,GraphQLResolver14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 35, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 36, 2, 0, 4<br /><br />ROOT GraphQLResolver{1}ᐸresolveᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,GraphQLResolver16,GraphQLResolver18 bucket2
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics.deopt.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda19 & Lambda22 & Lambda27 & Lambda32 --> PgSelect6
-    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda19 & Constant23 & Constant24 & Constant25 --> Object26
+    Access23{{"Access[23∈0] ➊<br />ᐸ22.0ᐳ"}}:::plan
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda19 & Access23 & Lambda28 & Lambda33 --> PgSelect6
+    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda19 & Constant24 & Constant25 & Constant26 --> Object27
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,19 +31,21 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda19
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda22
-    Object26 --> Lambda27
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant36 --> Lambda32
+    Constant35 --> Lambda19
+    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda22
+    Lambda22 --> Access23
+    Object27 --> Lambda28
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant37 --> Lambda33
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ hashType: 'sha1' }ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ hashType: 'sha1' }ᐳ"}}:::plan
     GraphQLResolver16[["GraphQLResolver[16∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     Object14{{"Object[14∈1] ➊<br />ᐸ{username}ᐳ"}}:::plan
-    Object14 & Constant37 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    Object14 & Constant38 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgClassExpression12 --> Object14
@@ -51,10 +53,10 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 23, 24, 25, 34, 35, 36, 37, 9, 19, 22, 26, 27, 32<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 24, 25, 26, 35, 36, 37, 38, 9, 19, 22, 23, 27, 28, 33<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda19,Lambda22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant34,Constant35,Constant36,Constant37 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 37, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12], Object[14]<br />2: GraphQLResolver[16]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda19,Lambda22,Access23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant35,Constant36,Constant37,Constant38 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 38, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12], Object[14]<br />2: GraphQLResolver[16]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,Object14,GraphQLResolver16 bucket1
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics.mermaid
@@ -12,15 +12,15 @@ graph TD
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_userᐳ"]]:::plan
     Object9{{"Object[9∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object9 & Lambda19 & Lambda22 & Lambda27 & Lambda32 --> PgSelect6
-    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda19 & Constant23 & Constant24 & Constant25 --> Object26
+    Access23{{"Access[23∈0] ➊<br />ᐸ22.0ᐳ"}}:::plan
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object9 & Lambda19 & Access23 & Lambda28 & Lambda33 --> PgSelect6
+    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”random_user”)ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda19 & Constant24 & Constant25 & Constant26 --> Object27
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
@@ -31,19 +31,21 @@ graph TD
     PgSelect6 --> First10
     PgSelectSingle11{{"PgSelectSingle[11∈0] ➊<br />ᐸusersᐳ"}}:::plan
     First10 --> PgSelectSingle11
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda19
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda22
-    Object26 --> Lambda27
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
-    Constant36 --> Lambda32
+    Constant35 --> Lambda19
+    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda22
+    Lambda22 --> Access23
+    Object27 --> Lambda28
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”randomᐳ"}}:::plan
+    Constant37 --> Lambda33
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ hashType: 'sha1' }ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ hashType: 'sha1' }ᐳ"}}:::plan
     GraphQLResolver16[["GraphQLResolver[16∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     Object14{{"Object[14∈1] ➊<br />ᐸ{username}ᐳ"}}:::plan
-    Object14 & Constant37 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
+    Object14 & Constant38 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12
     PgClassExpression12 --> Object14
@@ -51,10 +53,10 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/resolvers/basics"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 23, 24, 25, 34, 35, 36, 37, 9, 19, 22, 26, 27, 32<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 8, 24, 25, 26, 35, 36, 37, 38, 9, 19, 22, 23, 27, 28, 33<br />2: PgSelect[6]<br />ᐳ: First[10], PgSelectSingle[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda19,Lambda22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant34,Constant35,Constant36,Constant37 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 37, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12], Object[14]<br />2: GraphQLResolver[16]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect6,Access7,Access8,Object9,First10,PgSelectSingle11,Lambda19,Lambda22,Access23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant35,Constant36,Constant37,Constant38 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 38, 2, 0, 4<br /><br />ROOT PgSelectSingleᐸusersᐳ[11]<br />1: <br />ᐳ: PgClassExpression[12], Object[14]<br />2: GraphQLResolver[16]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression12,Object14,GraphQLResolver16 bucket1
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/expression-columns.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/expression-columns.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda18 & Lambda21 & Lambda26 & Lambda31 --> PgSelect8
-    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda18 & Constant22 & Constant23 & Constant24 --> Object25
+    Access22{{"Access[22∈0] ➊<br />ᐸ21.0ᐳ"}}:::plan
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda18 & Access22 & Lambda27 & Lambda32 --> PgSelect8
+    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda18 & Constant23 & Constant24 & Constant25 --> Object26
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda18
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda21
-    Object25 --> Lambda26
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant34 --> Lambda31
+    Constant33 --> Lambda18
+    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda21
+    Lambda21 --> Access22
+    Object26 --> Lambda27
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant35 --> Lambda32
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/expression-columns"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 18, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 23, 24, 25, 33, 34, 35, 11, 18, 21, 22, 26, 27, 32<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Access22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/expression-columns.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/expression-columns.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda18 & Lambda21 & Lambda26 & Lambda31 --> PgSelect8
-    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda18 & Constant22 & Constant23 & Constant24 --> Object25
+    Access22{{"Access[22∈0] ➊<br />ᐸ21.0ᐳ"}}:::plan
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda18 & Access22 & Lambda27 & Lambda32 --> PgSelect8
+    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda18 & Constant23 & Constant24 & Constant25 --> Object26
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda18
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda21
-    Object25 --> Lambda26
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant34 --> Lambda31
+    Constant33 --> Lambda18
+    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda21
+    Lambda21 --> Access22
+    Object26 --> Lambda27
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant35 --> Lambda32
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/expression-columns"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 18, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 23, 24, 25, 33, 34, 35, 11, 18, 21, 22, 26, 27, 32<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Access22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/expression-plan.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/expression-plan.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda20 & Lambda23 & Lambda28 & Lambda33 --> PgSelect8
-    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda20 & Constant24 & Constant25 & Constant26 --> Object27
+    Access24{{"Access[24∈0] ➊<br />ᐸ23.0ᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda20 & Access24 & Lambda29 & Lambda34 --> PgSelect8
+    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda20 & Constant25 & Constant26 & Constant27 --> Object28
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda20
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda23
-    Object27 --> Lambda28
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant36 --> Lambda33
+    Constant35 --> Lambda20
+    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda23
+    Lambda23 --> Access24
+    Object28 --> Lambda29
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant37 --> Lambda34
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/expression-plan"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 24, 25, 26, 34, 35, 36, 11, 20, 23, 27, 28, 33<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 25, 26, 27, 35, 36, 37, 11, 20, 23, 24, 28, 29, 34<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda20,Lambda23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant34,Constant35,Constant36 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda20,Lambda23,Access24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/expression-plan.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/expression-plan.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda20 & Lambda23 & Lambda28 & Lambda33 --> PgSelect8
-    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda20 & Constant24 & Constant25 & Constant26 --> Object27
+    Access24{{"Access[24∈0] ➊<br />ᐸ23.0ᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda20 & Access24 & Lambda29 & Lambda34 --> PgSelect8
+    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda20 & Constant25 & Constant26 & Constant27 --> Object28
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda20
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda23
-    Object27 --> Lambda28
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant36 --> Lambda33
+    Constant35 --> Lambda20
+    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda23
+    Lambda23 --> Access24
+    Object28 --> Lambda29
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant37 --> Lambda34
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/expression-plan"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 24, 25, 26, 34, 35, 36, 11, 20, 23, 27, 28, 33<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 25, 26, 27, 35, 36, 37, 11, 20, 23, 24, 28, 29, 34<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda20,Lambda23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant34,Constant35,Constant36 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda20,Lambda23,Access24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/field-aliases.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/field-aliases.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect8
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect8
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda17
     Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda20
-    Object24 --> Lambda25
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant33 --> Lambda30
+    Constant32 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant33 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant34 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/field-aliases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 22, 23, 31, 32, 33, 11, 17, 20, 24, 25, 30<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 17, 20, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/field-aliases.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/field-aliases.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect8
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect8
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda17
     Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda20
-    Object24 --> Lambda25
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant33 --> Lambda30
+    Constant32 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant33 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant34 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/field-aliases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 22, 23, 31, 32, 33, 11, 17, 20, 24, 25, 30<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 17, 20, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases-and-mismatched-fields.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases-and-mismatched-fields.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda24 & Lambda27 & Lambda32 & Lambda37 --> PgSelect8
-    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda24 & Constant28 & Constant29 & Constant30 --> Object31
+    Access28{{"Access[28∈0] ➊<br />ᐸ27.0ᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda24 & Access28 & Lambda33 & Lambda38 --> PgSelect8
+    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda24 & Constant29 & Constant30 & Constant31 --> Object32
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda24
     Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant39 --> Lambda27
-    Object31 --> Lambda32
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant40 --> Lambda37
+    Constant39 --> Lambda24
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant40 --> Lambda27
+    Lambda27 --> Access28
+    Object32 --> Lambda33
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant41 --> Lambda38
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -49,9 +51,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/many-field-aliases-and-mismatched-fields"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 28, 29, 30, 38, 39, 40, 11, 24, 27, 31, 32, 37<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 29, 30, 31, 39, 40, 41, 11, 24, 27, 28, 32, 33, 38<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda24,Lambda27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda24,Lambda27,Access28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases-and-mismatched-fields.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases-and-mismatched-fields.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda24 & Lambda27 & Lambda32 & Lambda37 --> PgSelect8
-    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda24 & Constant28 & Constant29 & Constant30 --> Object31
+    Access28{{"Access[28∈0] ➊<br />ᐸ27.0ᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda24 & Access28 & Lambda33 & Lambda38 --> PgSelect8
+    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda24 & Constant29 & Constant30 & Constant31 --> Object32
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda24
     Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant39 --> Lambda27
-    Object31 --> Lambda32
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant40 --> Lambda37
+    Constant39 --> Lambda24
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant40 --> Lambda27
+    Lambda27 --> Access28
+    Object32 --> Lambda33
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant41 --> Lambda38
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -49,9 +51,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/many-field-aliases-and-mismatched-fields"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 28, 29, 30, 38, 39, 40, 11, 24, 27, 31, 32, 37<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 29, 30, 31, 39, 40, 41, 11, 24, 27, 28, 32, 33, 38<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda24,Lambda27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda24,Lambda27,Access28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda23 & Lambda26 & Lambda31 & Lambda36 --> PgSelect8
-    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda23 & Access27 & Lambda32 & Lambda37 --> PgSelect8
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda23
     Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda26
-    Object30 --> Lambda31
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant39 --> Lambda36
+    Constant38 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda26
+    Lambda26 --> Access27
+    Object31 --> Lambda32
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant40 --> Lambda37
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/many-field-aliases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 27, 28, 29, 37, 38, 39, 11, 23, 26, 30, 31, 36<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 28, 29, 30, 38, 39, 40, 11, 23, 26, 27, 31, 32, 37<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda23,Lambda26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant37,Constant38,Constant39 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda23,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/many-field-aliases.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda23 & Lambda26 & Lambda31 & Lambda36 --> PgSelect8
-    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda23 & Access27 & Lambda32 & Lambda37 --> PgSelect8
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda23
     Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda26
-    Object30 --> Lambda31
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant39 --> Lambda36
+    Constant38 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda26
+    Lambda26 --> Access27
+    Object31 --> Lambda32
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant40 --> Lambda37
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/many-field-aliases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 27, 28, 29, 37, 38, 39, 11, 23, 26, 30, 31, 36<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 28, 29, 30, 38, 39, 40, 11, 23, 26, 27, 31, 32, 37<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda23,Lambda26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant37,Constant38,Constant39 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda23,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/self-reference.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/self-reference.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda18 & Lambda21 & Lambda26 & Lambda31 --> PgSelect8
-    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda18 & Constant22 & Constant23 & Constant24 --> Object25
+    Access22{{"Access[22∈0] ➊<br />ᐸ21.0ᐳ"}}:::plan
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda18 & Access22 & Lambda27 & Lambda32 --> PgSelect8
+    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda18 & Constant23 & Constant24 & Constant25 --> Object26
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda18
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda21
-    Object25 --> Lambda26
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant34 --> Lambda31
+    Constant33 --> Lambda18
+    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda21
+    Lambda21 --> Access22
+    Object26 --> Lambda27
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant35 --> Lambda32
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/self-reference"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 18, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 23, 24, 25, 33, 34, 35, 11, 18, 21, 22, 26, 27, 32<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Access22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/self-reference.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/self-reference.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda18 & Lambda21 & Lambda26 & Lambda31 --> PgSelect8
-    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda18 & Constant22 & Constant23 & Constant24 --> Object25
+    Access22{{"Access[22∈0] ➊<br />ᐸ21.0ᐳ"}}:::plan
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda18 & Access22 & Lambda27 & Lambda32 --> PgSelect8
+    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda18 & Constant23 & Constant24 & Constant25 --> Object26
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda18
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda21
-    Object25 --> Lambda26
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant34 --> Lambda31
+    Constant33 --> Lambda18
+    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda21
+    Lambda21 --> Access22
+    Object26 --> Lambda27
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant35 --> Lambda32
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -47,9 +49,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/self-reference"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 18, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 23, 24, 25, 33, 34, 35, 11, 18, 21, 22, 26, 27, 32<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda18,Lambda21,Access22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/single-record-via-arg.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/single-record-via-arg.deopt.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant31 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect7
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant32 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect7
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda17
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda20
-    Object24 --> Lambda25
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant34 --> Lambda30
+    Constant33 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant35 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -48,9 +50,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/single-record-via-arg"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 22, 23, 31, 32, 33, 34, 10, 17, 20, 24, 25, 30<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 22, 23, 24, 32, 33, 34, 35, 10, 17, 20, 21, 25, 26, 31<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgClassExpression14 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/single-record-via-arg.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/single-record-via-arg.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ'f1700000-0000-0000-0000-000000000f17'ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant31 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect7
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant32 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect7
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda17
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda20
-    Object24 --> Lambda25
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant34 --> Lambda30
+    Constant33 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant35 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -48,9 +50,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/single-record-via-arg"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 22, 23, 31, 32, 33, 34, 10, 17, 20, 24, 25, 30<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 22, 23, 24, 32, 33, 34, 35, 10, 17, 20, 21, 25, 26, 31<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgClassExpression14 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/super-simple.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/super-simple.deopt.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect8
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect8
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda17
     Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda20
-    Object24 --> Lambda25
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant33 --> Lambda30
+    Constant32 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant33 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant34 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/super-simple"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 22, 23, 31, 32, 33, 11, 17, 20, 24, 25, 30<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 17, 20, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/super-simple.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/super-simple.mermaid
@@ -12,28 +12,30 @@ graph TD
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect8
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect8
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant31 --> Lambda17
     Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda20
-    Object24 --> Lambda25
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant33 --> Lambda30
+    Constant32 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant33 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant34 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
     PgSelect8 ==> __Item12
@@ -45,9 +47,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/super-simple"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 21, 22, 23, 31, 32, 33, 11, 17, 20, 24, 25, 30<br />2: PgSelect[8]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 22, 23, 24, 32, 33, 34, 11, 17, 20, 21, 25, 26, 31<br />2: PgSelect[8]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/unique-forum-message.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/unique-forum-message.deopt.mermaid
@@ -11,17 +11,27 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
     Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant77 & Lambda35 & Lambda38 & Lambda71 & Lambda76 --> PgSelect7
-    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda35 & Constant67 & Constant68 & Constant69 --> Object70
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant80 & Lambda35 & Access39 & Lambda74 & Lambda79 --> PgSelect7
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
+    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda35 & Constant55 & Constant56 & Constant57 --> Object58
+    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda35 & Constant70 & Constant71 & Constant72 --> Object73
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,50 +42,42 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸforumsᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant78 --> Lambda35
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant79 --> Lambda38
-    Object70 --> Lambda71
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant82 --> Lambda76
+    Access14{{"Access[14∈0] ➊<br />ᐸ0.idᐳ"}}:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
+    __Value0 --> Access14
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant81 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant82 --> Lambda38
+    Lambda38 --> Access39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object43 --> Lambda44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant83 --> Lambda49
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object58 --> Lambda59
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant84 --> Lambda64
+    Object73 --> Lambda74
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant85 --> Lambda79
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸmessagesᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    Access14{{"Access[14∈1] ➊<br />ᐸ0.idᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & PgClassExpression16 & Access14 & Lambda35 & Lambda38 & Lambda57 & Lambda62 --> PgSelect17
-    Object42{{"Object[42∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
-    Object56{{"Object[56∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda35 & Constant53 & Constant54 & Constant55 --> Object56
+    Object10 & PgClassExpression16 & Access14 & Lambda35 & Access39 & Lambda59 & Lambda64 --> PgSelect17
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
-    __Value0 --> Access14
     PgSelectSingle12 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelect17 --> First21
     PgSelectSingle22{{"PgSelectSingle[22∈1] ➊<br />ᐸmessagesᐳ"}}:::plan
     First21 --> PgSelectSingle22
-    Lambda43{{"Lambda[43∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object42 --> Lambda43
-    Lambda48{{"Lambda[48∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant80 --> Lambda48
-    Object56 --> Lambda57
-    Constant81 --> Lambda62
     PgSelect25[["PgSelect[25∈2] ➊<br />ᐸusersᐳ"]]:::plan
     PgClassExpression24{{"PgClassExpression[24∈2] ➊<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression24 & Lambda35 & Lambda38 & Lambda43 & Lambda48 --> PgSelect25
+    Object10 & PgClassExpression24 & Lambda35 & Access39 & Lambda44 & Lambda49 --> PgSelect25
     PgClassExpression23{{"PgClassExpression[23∈2] ➊<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression23
     PgSelectSingle22 --> PgClassExpression24
@@ -91,13 +93,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/unique-forum-message"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 39, 40, 41, 53, 54, 55, 67, 68, 69, 77, 78, 79, 80, 81, 82, 10, 35, 38, 70, 71, 76<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 14, 40, 41, 42, 55, 56, 57, 70, 71, 72, 80, 81, 82, 83, 84, 85, 10, 35, 38, 39, 43, 44, 49, 58, 59, 64, 73, 74, 79<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda35,Lambda38,Constant39,Constant40,Constant41,Constant53,Constant54,Constant55,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant77,Constant78,Constant79,Constant80,Constant81,Constant82 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 0, 10, 35, 38, 39, 40, 41, 80, 53, 54, 55, 81<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: 13, 14, 16, 42, 48, 56, 62, 43, 57<br />2: PgSelect[17]<br />ᐳ: First[21], PgSelectSingle[22]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Access14,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant70,Constant71,Constant72,Object73,Lambda74,Lambda79,Constant80,Constant81,Constant82,Constant83,Constant84,Constant85 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 10, 14, 35, 39, 59, 64, 44, 49<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]<br />1: <br />ᐳ: 13, 16<br />2: PgSelect[17]<br />ᐳ: First[21], PgSelectSingle[22]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,Access14,PgClassExpression16,PgSelect17,First21,PgSelectSingle22,Object42,Lambda43,Lambda48,Object56,Lambda57,Lambda62 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 22, 10, 35, 38, 43, 48<br /><br />ROOT PgSelectSingle{1}ᐸmessagesᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgSelect[25]<br />ᐳ: First[29], PgSelectSingle[30]"):::bucket
+    class Bucket1,PgClassExpression13,PgClassExpression16,PgSelect17,First21,PgSelectSingle22 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 22, 10, 35, 39, 44, 49<br /><br />ROOT PgSelectSingle{1}ᐸmessagesᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgSelect[25]<br />ᐳ: First[29], PgSelectSingle[30]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression23,PgClassExpression24,PgSelect25,First29,PgSelectSingle30 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 30<br /><br />ROOT PgSelectSingle{2}ᐸusersᐳ[30]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/super-simple/unique-forum-message.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/super-simple/unique-forum-message.mermaid
@@ -11,32 +11,32 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸforumsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ0.idᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access39{{"Access[39∈0] ➊<br />ᐸ38.0ᐳ"}}:::plan
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant81 & Access14 & Lambda38 & Lambda43 & Lambda48 & Lambda38 & Lambda59 & Lambda64 & Lambda35 & Lambda38 & Lambda75 & Lambda80 --> PgSelect7
-    Object42{{"Object[42∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Lambda35 & Constant39 & Constant40 & Constant41 --> Object42
-    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Lambda35 & Constant55 & Constant56 & Constant57 --> Object58
-    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Lambda35 & Constant71 & Constant72 & Constant73 --> Object74
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant84 & Access14 & Access39 & Lambda44 & Lambda49 & Access39 & Lambda61 & Lambda66 & Lambda35 & Access39 & Lambda78 & Lambda83 --> PgSelect7
+    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda35 & Constant40 & Constant41 & Constant42 --> Object43
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda35 & Constant57 & Constant58 & Constant59 --> Object60
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda35 & Constant74 & Constant75 & Constant76 --> Object77
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -49,19 +49,21 @@ graph TD
     First11 --> PgSelectSingle12
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access14
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda35
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda38
-    Object42 --> Lambda43
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant84 --> Lambda48
-    Object58 --> Lambda59
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Constant85 --> Lambda64
-    Object74 --> Lambda75
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant86 --> Lambda80
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda35
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda38
+    Lambda38 --> Access39
+    Object43 --> Lambda44
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant87 --> Lambda49
+    Object60 --> Lambda61
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant88 --> Lambda66
+    Object77 --> Lambda78
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant89 --> Lambda83
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -70,9 +72,9 @@ graph TD
     PgClassExpression23{{"PgClassExpression[23∈2] ➊<br />ᐸ__messages__.”body”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression23
     PgSelectSingle30{{"PgSelectSingle[30∈2] ➊<br />ᐸusersᐳ"}}:::plan
-    RemapKeys49{{"RemapKeys[49∈2] ➊<br />ᐸ22:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys49 --> PgSelectSingle30
-    PgSelectSingle22 --> RemapKeys49
+    RemapKeys50{{"RemapKeys[50∈2] ➊<br />ᐸ22:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys50 --> PgSelectSingle30
+    PgSelectSingle22 --> RemapKeys50
     PgClassExpression31{{"PgClassExpression[31∈3] ➊<br />ᐸ__users__.”username”ᐳ"}}:::plan
     PgSelectSingle30 --> PgClassExpression31
     PgClassExpression32{{"PgClassExpression[32∈3] ➊<br />ᐸ__users__....vatar_url”ᐳ"}}:::plan
@@ -81,15 +83,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/super-simple/unique-forum-message"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 14, 39, 40, 41, 55, 56, 57, 71, 72, 73, 81, 82, 83, 84, 85, 86, 10, 35, 38, 42, 43, 48, 58, 59, 64, 74, 75, 80<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 14, 40, 41, 42, 57, 58, 59, 74, 75, 76, 84, 85, 86, 87, 88, 89, 10, 35, 38, 39, 43, 44, 49, 60, 61, 66, 77, 78, 83<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Access14,Lambda35,Lambda38,Constant39,Constant40,Constant41,Object42,Lambda43,Lambda48,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
+    class Bucket0,__Value0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Access14,Lambda35,Lambda38,Access39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸforumsᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle22 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 22<br /><br />ROOT PgSelectSingle{1}ᐸmessagesᐳ[22]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression23,PgSelectSingle30,RemapKeys49 bucket2
+    class Bucket2,PgClassExpression23,PgSelectSingle30,RemapKeys50 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 30<br /><br />ROOT PgSelectSingle{2}ᐸusersᐳ[30]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression31,PgClassExpression32 bucket3

--- a/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.deopt.mermaid
@@ -11,44 +11,44 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸentity_searchᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
     Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant160 & Lambda62 & Lambda65 & Lambda154 & Lambda159 --> PgSelect7
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda62 & Constant66 & Constant67 & Constant68 --> Object69
-    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda62 & Constant80 & Constant81 & Constant68 --> Object83
-    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
-    Lambda62 & Constant94 & Constant95 & Constant96 --> Object97
-    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda62 & Constant108 & Constant109 & Constant68 --> Object111
-    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Lambda62 & Constant122 & Constant123 & Constant96 --> Object125
-    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
-    Lambda62 & Constant136 & Constant137 & Constant138 --> Object139
-    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”entity_search”)ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸRecordCodec(union__entity)ᐳ"}}:::plan
-    Lambda62 & Constant150 & Constant151 & Constant152 --> Object153
+    Access66{{"Access[66∈0] ➊<br />ᐸ65.0ᐳ"}}:::plan
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant167 & Lambda62 & Access66 & Lambda161 & Lambda166 --> PgSelect7
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda62 & Constant67 & Constant68 & Constant69 --> Object70
+    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda62 & Constant82 & Constant83 & Constant69 --> Object85
+    Object100{{"Object[100∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
+    Lambda62 & Constant97 & Constant98 & Constant99 --> Object100
+    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda62 & Constant112 & Constant113 & Constant69 --> Object115
+    Object130{{"Object[130∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Lambda62 & Constant127 & Constant128 & Constant99 --> Object130
+    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
+    Lambda62 & Constant142 & Constant143 & Constant144 --> Object145
+    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”entity_search”)ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸRecordCodec(union__entity)ᐳ"}}:::plan
+    Lambda62 & Constant157 & Constant158 & Constant159 --> Object160
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -57,43 +57,45 @@ graph TD
     __Value2 --> Access9
     __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
     PgSelect7 --> __ListTransform11
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant161 --> Lambda62
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant162 --> Lambda65
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object69 --> Lambda70
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant163 --> Lambda75
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object83 --> Lambda84
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant164 --> Lambda89
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object97 --> Lambda98
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant165 --> Lambda103
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object111 --> Lambda112
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant166 --> Lambda117
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object125 --> Lambda126
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant168 --> Lambda62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant169 --> Lambda65
+    Lambda65 --> Access66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant170 --> Lambda76
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object85 --> Lambda86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant171 --> Lambda91
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object100 --> Lambda101
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant172 --> Lambda106
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object115 --> Lambda116
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant173 --> Lambda121
     Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant167 --> Lambda131
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object139 --> Lambda140
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
-    Constant168 --> Lambda145
-    Object153 --> Lambda154
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”entityᐳ"}}:::plan
-    Constant169 --> Lambda159
+    Object130 --> Lambda131
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant174 --> Lambda136
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object145 --> Lambda146
+    Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
+    Constant175 --> Lambda151
+    Object160 --> Lambda161
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”entityᐳ"}}:::plan
+    Constant176 --> Lambda166
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 -.-> __Item12
@@ -114,20 +116,20 @@ graph TD
     PgSelectSingle15 --> PgClassExpression17
     PgSelectSingle15 --> PgClassExpression18
     PgSelect21[["PgSelect[21∈3]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
-    Object10 & PgClassExpression16 & Lambda62 & Lambda65 & Lambda70 & Lambda75 --> PgSelect21
+    Object10 & PgClassExpression16 & Lambda62 & Access66 & Lambda71 & Lambda76 --> PgSelect21
     PgSelect29[["PgSelect[29∈3]<br />ᐸpostsᐳ<br />ᐳPost"]]:::plan
-    Object10 & PgClassExpression17 & Lambda62 & Lambda65 & Lambda98 & Lambda103 --> PgSelect29
+    Object10 & PgClassExpression17 & Lambda62 & Access66 & Lambda101 & Lambda106 --> PgSelect29
     PgSelect35[["PgSelect[35∈3]<br />ᐸpeopleᐳ<br />ᐳPost"]]:::plan
     PgClassExpression34{{"PgClassExpression[34∈3]<br />ᐸ__posts__.”author_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression34 & Lambda62 & Lambda65 & Lambda84 & Lambda89 --> PgSelect35
+    Object10 & PgClassExpression34 & Lambda62 & Access66 & Lambda86 & Lambda91 --> PgSelect35
     PgSelect41[["PgSelect[41∈3]<br />ᐸcommentsᐳ<br />ᐳComment"]]:::plan
-    Object10 & PgClassExpression18 & Lambda62 & Lambda65 & Lambda140 & Lambda145 --> PgSelect41
+    Object10 & PgClassExpression18 & Lambda62 & Access66 & Lambda146 & Lambda151 --> PgSelect41
     PgSelect47[["PgSelect[47∈3]<br />ᐸpeopleᐳ<br />ᐳComment"]]:::plan
     PgClassExpression46{{"PgClassExpression[46∈3]<br />ᐸ__comments...author_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression46 & Lambda62 & Lambda65 & Lambda112 & Lambda117 --> PgSelect47
+    Object10 & PgClassExpression46 & Lambda62 & Access66 & Lambda116 & Lambda121 --> PgSelect47
     PgSelect53[["PgSelect[53∈3]<br />ᐸpostsᐳ<br />ᐳComment"]]:::plan
     PgClassExpression52{{"PgClassExpression[52∈3]<br />ᐸ__comments__.”post_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression52 & Lambda62 & Lambda65 & Lambda126 & Lambda131 --> PgSelect53
+    Object10 & PgClassExpression52 & Lambda62 & Access66 & Lambda131 & Lambda136 --> PgSelect53
     First25{{"First[25∈3]"}}:::plan
     PgSelect21 --> First25
     PgSelectSingle26{{"PgSelectSingle[26∈3]<br />ᐸpeopleᐳ"}}:::plan
@@ -179,16 +181,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-search-entities/search"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 66, 67, 68, 80, 81, 94, 95, 96, 108, 109, 122, 123, 136, 137, 138, 150, 151, 152, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 10, 62, 65, 69, 70, 75, 83, 84, 89, 97, 98, 103, 111, 112, 117, 125, 126, 131, 139, 140, 145, 153, 154, 159<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 67, 68, 69, 82, 83, 97, 98, 99, 112, 113, 127, 128, 142, 143, 144, 157, 158, 159, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 10, 62, 65, 66, 70, 71, 76, 85, 86, 91, 100, 101, 106, 115, 116, 121, 130, 131, 136, 145, 146, 151, 160, 161, 166<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda62,Lambda65,Constant66,Constant67,Constant68,Object69,Lambda70,Lambda75,Constant80,Constant81,Object83,Lambda84,Lambda89,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Constant108,Constant109,Object111,Lambda112,Lambda117,Constant122,Constant123,Object125,Lambda126,Lambda131,Constant136,Constant137,Constant138,Object139,Lambda140,Lambda145,Constant150,Constant151,Constant152,Object153,Lambda154,Lambda159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda62,Lambda65,Access66,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant82,Constant83,Object85,Lambda86,Lambda91,Constant97,Constant98,Constant99,Object100,Lambda101,Lambda106,Constant112,Constant113,Object115,Lambda116,Lambda121,Constant127,Constant128,Object130,Lambda131,Lambda136,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Constant157,Constant158,Constant159,Object160,Lambda161,Lambda166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175,Constant176 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgSelectSingle{1}ᐸentity_searchᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 62, 65, 70, 75, 98, 103, 84, 89, 140, 145, 112, 117, 126, 131<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 62, 66, 71, 76, 101, 106, 86, 91, 146, 151, 116, 121, 131, 136<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15,PgClassExpression16,PgClassExpression17,PgClassExpression18,List19,PgPolymorphic20 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 16, 62, 65, 70, 75, 17, 98, 103, 84, 89, 18, 140, 145, 112, 117, 126, 131, 20<br />ᐳPerson<br />ᐳPost<br />ᐳComment<br /><br />1: 21, 29, 41<br />ᐳ: 25, 26, 27, 28, 31, 32, 33, 34, 40, 43, 44, 45, 46, 52, 59<br />2: 35, 47, 53<br />ᐳ: 37, 38, 49, 50, 55, 56"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 16, 62, 66, 71, 76, 17, 101, 106, 86, 91, 18, 146, 151, 116, 121, 131, 136, 20<br />ᐳPerson<br />ᐳPost<br />ᐳComment<br /><br />1: 21, 29, 41<br />ᐳ: 25, 26, 27, 28, 31, 32, 33, 34, 40, 43, 44, 45, 46, 52, 59<br />2: 35, 47, 53<br />ᐳ: 37, 38, 49, 50, 55, 56"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgSelect21,First25,PgSelectSingle26,PgClassExpression27,PgClassExpression28,PgSelect29,First31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectSingle38,PgClassExpression40,PgSelect41,First43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgSelect47,First49,PgSelectSingle50,PgClassExpression52,PgSelect53,First55,PgSelectSingle56,PgClassExpression59 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[38]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.mermaid
@@ -11,44 +11,44 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸentity_searchᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
     Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant166 & Lambda62 & Lambda65 & Lambda160 & Lambda165 --> PgSelect7
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda62 & Constant66 & Constant67 & Constant68 --> Object69
-    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda62 & Constant80 & Constant81 & Constant68 --> Object83
-    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
-    Lambda62 & Constant96 & Constant97 & Constant98 --> Object99
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda62 & Constant110 & Constant111 & Constant68 --> Object113
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Lambda62 & Constant126 & Constant127 & Constant98 --> Object129
-    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
-    Lambda62 & Constant142 & Constant143 & Constant144 --> Object145
-    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”entity_search”)ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(union__entity)ᐳ"}}:::plan
-    Lambda62 & Constant156 & Constant157 & Constant158 --> Object159
+    Access66{{"Access[66∈0] ➊<br />ᐸ65.0ᐳ"}}:::plan
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant173 & Lambda62 & Access66 & Lambda167 & Lambda172 --> PgSelect7
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda62 & Constant67 & Constant68 & Constant69 --> Object70
+    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda62 & Constant82 & Constant83 & Constant69 --> Object85
+    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
+    Lambda62 & Constant99 & Constant100 & Constant101 --> Object102
+    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda62 & Constant114 & Constant115 & Constant69 --> Object117
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Lambda62 & Constant131 & Constant132 & Constant101 --> Object134
+    Object151{{"Object[151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
+    Lambda62 & Constant148 & Constant149 & Constant150 --> Object151
+    Object166{{"Object[166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸsql.identifier(”entity_search”)ᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸRecordCodec(union__entity)ᐳ"}}:::plan
+    Lambda62 & Constant163 & Constant164 & Constant165 --> Object166
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -57,43 +57,45 @@ graph TD
     __Value2 --> Access9
     __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
     PgSelect7 --> __ListTransform11
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant167 --> Lambda62
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant168 --> Lambda65
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object69 --> Lambda70
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant169 --> Lambda75
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object83 --> Lambda84
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant170 --> Lambda89
-    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object99 --> Lambda100
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant171 --> Lambda105
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object113 --> Lambda114
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant172 --> Lambda119
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object129 --> Lambda130
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant174 --> Lambda62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant175 --> Lambda65
+    Lambda65 --> Access66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant176 --> Lambda76
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object85 --> Lambda86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant177 --> Lambda91
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object102 --> Lambda103
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant178 --> Lambda108
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object117 --> Lambda118
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant179 --> Lambda123
     Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant173 --> Lambda135
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object145 --> Lambda146
-    Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
-    Constant174 --> Lambda151
-    Object159 --> Lambda160
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”entityᐳ"}}:::plan
-    Constant175 --> Lambda165
+    Object134 --> Lambda135
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant180 --> Lambda140
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object151 --> Lambda152
+    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
+    Constant181 --> Lambda157
+    Object166 --> Lambda167
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”entityᐳ"}}:::plan
+    Constant182 --> Lambda172
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 -.-> __Item12
@@ -114,11 +116,11 @@ graph TD
     PgSelectSingle15 --> PgClassExpression17
     PgSelectSingle15 --> PgClassExpression18
     PgSelect41[["PgSelect[41∈3]<br />ᐸcommentsᐳ<br />ᐳComment"]]:::plan
-    Object10 & PgClassExpression18 & Lambda65 & Lambda114 & Lambda119 & Lambda65 & Lambda130 & Lambda135 & Lambda62 & Lambda65 & Lambda146 & Lambda151 --> PgSelect41
+    Object10 & PgClassExpression18 & Access66 & Lambda118 & Lambda123 & Access66 & Lambda135 & Lambda140 & Lambda62 & Access66 & Lambda152 & Lambda157 --> PgSelect41
     PgSelect29[["PgSelect[29∈3]<br />ᐸpostsᐳ<br />ᐳPost"]]:::plan
-    Object10 & PgClassExpression17 & Lambda65 & Lambda84 & Lambda89 & Lambda62 & Lambda65 & Lambda100 & Lambda105 --> PgSelect29
+    Object10 & PgClassExpression17 & Access66 & Lambda86 & Lambda91 & Lambda62 & Access66 & Lambda103 & Lambda108 --> PgSelect29
     PgSelect21[["PgSelect[21∈3]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
-    Object10 & PgClassExpression16 & Lambda62 & Lambda65 & Lambda70 & Lambda75 --> PgSelect21
+    Object10 & PgClassExpression16 & Lambda62 & Access66 & Lambda71 & Lambda76 --> PgSelect21
     First25{{"First[25∈3]"}}:::plan
     PgSelect21 --> First25
     PgSelectSingle26{{"PgSelectSingle[26∈3]<br />ᐸpeopleᐳ"}}:::plan
@@ -134,8 +136,8 @@ graph TD
     PgClassExpression33{{"PgClassExpression[33∈3]<br />ᐸ__posts__.”post_id”ᐳ"}}:::plan
     PgSelectSingle32 --> PgClassExpression33
     PgSelectSingle38{{"PgSelectSingle[38∈3]<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys90{{"RemapKeys[90∈3]<br />ᐸ32:{”0”:1}ᐳ"}}:::plan
-    RemapKeys90 --> PgSelectSingle38
+    RemapKeys92{{"RemapKeys[92∈3]<br />ᐸ32:{”0”:1}ᐳ"}}:::plan
+    RemapKeys92 --> PgSelectSingle38
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸ__posts__.”body”ᐳ"}}:::plan
     PgSelectSingle32 --> PgClassExpression40
     First43{{"First[43∈3]"}}:::plan
@@ -145,16 +147,16 @@ graph TD
     PgClassExpression45{{"PgClassExpression[45∈3]<br />ᐸ__comments...omment_id”ᐳ"}}:::plan
     PgSelectSingle44 --> PgClassExpression45
     PgSelectSingle50{{"PgSelectSingle[50∈3]<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys120{{"RemapKeys[120∈3]<br />ᐸ44:{”0”:1}ᐳ"}}:::plan
-    RemapKeys120 --> PgSelectSingle50
+    RemapKeys124{{"RemapKeys[124∈3]<br />ᐸ44:{”0”:1}ᐳ"}}:::plan
+    RemapKeys124 --> PgSelectSingle50
     PgSelectSingle56{{"PgSelectSingle[56∈3]<br />ᐸpostsᐳ"}}:::plan
-    RemapKeys136{{"RemapKeys[136∈3]<br />ᐸ44:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys136 --> PgSelectSingle56
+    RemapKeys141{{"RemapKeys[141∈3]<br />ᐸ44:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys141 --> PgSelectSingle56
     PgClassExpression59{{"PgClassExpression[59∈3]<br />ᐸ__comments__.”body”ᐳ"}}:::plan
     PgSelectSingle44 --> PgClassExpression59
-    PgSelectSingle32 --> RemapKeys90
-    PgSelectSingle44 --> RemapKeys120
-    PgSelectSingle44 --> RemapKeys136
+    PgSelectSingle32 --> RemapKeys92
+    PgSelectSingle44 --> RemapKeys124
+    PgSelectSingle44 --> RemapKeys141
     PgClassExpression39{{"PgClassExpression[39∈4]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
     PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -167,18 +169,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-search-entities/search"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 66, 67, 68, 80, 81, 96, 97, 98, 110, 111, 126, 127, 142, 143, 144, 156, 157, 158, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 10, 62, 65, 69, 70, 75, 83, 84, 89, 99, 100, 105, 113, 114, 119, 129, 130, 135, 145, 146, 151, 159, 160, 165<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 67, 68, 69, 82, 83, 99, 100, 101, 114, 115, 131, 132, 148, 149, 150, 163, 164, 165, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 10, 62, 65, 66, 70, 71, 76, 85, 86, 91, 102, 103, 108, 117, 118, 123, 134, 135, 140, 151, 152, 157, 166, 167, 172<br />2: PgSelect[7]<br />3: __ListTransform[11]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda62,Lambda65,Constant66,Constant67,Constant68,Object69,Lambda70,Lambda75,Constant80,Constant81,Object83,Lambda84,Lambda89,Constant96,Constant97,Constant98,Object99,Lambda100,Lambda105,Constant110,Constant111,Object113,Lambda114,Lambda119,Constant126,Constant127,Object129,Lambda130,Lambda135,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant166,Constant167,Constant168,Constant169,Constant170,Constant171,Constant172,Constant173,Constant174,Constant175 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,__ListTransform11,Lambda62,Lambda65,Access66,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant82,Constant83,Object85,Lambda86,Lambda91,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant114,Constant115,Object117,Lambda118,Lambda123,Constant131,Constant132,Object134,Lambda135,Lambda140,Constant148,Constant149,Constant150,Object151,Lambda152,Lambda157,Constant163,Constant164,Constant165,Object166,Lambda167,Lambda172,Constant173,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182 bucket0
     Bucket1("Bucket 1 (subroutine)<br /><br />ROOT PgSelectSingle{1}ᐸentity_searchᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 62, 65, 70, 75, 84, 89, 100, 105, 114, 119, 130, 135, 146, 151<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 62, 66, 71, 76, 86, 91, 103, 108, 118, 123, 135, 140, 152, 157<br /><br />ROOT __Item{2}ᐸ11ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgSelectSingle15,PgClassExpression16,PgClassExpression17,PgClassExpression18,List19,PgPolymorphic20 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 16, 62, 65, 70, 75, 17, 84, 89, 100, 105, 18, 114, 119, 130, 135, 146, 151, 20<br />ᐳPerson<br />ᐳPost<br />ᐳComment"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 16, 62, 66, 71, 76, 17, 86, 91, 103, 108, 18, 118, 123, 135, 140, 152, 157, 20<br />ᐳPerson<br />ᐳPost<br />ᐳComment"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect21,First25,PgSelectSingle26,PgClassExpression27,PgClassExpression28,PgSelect29,First31,PgSelectSingle32,PgClassExpression33,PgSelectSingle38,PgClassExpression40,PgSelect41,First43,PgSelectSingle44,PgClassExpression45,PgSelectSingle50,PgSelectSingle56,PgClassExpression59,RemapKeys90,RemapKeys120,RemapKeys136 bucket3
+    class Bucket3,PgSelect21,First25,PgSelectSingle26,PgClassExpression27,PgClassExpression28,PgSelect29,First31,PgSelectSingle32,PgClassExpression33,PgSelectSingle38,PgClassExpression40,PgSelect41,First43,PgSelectSingle44,PgClassExpression45,PgSelectSingle50,PgSelectSingle56,PgClassExpression59,RemapKeys92,RemapKeys124,RemapKeys141 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[38]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression39 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/bookmarks.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/bookmarks.deopt.mermaid
@@ -11,50 +11,54 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Access80{{"Access[80∈0] ➊<br />ᐸ79.0ᐳ"}}:::plan
+    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant207 & Lambda79 & Lambda182 & Lambda187 & Lambda76 & Lambda79 & Lambda201 & Lambda206 --> PgSelect7
-    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda76 & Constant94 & Constant95 & Constant82 --> Object97
-    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant108 & Constant109 & Constant82 --> Object111
-    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
-    Lambda76 & Constant122 & Constant123 & Constant124 --> Object125
-    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant136 & Constant137 & Constant82 --> Object139
-    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Lambda76 & Constant150 & Constant151 & Constant124 --> Object153
-    Object167{{"Object[167∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
-    Lambda76 & Constant164 & Constant165 & Constant166 --> Object167
-    Object181{{"Object[181∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸsql.identifier(”person_bookmarks”)ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸRecordCodec(person_bookmarks)ᐳ"}}:::plan
-    Lambda76 & Constant178 & Constant179 & Constant180 --> Object181
-    Object200{{"Object[200∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant197 & Constant198 & Constant82 --> Object200
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda215{{"Lambda[215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant216 & Access80 & Lambda190 & Lambda195 & Lambda76 & Access80 & Lambda210 & Lambda215 --> PgSelect7
+    Object84{{"Object[84∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda76 & Constant81 & Constant82 & Constant83 --> Object84
+    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant96 & Constant97 & Constant83 --> Object99
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant111 & Constant112 & Constant83 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
+    Lambda76 & Constant126 & Constant127 & Constant128 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant141 & Constant142 & Constant83 --> Object144
+    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Lambda76 & Constant156 & Constant157 & Constant128 --> Object159
+    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
+    Lambda76 & Constant171 & Constant172 & Constant173 --> Object174
+    Object189{{"Object[189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸsql.identifier(”person_bookmarks”)ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸRecordCodec(person_bookmarks)ᐳ"}}:::plan
+    Lambda76 & Constant186 & Constant187 & Constant188 --> Object189
+    Object209{{"Object[209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant206 & Constant207 & Constant83 --> Object209
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -65,75 +69,73 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸpeopleᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant208 --> Lambda76
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant209 --> Lambda79
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object97 --> Lambda98
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant211 --> Lambda103
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object111 --> Lambda112
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant212 --> Lambda117
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object125 --> Lambda126
-    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant213 --> Lambda131
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object139 --> Lambda140
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant217 --> Lambda76
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant218 --> Lambda79
+    Lambda79 --> Access80
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object84 --> Lambda85
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant219 --> Lambda90
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object99 --> Lambda100
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant220 --> Lambda105
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant221 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant222 --> Lambda135
     Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant214 --> Lambda145
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object153 --> Lambda154
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant215 --> Lambda159
-    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object167 --> Lambda168
-    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
-    Constant216 --> Lambda173
-    Object181 --> Lambda182
-    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant217 --> Lambda187
-    Object200 --> Lambda201
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant218 --> Lambda206
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant223 --> Lambda150
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object159 --> Lambda160
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant224 --> Lambda165
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object174 --> Lambda175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
+    Constant225 --> Lambda180
+    Object189 --> Lambda190
+    Constant226{{"Constant[226∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant226 --> Lambda195
+    Object209 --> Lambda210
+    Constant227{{"Constant[227∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant227 --> Lambda215
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant74{{"Constant[74∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant77{{"Constant[77∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Object191{{"Object[191∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access189{{"Access[189∈1] ➊<br />ᐸ11.0ᐳ"}}:::plan
-    Access189 & Constant74 & Constant74 & Lambda76 & Constant77 --> Object191
-    Object83{{"Object[83∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda76 & Constant80 & Constant81 & Constant82 --> Object83
+    Object199{{"Object[199∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access197{{"Access[197∈1] ➊<br />ᐸ11.0ᐳ"}}:::plan
+    Access197 & Constant74 & Constant74 & Lambda76 & Constant77 --> Object199
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression14
-    Lambda84{{"Lambda[84∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object83 --> Lambda84
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant210 --> Lambda89
-    First11 --> Access189
-    Lambda192{{"Lambda[192∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object191 --> Lambda192
-    __Item19[/"__Item[19∈2]<br />ᐸ192ᐳ"\]:::itemplan
-    Lambda192 ==> __Item19
+    First11 --> Access197
+    Lambda200{{"Lambda[200∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object199 --> Lambda200
+    __Item19[/"__Item[19∈2]<br />ᐸ200ᐳ"\]:::itemplan
+    Lambda200 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸperson_bookmarksᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     PgSelect23[["PgSelect[23∈3]<br />ᐸpeopleᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__person_b...person_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression22 & Lambda76 & Lambda79 & Lambda84 & Lambda89 --> PgSelect23
+    Object10 & PgClassExpression22 & Lambda76 & Access80 & Lambda85 & Lambda90 --> PgSelect23
     List34{{"List[34∈3]<br />ᐸ31,32,33ᐳ"}}:::plan
     PgClassExpression31{{"PgClassExpression[31∈3]<br />ᐸ(__person_...person_id”ᐳ"}}:::plan
     PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ(__person_....”post_id”ᐳ"}}:::plan
@@ -156,20 +158,20 @@ graph TD
     PgClassExpression29{{"PgClassExpression[29∈4]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgSelect36[["PgSelect[36∈5]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
-    Object10 & PgClassExpression31 & Lambda76 & Lambda79 & Lambda98 & Lambda103 --> PgSelect36
+    Object10 & PgClassExpression31 & Lambda76 & Access80 & Lambda100 & Lambda105 --> PgSelect36
     PgSelect44[["PgSelect[44∈5]<br />ᐸpostsᐳ<br />ᐳPost"]]:::plan
-    Object10 & PgClassExpression32 & Lambda76 & Lambda79 & Lambda126 & Lambda131 --> PgSelect44
+    Object10 & PgClassExpression32 & Lambda76 & Access80 & Lambda130 & Lambda135 --> PgSelect44
     PgSelect50[["PgSelect[50∈5]<br />ᐸpeopleᐳ<br />ᐳPost"]]:::plan
     PgClassExpression49{{"PgClassExpression[49∈5]<br />ᐸ__posts__.”author_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression49 & Lambda76 & Lambda79 & Lambda112 & Lambda117 --> PgSelect50
+    Object10 & PgClassExpression49 & Lambda76 & Access80 & Lambda115 & Lambda120 --> PgSelect50
     PgSelect56[["PgSelect[56∈5]<br />ᐸcommentsᐳ<br />ᐳComment"]]:::plan
-    Object10 & PgClassExpression33 & Lambda76 & Lambda79 & Lambda168 & Lambda173 --> PgSelect56
+    Object10 & PgClassExpression33 & Lambda76 & Access80 & Lambda175 & Lambda180 --> PgSelect56
     PgSelect62[["PgSelect[62∈5]<br />ᐸpeopleᐳ<br />ᐳComment"]]:::plan
     PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__comments...author_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression61 & Lambda76 & Lambda79 & Lambda140 & Lambda145 --> PgSelect62
+    Object10 & PgClassExpression61 & Lambda76 & Access80 & Lambda145 & Lambda150 --> PgSelect62
     PgSelect68[["PgSelect[68∈5]<br />ᐸpostsᐳ<br />ᐳComment"]]:::plan
     PgClassExpression67{{"PgClassExpression[67∈5]<br />ᐸ__comments__.”post_id”ᐳ"}}:::plan
-    Object10 & PgClassExpression67 & Lambda76 & Lambda79 & Lambda154 & Lambda159 --> PgSelect68
+    Object10 & PgClassExpression67 & Lambda76 & Access80 & Lambda160 & Lambda165 --> PgSelect68
     First40{{"First[40∈5]"}}:::plan
     PgSelect36 --> First40
     PgSelectSingle41{{"PgSelectSingle[41∈5]<br />ᐸpeopleᐳ"}}:::plan
@@ -219,22 +221,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/bookmarks"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 74, 77, 80, 81, 82, 94, 95, 108, 109, 122, 123, 124, 136, 137, 150, 151, 164, 165, 166, 178, 179, 180, 197, 198, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 10, 76, 79, 97, 98, 103, 111, 112, 117, 125, 126, 131, 139, 140, 145, 153, 154, 159, 167, 168, 173, 181, 182, 187, 200, 201, 206<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 74, 77, 81, 82, 83, 96, 97, 111, 112, 126, 127, 128, 141, 142, 156, 157, 171, 172, 173, 186, 187, 188, 206, 207, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 10, 76, 79, 80, 84, 85, 90, 99, 100, 105, 114, 115, 120, 129, 130, 135, 144, 145, 150, 159, 160, 165, 174, 175, 180, 189, 190, 195, 209, 210, 215<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant74,Lambda76,Constant77,Lambda79,Constant80,Constant81,Constant82,Constant94,Constant95,Object97,Lambda98,Lambda103,Constant108,Constant109,Object111,Lambda112,Lambda117,Constant122,Constant123,Constant124,Object125,Lambda126,Lambda131,Constant136,Constant137,Object139,Lambda140,Lambda145,Constant150,Constant151,Object153,Lambda154,Lambda159,Constant164,Constant165,Constant166,Object167,Lambda168,Lambda173,Constant178,Constant179,Constant180,Object181,Lambda182,Lambda187,Constant197,Constant198,Object200,Lambda201,Lambda206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 76, 80, 81, 82, 210, 11, 74, 77, 10, 79, 98, 103, 126, 131, 112, 117, 168, 173, 140, 145, 154, 159<br /><br />ROOT PgSelectSingleᐸpeopleᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant74,Lambda76,Constant77,Lambda79,Access80,Constant81,Constant82,Constant83,Object84,Lambda85,Lambda90,Constant96,Constant97,Object99,Lambda100,Lambda105,Constant111,Constant112,Object114,Lambda115,Lambda120,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant141,Constant142,Object144,Lambda145,Lambda150,Constant156,Constant157,Object159,Lambda160,Lambda165,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant186,Constant187,Constant188,Object189,Lambda190,Lambda195,Constant206,Constant207,Object209,Lambda210,Lambda215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222,Constant223,Constant224,Constant225,Constant226,Constant227 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 11, 74, 76, 77, 10, 80, 85, 90, 100, 105, 130, 135, 115, 120, 175, 180, 145, 150, 160, 165<br /><br />ROOT PgSelectSingleᐸpeopleᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgClassExpression14,Object83,Lambda84,Lambda89,Access189,Object191,Lambda192 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 76, 79, 84, 89, 98, 103, 126, 131, 112, 117, 168, 173, 140, 145, 154, 159<br /><br />ROOT __Item{2}ᐸ192ᐳ[19]"):::bucket
+    class Bucket1,PgClassExpression13,PgClassExpression14,Access197,Object199,Lambda200 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 76, 80, 85, 90, 100, 105, 130, 135, 115, 120, 175, 180, 145, 150, 160, 165<br /><br />ROOT __Item{2}ᐸ200ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 10, 76, 79, 84, 89, 98, 103, 126, 131, 112, 117, 168, 173, 140, 145, 154, 159<br /><br />ROOT PgSelectSingle{2}ᐸperson_bookmarksᐳ[20]<br />1: <br />ᐳ: 21, 22, 30, 31, 32, 33, 34, 35<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 10, 76, 80, 85, 90, 100, 105, 130, 135, 115, 120, 175, 180, 145, 150, 160, 165<br /><br />ROOT PgSelectSingle{2}ᐸperson_bookmarksᐳ[20]<br />1: <br />ᐳ: 21, 22, 30, 31, 32, 33, 34, 35<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression21,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,List34,PgPolymorphic35 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression29 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 31, 76, 79, 98, 103, 32, 126, 131, 112, 117, 33, 168, 173, 140, 145, 154, 159, 35<br />ᐳPerson<br />ᐳPost<br />ᐳComment<br /><br />1: 36, 44, 56<br />ᐳ: 40, 41, 42, 43, 46, 47, 48, 49, 55, 58, 59, 60, 61, 67, 73<br />2: 50, 62, 68<br />ᐳ: 52, 53, 64, 65, 70, 71"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 31, 76, 80, 100, 105, 32, 130, 135, 115, 120, 33, 175, 180, 145, 150, 160, 165, 35<br />ᐳPerson<br />ᐳPost<br />ᐳComment<br /><br />1: 36, 44, 56<br />ᐳ: 40, 41, 42, 43, 46, 47, 48, 49, 55, 58, 59, 60, 61, 67, 73<br />2: 50, 62, 68<br />ᐳ: 52, 53, 64, 65, 70, 71"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgSelect44,First46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectSingle53,PgClassExpression55,PgSelect56,First58,PgSelectSingle59,PgClassExpression60,PgClassExpression61,PgSelect62,First64,PgSelectSingle65,PgClassExpression67,PgSelect68,First70,PgSelectSingle71,PgClassExpression73 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 53<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[53]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/bookmarks.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/bookmarks.mermaid
@@ -11,56 +11,56 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpeopleᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant215{{"Constant[215∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Access80{{"Access[80∈0] ➊<br />ᐸ79.0ᐳ"}}:::plan
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda209{{"Lambda[209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda214{{"Lambda[214∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant215 & Lambda79 & Lambda84 & Lambda89 & Lambda79 & Lambda190 & Lambda195 & Lambda76 & Lambda79 & Lambda209 & Lambda214 --> PgSelect7
-    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda76 & Constant80 & Constant81 & Constant82 --> Object83
-    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant96 & Constant97 & Constant82 --> Object99
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant110 & Constant111 & Constant82 --> Object113
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
-    Lambda76 & Constant126 & Constant127 & Constant128 --> Object129
-    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant140 & Constant141 & Constant82 --> Object143
-    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Lambda76 & Constant156 & Constant157 & Constant128 --> Object159
-    Object175{{"Object[175∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
-    Lambda76 & Constant172 & Constant173 & Constant174 --> Object175
-    Object189{{"Object[189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸsql.identifier(”person_bookmarks”)ᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸRecordCodec(person_bookmarks)ᐳ"}}:::plan
-    Lambda76 & Constant186 & Constant187 & Constant188 --> Object189
-    Object208{{"Object[208∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant205{{"Constant[205∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda76 & Constant205 & Constant206 & Constant82 --> Object208
+    Lambda218{{"Lambda[218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda223{{"Lambda[223∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant224 & Access80 & Lambda85 & Lambda90 & Access80 & Lambda198 & Lambda203 & Lambda76 & Access80 & Lambda218 & Lambda223 --> PgSelect7
+    Object84{{"Object[84∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda76 & Constant81 & Constant82 & Constant83 --> Object84
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant98 & Constant99 & Constant83 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant113 & Constant114 & Constant83 --> Object116
+    Object133{{"Object[133∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
+    Lambda76 & Constant130 & Constant131 & Constant132 --> Object133
+    Object148{{"Object[148∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant145 & Constant146 & Constant83 --> Object148
+    Object165{{"Object[165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant163{{"Constant[163∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Lambda76 & Constant162 & Constant163 & Constant132 --> Object165
+    Object182{{"Object[182∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸsql.identifier(”comments”)ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸRecordCodec(comments)ᐳ"}}:::plan
+    Lambda76 & Constant179 & Constant180 & Constant181 --> Object182
+    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”person_bookmarks”)ᐳ"}}:::plan
+    Constant196{{"Constant[196∈0] ➊<br />ᐸRecordCodec(person_bookmarks)ᐳ"}}:::plan
+    Lambda76 & Constant194 & Constant195 & Constant196 --> Object197
+    Object217{{"Object[217∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant215{{"Constant[215∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda76 & Constant214 & Constant215 & Constant83 --> Object217
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -71,64 +71,66 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸpeopleᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant216 --> Lambda76
-    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant217 --> Lambda79
-    Object83 --> Lambda84
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant218 --> Lambda89
-    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object99 --> Lambda100
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant219 --> Lambda105
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object113 --> Lambda114
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant220 --> Lambda119
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object129 --> Lambda130
-    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant221 --> Lambda135
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object143 --> Lambda144
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant225 --> Lambda76
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant226{{"Constant[226∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant226 --> Lambda79
+    Lambda79 --> Access80
+    Object84 --> Lambda85
+    Constant227{{"Constant[227∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant227 --> Lambda90
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object101 --> Lambda102
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant228 --> Lambda107
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object116 --> Lambda117
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant229 --> Lambda122
+    Lambda134{{"Lambda[134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object133 --> Lambda134
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant230{{"Constant[230∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant230 --> Lambda139
     Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant222 --> Lambda149
-    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object159 --> Lambda160
-    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
-    Constant223 --> Lambda165
-    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object175 --> Lambda176
-    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
-    Constant224 --> Lambda181
-    Object189 --> Lambda190
-    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant225 --> Lambda195
-    Object208 --> Lambda209
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant226 --> Lambda214
+    Object148 --> Lambda149
+    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant231{{"Constant[231∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant231 --> Lambda154
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object165 --> Lambda166
+    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”posts”ᐳ"}}:::plan
+    Constant232 --> Lambda171
+    Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object182 --> Lambda183
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant233{{"Constant[233∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”commenᐳ"}}:::plan
+    Constant233 --> Lambda188
+    Object197 --> Lambda198
+    Constant234{{"Constant[234∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant234 --> Lambda203
+    Object217 --> Lambda218
+    Constant235{{"Constant[235∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant235 --> Lambda223
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant74{{"Constant[74∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant77{{"Constant[77∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Object199{{"Object[199∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access197{{"Access[197∈1] ➊<br />ᐸ11.0ᐳ"}}:::plan
-    Access197 & Constant74 & Constant74 & Lambda76 & Constant77 --> Object199
+    Object207{{"Object[207∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access205{{"Access[205∈1] ➊<br />ᐸ11.0ᐳ"}}:::plan
+    Access205 & Constant74 & Constant74 & Lambda76 & Constant77 --> Object207
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression14
-    First11 --> Access197
-    Lambda200{{"Lambda[200∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object199 --> Lambda200
-    __Item19[/"__Item[19∈2]<br />ᐸ200ᐳ"\]:::itemplan
-    Lambda200 ==> __Item19
+    First11 --> Access205
+    Lambda208{{"Lambda[208∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object207 --> Lambda208
+    __Item19[/"__Item[19∈2]<br />ᐸ208ᐳ"\]:::itemplan
+    Lambda208 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸperson_bookmarksᐳ"}}:::plan
     __Item19 --> PgSelectSingle20
     List34{{"List[34∈3]<br />ᐸ31,32,33ᐳ"}}:::plan
@@ -142,21 +144,21 @@ graph TD
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__person_b...rks__.”id”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression21
     PgSelectSingle28{{"PgSelectSingle[28∈3]<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys90{{"RemapKeys[90∈3]<br />ᐸ20:{”0”:1}ᐳ"}}:::plan
-    RemapKeys90 --> PgSelectSingle28
+    RemapKeys91{{"RemapKeys[91∈3]<br />ᐸ20:{”0”:1}ᐳ"}}:::plan
+    RemapKeys91 --> PgSelectSingle28
     PgSelectSingle20 --> PgClassExpression30
     PgSelectSingle20 --> PgClassExpression31
     PgSelectSingle20 --> PgClassExpression32
     PgSelectSingle20 --> PgClassExpression33
-    PgSelectSingle20 --> RemapKeys90
+    PgSelectSingle20 --> RemapKeys91
     PgClassExpression29{{"PgClassExpression[29∈4]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression29
     PgSelect56[["PgSelect[56∈5]<br />ᐸcommentsᐳ<br />ᐳComment"]]:::plan
-    Object10 & PgClassExpression33 & Lambda79 & Lambda144 & Lambda149 & Lambda79 & Lambda160 & Lambda165 & Lambda76 & Lambda79 & Lambda176 & Lambda181 --> PgSelect56
+    Object10 & PgClassExpression33 & Access80 & Lambda149 & Lambda154 & Access80 & Lambda166 & Lambda171 & Lambda76 & Access80 & Lambda183 & Lambda188 --> PgSelect56
     PgSelect44[["PgSelect[44∈5]<br />ᐸpostsᐳ<br />ᐳPost"]]:::plan
-    Object10 & PgClassExpression32 & Lambda79 & Lambda114 & Lambda119 & Lambda76 & Lambda79 & Lambda130 & Lambda135 --> PgSelect44
+    Object10 & PgClassExpression32 & Access80 & Lambda117 & Lambda122 & Lambda76 & Access80 & Lambda134 & Lambda139 --> PgSelect44
     PgSelect36[["PgSelect[36∈5]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
-    Object10 & PgClassExpression31 & Lambda76 & Lambda79 & Lambda100 & Lambda105 --> PgSelect36
+    Object10 & PgClassExpression31 & Lambda76 & Access80 & Lambda102 & Lambda107 --> PgSelect36
     First40{{"First[40∈5]"}}:::plan
     PgSelect36 --> First40
     PgSelectSingle41{{"PgSelectSingle[41∈5]<br />ᐸpeopleᐳ"}}:::plan
@@ -172,8 +174,8 @@ graph TD
     PgClassExpression48{{"PgClassExpression[48∈5]<br />ᐸ__posts__.”post_id”ᐳ"}}:::plan
     PgSelectSingle47 --> PgClassExpression48
     PgSelectSingle53{{"PgSelectSingle[53∈5]<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys120{{"RemapKeys[120∈5]<br />ᐸ47:{”0”:1}ᐳ"}}:::plan
-    RemapKeys120 --> PgSelectSingle53
+    RemapKeys123{{"RemapKeys[123∈5]<br />ᐸ47:{”0”:1}ᐳ"}}:::plan
+    RemapKeys123 --> PgSelectSingle53
     PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__posts__.”body”ᐳ"}}:::plan
     PgSelectSingle47 --> PgClassExpression55
     First58{{"First[58∈5]"}}:::plan
@@ -183,16 +185,16 @@ graph TD
     PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__comments...omment_id”ᐳ"}}:::plan
     PgSelectSingle59 --> PgClassExpression60
     PgSelectSingle65{{"PgSelectSingle[65∈5]<br />ᐸpeopleᐳ"}}:::plan
-    RemapKeys150{{"RemapKeys[150∈5]<br />ᐸ59:{”0”:1}ᐳ"}}:::plan
-    RemapKeys150 --> PgSelectSingle65
+    RemapKeys155{{"RemapKeys[155∈5]<br />ᐸ59:{”0”:1}ᐳ"}}:::plan
+    RemapKeys155 --> PgSelectSingle65
     PgSelectSingle71{{"PgSelectSingle[71∈5]<br />ᐸpostsᐳ"}}:::plan
-    RemapKeys166{{"RemapKeys[166∈5]<br />ᐸ59:{”0”:2}ᐳ"}}:::plan
-    RemapKeys166 --> PgSelectSingle71
+    RemapKeys172{{"RemapKeys[172∈5]<br />ᐸ59:{”0”:2}ᐳ"}}:::plan
+    RemapKeys172 --> PgSelectSingle71
     PgClassExpression73{{"PgClassExpression[73∈5]<br />ᐸ__comments__.”body”ᐳ"}}:::plan
     PgSelectSingle59 --> PgClassExpression73
-    PgSelectSingle47 --> RemapKeys120
-    PgSelectSingle59 --> RemapKeys150
-    PgSelectSingle59 --> RemapKeys166
+    PgSelectSingle47 --> RemapKeys123
+    PgSelectSingle59 --> RemapKeys155
+    PgSelectSingle59 --> RemapKeys172
     PgClassExpression54{{"PgClassExpression[54∈6]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle53 --> PgClassExpression54
     PgClassExpression66{{"PgClassExpression[66∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -203,24 +205,24 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/bookmarks"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 74, 77, 80, 81, 82, 96, 97, 110, 111, 126, 127, 128, 140, 141, 156, 157, 172, 173, 174, 186, 187, 188, 205, 206, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 10, 76, 79, 83, 84, 89, 99, 100, 105, 113, 114, 119, 129, 130, 135, 143, 144, 149, 159, 160, 165, 175, 176, 181, 189, 190, 195, 208, 209, 214<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 74, 77, 81, 82, 83, 98, 99, 113, 114, 130, 131, 132, 145, 146, 162, 163, 179, 180, 181, 194, 195, 196, 214, 215, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 10, 76, 79, 80, 84, 85, 90, 101, 102, 107, 116, 117, 122, 133, 134, 139, 148, 149, 154, 165, 166, 171, 182, 183, 188, 197, 198, 203, 217, 218, 223<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant74,Lambda76,Constant77,Lambda79,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant96,Constant97,Object99,Lambda100,Lambda105,Constant110,Constant111,Object113,Lambda114,Lambda119,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant140,Constant141,Object143,Lambda144,Lambda149,Constant156,Constant157,Object159,Lambda160,Lambda165,Constant172,Constant173,Constant174,Object175,Lambda176,Lambda181,Constant186,Constant187,Constant188,Object189,Lambda190,Lambda195,Constant205,Constant206,Object208,Lambda209,Lambda214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222,Constant223,Constant224,Constant225,Constant226 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 11, 74, 76, 77, 10, 79, 100, 105, 114, 119, 130, 135, 144, 149, 160, 165, 176, 181<br /><br />ROOT PgSelectSingleᐸpeopleᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant74,Lambda76,Constant77,Lambda79,Access80,Constant81,Constant82,Constant83,Object84,Lambda85,Lambda90,Constant98,Constant99,Object101,Lambda102,Lambda107,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant130,Constant131,Constant132,Object133,Lambda134,Lambda139,Constant145,Constant146,Object148,Lambda149,Lambda154,Constant162,Constant163,Object165,Lambda166,Lambda171,Constant179,Constant180,Constant181,Object182,Lambda183,Lambda188,Constant194,Constant195,Constant196,Object197,Lambda198,Lambda203,Constant214,Constant215,Object217,Lambda218,Lambda223,Constant224,Constant225,Constant226,Constant227,Constant228,Constant229,Constant230,Constant231,Constant232,Constant233,Constant234,Constant235 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 11, 74, 76, 77, 10, 80, 102, 107, 117, 122, 134, 139, 149, 154, 166, 171, 183, 188<br /><br />ROOT PgSelectSingleᐸpeopleᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,PgClassExpression14,Access197,Object199,Lambda200 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 76, 79, 100, 105, 114, 119, 130, 135, 144, 149, 160, 165, 176, 181<br /><br />ROOT __Item{2}ᐸ200ᐳ[19]"):::bucket
+    class Bucket1,PgClassExpression13,PgClassExpression14,Access205,Object207,Lambda208 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 10, 76, 80, 102, 107, 117, 122, 134, 139, 149, 154, 166, 171, 183, 188<br /><br />ROOT __Item{2}ᐸ208ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 10, 76, 79, 100, 105, 114, 119, 130, 135, 144, 149, 160, 165, 176, 181<br /><br />ROOT PgSelectSingle{2}ᐸperson_bookmarksᐳ[20]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 10, 76, 80, 102, 107, 117, 122, 134, 139, 149, 154, 166, 171, 183, 188<br /><br />ROOT PgSelectSingle{2}ᐸperson_bookmarksᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression21,PgSelectSingle28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,List34,PgPolymorphic35,RemapKeys90 bucket3
+    class Bucket3,PgClassExpression21,PgSelectSingle28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,List34,PgPolymorphic35,RemapKeys91 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression29 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 31, 76, 79, 100, 105, 32, 114, 119, 130, 135, 33, 144, 149, 160, 165, 176, 181, 35<br />ᐳPerson<br />ᐳPost<br />ᐳComment"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />Person,Post,Comment<br />Deps: 10, 31, 76, 80, 102, 107, 32, 117, 122, 134, 139, 33, 149, 154, 166, 171, 183, 188, 35<br />ᐳPerson<br />ᐳPost<br />ᐳComment"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgSelect44,First46,PgSelectSingle47,PgClassExpression48,PgSelectSingle53,PgClassExpression55,PgSelect56,First58,PgSelectSingle59,PgClassExpression60,PgSelectSingle65,PgSelectSingle71,PgClassExpression73,RemapKeys120,RemapKeys150,RemapKeys166 bucket5
+    class Bucket5,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgSelect44,First46,PgSelectSingle47,PgClassExpression48,PgSelectSingle53,PgClassExpression55,PgSelect56,First58,PgSelectSingle59,PgClassExpression60,PgSelectSingle65,PgSelectSingle71,PgClassExpression73,RemapKeys123,RemapKeys155,RemapKeys172 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 53<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[53]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression54 bucket6

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.deopt.mermaid
@@ -11,42 +11,42 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant138 & Lambda54 & Lambda57 & Lambda132 & Lambda137 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
-    Lambda54 & Constant72 & Constant73 & Constant74 --> Object75
-    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
-    Lambda54 & Constant86 & Constant87 & Constant88 --> Object89
-    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
-    Lambda54 & Constant100 & Constant101 & Constant102 --> Object103
-    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
-    Lambda54 & Constant114 & Constant115 & Constant116 --> Object117
-    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
-    Lambda54 & Constant128 & Constant129 & Constant130 --> Object131
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant144 & Lambda54 & Access58 & Lambda138 & Lambda143 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
+    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
+    Lambda54 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
+    Lambda54 & Constant104 & Constant105 & Constant106 --> Object107
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
+    Lambda54 & Constant119 & Constant120 & Constant121 --> Object122
+    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
+    Lambda54 & Constant134 & Constant135 & Constant136 --> Object137
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -61,50 +61,52 @@ graph TD
     PgSelect7 --> First11
     First11 --> PgSelectSingle12
     PgSelectSingle12 --> PgClassExpression13
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant139 --> Lambda54
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant140 --> Lambda57
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant141 --> Lambda67
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant142 --> Lambda81
-    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object89 --> Lambda90
-    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant143 --> Lambda95
-    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object103 --> Lambda104
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant144 --> Lambda109
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object117 --> Lambda118
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant145 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant146 --> Lambda57
+    Lambda57 --> Access58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant147 --> Lambda68
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant148 --> Lambda83
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant149 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant150 --> Lambda113
     Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant145 --> Lambda123
-    Object131 --> Lambda132
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant146 --> Lambda137
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant151 --> Lambda128
+    Object137 --> Lambda138
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant152 --> Lambda143
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda62 & Lambda67 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda63 & Lambda68 --> PgSelect16
     PgSelect24[["PgSelect[24∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda76 & Lambda81 --> PgSelect24
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda78 & Lambda83 --> PgSelect24
     PgSelect32[["PgSelect[32∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda90 & Lambda95 --> PgSelect32
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda93 & Lambda98 --> PgSelect32
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda104 & Lambda109 --> PgSelect39
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda108 & Lambda113 --> PgSelect39
     PgSelect45[["PgSelect[45∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda118 & Lambda123 --> PgSelect45
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda123 & Lambda128 --> PgSelect45
     PgSelectSingle12 --> PgClassExpression15
     First20{{"First[20∈1] ➊"}}:::plan
     PgSelect16 --> First20
@@ -158,10 +160,10 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 72, 73, 74, 86, 87, 88, 100, 101, 102, 114, 115, 116, 128, 129, 130, 138, 139, 140, 141, 142, 143, 144, 145, 146, 10, 54, 57, 61, 62, 67, 75, 76, 81, 89, 90, 95, 103, 104, 109, 117, 118, 123, 131, 132, 137<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 74, 75, 76, 89, 90, 91, 104, 105, 106, 119, 120, 121, 134, 135, 136, 144, 145, 146, 147, 148, 149, 150, 151, 152, 10, 54, 57, 58, 62, 63, 68, 77, 78, 83, 92, 93, 98, 107, 108, 113, 122, 123, 128, 137, 138, 143<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant100,Constant101,Constant102,Object103,Lambda104,Lambda109,Constant114,Constant115,Constant116,Object117,Lambda118,Lambda123,Constant128,Constant129,Constant130,Object131,Lambda132,Lambda137,Constant138,Constant139,Constant140,Constant141,Constant142,Constant143,Constant144,Constant145,Constant146 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 54, 57, 62, 67, 76, 81, 90, 95, 104, 109, 118, 123, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Constant144,Constant145,Constant146,Constant147,Constant148,Constant149,Constant150,Constant151,Constant152 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 54, 58, 63, 68, 78, 83, 93, 98, 108, 113, 123, 128, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect24,First26,PgSelectSingle27,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First34,PgSelectSingle35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket1
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.mermaid
@@ -11,42 +11,42 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant138 & Lambda54 & Lambda57 & Lambda132 & Lambda137 --> PgSelect7
-    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
-    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
-    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
-    Lambda54 & Constant72 & Constant73 & Constant74 --> Object75
-    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
-    Lambda54 & Constant86 & Constant87 & Constant88 --> Object89
-    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
-    Lambda54 & Constant100 & Constant101 & Constant102 --> Object103
-    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
-    Lambda54 & Constant114 & Constant115 & Constant116 --> Object117
-    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
-    Lambda54 & Constant128 & Constant129 & Constant130 --> Object131
+    Access58{{"Access[58∈0] ➊<br />ᐸ57.0ᐳ"}}:::plan
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant144 & Lambda54 & Access58 & Lambda138 & Lambda143 --> PgSelect7
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
+    Lambda54 & Constant59 & Constant60 & Constant61 --> Object62
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
+    Lambda54 & Constant74 & Constant75 & Constant76 --> Object77
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
+    Lambda54 & Constant89 & Constant90 & Constant91 --> Object92
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
+    Lambda54 & Constant104 & Constant105 & Constant106 --> Object107
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
+    Lambda54 & Constant119 & Constant120 & Constant121 --> Object122
+    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
+    Lambda54 & Constant134 & Constant135 & Constant136 --> Object137
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -61,50 +61,52 @@ graph TD
     PgSelect7 --> First11
     First11 --> PgSelectSingle12
     PgSelectSingle12 --> PgClassExpression13
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant139 --> Lambda54
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant140 --> Lambda57
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object61 --> Lambda62
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant141 --> Lambda67
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object75 --> Lambda76
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant142 --> Lambda81
-    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object89 --> Lambda90
-    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant143 --> Lambda95
-    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object103 --> Lambda104
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant144 --> Lambda109
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object117 --> Lambda118
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant145 --> Lambda54
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant146 --> Lambda57
+    Lambda57 --> Access58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant147 --> Lambda68
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object77 --> Lambda78
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant148 --> Lambda83
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant149 --> Lambda98
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant150 --> Lambda113
     Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant145 --> Lambda123
-    Object131 --> Lambda132
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant146 --> Lambda137
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant151 --> Lambda128
+    Object137 --> Lambda138
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant152 --> Lambda143
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda62 & Lambda67 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda63 & Lambda68 --> PgSelect16
     PgSelect24[["PgSelect[24∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda76 & Lambda81 --> PgSelect24
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda78 & Lambda83 --> PgSelect24
     PgSelect32[["PgSelect[32∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda90 & Lambda95 --> PgSelect32
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda93 & Lambda98 --> PgSelect32
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda104 & Lambda109 --> PgSelect39
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda108 & Lambda113 --> PgSelect39
     PgSelect45[["PgSelect[45∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda54 & Lambda57 & Lambda118 & Lambda123 --> PgSelect45
+    Object10 & PgClassExpression15 & Lambda54 & Access58 & Lambda123 & Lambda128 --> PgSelect45
     PgSelectSingle12 --> PgClassExpression15
     First20{{"First[20∈1] ➊"}}:::plan
     PgSelect16 --> First20
@@ -158,10 +160,10 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 59, 60, 72, 73, 74, 86, 87, 88, 100, 101, 102, 114, 115, 116, 128, 129, 130, 138, 139, 140, 141, 142, 143, 144, 145, 146, 10, 54, 57, 61, 62, 67, 75, 76, 81, 89, 90, 95, 103, 104, 109, 117, 118, 123, 131, 132, 137<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 59, 60, 61, 74, 75, 76, 89, 90, 91, 104, 105, 106, 119, 120, 121, 134, 135, 136, 144, 145, 146, 147, 148, 149, 150, 151, 152, 10, 54, 57, 58, 62, 63, 68, 77, 78, 83, 92, 93, 98, 107, 108, 113, 122, 123, 128, 137, 138, 143<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda54,Lambda57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant100,Constant101,Constant102,Object103,Lambda104,Lambda109,Constant114,Constant115,Constant116,Object117,Lambda118,Lambda123,Constant128,Constant129,Constant130,Object131,Lambda132,Lambda137,Constant138,Constant139,Constant140,Constant141,Constant142,Constant143,Constant144,Constant145,Constant146 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 54, 57, 62, 67, 76, 81, 90, 95, 104, 109, 118, 123, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,Lambda54,Lambda57,Access58,Constant59,Constant60,Constant61,Object62,Lambda63,Lambda68,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Constant144,Constant145,Constant146,Constant147,Constant148,Constant149,Constant150,Constant151,Constant152 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 54, 58, 63, 68, 78, 83, 93, 98, 108, 113, 123, 128, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect24,First26,PgSelectSingle27,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First34,PgSelectSingle35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket1
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.mermaid
@@ -11,62 +11,65 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ18ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸ18ᐳ"}}:::plan
     Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant260 & Lambda106 & Lambda109 & Lambda184 & Lambda189 --> PgSelect7
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
-    Lambda106 & Constant110 & Constant111 & Constant112 --> Object113
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
-    Lambda106 & Constant124 & Constant125 & Constant126 --> Object127
-    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
-    Lambda106 & Constant138 & Constant139 & Constant140 --> Object141
-    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
-    Lambda106 & Constant152 & Constant153 & Constant154 --> Object155
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
-    Lambda106 & Constant166 & Constant167 & Constant168 --> Object169
-    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
-    Lambda106 & Constant180 & Constant181 & Constant182 --> Object183
-    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Lambda106 & Constant194 & Constant195 & Constant112 --> Object197
-    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Lambda106 & Constant208 & Constant209 & Constant126 --> Object211
-    Object225{{"Object[225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Lambda106 & Constant222 & Constant223 & Constant140 --> Object225
-    Object239{{"Object[239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant237{{"Constant[237∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Lambda106 & Constant236 & Constant237 & Constant154 --> Object239
-    Object253{{"Object[253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant251{{"Constant[251∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Lambda106 & Constant250 & Constant251 & Constant168 --> Object253
+    Access110{{"Access[110∈0] ➊<br />ᐸ109.0ᐳ"}}:::plan
+    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Lambda190 & Lambda195 --> PgSelect7
+    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
+    Access276{{"Access[276∈0] ➊<br />ᐸ109.1ᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Access276 --> PgUnionAll53
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
+    Lambda106 & Constant111 & Constant112 & Constant113 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
+    Lambda106 & Constant126 & Constant127 & Constant128 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
+    Lambda106 & Constant141 & Constant142 & Constant143 --> Object144
+    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
+    Lambda106 & Constant156 & Constant157 & Constant158 --> Object159
+    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
+    Lambda106 & Constant171 & Constant172 & Constant173 --> Object174
+    Object189{{"Object[189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
+    Lambda106 & Constant186 & Constant187 & Constant188 --> Object189
+    Object204{{"Object[204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Lambda106 & Constant201 & Constant202 & Constant113 --> Object204
+    Object219{{"Object[219∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Lambda106 & Constant216 & Constant217 & Constant128 --> Object219
+    Object234{{"Object[234∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant231{{"Constant[231∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Lambda106 & Constant231 & Constant232 & Constant143 --> Object234
+    Object249{{"Object[249∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Lambda106 & Constant246 & Constant247 & Constant158 --> Object249
+    Object264{{"Object[264∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant261{{"Constant[261∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Lambda106 & Constant261 & Constant262 & Constant173 --> Object264
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -74,8 +77,6 @@ graph TD
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
     PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
-    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
-    Object10 & Constant260 --> PgUnionAll53
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -87,75 +88,78 @@ graph TD
     PgUnionAll53 --> First55
     PgUnionAllSingle56["PgUnionAllSingle[56∈0] ➊"]:::plan
     First55 --> PgUnionAllSingle56
-    Constant261{{"Constant[261∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant261 --> Lambda106
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant262 --> Lambda109
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object113 --> Lambda114
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant263 --> Lambda119
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object127 --> Lambda128
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant264{{"Constant[264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant264 --> Lambda133
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object141 --> Lambda142
-    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant265 --> Lambda147
-    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object155 --> Lambda156
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant266 --> Lambda161
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object169 --> Lambda170
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant278 --> Lambda106
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant279 --> Lambda109
+    Lambda109 --> Access110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant280 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant281 --> Lambda135
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant282 --> Lambda150
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object159 --> Lambda160
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant283 --> Lambda165
     Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant267 --> Lambda175
-    Object183 --> Lambda184
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant268 --> Lambda189
-    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object197 --> Lambda198
-    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant269 --> Lambda203
-    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object211 --> Lambda212
-    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant270 --> Lambda217
-    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object225 --> Lambda226
-    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant271 --> Lambda231
+    Object174 --> Lambda175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant284 --> Lambda180
+    Object189 --> Lambda190
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant285 --> Lambda195
+    Lambda205{{"Lambda[205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object204 --> Lambda205
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant286 --> Lambda210
+    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object219 --> Lambda220
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant287 --> Lambda225
+    Lambda235{{"Lambda[235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object234 --> Lambda235
     Lambda240{{"Lambda[240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object239 --> Lambda240
-    Lambda245{{"Lambda[245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant272 --> Lambda245
-    Lambda254{{"Lambda[254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object253 --> Lambda254
-    Lambda259{{"Lambda[259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant273 --> Lambda259
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant288 --> Lambda240
+    Lambda250{{"Lambda[250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object249 --> Lambda250
+    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant289 --> Lambda255
+    Lambda265{{"Lambda[265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object264 --> Lambda265
+    Lambda270{{"Lambda[270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant290 --> Lambda270
+    Lambda109 --> Access276
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda114 & Lambda119 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda115 & Lambda120 --> PgSelect16
     PgSelect24[["PgSelect[24∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda128 & Lambda133 --> PgSelect24
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda130 & Lambda135 --> PgSelect24
     PgSelect32[["PgSelect[32∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda142 & Lambda147 --> PgSelect32
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda145 & Lambda150 --> PgSelect32
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda156 & Lambda161 --> PgSelect39
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda160 & Lambda165 --> PgSelect39
     PgSelect45[["PgSelect[45∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda170 & Lambda175 --> PgSelect45
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda175 & Lambda180 --> PgSelect45
     PgSelectSingle12 --> PgClassExpression15
     First20{{"First[20∈1] ➊"}}:::plan
     PgSelect16 --> First20
@@ -207,19 +211,19 @@ graph TD
     PgSelectSingle48 --> PgClassExpression51
     PgSelect60[["PgSelect[60∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     Access59{{"Access[59∈2] ➊<br />ᐸ58.0ᐳ"}}:::plan
-    Object10 & Access59 & Lambda106 & Lambda109 & Lambda198 & Lambda203 --> PgSelect60
+    Object10 & Access59 & Lambda106 & Access110 & Lambda205 & Lambda210 --> PgSelect60
     PgSelect70[["PgSelect[70∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Access69{{"Access[69∈2] ➊<br />ᐸ68.0ᐳ"}}:::plan
-    Object10 & Access69 & Lambda106 & Lambda109 & Lambda212 & Lambda217 --> PgSelect70
+    Object10 & Access69 & Lambda106 & Access110 & Lambda220 & Lambda225 --> PgSelect70
     PgSelect80[["PgSelect[80∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
     Access79{{"Access[79∈2] ➊<br />ᐸ78.0ᐳ"}}:::plan
-    Object10 & Access79 & Lambda106 & Lambda109 & Lambda226 & Lambda231 --> PgSelect80
+    Object10 & Access79 & Lambda106 & Access110 & Lambda235 & Lambda240 --> PgSelect80
     PgSelect89[["PgSelect[89∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
     Access88{{"Access[88∈2] ➊<br />ᐸ87.0ᐳ"}}:::plan
-    Object10 & Access88 & Lambda106 & Lambda109 & Lambda240 & Lambda245 --> PgSelect89
+    Object10 & Access88 & Lambda106 & Access110 & Lambda250 & Lambda255 --> PgSelect89
     PgSelect97[["PgSelect[97∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access96{{"Access[96∈2] ➊<br />ᐸ95.0ᐳ"}}:::plan
-    Object10 & Access96 & Lambda106 & Lambda109 & Lambda254 & Lambda259 --> PgSelect97
+    Object10 & Access96 & Lambda106 & Access110 & Lambda265 & Lambda270 --> PgSelect97
     Access57{{"Access[57∈2] ➊<br />ᐸ56.1ᐳ<br />ᐳUnionTopic"}}:::plan
     PgUnionAllSingle56 --> Access57
     JSONParse58[["JSONParse[58∈2] ➊<br />ᐸ57ᐳ"]]:::plan
@@ -289,13 +293,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-18"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 110, 111, 112, 124, 125, 126, 138, 139, 140, 152, 153, 154, 166, 167, 168, 180, 181, 182, 194, 195, 208, 209, 222, 223, 236, 237, 250, 251, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 10, 106, 109, 113, 114, 119, 127, 128, 133, 141, 142, 147, 155, 156, 161, 169, 170, 175, 183, 184, 189, 197, 198, 203, 211, 212, 217, 225, 226, 231, 239, 240, 245, 253, 254, 259<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 111, 112, 113, 126, 127, 128, 141, 142, 143, 156, 157, 158, 171, 172, 173, 186, 187, 188, 201, 202, 216, 217, 231, 232, 246, 247, 261, 262, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 10, 106, 109, 110, 114, 115, 120, 129, 130, 135, 144, 145, 150, 159, 160, 165, 174, 175, 180, 189, 190, 195, 204, 205, 210, 219, 220, 225, 234, 235, 240, 249, 250, 255, 264, 265, 270, 276<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Constant110,Constant111,Constant112,Object113,Lambda114,Lambda119,Constant124,Constant125,Constant126,Object127,Lambda128,Lambda133,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant194,Constant195,Object197,Lambda198,Lambda203,Constant208,Constant209,Object211,Lambda212,Lambda217,Constant222,Constant223,Object225,Lambda226,Lambda231,Constant236,Constant237,Object239,Lambda240,Lambda245,Constant250,Constant251,Object253,Lambda254,Lambda259,Constant260,Constant261,Constant262,Constant263,Constant264,Constant265,Constant266,Constant267,Constant268,Constant269,Constant270,Constant271,Constant272,Constant273 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 109, 114, 119, 128, 133, 142, 147, 156, 161, 170, 175, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Access110,Constant111,Constant112,Constant113,Object114,Lambda115,Lambda120,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant186,Constant187,Constant188,Object189,Lambda190,Lambda195,Constant201,Constant202,Object204,Lambda205,Lambda210,Constant216,Constant217,Object219,Lambda220,Lambda225,Constant231,Constant232,Object234,Lambda235,Lambda240,Constant246,Constant247,Object249,Lambda250,Lambda255,Constant261,Constant262,Object264,Lambda265,Lambda270,Access276,Constant277,Constant278,Constant279,Constant280,Constant281,Constant282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289,Constant290 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 110, 115, 120, 130, 135, 145, 150, 160, 165, 175, 180, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect24,First26,PgSelectSingle27,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First34,PgSelectSingle35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 109, 198, 203, 212, 217, 226, 231, 240, 245, 254, 259<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 110, 205, 210, 220, 225, 235, 240, 250, 255, 265, 270<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access57,JSONParse58,Access59,PgSelect60,First64,PgSelectSingle65,PgClassExpression66,PgClassExpression67,JSONParse68,Access69,PgSelect70,First72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,PgClassExpression76,PgClassExpression77,JSONParse78,Access79,PgSelect80,First82,PgSelectSingle83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectSingle92,PgClassExpression93,PgClassExpression94,JSONParse95,Access96,PgSelect97,First99,PgSelectSingle100,PgClassExpression101,PgClassExpression102,PgClassExpression103 bucket2
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.mermaid
@@ -11,62 +11,65 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ18ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸ18ᐳ"}}:::plan
     Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant260 & Lambda106 & Lambda109 & Lambda184 & Lambda189 --> PgSelect7
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
-    Lambda106 & Constant110 & Constant111 & Constant112 --> Object113
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
-    Lambda106 & Constant124 & Constant125 & Constant126 --> Object127
-    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
-    Lambda106 & Constant138 & Constant139 & Constant140 --> Object141
-    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
-    Lambda106 & Constant152 & Constant153 & Constant154 --> Object155
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
-    Lambda106 & Constant166 & Constant167 & Constant168 --> Object169
-    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
-    Lambda106 & Constant180 & Constant181 & Constant182 --> Object183
-    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Lambda106 & Constant194 & Constant195 & Constant112 --> Object197
-    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Lambda106 & Constant208 & Constant209 & Constant126 --> Object211
-    Object225{{"Object[225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Lambda106 & Constant222 & Constant223 & Constant140 --> Object225
-    Object239{{"Object[239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant237{{"Constant[237∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Lambda106 & Constant236 & Constant237 & Constant154 --> Object239
-    Object253{{"Object[253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant251{{"Constant[251∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Lambda106 & Constant250 & Constant251 & Constant168 --> Object253
+    Access110{{"Access[110∈0] ➊<br />ᐸ109.0ᐳ"}}:::plan
+    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Lambda190 & Lambda195 --> PgSelect7
+    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
+    Access276{{"Access[276∈0] ➊<br />ᐸ109.1ᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Access276 --> PgUnionAll53
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
+    Lambda106 & Constant111 & Constant112 & Constant113 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
+    Lambda106 & Constant126 & Constant127 & Constant128 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
+    Lambda106 & Constant141 & Constant142 & Constant143 --> Object144
+    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
+    Lambda106 & Constant156 & Constant157 & Constant158 --> Object159
+    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
+    Lambda106 & Constant171 & Constant172 & Constant173 --> Object174
+    Object189{{"Object[189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
+    Lambda106 & Constant186 & Constant187 & Constant188 --> Object189
+    Object204{{"Object[204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Lambda106 & Constant201 & Constant202 & Constant113 --> Object204
+    Object219{{"Object[219∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Lambda106 & Constant216 & Constant217 & Constant128 --> Object219
+    Object234{{"Object[234∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant231{{"Constant[231∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Lambda106 & Constant231 & Constant232 & Constant143 --> Object234
+    Object249{{"Object[249∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Lambda106 & Constant246 & Constant247 & Constant158 --> Object249
+    Object264{{"Object[264∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant261{{"Constant[261∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Lambda106 & Constant261 & Constant262 & Constant173 --> Object264
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -74,8 +77,6 @@ graph TD
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
     PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
-    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
-    Object10 & Constant260 --> PgUnionAll53
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -87,75 +88,78 @@ graph TD
     PgUnionAll53 --> First55
     PgUnionAllSingle56["PgUnionAllSingle[56∈0] ➊"]:::plan
     First55 --> PgUnionAllSingle56
-    Constant261{{"Constant[261∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant261 --> Lambda106
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant262 --> Lambda109
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object113 --> Lambda114
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant263 --> Lambda119
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object127 --> Lambda128
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant264{{"Constant[264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant264 --> Lambda133
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object141 --> Lambda142
-    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant265 --> Lambda147
-    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object155 --> Lambda156
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant266 --> Lambda161
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object169 --> Lambda170
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant278 --> Lambda106
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant279 --> Lambda109
+    Lambda109 --> Access110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant280 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant281 --> Lambda135
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant282 --> Lambda150
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object159 --> Lambda160
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant283 --> Lambda165
     Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant267 --> Lambda175
-    Object183 --> Lambda184
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant268 --> Lambda189
-    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object197 --> Lambda198
-    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant269 --> Lambda203
-    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object211 --> Lambda212
-    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant270 --> Lambda217
-    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object225 --> Lambda226
-    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant271 --> Lambda231
+    Object174 --> Lambda175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant284 --> Lambda180
+    Object189 --> Lambda190
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant285 --> Lambda195
+    Lambda205{{"Lambda[205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object204 --> Lambda205
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant286 --> Lambda210
+    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object219 --> Lambda220
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant287 --> Lambda225
+    Lambda235{{"Lambda[235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object234 --> Lambda235
     Lambda240{{"Lambda[240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object239 --> Lambda240
-    Lambda245{{"Lambda[245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant272 --> Lambda245
-    Lambda254{{"Lambda[254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object253 --> Lambda254
-    Lambda259{{"Lambda[259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant273 --> Lambda259
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant288 --> Lambda240
+    Lambda250{{"Lambda[250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object249 --> Lambda250
+    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant289 --> Lambda255
+    Lambda265{{"Lambda[265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object264 --> Lambda265
+    Lambda270{{"Lambda[270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant290 --> Lambda270
+    Lambda109 --> Access276
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda114 & Lambda119 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda115 & Lambda120 --> PgSelect16
     PgSelect24[["PgSelect[24∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda128 & Lambda133 --> PgSelect24
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda130 & Lambda135 --> PgSelect24
     PgSelect32[["PgSelect[32∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda142 & Lambda147 --> PgSelect32
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda145 & Lambda150 --> PgSelect32
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda156 & Lambda161 --> PgSelect39
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda160 & Lambda165 --> PgSelect39
     PgSelect45[["PgSelect[45∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda170 & Lambda175 --> PgSelect45
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda175 & Lambda180 --> PgSelect45
     PgSelectSingle12 --> PgClassExpression15
     First20{{"First[20∈1] ➊"}}:::plan
     PgSelect16 --> First20
@@ -207,19 +211,19 @@ graph TD
     PgSelectSingle48 --> PgClassExpression51
     PgSelect60[["PgSelect[60∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     Access59{{"Access[59∈2] ➊<br />ᐸ58.0ᐳ"}}:::plan
-    Object10 & Access59 & Lambda106 & Lambda109 & Lambda198 & Lambda203 --> PgSelect60
+    Object10 & Access59 & Lambda106 & Access110 & Lambda205 & Lambda210 --> PgSelect60
     PgSelect70[["PgSelect[70∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Access69{{"Access[69∈2] ➊<br />ᐸ68.0ᐳ"}}:::plan
-    Object10 & Access69 & Lambda106 & Lambda109 & Lambda212 & Lambda217 --> PgSelect70
+    Object10 & Access69 & Lambda106 & Access110 & Lambda220 & Lambda225 --> PgSelect70
     PgSelect80[["PgSelect[80∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
     Access79{{"Access[79∈2] ➊<br />ᐸ78.0ᐳ"}}:::plan
-    Object10 & Access79 & Lambda106 & Lambda109 & Lambda226 & Lambda231 --> PgSelect80
+    Object10 & Access79 & Lambda106 & Access110 & Lambda235 & Lambda240 --> PgSelect80
     PgSelect89[["PgSelect[89∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
     Access88{{"Access[88∈2] ➊<br />ᐸ87.0ᐳ"}}:::plan
-    Object10 & Access88 & Lambda106 & Lambda109 & Lambda240 & Lambda245 --> PgSelect89
+    Object10 & Access88 & Lambda106 & Access110 & Lambda250 & Lambda255 --> PgSelect89
     PgSelect97[["PgSelect[97∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access96{{"Access[96∈2] ➊<br />ᐸ95.0ᐳ"}}:::plan
-    Object10 & Access96 & Lambda106 & Lambda109 & Lambda254 & Lambda259 --> PgSelect97
+    Object10 & Access96 & Lambda106 & Access110 & Lambda265 & Lambda270 --> PgSelect97
     Access57{{"Access[57∈2] ➊<br />ᐸ56.1ᐳ<br />ᐳUnionTopic"}}:::plan
     PgUnionAllSingle56 --> Access57
     JSONParse58[["JSONParse[58∈2] ➊<br />ᐸ57ᐳ"]]:::plan
@@ -289,13 +293,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-18"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 110, 111, 112, 124, 125, 126, 138, 139, 140, 152, 153, 154, 166, 167, 168, 180, 181, 182, 194, 195, 208, 209, 222, 223, 236, 237, 250, 251, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 10, 106, 109, 113, 114, 119, 127, 128, 133, 141, 142, 147, 155, 156, 161, 169, 170, 175, 183, 184, 189, 197, 198, 203, 211, 212, 217, 225, 226, 231, 239, 240, 245, 253, 254, 259<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 111, 112, 113, 126, 127, 128, 141, 142, 143, 156, 157, 158, 171, 172, 173, 186, 187, 188, 201, 202, 216, 217, 231, 232, 246, 247, 261, 262, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 10, 106, 109, 110, 114, 115, 120, 129, 130, 135, 144, 145, 150, 159, 160, 165, 174, 175, 180, 189, 190, 195, 204, 205, 210, 219, 220, 225, 234, 235, 240, 249, 250, 255, 264, 265, 270, 276<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Constant110,Constant111,Constant112,Object113,Lambda114,Lambda119,Constant124,Constant125,Constant126,Object127,Lambda128,Lambda133,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant194,Constant195,Object197,Lambda198,Lambda203,Constant208,Constant209,Object211,Lambda212,Lambda217,Constant222,Constant223,Object225,Lambda226,Lambda231,Constant236,Constant237,Object239,Lambda240,Lambda245,Constant250,Constant251,Object253,Lambda254,Lambda259,Constant260,Constant261,Constant262,Constant263,Constant264,Constant265,Constant266,Constant267,Constant268,Constant269,Constant270,Constant271,Constant272,Constant273 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 109, 114, 119, 128, 133, 142, 147, 156, 161, 170, 175, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Access110,Constant111,Constant112,Constant113,Object114,Lambda115,Lambda120,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant186,Constant187,Constant188,Object189,Lambda190,Lambda195,Constant201,Constant202,Object204,Lambda205,Lambda210,Constant216,Constant217,Object219,Lambda220,Lambda225,Constant231,Constant232,Object234,Lambda235,Lambda240,Constant246,Constant247,Object249,Lambda250,Lambda255,Constant261,Constant262,Object264,Lambda265,Lambda270,Access276,Constant277,Constant278,Constant279,Constant280,Constant281,Constant282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289,Constant290 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 110, 115, 120, 130, 135, 145, 150, 160, 165, 175, 180, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect24,First26,PgSelectSingle27,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First34,PgSelectSingle35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 109, 198, 203, 212, 217, 226, 231, 240, 245, 254, 259<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 110, 205, 210, 220, 225, 235, 240, 250, 255, 265, 270<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access57,JSONParse58,Access59,PgSelect60,First64,PgSelectSingle65,PgClassExpression66,PgClassExpression67,JSONParse68,Access69,PgSelect70,First72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,PgClassExpression76,PgClassExpression77,JSONParse78,Access79,PgSelect80,First82,PgSelectSingle83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectSingle92,PgClassExpression93,PgClassExpression94,JSONParse95,Access96,PgSelect97,First99,PgSelectSingle100,PgClassExpression101,PgClassExpression102,PgClassExpression103 bucket2
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.mermaid
@@ -11,62 +11,65 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ987654321ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸ987654321ᐳ"}}:::plan
     Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant260 & Lambda106 & Lambda109 & Lambda184 & Lambda189 --> PgSelect7
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
-    Lambda106 & Constant110 & Constant111 & Constant112 --> Object113
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
-    Lambda106 & Constant124 & Constant125 & Constant126 --> Object127
-    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
-    Lambda106 & Constant138 & Constant139 & Constant140 --> Object141
-    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
-    Lambda106 & Constant152 & Constant153 & Constant154 --> Object155
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
-    Lambda106 & Constant166 & Constant167 & Constant168 --> Object169
-    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
-    Lambda106 & Constant180 & Constant181 & Constant182 --> Object183
-    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Lambda106 & Constant194 & Constant195 & Constant112 --> Object197
-    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Lambda106 & Constant208 & Constant209 & Constant126 --> Object211
-    Object225{{"Object[225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Lambda106 & Constant222 & Constant223 & Constant140 --> Object225
-    Object239{{"Object[239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant237{{"Constant[237∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Lambda106 & Constant236 & Constant237 & Constant154 --> Object239
-    Object253{{"Object[253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant251{{"Constant[251∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Lambda106 & Constant250 & Constant251 & Constant168 --> Object253
+    Access110{{"Access[110∈0] ➊<br />ᐸ109.0ᐳ"}}:::plan
+    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Lambda190 & Lambda195 --> PgSelect7
+    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
+    Access276{{"Access[276∈0] ➊<br />ᐸ109.1ᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Access276 --> PgUnionAll53
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
+    Lambda106 & Constant111 & Constant112 & Constant113 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
+    Lambda106 & Constant126 & Constant127 & Constant128 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
+    Lambda106 & Constant141 & Constant142 & Constant143 --> Object144
+    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
+    Lambda106 & Constant156 & Constant157 & Constant158 --> Object159
+    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
+    Lambda106 & Constant171 & Constant172 & Constant173 --> Object174
+    Object189{{"Object[189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
+    Lambda106 & Constant186 & Constant187 & Constant188 --> Object189
+    Object204{{"Object[204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Lambda106 & Constant201 & Constant202 & Constant113 --> Object204
+    Object219{{"Object[219∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Lambda106 & Constant216 & Constant217 & Constant128 --> Object219
+    Object234{{"Object[234∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant231{{"Constant[231∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Lambda106 & Constant231 & Constant232 & Constant143 --> Object234
+    Object249{{"Object[249∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Lambda106 & Constant246 & Constant247 & Constant158 --> Object249
+    Object264{{"Object[264∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant261{{"Constant[261∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Lambda106 & Constant261 & Constant262 & Constant173 --> Object264
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -74,8 +77,6 @@ graph TD
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
     PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
-    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
-    Object10 & Constant260 --> PgUnionAll53
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -87,75 +88,78 @@ graph TD
     PgUnionAll53 --> First55
     PgUnionAllSingle56["PgUnionAllSingle[56∈0] ➊"]:::plan
     First55 --> PgUnionAllSingle56
-    Constant261{{"Constant[261∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant261 --> Lambda106
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant262 --> Lambda109
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object113 --> Lambda114
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant263 --> Lambda119
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object127 --> Lambda128
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant264{{"Constant[264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant264 --> Lambda133
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object141 --> Lambda142
-    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant265 --> Lambda147
-    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object155 --> Lambda156
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant266 --> Lambda161
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object169 --> Lambda170
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant278 --> Lambda106
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant279 --> Lambda109
+    Lambda109 --> Access110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant280 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant281 --> Lambda135
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant282 --> Lambda150
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object159 --> Lambda160
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant283 --> Lambda165
     Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant267 --> Lambda175
-    Object183 --> Lambda184
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant268 --> Lambda189
-    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object197 --> Lambda198
-    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant269 --> Lambda203
-    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object211 --> Lambda212
-    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant270 --> Lambda217
-    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object225 --> Lambda226
-    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant271 --> Lambda231
+    Object174 --> Lambda175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant284 --> Lambda180
+    Object189 --> Lambda190
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant285 --> Lambda195
+    Lambda205{{"Lambda[205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object204 --> Lambda205
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant286 --> Lambda210
+    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object219 --> Lambda220
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant287 --> Lambda225
+    Lambda235{{"Lambda[235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object234 --> Lambda235
     Lambda240{{"Lambda[240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object239 --> Lambda240
-    Lambda245{{"Lambda[245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant272 --> Lambda245
-    Lambda254{{"Lambda[254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object253 --> Lambda254
-    Lambda259{{"Lambda[259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant273 --> Lambda259
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant288 --> Lambda240
+    Lambda250{{"Lambda[250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object249 --> Lambda250
+    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant289 --> Lambda255
+    Lambda265{{"Lambda[265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object264 --> Lambda265
+    Lambda270{{"Lambda[270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant290 --> Lambda270
+    Lambda109 --> Access276
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda114 & Lambda119 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda115 & Lambda120 --> PgSelect16
     PgSelect24[["PgSelect[24∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda128 & Lambda133 --> PgSelect24
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda130 & Lambda135 --> PgSelect24
     PgSelect32[["PgSelect[32∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda142 & Lambda147 --> PgSelect32
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda145 & Lambda150 --> PgSelect32
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda156 & Lambda161 --> PgSelect39
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda160 & Lambda165 --> PgSelect39
     PgSelect45[["PgSelect[45∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda170 & Lambda175 --> PgSelect45
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda175 & Lambda180 --> PgSelect45
     PgSelectSingle12 --> PgClassExpression15
     First20{{"First[20∈1] ➊"}}:::plan
     PgSelect16 --> First20
@@ -207,19 +211,19 @@ graph TD
     PgSelectSingle48 --> PgClassExpression51
     PgSelect60[["PgSelect[60∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     Access59{{"Access[59∈2] ➊<br />ᐸ58.0ᐳ"}}:::plan
-    Object10 & Access59 & Lambda106 & Lambda109 & Lambda198 & Lambda203 --> PgSelect60
+    Object10 & Access59 & Lambda106 & Access110 & Lambda205 & Lambda210 --> PgSelect60
     PgSelect70[["PgSelect[70∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Access69{{"Access[69∈2] ➊<br />ᐸ68.0ᐳ"}}:::plan
-    Object10 & Access69 & Lambda106 & Lambda109 & Lambda212 & Lambda217 --> PgSelect70
+    Object10 & Access69 & Lambda106 & Access110 & Lambda220 & Lambda225 --> PgSelect70
     PgSelect80[["PgSelect[80∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
     Access79{{"Access[79∈2] ➊<br />ᐸ78.0ᐳ"}}:::plan
-    Object10 & Access79 & Lambda106 & Lambda109 & Lambda226 & Lambda231 --> PgSelect80
+    Object10 & Access79 & Lambda106 & Access110 & Lambda235 & Lambda240 --> PgSelect80
     PgSelect89[["PgSelect[89∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
     Access88{{"Access[88∈2] ➊<br />ᐸ87.0ᐳ"}}:::plan
-    Object10 & Access88 & Lambda106 & Lambda109 & Lambda240 & Lambda245 --> PgSelect89
+    Object10 & Access88 & Lambda106 & Access110 & Lambda250 & Lambda255 --> PgSelect89
     PgSelect97[["PgSelect[97∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access96{{"Access[96∈2] ➊<br />ᐸ95.0ᐳ"}}:::plan
-    Object10 & Access96 & Lambda106 & Lambda109 & Lambda254 & Lambda259 --> PgSelect97
+    Object10 & Access96 & Lambda106 & Access110 & Lambda265 & Lambda270 --> PgSelect97
     Access57{{"Access[57∈2] ➊<br />ᐸ56.1ᐳ<br />ᐳUnionTopic"}}:::plan
     PgUnionAllSingle56 --> Access57
     JSONParse58[["JSONParse[58∈2] ➊<br />ᐸ57ᐳ"]]:::plan
@@ -289,13 +293,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-987654321"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 110, 111, 112, 124, 125, 126, 138, 139, 140, 152, 153, 154, 166, 167, 168, 180, 181, 182, 194, 195, 208, 209, 222, 223, 236, 237, 250, 251, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 10, 106, 109, 113, 114, 119, 127, 128, 133, 141, 142, 147, 155, 156, 161, 169, 170, 175, 183, 184, 189, 197, 198, 203, 211, 212, 217, 225, 226, 231, 239, 240, 245, 253, 254, 259<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 111, 112, 113, 126, 127, 128, 141, 142, 143, 156, 157, 158, 171, 172, 173, 186, 187, 188, 201, 202, 216, 217, 231, 232, 246, 247, 261, 262, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 10, 106, 109, 110, 114, 115, 120, 129, 130, 135, 144, 145, 150, 159, 160, 165, 174, 175, 180, 189, 190, 195, 204, 205, 210, 219, 220, 225, 234, 235, 240, 249, 250, 255, 264, 265, 270, 276<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Constant110,Constant111,Constant112,Object113,Lambda114,Lambda119,Constant124,Constant125,Constant126,Object127,Lambda128,Lambda133,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant194,Constant195,Object197,Lambda198,Lambda203,Constant208,Constant209,Object211,Lambda212,Lambda217,Constant222,Constant223,Object225,Lambda226,Lambda231,Constant236,Constant237,Object239,Lambda240,Lambda245,Constant250,Constant251,Object253,Lambda254,Lambda259,Constant260,Constant261,Constant262,Constant263,Constant264,Constant265,Constant266,Constant267,Constant268,Constant269,Constant270,Constant271,Constant272,Constant273 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 109, 114, 119, 128, 133, 142, 147, 156, 161, 170, 175, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Access110,Constant111,Constant112,Constant113,Object114,Lambda115,Lambda120,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant186,Constant187,Constant188,Object189,Lambda190,Lambda195,Constant201,Constant202,Object204,Lambda205,Lambda210,Constant216,Constant217,Object219,Lambda220,Lambda225,Constant231,Constant232,Object234,Lambda235,Lambda240,Constant246,Constant247,Object249,Lambda250,Lambda255,Constant261,Constant262,Object264,Lambda265,Lambda270,Access276,Constant277,Constant278,Constant279,Constant280,Constant281,Constant282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289,Constant290 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 110, 115, 120, 130, 135, 145, 150, 160, 165, 175, 180, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect24,First26,PgSelectSingle27,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First34,PgSelectSingle35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 109, 198, 203, 212, 217, 226, 231, 240, 245, 254, 259<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 110, 205, 210, 220, 225, 235, 240, 250, 255, 265, 270<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access57,JSONParse58,Access59,PgSelect60,First64,PgSelectSingle65,PgClassExpression66,PgClassExpression67,JSONParse68,Access69,PgSelect70,First72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,PgClassExpression76,PgClassExpression77,JSONParse78,Access79,PgSelect80,First82,PgSelectSingle83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectSingle92,PgClassExpression93,PgClassExpression94,JSONParse95,Access96,PgSelect97,First99,PgSelectSingle100,PgClassExpression101,PgClassExpression102,PgClassExpression103 bucket2
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.mermaid
@@ -11,62 +11,65 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ987654321ᐳ"}}:::plan
+    Constant277{{"Constant[277∈0] ➊<br />ᐸ987654321ᐳ"}}:::plan
     Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant260 & Lambda106 & Lambda109 & Lambda184 & Lambda189 --> PgSelect7
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
-    Lambda106 & Constant110 & Constant111 & Constant112 --> Object113
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
-    Lambda106 & Constant124 & Constant125 & Constant126 --> Object127
-    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
-    Lambda106 & Constant138 & Constant139 & Constant140 --> Object141
-    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
-    Lambda106 & Constant152 & Constant153 & Constant154 --> Object155
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
-    Lambda106 & Constant166 & Constant167 & Constant168 --> Object169
-    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
-    Lambda106 & Constant180 & Constant181 & Constant182 --> Object183
-    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
-    Lambda106 & Constant194 & Constant195 & Constant112 --> Object197
-    Object211{{"Object[211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
-    Lambda106 & Constant208 & Constant209 & Constant126 --> Object211
-    Object225{{"Object[225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
-    Lambda106 & Constant222 & Constant223 & Constant140 --> Object225
-    Object239{{"Object[239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant237{{"Constant[237∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
-    Lambda106 & Constant236 & Constant237 & Constant154 --> Object239
-    Object253{{"Object[253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant251{{"Constant[251∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
-    Lambda106 & Constant250 & Constant251 & Constant168 --> Object253
+    Access110{{"Access[110∈0] ➊<br />ᐸ109.0ᐳ"}}:::plan
+    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Lambda190 & Lambda195 --> PgSelect7
+    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
+    Access276{{"Access[276∈0] ➊<br />ᐸ109.1ᐳ"}}:::plan
+    Object10 & Constant277 & Lambda106 & Access110 & Access276 --> PgUnionAll53
+    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸRecordCodec(union_topics)ᐳ"}}:::plan
+    Lambda106 & Constant111 & Constant112 & Constant113 --> Object114
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(union_posts)ᐳ"}}:::plan
+    Lambda106 & Constant126 & Constant127 & Constant128 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(union_dividers)ᐳ"}}:::plan
+    Lambda106 & Constant141 & Constant142 & Constant143 --> Object144
+    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(union_checklists)ᐳ"}}:::plan
+    Lambda106 & Constant156 & Constant157 & Constant158 --> Object159
+    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(union_checklist_items)ᐳ"}}:::plan
+    Lambda106 & Constant171 & Constant172 & Constant173 --> Object174
+    Object189{{"Object[189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸsql.identifier(”union_items”)ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸRecordCodec(union_items)ᐳ"}}:::plan
+    Lambda106 & Constant186 & Constant187 & Constant188 --> Object189
+    Object204{{"Object[204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸsql.identifier(”union_topics”)ᐳ"}}:::plan
+    Lambda106 & Constant201 & Constant202 & Constant113 --> Object204
+    Object219{{"Object[219∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸsql.identifier(”union_posts”)ᐳ"}}:::plan
+    Lambda106 & Constant216 & Constant217 & Constant128 --> Object219
+    Object234{{"Object[234∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant231{{"Constant[231∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant232{{"Constant[232∈0] ➊<br />ᐸsql.identifier(”union_dividers”)ᐳ"}}:::plan
+    Lambda106 & Constant231 & Constant232 & Constant143 --> Object234
+    Object249{{"Object[249∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸsql.identifier(”union_checklists”)ᐳ"}}:::plan
+    Lambda106 & Constant246 & Constant247 & Constant158 --> Object249
+    Object264{{"Object[264∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant261{{"Constant[261∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸsql.identifier(”union_checklist_items”)ᐳ"}}:::plan
+    Lambda106 & Constant261 & Constant262 & Constant173 --> Object264
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -74,8 +77,6 @@ graph TD
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
     PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
-    PgUnionAll53[["PgUnionAll[53∈0] ➊"]]:::plan
-    Object10 & Constant260 --> PgUnionAll53
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -87,75 +88,78 @@ graph TD
     PgUnionAll53 --> First55
     PgUnionAllSingle56["PgUnionAllSingle[56∈0] ➊"]:::plan
     First55 --> PgUnionAllSingle56
-    Constant261{{"Constant[261∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant261 --> Lambda106
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant262 --> Lambda109
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object113 --> Lambda114
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant263{{"Constant[263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant263 --> Lambda119
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object127 --> Lambda128
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant264{{"Constant[264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant264 --> Lambda133
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object141 --> Lambda142
-    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant265 --> Lambda147
-    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object155 --> Lambda156
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant266 --> Lambda161
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object169 --> Lambda170
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant278 --> Lambda106
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant279 --> Lambda109
+    Lambda109 --> Access110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object114 --> Lambda115
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant280 --> Lambda120
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant281 --> Lambda135
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant282{{"Constant[282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant282 --> Lambda150
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object159 --> Lambda160
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant283 --> Lambda165
     Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant267 --> Lambda175
-    Object183 --> Lambda184
-    Constant268{{"Constant[268∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant268 --> Lambda189
-    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object197 --> Lambda198
-    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant269 --> Lambda203
-    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object211 --> Lambda212
-    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant270 --> Lambda217
-    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object225 --> Lambda226
-    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant271 --> Lambda231
+    Object174 --> Lambda175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant284 --> Lambda180
+    Object189 --> Lambda190
+    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant285 --> Lambda195
+    Lambda205{{"Lambda[205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object204 --> Lambda205
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant286 --> Lambda210
+    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object219 --> Lambda220
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant287 --> Lambda225
+    Lambda235{{"Lambda[235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object234 --> Lambda235
     Lambda240{{"Lambda[240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object239 --> Lambda240
-    Lambda245{{"Lambda[245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant272 --> Lambda245
-    Lambda254{{"Lambda[254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object253 --> Lambda254
-    Lambda259{{"Lambda[259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
-    Constant273 --> Lambda259
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant288 --> Lambda240
+    Lambda250{{"Lambda[250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object249 --> Lambda250
+    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant289 --> Lambda255
+    Lambda265{{"Lambda[265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object264 --> Lambda265
+    Lambda270{{"Lambda[270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”union_ᐳ"}}:::plan
+    Constant290 --> Lambda270
+    Lambda109 --> Access276
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda114 & Lambda119 --> PgSelect16
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda115 & Lambda120 --> PgSelect16
     PgSelect24[["PgSelect[24∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda128 & Lambda133 --> PgSelect24
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda130 & Lambda135 --> PgSelect24
     PgSelect32[["PgSelect[32∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda142 & Lambda147 --> PgSelect32
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda145 & Lambda150 --> PgSelect32
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda156 & Lambda161 --> PgSelect39
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda160 & Lambda165 --> PgSelect39
     PgSelect45[["PgSelect[45∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
-    Object10 & PgClassExpression15 & Lambda106 & Lambda109 & Lambda170 & Lambda175 --> PgSelect45
+    Object10 & PgClassExpression15 & Lambda106 & Access110 & Lambda175 & Lambda180 --> PgSelect45
     PgSelectSingle12 --> PgClassExpression15
     First20{{"First[20∈1] ➊"}}:::plan
     PgSelect16 --> First20
@@ -207,19 +211,19 @@ graph TD
     PgSelectSingle48 --> PgClassExpression51
     PgSelect60[["PgSelect[60∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     Access59{{"Access[59∈2] ➊<br />ᐸ58.0ᐳ"}}:::plan
-    Object10 & Access59 & Lambda106 & Lambda109 & Lambda198 & Lambda203 --> PgSelect60
+    Object10 & Access59 & Lambda106 & Access110 & Lambda205 & Lambda210 --> PgSelect60
     PgSelect70[["PgSelect[70∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Access69{{"Access[69∈2] ➊<br />ᐸ68.0ᐳ"}}:::plan
-    Object10 & Access69 & Lambda106 & Lambda109 & Lambda212 & Lambda217 --> PgSelect70
+    Object10 & Access69 & Lambda106 & Access110 & Lambda220 & Lambda225 --> PgSelect70
     PgSelect80[["PgSelect[80∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
     Access79{{"Access[79∈2] ➊<br />ᐸ78.0ᐳ"}}:::plan
-    Object10 & Access79 & Lambda106 & Lambda109 & Lambda226 & Lambda231 --> PgSelect80
+    Object10 & Access79 & Lambda106 & Access110 & Lambda235 & Lambda240 --> PgSelect80
     PgSelect89[["PgSelect[89∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
     Access88{{"Access[88∈2] ➊<br />ᐸ87.0ᐳ"}}:::plan
-    Object10 & Access88 & Lambda106 & Lambda109 & Lambda240 & Lambda245 --> PgSelect89
+    Object10 & Access88 & Lambda106 & Access110 & Lambda250 & Lambda255 --> PgSelect89
     PgSelect97[["PgSelect[97∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access96{{"Access[96∈2] ➊<br />ᐸ95.0ᐳ"}}:::plan
-    Object10 & Access96 & Lambda106 & Lambda109 & Lambda254 & Lambda259 --> PgSelect97
+    Object10 & Access96 & Lambda106 & Access110 & Lambda265 & Lambda270 --> PgSelect97
     Access57{{"Access[57∈2] ➊<br />ᐸ56.1ᐳ<br />ᐳUnionTopic"}}:::plan
     PgUnionAllSingle56 --> Access57
     JSONParse58[["JSONParse[58∈2] ➊<br />ᐸ57ᐳ"]]:::plan
@@ -289,13 +293,13 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-987654321"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 110, 111, 112, 124, 125, 126, 138, 139, 140, 152, 153, 154, 166, 167, 168, 180, 181, 182, 194, 195, 208, 209, 222, 223, 236, 237, 250, 251, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 10, 106, 109, 113, 114, 119, 127, 128, 133, 141, 142, 147, 155, 156, 161, 169, 170, 175, 183, 184, 189, 197, 198, 203, 211, 212, 217, 225, 226, 231, 239, 240, 245, 253, 254, 259<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 111, 112, 113, 126, 127, 128, 141, 142, 143, 156, 157, 158, 171, 172, 173, 186, 187, 188, 201, 202, 216, 217, 231, 232, 246, 247, 261, 262, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 10, 106, 109, 110, 114, 115, 120, 129, 130, 135, 144, 145, 150, 159, 160, 165, 174, 175, 180, 189, 190, 195, 204, 205, 210, 219, 220, 225, 234, 235, 240, 249, 250, 255, 264, 265, 270, 276<br />2: PgSelect[7], PgUnionAll[53]<br />ᐳ: 11, 12, 13, 14, 55<br />3: PgUnionAllSingle[56]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Constant110,Constant111,Constant112,Object113,Lambda114,Lambda119,Constant124,Constant125,Constant126,Object127,Lambda128,Lambda133,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant166,Constant167,Constant168,Object169,Lambda170,Lambda175,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant194,Constant195,Object197,Lambda198,Lambda203,Constant208,Constant209,Object211,Lambda212,Lambda217,Constant222,Constant223,Object225,Lambda226,Lambda231,Constant236,Constant237,Object239,Lambda240,Lambda245,Constant250,Constant251,Object253,Lambda254,Lambda259,Constant260,Constant261,Constant262,Constant263,Constant264,Constant265,Constant266,Constant267,Constant268,Constant269,Constant270,Constant271,Constant272,Constant273 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 109, 114, 119, 128, 133, 142, 147, 156, 161, 170, 175, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgUnionAll53,First55,PgUnionAllSingle56,Lambda106,Lambda109,Access110,Constant111,Constant112,Constant113,Object114,Lambda115,Lambda120,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant186,Constant187,Constant188,Object189,Lambda190,Lambda195,Constant201,Constant202,Object204,Lambda205,Lambda210,Constant216,Constant217,Object219,Lambda220,Lambda225,Constant231,Constant232,Object234,Lambda235,Lambda240,Constant246,Constant247,Object249,Lambda250,Lambda255,Constant261,Constant262,Object264,Lambda265,Lambda270,Access276,Constant277,Constant278,Constant279,Constant280,Constant281,Constant282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289,Constant290 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 12, 10, 106, 110, 115, 120, 130, 135, 145, 150, 160, 165, 175, 180, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[15]<br />2: 16, 24, 32, 39, 45<br />ᐳ: 20, 21, 22, 23, 26, 27, 28, 29, 30, 31, 34, 35, 36, 37, 38, 41, 42, 43, 44, 47, 48, 49, 50, 51"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect24,First26,PgSelectSingle27,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First34,PgSelectSingle35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 109, 198, 203, 212, 217, 226, 231, 240, 245, 254, 259<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 56, 10, 106, 110, 205, 210, 220, 225, 235, 240, 250, 255, 265, 270<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[57]<br />2: 58, 68, 78, 87, 95<br />ᐳ: 59, 69, 79, 88, 96<br />3: 60, 70, 80, 89, 97<br />ᐳ: 64, 65, 66, 67, 72, 73, 74, 75, 76, 77, 82, 83, 84, 85, 86, 91, 92, 93, 94, 99, 100, 101, 102, 103"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access57,JSONParse58,Access59,PgSelect60,First64,PgSelectSingle65,PgClassExpression66,PgClassExpression67,JSONParse68,Access69,PgSelect70,First72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,PgClassExpression76,PgClassExpression77,JSONParse78,Access79,PgSelect80,First82,PgSelectSingle83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectSingle92,PgClassExpression93,PgClassExpression94,JSONParse95,Access96,PgSelect97,First99,PgSelectSingle100,PgClassExpression101,PgClassExpression102,PgClassExpression103 bucket2
     Bucket0 --> Bucket1 & Bucket2

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.deopt.mermaid
@@ -9,6 +9,22 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda45 & Constant80 & Constant81 & Constant82 --> Object83
     Listen9["Listen[9∈0@s] ➊"]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊"}}:::plan
@@ -17,56 +33,42 @@ graph TD
     Access17{{"Access[17∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access18{{"Access[18∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access17 & Access18 --> Object19
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
-    Constant87 --> Lambda7
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
+    Constant90 --> Lambda7
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access17
     __Value2 --> Access18
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant88 --> Lambda45
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant91 --> Lambda45
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant89 --> Lambda48
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant92 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant93 --> Lambda59
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant94 --> Lambda74
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object83 --> Lambda84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant95 --> Lambda89
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object52{{"Object[52∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object66{{"Object[66∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant63 & Constant64 & Constant65 --> Object66
-    Object80{{"Object[80∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant77 & Constant78 & Constant79 --> Object80
     __Item10[/"__Item[10∈1]<br />ᐸ9ᐳ"\]:::itemplan
     Listen9 ==> __Item10
     JSONParse11[["JSONParse[11∈1]<br />ᐸ10ᐳ"]]:::plan
     __Item10 --> JSONParse11
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant90 --> Lambda58
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object66 --> Lambda67
-    Lambda72{{"Lambda[72∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant91 --> Lambda72
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object80 --> Lambda81
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant92 --> Lambda86
     PgSelect16[["PgSelect[16∈2]<br />ᐸmessagesᐳ"]]:::plan
     Access15{{"Access[15∈2]<br />ᐸ11.idᐳ"}}:::plan
-    Object19 & Access15 & Lambda45 & Lambda48 & Lambda81 & Lambda86 --> PgSelect16
+    Object19 & Access15 & Lambda45 & Access49 & Lambda84 & Lambda89 --> PgSelect16
     Access13{{"Access[13∈2]<br />ᐸ11.opᐳ"}}:::plan
     JSONParse11 --> Access13
     Lambda14{{"Lambda[14∈2]"}}:::plan
@@ -78,10 +80,10 @@ graph TD
     First20 --> PgSelectSingle21
     PgSelect27[["PgSelect[27∈3]<br />ᐸforumsᐳ"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
-    Object19 & PgClassExpression26 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect27
+    Object19 & PgClassExpression26 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect27
     PgSelect37[["PgSelect[37∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object19 & PgClassExpression36 & Lambda45 & Lambda48 & Lambda67 & Lambda72 --> PgSelect37
+    Object19 & PgClassExpression36 & Lambda45 & Access49 & Lambda69 & Lambda74 --> PgSelect37
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression22
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__messages__.”featured”ᐳ"}}:::plan
@@ -112,16 +114,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for subscriptions/basics/forum-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 17, 18, 49, 50, 51, 63, 64, 65, 77, 78, 79, 87, 88, 89, 90, 91, 92, 7, 19, 45, 48<br />2: Listen[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 17, 18, 50, 51, 52, 65, 66, 67, 80, 81, 82, 90, 91, 92, 93, 94, 95, 7, 19, 45, 48, 49, 53, 54, 59, 68, 69, 74, 83, 84, 89<br />2: Listen[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Access17,Access18,Object19,Lambda45,Lambda48,Constant49,Constant50,Constant51,Constant63,Constant64,Constant65,Constant77,Constant78,Constant79,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92 bucket0
-    Bucket1("Bucket 1 (subscription)<br />Deps: 45, 49, 50, 51, 90, 63, 64, 65, 91, 77, 78, 79, 92, 19, 48, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Access17,Access18,Object19,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant90,Constant91,Constant92,Constant93,Constant94,Constant95 bucket0
+    Bucket1("Bucket 1 (subscription)<br />Deps: 19, 45, 49, 84, 89, 54, 59, 69, 74, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,JSONParse11,Object52,Lambda53,Lambda58,Object66,Lambda67,Lambda72,Object80,Lambda81,Lambda86 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 45, 48, 81, 86, 53, 58, 67, 72<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
+    class Bucket1,__Item10,JSONParse11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 45, 49, 84, 89, 54, 59, 69, 74<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access13,Lambda14,Access15,PgSelect16,First20,PgSelectSingle21 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 19, 45, 48, 53, 58, 67, 72<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[21]<br />1: <br />ᐳ: 22, 23, 24, 25, 26, 36<br />2: PgSelect[27], PgSelect[37]<br />ᐳ: 31, 32, 39, 40"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 19, 45, 49, 54, 59, 69, 74<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[21]<br />1: <br />ᐳ: 22, 23, 24, 25, 26, 36<br />2: PgSelect[27], PgSelect[37]<br />ᐳ: 31, 32, 39, 40"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression36,PgSelect37,First39,PgSelectSingle40 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32, 26<br /><br />ROOT PgSelectSingle{3}ᐸforumsᐳ[32]"):::bucket

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.mermaid
@@ -9,64 +9,66 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda45 & Constant67 & Constant68 & Constant69 --> Object70
+    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda45 & Constant84 & Constant85 & Constant86 --> Object87
     Listen9["Listen[9∈0@s] ➊"]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊"}}:::plan
     Access8 & Lambda7 --> Listen9
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
-    Constant91 --> Lambda7
+    Object19{{"Object[19∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access17{{"Access[17∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access18{{"Access[18∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access17 & Access18 --> Object19
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
+    Constant94 --> Lambda7
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant92 --> Lambda45
+    __Value2 --> Access17
+    __Value2 --> Access18
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant96 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant97 --> Lambda59
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant98 --> Lambda76
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object87 --> Lambda88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant99 --> Lambda93
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object52{{"Object[52∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object68{{"Object[68∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
-    Object84{{"Object[84∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant81 & Constant82 & Constant83 --> Object84
-    Object19{{"Object[19∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access17{{"Access[17∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access17 & Access18 --> Object19
     __Item10[/"__Item[10∈1]<br />ᐸ9ᐳ"\]:::itemplan
     Listen9 ==> __Item10
     JSONParse11[["JSONParse[11∈1]<br />ᐸ10ᐳ"]]:::plan
     __Item10 --> JSONParse11
-    __Value2 --> Access17
-    __Value2 --> Access18
-    Lambda48{{"Lambda[48∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant93 --> Lambda48
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant94 --> Lambda58
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object68 --> Lambda69
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant95 --> Lambda74
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object84 --> Lambda85
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant96 --> Lambda90
     PgSelect16[["PgSelect[16∈2]<br />ᐸmessagesᐳ"]]:::plan
     Access15{{"Access[15∈2]<br />ᐸ11.idᐳ"}}:::plan
-    Object19 & Access15 & Lambda48 & Lambda53 & Lambda58 & Lambda48 & Lambda69 & Lambda74 & Lambda45 & Lambda48 & Lambda85 & Lambda90 --> PgSelect16
+    Object19 & Access15 & Access49 & Lambda54 & Lambda59 & Access49 & Lambda71 & Lambda76 & Lambda45 & Access49 & Lambda88 & Lambda93 --> PgSelect16
     Access13{{"Access[13∈2]<br />ᐸ11.opᐳ"}}:::plan
     JSONParse11 --> Access13
     Lambda14{{"Lambda[14∈2]"}}:::plan
@@ -85,13 +87,13 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ(__message... not null)ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression25
     PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸforumsᐳ"}}:::plan
-    RemapKeys59{{"RemapKeys[59∈3]<br />ᐸ21:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys59 --> PgSelectSingle32
+    RemapKeys60{{"RemapKeys[60∈3]<br />ᐸ21:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys60 --> PgSelectSingle32
     PgSelectSingle40{{"PgSelectSingle[40∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys75{{"RemapKeys[75∈3]<br />ᐸ21:{”0”:7,”1”:8}ᐳ"}}:::plan
-    RemapKeys75 --> PgSelectSingle40
-    PgSelectSingle21 --> RemapKeys59
-    PgSelectSingle21 --> RemapKeys75
+    RemapKeys77{{"RemapKeys[77∈3]<br />ᐸ21:{”0”:7,”1”:8}ᐳ"}}:::plan
+    RemapKeys77 --> PgSelectSingle40
+    PgSelectSingle21 --> RemapKeys60
+    PgSelectSingle21 --> RemapKeys77
     PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression26
     PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
@@ -106,18 +108,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for subscriptions/basics/forum-messages"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 49, 50, 51, 65, 66, 67, 81, 82, 83, 91, 92, 93, 94, 95, 96, 7, 45<br />2: Listen[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 17, 18, 50, 51, 52, 67, 68, 69, 84, 85, 86, 94, 95, 96, 97, 98, 99, 7, 19, 45, 48, 49, 53, 54, 59, 70, 71, 76, 87, 88, 93<br />2: Listen[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Lambda45,Constant49,Constant50,Constant51,Constant65,Constant66,Constant67,Constant81,Constant82,Constant83,Constant91,Constant92,Constant93,Constant94,Constant95,Constant96 bucket0
-    Bucket1("Bucket 1 (subscription)<br />Deps: 2, 93, 45, 49, 50, 51, 94, 65, 66, 67, 95, 81, 82, 83, 96, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Access17,Access18,Object19,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (subscription)<br />Deps: 19, 49, 54, 59, 71, 76, 45, 88, 93, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,JSONParse11,Access17,Access18,Object19,Lambda48,Object52,Lambda53,Lambda58,Object68,Lambda69,Lambda74,Object84,Lambda85,Lambda90 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 48, 53, 58, 69, 74, 45, 85, 90<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
+    class Bucket1,__Item10,JSONParse11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 49, 54, 59, 71, 76, 45, 88, 93<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access13,Lambda14,Access15,PgSelect16,First20,PgSelectSingle21 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgSelectSingle32,PgSelectSingle40,RemapKeys59,RemapKeys75 bucket3
+    class Bucket3,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgSelectSingle32,PgSelectSingle40,RemapKeys60,RemapKeys77 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 21, 32<br /><br />ROOT PgSelectSingle{3}ᐸforumsᐳ[32]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression26,PgClassExpression34,PgClassExpression35 bucket4

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.deopt.mermaid
@@ -9,6 +9,22 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda45 & Constant80 & Constant81 & Constant82 --> Object83
     Listen9["Listen[9∈0@s] ➊"]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊"}}:::plan
@@ -17,56 +33,42 @@ graph TD
     Access17{{"Access[17∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access18{{"Access[18∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access17 & Access18 --> Object19
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
-    Constant87 --> Lambda7
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
+    Constant90 --> Lambda7
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access17
     __Value2 --> Access18
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant88 --> Lambda45
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant91 --> Lambda45
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant89 --> Lambda48
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant92 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant93 --> Lambda59
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant94 --> Lambda74
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object83 --> Lambda84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant95 --> Lambda89
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object52{{"Object[52∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object66{{"Object[66∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant63 & Constant64 & Constant65 --> Object66
-    Object80{{"Object[80∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant77 & Constant78 & Constant79 --> Object80
     __Item10[/"__Item[10∈1]<br />ᐸ9ᐳ"\]:::itemplan
     Listen9 ==> __Item10
     JSONParse11[["JSONParse[11∈1]<br />ᐸ10ᐳ"]]:::plan
     __Item10 --> JSONParse11
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant90 --> Lambda58
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object66 --> Lambda67
-    Lambda72{{"Lambda[72∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant91 --> Lambda72
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object80 --> Lambda81
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant92 --> Lambda86
     PgSelect16[["PgSelect[16∈2]<br />ᐸmessagesᐳ"]]:::plan
     Access15{{"Access[15∈2]<br />ᐸ11.idᐳ"}}:::plan
-    Object19 & Access15 & Lambda45 & Lambda48 & Lambda81 & Lambda86 --> PgSelect16
+    Object19 & Access15 & Lambda45 & Access49 & Lambda84 & Lambda89 --> PgSelect16
     Access13{{"Access[13∈2]<br />ᐸ11.opᐳ"}}:::plan
     JSONParse11 --> Access13
     Lambda14{{"Lambda[14∈2]"}}:::plan
@@ -78,10 +80,10 @@ graph TD
     First20 --> PgSelectSingle21
     PgSelect27[["PgSelect[27∈3]<br />ᐸforumsᐳ"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
-    Object19 & PgClassExpression26 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect27
+    Object19 & PgClassExpression26 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect27
     PgSelect37[["PgSelect[37∈3]<br />ᐸusersᐳ"]]:::plan
     PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸ__messages...author_id”ᐳ"}}:::plan
-    Object19 & PgClassExpression36 & Lambda45 & Lambda48 & Lambda67 & Lambda72 --> PgSelect37
+    Object19 & PgClassExpression36 & Lambda45 & Access49 & Lambda69 & Lambda74 --> PgSelect37
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__messages__.”id”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression22
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__messages__.”featured”ᐳ"}}:::plan
@@ -112,16 +114,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for subscriptions/basics/forum-single-message-evolve"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 17, 18, 49, 50, 51, 63, 64, 65, 77, 78, 79, 87, 88, 89, 90, 91, 92, 7, 19, 45, 48<br />2: Listen[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 17, 18, 50, 51, 52, 65, 66, 67, 80, 81, 82, 90, 91, 92, 93, 94, 95, 7, 19, 45, 48, 49, 53, 54, 59, 68, 69, 74, 83, 84, 89<br />2: Listen[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Access17,Access18,Object19,Lambda45,Lambda48,Constant49,Constant50,Constant51,Constant63,Constant64,Constant65,Constant77,Constant78,Constant79,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92 bucket0
-    Bucket1("Bucket 1 (subscription)<br />Deps: 45, 49, 50, 51, 90, 63, 64, 65, 91, 77, 78, 79, 92, 19, 48, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Access17,Access18,Object19,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant90,Constant91,Constant92,Constant93,Constant94,Constant95 bucket0
+    Bucket1("Bucket 1 (subscription)<br />Deps: 19, 45, 49, 84, 89, 54, 59, 69, 74, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,JSONParse11,Object52,Lambda53,Lambda58,Object66,Lambda67,Lambda72,Object80,Lambda81,Lambda86 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 45, 48, 81, 86, 53, 58, 67, 72<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
+    class Bucket1,__Item10,JSONParse11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 45, 49, 84, 89, 54, 59, 69, 74<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access13,Lambda14,Access15,PgSelect16,First20,PgSelectSingle21 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 19, 45, 48, 53, 58, 67, 72<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[21]<br />1: <br />ᐳ: 22, 23, 24, 25, 26, 36<br />2: PgSelect[27], PgSelect[37]<br />ᐳ: 31, 32, 39, 40"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 19, 45, 49, 54, 59, 69, 74<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[21]<br />1: <br />ᐳ: 22, 23, 24, 25, 26, 36<br />2: PgSelect[27], PgSelect[37]<br />ᐳ: 31, 32, 39, 40"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression36,PgSelect37,First39,PgSelectSingle40 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32, 26<br /><br />ROOT PgSelectSingle{3}ᐸforumsᐳ[32]"):::bucket

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.mermaid
@@ -9,64 +9,66 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda45 & Constant67 & Constant68 & Constant69 --> Object70
+    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
+    Lambda45 & Constant84 & Constant85 & Constant86 --> Object87
     Listen9["Listen[9∈0@s] ➊"]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊"}}:::plan
     Access8 & Lambda7 --> Listen9
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
-    Constant91 --> Lambda7
+    Object19{{"Object[19∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access17{{"Access[17∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access18{{"Access[18∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access17 & Access18 --> Object19
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ"}}:::plan
+    Constant94 --> Lambda7
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant92 --> Lambda45
+    __Value2 --> Access17
+    __Value2 --> Access18
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant96 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
+    Constant97 --> Lambda59
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant98 --> Lambda76
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object87 --> Lambda88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
+    Constant99 --> Lambda93
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”forums”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(forums)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”messages”)ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸRecordCodec(messages)ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”forumsᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”messagᐳ"}}:::plan
-    Object52{{"Object[52∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object68{{"Object[68∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
-    Object84{{"Object[84∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant81 & Constant82 & Constant83 --> Object84
-    Object19{{"Object[19∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access17{{"Access[17∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access18{{"Access[18∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access17 & Access18 --> Object19
     __Item10[/"__Item[10∈1]<br />ᐸ9ᐳ"\]:::itemplan
     Listen9 ==> __Item10
     JSONParse11[["JSONParse[11∈1]<br />ᐸ10ᐳ"]]:::plan
     __Item10 --> JSONParse11
-    __Value2 --> Access17
-    __Value2 --> Access18
-    Lambda48{{"Lambda[48∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant93 --> Lambda48
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant94 --> Lambda58
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object68 --> Lambda69
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant95 --> Lambda74
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object84 --> Lambda85
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant96 --> Lambda90
     PgSelect16[["PgSelect[16∈2]<br />ᐸmessagesᐳ"]]:::plan
     Access15{{"Access[15∈2]<br />ᐸ11.idᐳ"}}:::plan
-    Object19 & Access15 & Lambda48 & Lambda53 & Lambda58 & Lambda48 & Lambda69 & Lambda74 & Lambda45 & Lambda48 & Lambda85 & Lambda90 --> PgSelect16
+    Object19 & Access15 & Access49 & Lambda54 & Lambda59 & Access49 & Lambda71 & Lambda76 & Lambda45 & Access49 & Lambda88 & Lambda93 --> PgSelect16
     Access13{{"Access[13∈2]<br />ᐸ11.opᐳ"}}:::plan
     JSONParse11 --> Access13
     Lambda14{{"Lambda[14∈2]"}}:::plan
@@ -85,13 +87,13 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ(__message... not null)ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression25
     PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸforumsᐳ"}}:::plan
-    RemapKeys59{{"RemapKeys[59∈3]<br />ᐸ21:{”0”:4,”1”:5}ᐳ"}}:::plan
-    RemapKeys59 --> PgSelectSingle32
+    RemapKeys60{{"RemapKeys[60∈3]<br />ᐸ21:{”0”:4,”1”:5}ᐳ"}}:::plan
+    RemapKeys60 --> PgSelectSingle32
     PgSelectSingle40{{"PgSelectSingle[40∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys75{{"RemapKeys[75∈3]<br />ᐸ21:{”0”:7,”1”:8}ᐳ"}}:::plan
-    RemapKeys75 --> PgSelectSingle40
-    PgSelectSingle21 --> RemapKeys59
-    PgSelectSingle21 --> RemapKeys75
+    RemapKeys77{{"RemapKeys[77∈3]<br />ᐸ21:{”0”:7,”1”:8}ᐳ"}}:::plan
+    RemapKeys77 --> PgSelectSingle40
+    PgSelectSingle21 --> RemapKeys60
+    PgSelectSingle21 --> RemapKeys77
     PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__messages__.”forum_id”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression26
     PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
@@ -106,18 +108,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for subscriptions/basics/forum-single-message-evolve"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 49, 50, 51, 65, 66, 67, 81, 82, 83, 91, 92, 93, 94, 95, 96, 7, 45<br />2: Listen[9]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 17, 18, 50, 51, 52, 67, 68, 69, 84, 85, 86, 94, 95, 96, 97, 98, 99, 7, 19, 45, 48, 49, 53, 54, 59, 70, 71, 76, 87, 88, 93<br />2: Listen[9]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Lambda45,Constant49,Constant50,Constant51,Constant65,Constant66,Constant67,Constant81,Constant82,Constant83,Constant91,Constant92,Constant93,Constant94,Constant95,Constant96 bucket0
-    Bucket1("Bucket 1 (subscription)<br />Deps: 2, 93, 45, 49, 50, 51, 94, 65, 66, 67, 95, 81, 82, 83, 96, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda7,Access8,Listen9,Access17,Access18,Object19,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant84,Constant85,Constant86,Object87,Lambda88,Lambda93,Constant94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (subscription)<br />Deps: 19, 49, 54, 59, 71, 76, 45, 88, 93, 4<br /><br />ROOT __Item{1}ᐸ9ᐳ[10]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item10,JSONParse11,Access17,Access18,Object19,Lambda48,Object52,Lambda53,Lambda58,Object68,Lambda69,Lambda74,Object84,Lambda85,Lambda90 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 48, 53, 58, 69, 74, 45, 85, 90<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
+    class Bucket1,__Item10,JSONParse11 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 19, 49, 54, 59, 71, 76, 45, 88, 93<br /><br />ROOT JSONParse{1}ᐸ10ᐳ[11]<br />1: <br />ᐳ: Access[13], Access[15], Lambda[14]<br />2: PgSelect[16]<br />ᐳ: First[20], PgSelectSingle[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,Access13,Lambda14,Access15,PgSelect16,First20,PgSelectSingle21 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21<br /><br />ROOT PgSelectSingle{2}ᐸmessagesᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgSelectSingle32,PgSelectSingle40,RemapKeys59,RemapKeys75 bucket3
+    class Bucket3,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgSelectSingle32,PgSelectSingle40,RemapKeys60,RemapKeys77 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 21, 32<br /><br />ROOT PgSelectSingle{3}ᐸforumsᐳ[32]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression26,PgClassExpression34,PgClassExpression35 bucket4

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -2211,10 +2211,12 @@ ${lateralText};`;
     const $shouldReverseOrder = this.shouldReverseOrder();
     this.shouldReverseOrderId = this.addUnaryDependency($shouldReverseOrder);
     // This cannot be done in deduplicate because setting fetchOneExtra comes later.
-    const $limitAndOffsets = this.planLimitAndOffsets();
-    this.limitAndOffsetSQL = this.deferredSQL(access($limitAndOffsets, 0));
-    this.orderBySQL = this.deferredSQL(this.planOrderBy($shouldReverseOrder));
-    this.trueOrderBySQL = this.deferredSQL(this.planOrderBy(null));
+    operationPlan().withRootLayerPlan(() => {
+      const $limitAndOffsets = this.planLimitAndOffsets();
+      this.limitAndOffsetSQL = this.deferredSQL(access($limitAndOffsets, 0));
+      this.orderBySQL = this.deferredSQL(this.planOrderBy($shouldReverseOrder));
+      this.trueOrderBySQL = this.deferredSQL(this.planOrderBy(null));
+    });
 
     // PERF: we should serialize our `SELECT` clauses and then if any are
     // identical we should omit the later copies and have them link back to the

--- a/grafast/dataplan-pg/src/steps/pgStmt.ts
+++ b/grafast/dataplan-pg/src/steps/pgStmt.ts
@@ -223,11 +223,11 @@ export abstract class PgStmtBaseStep<T> extends ExecutableStep<T> {
   }
 
   setAfter($parsedCursorPlan: PgSelectParsedCursorStep): void {
-    this.afterStepId = this.addDependency($parsedCursorPlan);
+    this.afterStepId = this.addUnaryDependency($parsedCursorPlan);
   }
 
   setBefore($parsedCursorPlan: PgSelectParsedCursorStep): void {
-    this.beforeStepId = this.addDependency($parsedCursorPlan);
+    this.beforeStepId = this.addUnaryDependency($parsedCursorPlan);
   }
 
   parseCursor(

--- a/grafast/dataplan-pg/src/steps/pgStmt.ts
+++ b/grafast/dataplan-pg/src/steps/pgStmt.ts
@@ -1,10 +1,19 @@
-import type { ExecutionDetails } from "grafast";
-import { applyTransforms, ExecutableStep } from "grafast";
+import type { __InputStaticLeafStep, ExecutionDetails, Maybe } from "grafast";
+import {
+  access,
+  applyTransforms,
+  constant,
+  ExecutableStep,
+  lambda,
+  operationPlan,
+  SafeError,
+} from "grafast";
 import { type SQL, sql } from "pg-sql2";
 
 import type { PgCodec, PgTypedExecutableStep } from "../interfaces.js";
 import type { PgLocker } from "../pgLocker.js";
 import { makeScopedSQL } from "../utils.js";
+import type { PgSelectParsedCursorStep } from "./pgSelect.js";
 
 export interface QueryValue {
   dependencyIndex: number;
@@ -50,6 +59,17 @@ export abstract class PgStmtBaseStep<T> extends ExecutableStep<T> {
    */
   protected abstract placeholders: Array<PgStmtDeferredPlaceholder>;
   protected abstract deferreds: Array<PgStmtDeferredSQL>;
+  protected abstract firstStepId: number | null;
+  protected abstract lastStepId: number | null;
+  protected abstract fetchOneExtra: boolean;
+  protected abstract offsetStepId: number | null;
+  protected abstract beforeStepId: number | null;
+  protected abstract afterStepId: number | null;
+  /** When using natural pagination, this index is the lower bound (and should be excluded) */
+  protected abstract lowerIndexStepId: number | null;
+  /** When using natural pagination, this index is the upper bound (and should be excluded) */
+  protected abstract upperIndexStepId: number | null;
+  protected abstract shouldReverseOrderId: number | null;
 
   public scopedSQL = makeScopedSQL(this);
 
@@ -177,4 +197,327 @@ export abstract class PgStmtBaseStep<T> extends ExecutableStep<T> {
       handlePlaceholder,
     };
   }
+  protected abstract assertCursorPaginationAllowed(): void;
+
+  public setFirst($first: ExecutableStep<Maybe<number>>): this {
+    this.locker.assertParameterUnlocked("first");
+    this.firstStepId = this.addUnaryDependency($first);
+    this.locker.lockParameter("first");
+    return this;
+  }
+
+  public setLast($last: ExecutableStep<Maybe<number>>): this {
+    this.assertCursorPaginationAllowed();
+    this.locker.assertParameterUnlocked("orderBy");
+    this.locker.assertParameterUnlocked("last");
+    this.lastStepId = this.addUnaryDependency($last);
+    this.locker.lockParameter("last");
+    return this;
+  }
+
+  public setOffset($offset: ExecutableStep<Maybe<number>>): this {
+    this.locker.assertParameterUnlocked("offset");
+    this.offsetStepId = this.addUnaryDependency($offset);
+    this.locker.lockParameter("offset");
+    return this;
+  }
+
+  setAfter($parsedCursorPlan: PgSelectParsedCursorStep): void {
+    this.afterStepId = this.addDependency($parsedCursorPlan);
+  }
+
+  setBefore($parsedCursorPlan: PgSelectParsedCursorStep): void {
+    this.beforeStepId = this.addDependency($parsedCursorPlan);
+  }
+
+  parseCursor(
+    $cursorPlan: __InputStaticLeafStep<string>,
+  ): PgSelectParsedCursorStep | null {
+    this.assertCursorPaginationAllowed();
+    if ($cursorPlan.evalIs(null)) {
+      return null;
+    } else if ($cursorPlan.evalIs(undefined)) {
+      return null;
+    }
+
+    const $parsedCursorPlan = lambda($cursorPlan, parseCursor);
+    return $parsedCursorPlan;
+  }
+
+  shouldReverseOrder() {
+    return operationPlan().withRootLayerPlan(() => {
+      const numberDep = (stepId: number | null) =>
+        this.getDepOrConstant<Maybe<number>>(stepId, null);
+      return lambda(
+        {
+          first: numberDep(this.firstStepId),
+          last: numberDep(this.lastStepId),
+          cursorLower: numberDep(this.lowerIndexStepId),
+          cursorUpper: numberDep(this.upperIndexStepId),
+        },
+        calculateShouldReverseOrder,
+        true,
+      );
+    });
+  }
+
+  /**
+   * Someone (probably pageInfo) wants to know if there's more records. To
+   * determine this we fetch one extra record and then throw it away.
+   */
+  public hasMore(): ExecutableStep<boolean> {
+    this.fetchOneExtra = true;
+    return access(this, "hasMore", false);
+  }
+
+  protected getExecutionCommon(executionDetails: ExecutionDetails) {
+    const { values } = executionDetails;
+
+    const first = getUnary<Maybe<number>>(values, this.firstStepId);
+    const last = getUnary<Maybe<number>>(values, this.lastStepId);
+    const offset = getUnary<Maybe<number>>(values, this.offsetStepId);
+
+    if (offset != null && last != null) {
+      throw new SafeError("Cannot use 'offset' with 'last'");
+    }
+
+    if (!this.shouldReverseOrderId) {
+      throw new Error(
+        `Cannot call getExecutionCommon before shouldReverseOrderId has been set`,
+      );
+    }
+
+    /**
+     * If `last` is in use then we reverse the order from the database and then
+     * re-reverse it in JS-land.
+     */
+    const shouldReverseOrder = getUnary<boolean>(
+      values,
+      this.shouldReverseOrderId,
+    );
+
+    return { first, last, offset, shouldReverseOrder };
+  }
+
+  protected abstract limitAndOffsetSQL: SQL | null;
+  protected planLimitAndOffsets() {
+    const numberDep = (stepId: number | null) =>
+      this.getDepOrConstant<Maybe<number>>(stepId, null);
+    return this.operationPlan.withRootLayerPlan(() =>
+      lambda(
+        {
+          first: numberDep(this.firstStepId),
+          last: numberDep(this.lastStepId),
+          cursorLower: numberDep(this.lowerIndexStepId),
+          cursorUpper: numberDep(this.upperIndexStepId),
+          offset: numberDep(this.offsetStepId),
+          fetchOneExtra: constant(this.fetchOneExtra, false),
+        },
+        calculateLimitAndOffsetSQL,
+        true,
+      ),
+    );
+  }
+}
+
+function parseCursor(cursor: string | null) {
+  if (cursor == null) {
+    // This throw should never happen, so we can still be isSyncAndSafe.
+    // If it does throw, the entire lambda will throw, which is allowed.
+    throw new Error(
+      "GrafastInternalError<3b076b86-828b-46b3-885d-ed2577068b8d>: cursor is null, but we have a constraint preventing that...",
+    );
+  }
+  try {
+    if (typeof cursor !== "string") {
+      throw new Error("Invalid cursor");
+    }
+    const decoded = JSON.parse(Buffer.from(cursor, "base64").toString("utf8"));
+    if (!Array.isArray(decoded)) {
+      throw new Error("Expected array");
+    }
+    return decoded;
+  } catch (e) {
+    throw new SafeError(
+      "Invalid cursor, please enter a cursor from a previous request, or null.",
+    );
+  }
+}
+parseCursor.isSyncAndSafe = true; // Optimization
+
+function calculateShouldReverseOrder(params: {
+  first: Maybe<number>;
+  last: Maybe<number>;
+  cursorLower: Maybe<number>;
+  cursorUpper: Maybe<number>;
+}) {
+  const { first, last, cursorLower, cursorUpper } = params;
+  return (
+    first == null && last != null && cursorLower == null && cursorUpper == null
+  );
+}
+
+export function getUnary<T>(
+  values: ExecutionDetails["values"],
+  stepId: number,
+): T;
+export function getUnary<T>(
+  values: ExecutionDetails["values"],
+  stepId: number | null,
+): T | undefined;
+export function getUnary<T>(
+  values: ExecutionDetails["values"],
+  stepId: number | null,
+): T | undefined {
+  return stepId == null ? undefined : (values[stepId].unaryValue() as T);
+}
+
+function calculateLimitAndOffsetSQL(params: {
+  cursorLower: Maybe<number>;
+  cursorUpper: Maybe<number>;
+  first: Maybe<number>;
+  last: Maybe<number>;
+  offset: Maybe<number>;
+  fetchOneExtra: boolean;
+}) {
+  const { cursorLower, cursorUpper, first, last, offset, fetchOneExtra } =
+    params;
+  let limitValue: Maybe<number>;
+  let offsetValue: Maybe<number>;
+  let innerLimitValue: Maybe<number>;
+  if (cursorLower != null || cursorUpper != null) {
+    /*
+     * When using cursor-base pagination with 'natural' cursors, we are actually
+     * applying limit/offset under the hood (presumably because we're paginating
+     * something that has no explicit order, like a function).
+     *
+     * If you have:
+     * - first: 3
+     * - after: ['natural', 4]
+     *
+     * Then we want `limit 3 offset 4`.
+     * With `fetchOneExtra` it'd be `limit 4 offset 4`.
+     *
+     * For:
+     * - last: 2
+     * - before: ['natural', 6]
+     *
+     * We want `limit 2 offset 4`
+     * With `fetchOneExtra` it'd be `limit 3 offset 3`.
+     *
+     * For:
+     * - last: 2
+     * - before: ['natural', 3]
+     *
+     * We want `limit 2`
+     * With `fetchOneExtra` it'd still be `limit 2`.
+     *
+     * For:
+     * - last: 2
+     * - before: ['natural', 4]
+     *
+     * We want `limit 2 offset 1`
+     * With `fetchOneExtra` it'd be `limit 3`.
+     *
+     * Using `offset` with `after`/`before` is forbidden, so we do not need to
+     * consider that.
+     *
+     * For:
+     * - after: ['natural', 2]
+     * - before: ['natural', 6]
+     *
+     * We want `limit 4 offset 2`
+     * With `fetchOneExtra` it'd be `limit 4 offset 2` still.
+     *
+     * For:
+     * - first: 2
+     * - after: ['natural', 2]
+     * - before: ['natural', 6]
+     *
+     * We want `limit 2 offset 2`
+     * With `fetchOneExtra` it'd be `limit 3 offset 2` still.
+     */
+
+    /** lower bound - exclusive (1-indexed) */
+    let lower = 0;
+    /** upper bound - exclusive (1-indexed) */
+    let upper = Infinity;
+
+    // Apply 'after', if present
+    if (cursorLower != null) {
+      lower = Math.max(0, cursorLower);
+    }
+
+    // Apply 'before', if present
+    if (cursorUpper != null) {
+      upper = cursorUpper;
+    }
+
+    // Cannot go beyond these bounds
+    const maxUpper = upper;
+
+    // Apply 'first', if present
+    if (first != null) {
+      upper = Math.min(upper, lower + first + 1);
+    }
+
+    // Apply 'last', if present
+    if (last != null) {
+      lower = Math.max(0, lower, upper - last - 1);
+    }
+
+    // Apply 'offset', if present
+    if (offset != null && offset > 0) {
+      lower = Math.min(lower + offset, maxUpper);
+      upper = Math.min(upper + offset, maxUpper);
+    }
+
+    // If 'fetch one extra', adjust:
+    if (fetchOneExtra) {
+      if (first != null) {
+        upper = upper + 1;
+      } else if (last != null) {
+        lower = Math.max(0, lower - 1);
+      }
+    }
+
+    /** lower, but 0-indexed and inclusive */
+    const lower0 = lower - 1 + 1;
+    /** upper, but 0-indexed and inclusive */
+    const upper0 = upper - 1 - 1;
+
+    // Calculate the final limit/offset
+    limitValue = isFinite(upper0) ? Math.max(0, upper0 - lower0 + 1) : null;
+    offsetValue = lower0;
+
+    innerLimitValue = limitValue != null ? limitValue + offsetValue : null;
+  } else {
+    limitValue =
+      first != null
+        ? first + (fetchOneExtra ? 1 : 0)
+        : last != null
+        ? last + (fetchOneExtra ? 1 : 0)
+        : null;
+    offsetValue = offset;
+
+    innerLimitValue =
+      first != null || last != null
+        ? (first ?? last ?? 0) + (offset ?? 0) + (fetchOneExtra ? 1 : 0)
+        : null;
+  }
+  // PERF: consider changing from `${sql.literal(v)}` to
+  // `${sql.value(v)}::"int4"`. (The advantage being that fewer SQL queries are
+  // generated, and thus chances of reusing a query are greater.)
+  const limitSql =
+    limitValue == null ? sql.blank : sql`\nlimit ${sql.literal(limitValue)}`;
+  const offsetSql =
+    offsetValue == null || offsetValue === 0
+      ? sql.blank
+      : sql`\noffset ${sql.literal(offsetValue)}`;
+  const limitAndOffset = sql`${limitSql}${offsetSql}`;
+  const innerLimitSQL: SQL =
+    innerLimitValue != null
+      ? sql`\nlimit ${sql.literal(innerLimitValue)}`
+      : sql.blank;
+  return [limitAndOffset, innerLimitSQL];
 }

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -21,6 +21,7 @@ import {
   first,
   isPromiseLike,
   list,
+  operationPlan,
   polymorphicWrap,
   reverseArray,
   SafeError,
@@ -1298,9 +1299,11 @@ and ${condition(i + 1)}`}
 
     const $shouldReverseOrder = this.shouldReverseOrder();
     this.shouldReverseOrderId = this.addUnaryDependency($shouldReverseOrder);
-    const $limitAndOffsets = this.planLimitAndOffsets();
-    this.limitAndOffsetSQL = this.deferredSQL(access($limitAndOffsets, 0));
-    this.innerLimitSQL = this.deferredSQL(access($limitAndOffsets, 1));
+    operationPlan().withRootLayerPlan(() => {
+      const $limitAndOffsets = this.planLimitAndOffsets();
+      this.limitAndOffsetSQL = this.deferredSQL(access($limitAndOffsets, 0));
+      this.innerLimitSQL = this.deferredSQL(access($limitAndOffsets, 1));
+    });
 
     return this;
   }

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -2698,8 +2698,9 @@ export class OperationPlan {
     if (this.isImmoveable(step)) {
       return step;
     }
-    if (step instanceof ConstantStep && step.layerPlan === this.rootLayerPlan) {
-      // Don't push constants down
+    if (step._isUnary) {
+      step._isUnaryLocked = true;
+      // Don't push unary steps down
       return step;
     }
     switch (step.layerPlan.reason.type) {

--- a/grafast/grafast/src/steps/connection.ts
+++ b/grafast/grafast/src/steps/connection.ts
@@ -2,6 +2,7 @@ import * as assert from "../assert.js";
 import type {
   ExecutionDetails,
   GrafastResultsList,
+  Maybe,
   UnbatchedExecutionExtra,
 } from "../interfaces.js";
 import type { ExecutableStep } from "../step.js";
@@ -71,13 +72,11 @@ export interface ConnectionCapableStep<
       any
     >,
   ): PageInfoCapableStep;
-  setFirst(first: ExecutableStep<number | null | undefined> | number): void;
-  setLast(last: ExecutableStep<number | null | undefined> | number): void;
-  setOffset(offset: ExecutableStep<number | null | undefined> | number): void;
+  setFirst($first: ExecutableStep<Maybe<number>>): void;
+  setLast($last: ExecutableStep<Maybe<number>>): void;
+  setOffset($offset: ExecutableStep<Maybe<number>>): void;
 
-  parseCursor(
-    $cursor: ExecutableStep<string | null | undefined>,
-  ): TCursorStep | null | undefined;
+  parseCursor($cursor: ExecutableStep<Maybe<string>>): Maybe<TCursorStep>;
   setBefore($before: TCursorStep): void;
   setAfter($after: TCursorStep): void;
 }

--- a/postgraphile/postgraphile/__tests__/mutations/v4/authenticateFail.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/authenticateFail.mermaid
@@ -9,12 +9,12 @@ graph TD
 
 
     %% plan dependencies
-    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”authenticate_fail”)ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
-    Lambda18 & Constant22 & Constant23 & Constant24 --> Object25
+    Constant23{{"Constant[23∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”authenticate_fail”)ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
+    Lambda18 & Constant23 & Constant24 & Constant25 --> Object26
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,19 +22,21 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda18
-    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda21
-    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object25 --> Lambda26
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
-    Constant34 --> Lambda31
+    Constant33 --> Lambda18
+    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda21
+    Access22{{"Access[22∈0] ➊<br />ᐸ21.0ᐳ"}}:::plan
+    Lambda21 --> Access22
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object26 --> Lambda27
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
+    Constant35 --> Lambda32
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect8[["PgSelect[8∈1] ➊<br />ᐸauthenticate_fail(mutation)ᐳ"]]:::sideeffectplan
-    Object11 & Lambda18 & Lambda21 & Lambda26 & Lambda31 --> PgSelect8
+    Object11 & Lambda18 & Access22 & Lambda27 & Lambda32 --> PgSelect8
     First12{{"First[12∈1] ➊"}}:::plan
     PgSelect8 --> First12
     PgSelectSingle13{{"PgSelectSingle[13∈1] ➊<br />ᐸauthenticate_failᐳ"}}:::plan
@@ -49,8 +51,8 @@ graph TD
     subgraph "Buckets for mutations/v4/authenticateFail"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Lambda18,Lambda21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 18, 21, 26, 31<br /><br />1: PgSelect[8]<br />2: <br />ᐳ: 12, 13, 14"):::bucket
+    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Lambda18,Lambda21,Access22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 18, 22, 27, 32<br /><br />1: PgSelect[8]<br />2: <br />ᐳ: 12, 13, 14"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect8,First12,PgSelectSingle13,Object14 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 14<br /><br />ROOT Object{1}ᐸ{result}ᐳ[14]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/b.list_bde_mutation.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/b.list_bde_mutation.mermaid
@@ -9,24 +9,24 @@ graph TD
 
 
     %% plan dependencies
-    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸListCodecᐸuuid[]ᐳ(uuidArray)ᐳ"}}:::plan
-    Lambda70 & Constant74 & Constant75 & Constant76 --> Object77
-    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
-    Lambda70 & Constant88 & Constant89 & Constant76 --> Object91
-    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
-    Lambda70 & Constant102 & Constant103 & Constant76 --> Object105
-    Object119{{"Object[119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
-    Lambda70 & Constant116 & Constant117 & Constant76 --> Object119
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸListCodecᐸuuid[]ᐳ(uuidArray)ᐳ"}}:::plan
+    Lambda70 & Constant75 & Constant76 & Constant77 --> Object78
+    Object93{{"Object[93∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
+    Lambda70 & Constant90 & Constant91 & Constant77 --> Object93
+    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
+    Lambda70 & Constant105 & Constant106 & Constant77 --> Object108
+    Object123{{"Object[123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸsql.identifier(”list_bde_mutation”)ᐳ"}}:::plan
+    Lambda70 & Constant120 & Constant121 & Constant77 --> Object123
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -34,44 +34,46 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant137 --> Lambda70
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant141 --> Lambda70
     Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant138 --> Lambda73
-    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object77 --> Lambda78
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
-    Constant139 --> Lambda83
-    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object91 --> Lambda92
-    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
-    Constant140 --> Lambda97
-    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object105 --> Lambda106
-    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
-    Constant141 --> Lambda111
-    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object119 --> Lambda120
-    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
-    Constant142 --> Lambda125
+    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant142 --> Lambda73
+    Access74{{"Access[74∈0] ➊<br />ᐸ73.0ᐳ"}}:::plan
+    Lambda73 --> Access74
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object78 --> Lambda79
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
+    Constant143 --> Lambda84
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object93 --> Lambda94
+    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
+    Constant144 --> Lambda99
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object108 --> Lambda109
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
+    Constant145 --> Lambda114
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object123 --> Lambda124
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”list_bᐳ"}}:::plan
+    Constant146 --> Lambda129
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ'bar'ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ'q0'ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ''ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ'q1'ᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ'foo'ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸ'q2'ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ'q3'ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ[ 'option-1' ]ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ[ 'option-2' ]ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ'bar'ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ'q0'ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ''ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ'q1'ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸ'foo'ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ'q2'ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸ'q3'ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ[ 'option-1' ]ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ[ 'option-2' ]ᐳ"}}:::plan
     PgSelect12[["PgSelect[12∈1] ➊<br />ᐸlist_bde_mutation(mutation)ᐳ"]]:::sideeffectplan
-    Object15 & Constant128 & Constant126 & Constant127 & Lambda70 & Lambda73 & Lambda78 & Lambda83 --> PgSelect12
+    Object15 & Constant132 & Constant130 & Constant131 & Lambda70 & Access74 & Lambda79 & Lambda84 --> PgSelect12
     First16{{"First[16∈1] ➊"}}:::plan
     PgSelect12 --> First16
     PgSelectSingle17{{"PgSelectSingle[17∈1] ➊<br />ᐸlist_bde_mutationᐳ"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     PgClassExpression18 ==> __Item20
     PgSelect28[["PgSelect[28∈4] ➊<br />ᐸlist_bde_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object31{{"Object[31∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object31 & Constant143 & Constant130 & Constant131 & Lambda70 & Lambda73 & Lambda92 & Lambda97 --> PgSelect28
+    Object31 & Constant147 & Constant134 & Constant135 & Lambda70 & Access74 & Lambda94 & Lambda99 --> PgSelect28
     Access29{{"Access[29∈4] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access30{{"Access[30∈4] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access29 & Access30 --> Object31
@@ -102,7 +104,7 @@ graph TD
     PgClassExpression34 ==> __Item36
     PgSelect43[["PgSelect[43∈7] ➊<br />ᐸlist_bde_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object46{{"Object[46∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object46 & Constant128 & Constant132 & Constant133 & Lambda70 & Lambda73 & Lambda106 & Lambda111 --> PgSelect43
+    Object46 & Constant132 & Constant136 & Constant137 & Lambda70 & Access74 & Lambda109 & Lambda114 --> PgSelect43
     Access44{{"Access[44∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access45{{"Access[45∈7] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access44 & Access45 --> Object46
@@ -120,7 +122,7 @@ graph TD
     PgClassExpression49 ==> __Item51
     PgSelect59[["PgSelect[59∈10] ➊<br />ᐸlist_bde_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object62{{"Object[62∈10] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object62 & Constant144 & Constant130 & Constant136 & Lambda70 & Lambda73 & Lambda120 & Lambda125 --> PgSelect59
+    Object62 & Constant148 & Constant134 & Constant140 & Lambda70 & Access74 & Lambda124 & Lambda129 --> PgSelect59
     Access60{{"Access[60∈10] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access61{{"Access[61∈10] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access60 & Access61 --> Object62
@@ -142,8 +144,8 @@ graph TD
     subgraph "Buckets for mutations/v4/b.list_bde_mutation"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access13,Access14,Object15,Lambda70,Lambda73,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant88,Constant89,Object91,Lambda92,Lambda97,Constant102,Constant103,Object105,Lambda106,Lambda111,Constant116,Constant117,Object119,Lambda120,Lambda125,Constant126,Constant127,Constant128,Constant130,Constant131,Constant132,Constant133,Constant136,Constant137,Constant138,Constant139,Constant140,Constant141,Constant142,Constant143,Constant144 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 128, 126, 127, 70, 73, 78, 83<br /><br />1: PgSelect[12]<br />2: <br />ᐳ: 16, 17, 18, 19"):::bucket
+    class Bucket0,__Value2,__Value4,Access13,Access14,Object15,Lambda70,Lambda73,Access74,Constant75,Constant76,Constant77,Object78,Lambda79,Lambda84,Constant90,Constant91,Object93,Lambda94,Lambda99,Constant105,Constant106,Object108,Lambda109,Lambda114,Constant120,Constant121,Object123,Lambda124,Lambda129,Constant130,Constant131,Constant132,Constant134,Constant135,Constant136,Constant137,Constant140,Constant141,Constant142,Constant143,Constant144,Constant145,Constant146,Constant147,Constant148 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 132, 130, 131, 70, 74, 79, 84<br /><br />1: PgSelect[12]<br />2: <br />ᐳ: 16, 17, 18, 19"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect12,First16,PgSelectSingle17,PgClassExpression18,Object19 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 18<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
@@ -152,7 +154,7 @@ graph TD
     Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ18ᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item20 bucket3
-    Bucket4("Bucket 4 (mutationField)<br />Deps: 143, 130, 131, 70, 73, 92, 97, 2<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgSelect[28]<br />5: <br />ᐳ: 32, 33, 34, 35"):::bucket
+    Bucket4("Bucket 4 (mutationField)<br />Deps: 147, 134, 135, 70, 74, 94, 99, 2<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgSelect[28]<br />5: <br />ᐳ: 32, 33, 34, 35"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect28,Access29,Access30,Object31,First32,PgSelectSingle33,PgClassExpression34,Object35 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 35, 34<br /><br />ROOT Object{4}ᐸ{result}ᐳ[35]"):::bucket
@@ -161,7 +163,7 @@ graph TD
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ34ᐳ[36]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item36 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 128, 132, 133, 70, 73, 106, 111, 2<br /><br />1: Access[44]<br />2: Access[45]<br />3: Object[46]<br />4: PgSelect[43]<br />5: <br />ᐳ: 47, 48, 49, 50"):::bucket
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 132, 136, 137, 70, 74, 109, 114, 2<br /><br />1: Access[44]<br />2: Access[45]<br />3: Object[46]<br />4: PgSelect[43]<br />5: <br />ᐳ: 47, 48, 49, 50"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgSelect43,Access44,Access45,Object46,First47,PgSelectSingle48,PgClassExpression49,Object50 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 50, 49<br /><br />ROOT Object{7}ᐸ{result}ᐳ[50]"):::bucket
@@ -170,7 +172,7 @@ graph TD
     Bucket9("Bucket 9 (listItem)<br /><br />ROOT __Item{9}ᐸ49ᐳ[51]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,__Item51 bucket9
-    Bucket10("Bucket 10 (mutationField)<br />Deps: 144, 130, 136, 70, 73, 120, 125, 2<br /><br />1: Access[60]<br />2: Access[61]<br />3: Object[62]<br />4: PgSelect[59]<br />5: <br />ᐳ: 63, 64, 65, 66"):::bucket
+    Bucket10("Bucket 10 (mutationField)<br />Deps: 148, 134, 140, 70, 74, 124, 129, 2<br /><br />1: Access[60]<br />2: Access[61]<br />3: Object[62]<br />4: PgSelect[59]<br />5: <br />ᐳ: 63, 64, 65, 66"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgSelect59,Access60,Access61,Object62,First63,PgSelectSingle64,PgClassExpression65,Object66 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 66, 65<br /><br />ROOT Object{10}ᐸ{result}ᐳ[66]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/enum_tables.mutations.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/enum_tables.mutations.mermaid
@@ -9,12 +9,12 @@ graph TD
 
 
     %% plan dependencies
-    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”referencing_table_mutation”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda50 & Constant54 & Constant55 & Constant56 --> Object57
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”referencing_table_mutation”)ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda50 & Constant55 & Constant56 & Constant57 --> Object58
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,22 +22,24 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant70 --> Lambda50
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
     Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant71 --> Lambda53
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object57 --> Lambda58
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”refereᐳ"}}:::plan
-    Constant72 --> Lambda63
+    Constant71 --> Lambda50
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant72 --> Lambda53
+    Access54{{"Access[54∈0] ➊<br />ᐸ53.0ᐳ"}}:::plan
+    Lambda53 --> Access54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object58 --> Lambda59
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”refereᐳ"}}:::plan
+    Constant73 --> Lambda64
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ'C'ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ'One does like to see the letter C'ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ enum_1: 'a1', enum_2: 'b2', enum_3: 'c4', simple_enum: 'Qᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ'C'ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸ'One does like to see the letter C'ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ enum_1: 'a1', enum_2: 'b2', enum_3: 'c4', simple_enum: 'Qᐳ"}}:::plan
     PgDeleteSingle9[["PgDeleteSingle[9∈1] ➊<br />ᐸletter_descriptions(letter)ᐳ"]]:::sideeffectplan
-    Object12 & Constant64 --> PgDeleteSingle9
+    Object12 & Constant65 --> PgDeleteSingle9
     Object13{{"Object[13∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgDeleteSingle9 --> Object13
     PgClassExpression14{{"PgClassExpression[14∈3] ➊<br />ᐸ__letter_d...ons__.”id”ᐳ"}}:::plan
@@ -48,7 +50,7 @@ graph TD
     PgDeleteSingle9 --> PgClassExpression16
     PgInsertSingle23[["PgInsertSingle[23∈4] ➊<br />ᐸletter_descriptions(letter,letter_via_view,description)ᐳ"]]:::sideeffectplan
     Object26{{"Object[26∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object26 & Constant64 & Constant64 & Constant65 --> PgInsertSingle23
+    Object26 & Constant65 & Constant65 & Constant66 --> PgInsertSingle23
     Access24{{"Access[24∈4] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access25{{"Access[25∈4] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access24 & Access25 --> Object26
@@ -66,7 +68,7 @@ graph TD
     PgInsertSingle23 --> PgClassExpression31
     PgSelect40[["PgSelect[40∈7] ➊<br />ᐸreferencing_table_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object43{{"Object[43∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object43 & Constant73 & Lambda50 & Lambda53 & Lambda58 & Lambda63 --> PgSelect40
+    Object43 & Constant74 & Lambda50 & Access54 & Lambda59 & Lambda64 --> PgSelect40
     Access41{{"Access[41∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access42{{"Access[42∈7] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access41 & Access42 --> Object43
@@ -86,8 +88,8 @@ graph TD
     subgraph "Buckets for mutations/v4/enum_tables.mutations"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Lambda50,Lambda53,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant64,Constant65,Constant70,Constant71,Constant72,Constant73 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 12, 64<br /><br />1: PgDeleteSingle[9]<br />2: <br />ᐳ: Object[13]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Lambda50,Lambda53,Access54,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant65,Constant66,Constant71,Constant72,Constant73,Constant74 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 12, 65<br /><br />1: PgDeleteSingle[9]<br />2: <br />ᐳ: Object[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgDeleteSingle9,Object13 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 13, 9<br /><br />ROOT Object{1}ᐸ{result}ᐳ[13]"):::bucket
@@ -96,7 +98,7 @@ graph TD
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 9<br /><br />ROOT PgDeleteSingle{1}ᐸletter_descriptions(letter)ᐳ[9]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression14,PgClassExpression15,PgClassExpression16 bucket3
-    Bucket4("Bucket 4 (mutationField)<br />Deps: 64, 65, 2<br /><br />1: Access[24]<br />2: Access[25]<br />3: Object[26]<br />4: PgInsertSingle[23]<br />5: <br />ᐳ: Object[27]"):::bucket
+    Bucket4("Bucket 4 (mutationField)<br />Deps: 65, 66, 2<br /><br />1: Access[24]<br />2: Access[25]<br />3: Object[26]<br />4: PgInsertSingle[23]<br />5: <br />ᐳ: Object[27]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgInsertSingle23,Access24,Access25,Object26,Object27 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 27, 23<br /><br />ROOT Object{4}ᐸ{result}ᐳ[27]"):::bucket
@@ -105,7 +107,7 @@ graph TD
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 23<br /><br />ROOT PgInsertSingle{4}ᐸletter_descriptions(letter,letter_via_view,description)ᐳ[23]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgClassExpression31 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 73, 50, 53, 58, 63, 2<br /><br />1: Access[41]<br />2: Access[42]<br />3: Object[43]<br />4: PgSelect[40]<br />5: <br />ᐳ: 44, 45, 46, 47"):::bucket
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 74, 50, 54, 59, 64, 2<br /><br />1: Access[41]<br />2: Access[42]<br />3: Object[43]<br />4: PgSelect[40]<br />5: <br />ᐳ: 44, 45, 46, 47"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgSelect40,Access41,Access42,Object43,First44,PgSelectSingle45,PgClassExpression46,Object47 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 47, 46<br /><br />ROOT Object{7}ᐸ{result}ᐳ[47]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/inheritence.createUserFile.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/inheritence.createUserFile.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”user”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(user)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,21 +22,25 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda45
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant63 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”user”)ᐳ"}}:::plan
+    Constant65 --> Lambda59
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant16{{"Constant[16∈0] ➊<br />ᐸ'users'ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”user”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(user)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ'Bobby Tables'ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ'foo.txt'ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”user”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ'Bobby Tables'ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ'foo.txt'ᐳ"}}:::plan
     PgInsertSingle11[["PgInsertSingle[11∈1] ➊<br />ᐸuser(id,name)ᐳ"]]:::sideeffectplan
-    Object14 & Constant59 & Constant60 --> PgInsertSingle11
+    Object14 & Constant60 & Constant61 --> PgInsertSingle11
     Object15{{"Object[15∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle11 --> Object15
     List18{{"List[18∈3] ➊<br />ᐸ16,17ᐳ"}}:::plan
@@ -43,7 +53,7 @@ graph TD
     PgInsertSingle11 --> PgClassExpression21
     PgInsertSingle27[["PgInsertSingle[27∈4] ➊<br />ᐸuser_file(filename,user_id)ᐳ"]]:::sideeffectplan
     Object30{{"Object[30∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object30 & Constant61 & Constant59 --> PgInsertSingle27
+    Object30 & Constant62 & Constant60 --> PgInsertSingle27
     Access28{{"Access[28∈4] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access29{{"Access[29∈4] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access28 & Access29 --> Object30
@@ -51,17 +61,9 @@ graph TD
     __Value2 --> Access29
     Object31{{"Object[31∈4] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle27 --> Object31
-    Object52{{"Object[52∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Lambda48{{"Lambda[48∈5] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant63 --> Lambda48
-    Lambda53{{"Lambda[53∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant64 --> Lambda58
     PgSelect35[["PgSelect[35∈6] ➊<br />ᐸuserᐳ"]]:::plan
     PgClassExpression34{{"PgClassExpression[34∈6] ➊<br />ᐸ__user_file__.”user_id”ᐳ"}}:::plan
-    Object30 & PgClassExpression34 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect35
+    Object30 & PgClassExpression34 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect35
     PgClassExpression32{{"PgClassExpression[32∈6] ➊<br />ᐸ__user_file__.”id”ᐳ"}}:::plan
     PgInsertSingle27 --> PgClassExpression32
     PgClassExpression33{{"PgClassExpression[33∈6] ➊<br />ᐸ__user_fil...”filename”ᐳ"}}:::plan
@@ -81,8 +83,8 @@ graph TD
     subgraph "Buckets for mutations/v4/inheritence.createUserFile"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Constant16,Lambda45,Constant49,Constant50,Constant51,Constant59,Constant60,Constant61,Constant62,Constant63,Constant64 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 59, 60, 16<br /><br />1: PgInsertSingle[11]<br />2: <br />ᐳ: Object[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Constant16,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant60,Constant61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 60, 61, 16<br /><br />1: PgInsertSingle[11]<br />2: <br />ᐳ: Object[15]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle11,Object15 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 15, 11, 16<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
@@ -91,13 +93,13 @@ graph TD
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 16<br /><br />ROOT PgInsertSingle{1}ᐸuser(id,name)ᐳ[11]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,List18,Lambda19,PgClassExpression21 bucket3
-    Bucket4("Bucket 4 (mutationField)<br />Deps: 61, 59, 2, 63, 45, 49, 50, 51, 64<br /><br />1: Access[28]<br />2: Access[29]<br />3: Object[30]<br />4: PgInsertSingle[27]<br />5: <br />ᐳ: Object[31]"):::bucket
+    Bucket4("Bucket 4 (mutationField)<br />Deps: 62, 60, 2, 45, 49, 54, 59<br /><br />1: Access[28]<br />2: Access[29]<br />3: Object[30]<br />4: PgInsertSingle[27]<br />5: <br />ᐳ: Object[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgInsertSingle27,Access28,Access29,Object30,Object31 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 63, 45, 49, 50, 51, 64, 31, 27, 30<br /><br />ROOT Object{4}ᐸ{result}ᐳ[31]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 31, 27, 30, 45, 49, 54, 59<br /><br />ROOT Object{4}ᐸ{result}ᐳ[31]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Lambda48,Object52,Lambda53,Lambda58 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 27, 30, 45, 48, 53, 58<br /><br />ROOT PgInsertSingle{4}ᐸuser_file(filename,user_id)ᐳ[27]<br />1: <br />ᐳ: 32, 33, 34<br />2: PgSelect[35]<br />ᐳ: First[39], PgSelectSingle[40]"):::bucket
+    class Bucket5 bucket5
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 27, 30, 45, 49, 54, 59<br /><br />ROOT PgInsertSingle{4}ᐸuser_file(filename,user_id)ᐳ[27]<br />1: <br />ᐳ: 32, 33, 34<br />2: PgSelect[35]<br />ᐳ: First[39], PgSelectSingle[40]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First39,PgSelectSingle40 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 40<br /><br />ROOT PgSelectSingle{6}ᐸuserᐳ[40]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-create.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-create.mermaid
@@ -9,6 +9,160 @@ graph TD
 
 
     %% plan dependencies
+    Object1060{{"Object[1060∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1052{{"Lambda[1052∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1057{{"Constant[1057∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1058{{"Constant[1058∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant1059{{"Constant[1059∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda1052 & Constant1057 & Constant1058 & Constant1059 --> Object1060
+    Object1075{{"Object[1075∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1072{{"Constant[1072∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1073{{"Constant[1073∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1072 & Constant1073 & Constant1059 --> Object1075
+    Object1090{{"Object[1090∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1087{{"Constant[1087∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1088{{"Constant[1088∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1087 & Constant1088 & Constant1059 --> Object1090
+    Object1105{{"Object[1105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1102{{"Constant[1102∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1103{{"Constant[1103∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1102 & Constant1103 & Constant1059 --> Object1105
+    Object1120{{"Object[1120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1117{{"Constant[1117∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant1118{{"Constant[1118∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1117 & Constant1118 & Constant1059 --> Object1120
+    Object1135{{"Object[1135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1132{{"Constant[1132∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1133{{"Constant[1133∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1132 & Constant1133 & Constant1059 --> Object1135
+    Object1150{{"Object[1150∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1147{{"Constant[1147∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant1148{{"Constant[1148∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1147 & Constant1148 & Constant1059 --> Object1150
+    Object1165{{"Object[1165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1162{{"Constant[1162∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' }, { attribute: 'iᐳ"}}:::plan
+    Constant1163{{"Constant[1163∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1162 & Constant1163 & Constant1059 --> Object1165
+    Object1180{{"Object[1180∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1177{{"Constant[1177∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1178{{"Constant[1178∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant1179{{"Constant[1179∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda1052 & Constant1177 & Constant1178 & Constant1179 --> Object1180
+    Object1195{{"Object[1195∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1192{{"Constant[1192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1193{{"Constant[1193∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1052 & Constant1192 & Constant1193 & Constant1179 --> Object1195
+    Object1212{{"Object[1212∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1209{{"Constant[1209∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1210{{"Constant[1210∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1052 & Constant1209 & Constant1210 & Constant1179 --> Object1212
+    Object1229{{"Object[1229∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1226{{"Constant[1226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1227{{"Constant[1227∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Constant1228{{"Constant[1228∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
+    Lambda1052 & Constant1226 & Constant1227 & Constant1228 --> Object1229
+    Object1244{{"Object[1244∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1241{{"Constant[1241∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1242{{"Constant[1242∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1241 & Constant1242 & Constant1059 --> Object1244
+    Object1259{{"Object[1259∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1256{{"Constant[1256∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1257{{"Constant[1257∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1256 & Constant1257 & Constant1059 --> Object1259
+    Object1274{{"Object[1274∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1271{{"Constant[1271∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1272{{"Constant[1272∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1271 & Constant1272 & Constant1059 --> Object1274
+    Object1289{{"Object[1289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1286{{"Constant[1286∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1287{{"Constant[1287∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1286 & Constant1287 & Constant1059 --> Object1289
+    Object1304{{"Object[1304∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1301{{"Constant[1301∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant1302{{"Constant[1302∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1301 & Constant1302 & Constant1059 --> Object1304
+    Object1319{{"Object[1319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1316{{"Constant[1316∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1317{{"Constant[1317∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1316 & Constant1317 & Constant1059 --> Object1319
+    Object1334{{"Object[1334∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1331{{"Constant[1331∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant1332{{"Constant[1332∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1331 & Constant1332 & Constant1059 --> Object1334
+    Object1349{{"Object[1349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1346{{"Constant[1346∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' }, { attribute: 'iᐳ"}}:::plan
+    Constant1347{{"Constant[1347∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1346 & Constant1347 & Constant1059 --> Object1349
+    Object1364{{"Object[1364∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1361{{"Constant[1361∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1362{{"Constant[1362∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1361 & Constant1362 & Constant1059 --> Object1364
+    Object1379{{"Object[1379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1376{{"Constant[1376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1377{{"Constant[1377∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1376 & Constant1377 & Constant1059 --> Object1379
+    Object1394{{"Object[1394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1391{{"Constant[1391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1392{{"Constant[1392∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1391 & Constant1392 & Constant1059 --> Object1394
+    Object1409{{"Object[1409∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1406{{"Constant[1406∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1407{{"Constant[1407∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1406 & Constant1407 & Constant1059 --> Object1409
+    Object1424{{"Object[1424∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1421{{"Constant[1421∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1422{{"Constant[1422∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1421 & Constant1422 & Constant1059 --> Object1424
+    Object1439{{"Object[1439∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1436{{"Constant[1436∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1437{{"Constant[1437∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1436 & Constant1437 & Constant1059 --> Object1439
+    Object1454{{"Object[1454∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1451{{"Constant[1451∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant1452{{"Constant[1452∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1451 & Constant1452 & Constant1059 --> Object1454
+    Object1469{{"Object[1469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1466{{"Constant[1466∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1467{{"Constant[1467∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1466 & Constant1467 & Constant1059 --> Object1469
+    Object1484{{"Object[1484∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1481{{"Constant[1481∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant1482{{"Constant[1482∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1481 & Constant1482 & Constant1059 --> Object1484
+    Object1499{{"Object[1499∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1496{{"Constant[1496∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' }, { attribute: 'iᐳ"}}:::plan
+    Constant1497{{"Constant[1497∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1496 & Constant1497 & Constant1059 --> Object1499
+    Object1514{{"Object[1514∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1511{{"Constant[1511∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1512{{"Constant[1512∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1511 & Constant1512 & Constant1059 --> Object1514
+    Object1529{{"Object[1529∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1526{{"Constant[1526∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1527{{"Constant[1527∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
+    Constant1528{{"Constant[1528∈0] ➊<br />ᐸRecordCodec(comptype)ᐳ"}}:::plan
+    Lambda1052 & Constant1526 & Constant1527 & Constant1528 --> Object1529
+    Object1544{{"Object[1544∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1541{{"Constant[1541∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1542{{"Constant[1542∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
+    Lambda1052 & Constant1541 & Constant1542 & Constant1528 --> Object1544
+    Object1560{{"Object[1560∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1557{{"Constant[1557∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1558{{"Constant[1558∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
+    Lambda1052 & Constant1557 & Constant1558 & Constant1528 --> Object1560
+    Object1580{{"Object[1580∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1577{{"Constant[1577∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1578{{"Constant[1578∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1577 & Constant1578 & Constant1059 --> Object1580
+    Object1597{{"Object[1597∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1594{{"Constant[1594∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1595{{"Constant[1595∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant1596{{"Constant[1596∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda1052 & Constant1594 & Constant1595 & Constant1596 --> Object1597
+    Object1612{{"Object[1612∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1609{{"Constant[1609∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1610{{"Constant[1610∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1052 & Constant1609 & Constant1610 & Constant1059 --> Object1612
     Object119{{"Object[119∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access117{{"Access[117∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access118{{"Access[118∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -19,12 +173,198 @@ graph TD
     Access273{{"Access[273∈0] ➊<br />ᐸ0.configᐳ"}}:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access273
-    Lambda1052{{"Lambda[1052∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1646{{"Constant[1646∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1646 --> Lambda1052
+    Constant1683{{"Constant[1683∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1683 --> Lambda1052
     Lambda1055{{"Lambda[1055∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1647{{"Constant[1647∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1647 --> Lambda1055
+    Constant1684{{"Constant[1684∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1684 --> Lambda1055
+    Access1056{{"Access[1056∈0] ➊<br />ᐸ1055.0ᐳ"}}:::plan
+    Lambda1055 --> Access1056
+    Lambda1061{{"Lambda[1061∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1060 --> Lambda1061
+    Lambda1066{{"Lambda[1066∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1717{{"Constant[1717∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1717 --> Lambda1066
+    Lambda1076{{"Lambda[1076∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1075 --> Lambda1076
+    Lambda1081{{"Lambda[1081∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1718{{"Constant[1718∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1718 --> Lambda1081
+    Lambda1091{{"Lambda[1091∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1090 --> Lambda1091
+    Lambda1096{{"Lambda[1096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1719{{"Constant[1719∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1719 --> Lambda1096
+    Lambda1106{{"Lambda[1106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1105 --> Lambda1106
+    Lambda1111{{"Lambda[1111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1720{{"Constant[1720∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
+    Constant1720 --> Lambda1111
+    Lambda1121{{"Lambda[1121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1120 --> Lambda1121
+    Lambda1126{{"Lambda[1126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1721{{"Constant[1721∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
+    Constant1721 --> Lambda1126
+    Lambda1136{{"Lambda[1136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1135 --> Lambda1136
+    Lambda1141{{"Lambda[1141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1722{{"Constant[1722∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1722 --> Lambda1141
+    Lambda1151{{"Lambda[1151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1150 --> Lambda1151
+    Lambda1156{{"Lambda[1156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1723{{"Constant[1723∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1723 --> Lambda1156
+    Lambda1166{{"Lambda[1166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1165 --> Lambda1166
+    Lambda1171{{"Lambda[1171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1724{{"Constant[1724∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1724 --> Lambda1171
+    Lambda1181{{"Lambda[1181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1180 --> Lambda1181
+    Lambda1186{{"Lambda[1186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1725{{"Constant[1725∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1725 --> Lambda1186
+    Lambda1196{{"Lambda[1196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1195 --> Lambda1196
+    Lambda1201{{"Lambda[1201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1726{{"Constant[1726∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1726 --> Lambda1201
+    Lambda1213{{"Lambda[1213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1212 --> Lambda1213
+    Lambda1218{{"Lambda[1218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1727{{"Constant[1727∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1727 --> Lambda1218
+    Lambda1230{{"Lambda[1230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1229 --> Lambda1230
+    Lambda1235{{"Lambda[1235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1728{{"Constant[1728∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1728 --> Lambda1235
+    Lambda1245{{"Lambda[1245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1244 --> Lambda1245
+    Lambda1250{{"Lambda[1250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1729{{"Constant[1729∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1729 --> Lambda1250
+    Lambda1260{{"Lambda[1260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1259 --> Lambda1260
+    Lambda1265{{"Lambda[1265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1730{{"Constant[1730∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1730 --> Lambda1265
+    Lambda1275{{"Lambda[1275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1274 --> Lambda1275
+    Lambda1280{{"Lambda[1280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1731{{"Constant[1731∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1731 --> Lambda1280
+    Lambda1290{{"Lambda[1290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1289 --> Lambda1290
+    Lambda1295{{"Lambda[1295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1732{{"Constant[1732∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
+    Constant1732 --> Lambda1295
+    Lambda1305{{"Lambda[1305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1304 --> Lambda1305
+    Lambda1310{{"Lambda[1310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1733{{"Constant[1733∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
+    Constant1733 --> Lambda1310
+    Lambda1320{{"Lambda[1320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1319 --> Lambda1320
+    Lambda1325{{"Lambda[1325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1734{{"Constant[1734∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1734 --> Lambda1325
+    Lambda1335{{"Lambda[1335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1334 --> Lambda1335
+    Lambda1340{{"Lambda[1340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1735{{"Constant[1735∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1735 --> Lambda1340
+    Lambda1350{{"Lambda[1350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1349 --> Lambda1350
+    Lambda1355{{"Lambda[1355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1736{{"Constant[1736∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1736 --> Lambda1355
+    Lambda1365{{"Lambda[1365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1364 --> Lambda1365
+    Lambda1370{{"Lambda[1370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1737{{"Constant[1737∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1737 --> Lambda1370
+    Lambda1380{{"Lambda[1380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1379 --> Lambda1380
+    Lambda1385{{"Lambda[1385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1738{{"Constant[1738∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1738 --> Lambda1385
+    Lambda1395{{"Lambda[1395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1394 --> Lambda1395
+    Lambda1400{{"Lambda[1400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1739{{"Constant[1739∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1739 --> Lambda1400
+    Lambda1410{{"Lambda[1410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1409 --> Lambda1410
+    Lambda1415{{"Lambda[1415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1740{{"Constant[1740∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1740 --> Lambda1415
+    Lambda1425{{"Lambda[1425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1424 --> Lambda1425
+    Lambda1430{{"Lambda[1430∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1741{{"Constant[1741∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1741 --> Lambda1430
+    Lambda1440{{"Lambda[1440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1439 --> Lambda1440
+    Lambda1445{{"Lambda[1445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1742{{"Constant[1742∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
+    Constant1742 --> Lambda1445
+    Lambda1455{{"Lambda[1455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1454 --> Lambda1455
+    Lambda1460{{"Lambda[1460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1743{{"Constant[1743∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
+    Constant1743 --> Lambda1460
+    Lambda1470{{"Lambda[1470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1469 --> Lambda1470
+    Lambda1475{{"Lambda[1475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1744{{"Constant[1744∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1744 --> Lambda1475
+    Lambda1485{{"Lambda[1485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1484 --> Lambda1485
+    Lambda1490{{"Lambda[1490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1745{{"Constant[1745∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1745 --> Lambda1490
+    Lambda1500{{"Lambda[1500∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1499 --> Lambda1500
+    Lambda1505{{"Lambda[1505∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1746{{"Constant[1746∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
+    Constant1746 --> Lambda1505
+    Lambda1515{{"Lambda[1515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1514 --> Lambda1515
+    Lambda1520{{"Lambda[1520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1747{{"Constant[1747∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1747 --> Lambda1520
+    Lambda1530{{"Lambda[1530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1529 --> Lambda1530
+    Lambda1535{{"Lambda[1535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1748{{"Constant[1748∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1748 --> Lambda1535
+    Lambda1545{{"Lambda[1545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1544 --> Lambda1545
+    Lambda1550{{"Lambda[1550∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1749{{"Constant[1749∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1749 --> Lambda1550
+    Lambda1561{{"Lambda[1561∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1560 --> Lambda1561
+    Lambda1566{{"Lambda[1566∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1750{{"Constant[1750∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1750 --> Lambda1566
+    Lambda1581{{"Lambda[1581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1580 --> Lambda1581
+    Lambda1586{{"Lambda[1586∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1751{{"Constant[1751∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1751 --> Lambda1586
+    Lambda1598{{"Lambda[1598∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1597 --> Lambda1598
+    Lambda1603{{"Lambda[1603∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1752{{"Constant[1752∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1752 --> Lambda1603
+    Lambda1613{{"Lambda[1613∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1612 --> Lambda1613
+    Lambda1618{{"Lambda[1618∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1753{{"Constant[1753∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1753 --> Lambda1618
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant144{{"Constant[144∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant145{{"Constant[145∈0] ➊<br />ᐸ'types'ᐳ"}}:::plan
@@ -33,217 +373,79 @@ graph TD
     Constant640{{"Constant[640∈0] ➊<br />ᐸ'compound_keys'ᐳ"}}:::plan
     __InputDynamicScalar724{{"__InputDynamicScalar[724∈0] ➊"}}:::plan
     Constant1053{{"Constant[1053∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant1056{{"Constant[1056∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1057{{"Constant[1057∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1058{{"Constant[1058∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant1070{{"Constant[1070∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1071{{"Constant[1071∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1084{{"Constant[1084∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1085{{"Constant[1085∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1098{{"Constant[1098∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1099{{"Constant[1099∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1112{{"Constant[1112∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant1113{{"Constant[1113∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1126{{"Constant[1126∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1127{{"Constant[1127∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1140{{"Constant[1140∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant1141{{"Constant[1141∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1154{{"Constant[1154∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' }, { attribute: 'iᐳ"}}:::plan
-    Constant1155{{"Constant[1155∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1168{{"Constant[1168∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1169{{"Constant[1169∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1170{{"Constant[1170∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Constant1182{{"Constant[1182∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1183{{"Constant[1183∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1198{{"Constant[1198∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1199{{"Constant[1199∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1214{{"Constant[1214∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1215{{"Constant[1215∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1216{{"Constant[1216∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
-    Constant1228{{"Constant[1228∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1229{{"Constant[1229∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1242{{"Constant[1242∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1243{{"Constant[1243∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1256{{"Constant[1256∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1257{{"Constant[1257∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1270{{"Constant[1270∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1271{{"Constant[1271∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1284{{"Constant[1284∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant1285{{"Constant[1285∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1298{{"Constant[1298∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1299{{"Constant[1299∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1312{{"Constant[1312∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant1313{{"Constant[1313∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1326{{"Constant[1326∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' }, { attribute: 'iᐳ"}}:::plan
-    Constant1327{{"Constant[1327∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1340{{"Constant[1340∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1341{{"Constant[1341∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1354{{"Constant[1354∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1355{{"Constant[1355∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1368{{"Constant[1368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1369{{"Constant[1369∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1382{{"Constant[1382∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1383{{"Constant[1383∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1396{{"Constant[1396∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1397{{"Constant[1397∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1410{{"Constant[1410∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1411{{"Constant[1411∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1424{{"Constant[1424∈0] ➊<br />ᐸ[ { attribute: 'id', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant1425{{"Constant[1425∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1438{{"Constant[1438∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1439{{"Constant[1439∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1452{{"Constant[1452∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant1453{{"Constant[1453∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1466{{"Constant[1466∈0] ➊<br />ᐸ[ { attribute: 'email', direction: 'DESC' }, { attribute: 'iᐳ"}}:::plan
-    Constant1467{{"Constant[1467∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1480{{"Constant[1480∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1481{{"Constant[1481∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1494{{"Constant[1494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1495{{"Constant[1495∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
-    Constant1496{{"Constant[1496∈0] ➊<br />ᐸRecordCodec(comptype)ᐳ"}}:::plan
-    Constant1508{{"Constant[1508∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1509{{"Constant[1509∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
-    Constant1523{{"Constant[1523∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1524{{"Constant[1524∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
-    Constant1542{{"Constant[1542∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1543{{"Constant[1543∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1558{{"Constant[1558∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1559{{"Constant[1559∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1560{{"Constant[1560∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant1572{{"Constant[1572∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1573{{"Constant[1573∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1583{{"Constant[1583∈0] ➊<br />ᐸ201ᐳ"}}:::plan
-    Constant1584{{"Constant[1584∈0] ➊<br />ᐸ30ᐳ"}}:::plan
-    Constant1585{{"Constant[1585∈0] ➊<br />ᐸ'467131188225'ᐳ"}}:::plan
-    Constant1586{{"Constant[1586∈0] ➊<br />ᐸ'15.2'ᐳ"}}:::plan
-    Constant1587{{"Constant[1587∈0] ➊<br />ᐸ'abc'ᐳ"}}:::plan
-    Constant1588{{"Constant[1588∈0] ➊<br />ᐸ'red'ᐳ"}}:::plan
-    Constant1590{{"Constant[1590∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Constant1591{{"Constant[1591∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant1601{{"Constant[1601∈0] ➊<br />ᐸ{ x: 1, y: 2, z: 3 }ᐳ"}}:::plan
-    Constant1602{{"Constant[1602∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Constant1604{{"Constant[1604∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant1608{{"Constant[1608∈0] ➊<br />ᐸ'2016-10-07 16:12:21.747269'ᐳ"}}:::plan
-    Constant1609{{"Constant[1609∈0] ➊<br />ᐸ'2016-10-09 16:12:45.218676-04'ᐳ"}}:::plan
-    Constant1610{{"Constant[1610∈0] ➊<br />ᐸ'2016-10-15'ᐳ"}}:::plan
-    Constant1611{{"Constant[1611∈0] ➊<br />ᐸ'19:13:18.625699'ᐳ"}}:::plan
-    Constant1612{{"Constant[1612∈0] ➊<br />ᐸ'13:13:29.585176-04'ᐳ"}}:::plan
-    Constant1613{{"Constant[1613∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant1619{{"Constant[1619∈0] ➊<br />ᐸ1234567.89ᐳ"}}:::plan
-    Constant1624{{"Constant[1624∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant1638{{"Constant[1638∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
-    Constant1639{{"Constant[1639∈0] ➊<br />ᐸ'0cafec0ffee0'ᐳ"}}:::plan
-    Constant1648{{"Constant[1648∈0] ➊<br />ᐸ9000ᐳ"}}:::plan
-    Constant1649{{"Constant[1649∈0] ➊<br />ᐸ'John Smith Jr.'ᐳ"}}:::plan
-    Constant1650{{"Constant[1650∈0] ➊<br />ᐸ'Son of Sara and John Smith.'ᐳ"}}:::plan
-    Constant1651{{"Constant[1651∈0] ➊<br />ᐸ'johnny.boy.smith@email.com'ᐳ"}}:::plan
-    Constant1652{{"Constant[1652∈0] ➊<br />ᐸ'172.16.1.2'ᐳ"}}:::plan
-    Constant1653{{"Constant[1653∈0] ➊<br />ᐸ'172.16.0.0/12'ᐳ"}}:::plan
-    Constant1654{{"Constant[1654∈0] ➊<br />ᐸ'00:00:00:00:00:00'ᐳ"}}:::plan
-    Constant1655{{"Constant[1655∈0] ➊<br />ᐸ'graphile-build.issue.27@example.com'ᐳ"}}:::plan
-    Constant1656{{"Constant[1656∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
-    Constant1657{{"Constant[1657∈0] ➊<br />ᐸ'Best Pal'ᐳ"}}:::plan
-    Constant1658{{"Constant[1658∈0] ➊<br />ᐸ'My archnemisis is Budd Deey.'ᐳ"}}:::plan
-    Constant1659{{"Constant[1659∈0] ➊<br />ᐸ'best.pal@email.com'ᐳ"}}:::plan
-    Constant1660{{"Constant[1660∈0] ➊<br />ᐸ'192.168.0.42'ᐳ"}}:::plan
-    Constant1661{{"Constant[1661∈0] ➊<br />ᐸ'0000.0000.0000'ᐳ"}}:::plan
-    Constant1662{{"Constant[1662∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
-    Constant1663{{"Constant[1663∈0] ➊<br />ᐸ1998ᐳ"}}:::plan
-    Constant1664{{"Constant[1664∈0] ➊<br />ᐸ'Budd Deey'ᐳ"}}:::plan
-    Constant1665{{"Constant[1665∈0] ➊<br />ᐸ'budd.deey.the.second@email.com'ᐳ"}}:::plan
-    Constant1666{{"Constant[1666∈0] ➊<br />ᐸ'10.0.1.42'ᐳ"}}:::plan
-    Constant1667{{"Constant[1667∈0] ➊<br />ᐸ'10.0.0.0/8'ᐳ"}}:::plan
-    Constant1668{{"Constant[1668∈0] ➊<br />ᐸ'aa-bb-cc-dd-ee-ff'ᐳ"}}:::plan
-    Constant1669{{"Constant[1669∈0] ➊<br />ᐸ1999ᐳ"}}:::plan
-    Constant1670{{"Constant[1670∈0] ➊<br />ᐸ'Twenty Seven'ᐳ"}}:::plan
-    Constant1671{{"Constant[1671∈0] ➊<br />ᐸ2000ᐳ"}}:::plan
-    Constant1672{{"Constant[1672∈0] ➊<br />ᐸ'super headline'ᐳ"}}:::plan
-    Constant1676{{"Constant[1676∈0] ➊<br />ᐸ'super headline 2'ᐳ"}}:::plan
-    Constant1680{{"Constant[1680∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1681{{"Constant[1681∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1682{{"Constant[1682∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1683{{"Constant[1683∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
-    Constant1684{{"Constant[1684∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
-    Constant1685{{"Constant[1685∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1686{{"Constant[1686∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1687{{"Constant[1687∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1688{{"Constant[1688∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1689{{"Constant[1689∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1690{{"Constant[1690∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1691{{"Constant[1691∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1692{{"Constant[1692∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1693{{"Constant[1693∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1694{{"Constant[1694∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1695{{"Constant[1695∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
-    Constant1696{{"Constant[1696∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
-    Constant1697{{"Constant[1697∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1698{{"Constant[1698∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1699{{"Constant[1699∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1700{{"Constant[1700∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1701{{"Constant[1701∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1702{{"Constant[1702∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1703{{"Constant[1703∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1704{{"Constant[1704∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1705{{"Constant[1705∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
-    Constant1706{{"Constant[1706∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'id', direction: 'ᐳ"}}:::plan
-    Constant1707{{"Constant[1707∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1708{{"Constant[1708∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1709{{"Constant[1709∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'email', directionᐳ"}}:::plan
-    Constant1710{{"Constant[1710∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1711{{"Constant[1711∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1712{{"Constant[1712∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1713{{"Constant[1713∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1714{{"Constant[1714∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1715{{"Constant[1715∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1716{{"Constant[1716∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1717{{"Constant[1717∈0] ➊<br />ᐸ[ 'red', 'green' ]ᐳ"}}:::plan
-    Constant1718{{"Constant[1718∈0] ➊<br />ᐸ[   'have',  'you',   'ever',  'been',   'down',  'the',   'ᐳ"}}:::plan
-    Constant1723{{"Constant[1723∈0] ➊<br />ᐸ§{ seconds: 1, minutes: 2, hours: 3, days: 4, months: 5, yeaᐳ"}}:::plan
-    Constant1726{{"Constant[1726∈0] ➊<br />ᐸ§{ a: 123, b: 'abc', c: 'green', d: 'ec4a9fae-4ec5-4763-98ebᐳ"}}:::plan
-    Constant1729{{"Constant[1729∈0] ➊<br />ᐸ§{ x: 1, y: 3 }ᐳ"}}:::plan
-    Constant1730{{"Constant[1730∈0] ➊<br />ᐸ[ 'TEXT 2098288669218571759', 'TEXT 2098288669218571760', 'Tᐳ"}}:::plan
-    Constant1731{{"Constant[1731∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
-    Constant1738{{"Constant[1738∈0] ➊<br />ᐸ§{ start: §{ value: '50', inclusive: true }, end: §{ value: ᐳ"}}:::plan
-    Constant1739{{"Constant[1739∈0] ➊<br />ᐸ§{ start: §{ value: '1927-11-05', inclusive: false }, end: §ᐳ"}}:::plan
-    Constant1740{{"Constant[1740∈0] ➊<br />ᐸ§{ start: §{ value: undefined, inclusive: undefined }, end: ᐳ"}}:::plan
-    Constant1741{{"Constant[1741∈0] ➊<br />ᐸ[ §{ seconds: 2, minutes: 3, hours: 4, days: 5, months: 6, yᐳ"}}:::plan
-    Constant1742{{"Constant[1742∈0] ➊<br />ᐸ§{ a: §{ a: 456, b: 'def', c: 'blue', d: '79863dcf-0433-4c3dᐳ"}}:::plan
-    Constant1743{{"Constant[1743∈0] ➊<br />ᐸ[ §{ schedule: '2009-10-24 10:23:54+02', is_optimised: true ᐳ"}}:::plan
-    Constant1744{{"Constant[1744∈0] ➊<br />ᐸ[ §{ schedule: '2008-10-24 10:17:54+02', is_optimised: true ᐳ"}}:::plan
+    Constant1620{{"Constant[1620∈0] ➊<br />ᐸ201ᐳ"}}:::plan
+    Constant1621{{"Constant[1621∈0] ➊<br />ᐸ30ᐳ"}}:::plan
+    Constant1622{{"Constant[1622∈0] ➊<br />ᐸ'467131188225'ᐳ"}}:::plan
+    Constant1623{{"Constant[1623∈0] ➊<br />ᐸ'15.2'ᐳ"}}:::plan
+    Constant1624{{"Constant[1624∈0] ➊<br />ᐸ'abc'ᐳ"}}:::plan
+    Constant1625{{"Constant[1625∈0] ➊<br />ᐸ'red'ᐳ"}}:::plan
+    Constant1627{{"Constant[1627∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Constant1628{{"Constant[1628∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant1638{{"Constant[1638∈0] ➊<br />ᐸ{ x: 1, y: 2, z: 3 }ᐳ"}}:::plan
+    Constant1639{{"Constant[1639∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Constant1641{{"Constant[1641∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant1645{{"Constant[1645∈0] ➊<br />ᐸ'2016-10-07 16:12:21.747269'ᐳ"}}:::plan
+    Constant1646{{"Constant[1646∈0] ➊<br />ᐸ'2016-10-09 16:12:45.218676-04'ᐳ"}}:::plan
+    Constant1647{{"Constant[1647∈0] ➊<br />ᐸ'2016-10-15'ᐳ"}}:::plan
+    Constant1648{{"Constant[1648∈0] ➊<br />ᐸ'19:13:18.625699'ᐳ"}}:::plan
+    Constant1649{{"Constant[1649∈0] ➊<br />ᐸ'13:13:29.585176-04'ᐳ"}}:::plan
+    Constant1650{{"Constant[1650∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant1656{{"Constant[1656∈0] ➊<br />ᐸ1234567.89ᐳ"}}:::plan
+    Constant1661{{"Constant[1661∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    Constant1675{{"Constant[1675∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
+    Constant1676{{"Constant[1676∈0] ➊<br />ᐸ'0cafec0ffee0'ᐳ"}}:::plan
+    Constant1685{{"Constant[1685∈0] ➊<br />ᐸ9000ᐳ"}}:::plan
+    Constant1686{{"Constant[1686∈0] ➊<br />ᐸ'John Smith Jr.'ᐳ"}}:::plan
+    Constant1687{{"Constant[1687∈0] ➊<br />ᐸ'Son of Sara and John Smith.'ᐳ"}}:::plan
+    Constant1688{{"Constant[1688∈0] ➊<br />ᐸ'johnny.boy.smith@email.com'ᐳ"}}:::plan
+    Constant1689{{"Constant[1689∈0] ➊<br />ᐸ'172.16.1.2'ᐳ"}}:::plan
+    Constant1690{{"Constant[1690∈0] ➊<br />ᐸ'172.16.0.0/12'ᐳ"}}:::plan
+    Constant1691{{"Constant[1691∈0] ➊<br />ᐸ'00:00:00:00:00:00'ᐳ"}}:::plan
+    Constant1692{{"Constant[1692∈0] ➊<br />ᐸ'graphile-build.issue.27@example.com'ᐳ"}}:::plan
+    Constant1693{{"Constant[1693∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
+    Constant1694{{"Constant[1694∈0] ➊<br />ᐸ'Best Pal'ᐳ"}}:::plan
+    Constant1695{{"Constant[1695∈0] ➊<br />ᐸ'My archnemisis is Budd Deey.'ᐳ"}}:::plan
+    Constant1696{{"Constant[1696∈0] ➊<br />ᐸ'best.pal@email.com'ᐳ"}}:::plan
+    Constant1697{{"Constant[1697∈0] ➊<br />ᐸ'192.168.0.42'ᐳ"}}:::plan
+    Constant1698{{"Constant[1698∈0] ➊<br />ᐸ'0000.0000.0000'ᐳ"}}:::plan
+    Constant1699{{"Constant[1699∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
+    Constant1700{{"Constant[1700∈0] ➊<br />ᐸ1998ᐳ"}}:::plan
+    Constant1701{{"Constant[1701∈0] ➊<br />ᐸ'Budd Deey'ᐳ"}}:::plan
+    Constant1702{{"Constant[1702∈0] ➊<br />ᐸ'budd.deey.the.second@email.com'ᐳ"}}:::plan
+    Constant1703{{"Constant[1703∈0] ➊<br />ᐸ'10.0.1.42'ᐳ"}}:::plan
+    Constant1704{{"Constant[1704∈0] ➊<br />ᐸ'10.0.0.0/8'ᐳ"}}:::plan
+    Constant1705{{"Constant[1705∈0] ➊<br />ᐸ'aa-bb-cc-dd-ee-ff'ᐳ"}}:::plan
+    Constant1706{{"Constant[1706∈0] ➊<br />ᐸ1999ᐳ"}}:::plan
+    Constant1707{{"Constant[1707∈0] ➊<br />ᐸ'Twenty Seven'ᐳ"}}:::plan
+    Constant1708{{"Constant[1708∈0] ➊<br />ᐸ2000ᐳ"}}:::plan
+    Constant1709{{"Constant[1709∈0] ➊<br />ᐸ'super headline'ᐳ"}}:::plan
+    Constant1713{{"Constant[1713∈0] ➊<br />ᐸ'super headline 2'ᐳ"}}:::plan
+    Constant1754{{"Constant[1754∈0] ➊<br />ᐸ[ 'red', 'green' ]ᐳ"}}:::plan
+    Constant1755{{"Constant[1755∈0] ➊<br />ᐸ[   'have',  'you',   'ever',  'been',   'down',  'the',   'ᐳ"}}:::plan
+    Constant1760{{"Constant[1760∈0] ➊<br />ᐸ§{ seconds: 1, minutes: 2, hours: 3, days: 4, months: 5, yeaᐳ"}}:::plan
+    Constant1763{{"Constant[1763∈0] ➊<br />ᐸ§{ a: 123, b: 'abc', c: 'green', d: 'ec4a9fae-4ec5-4763-98ebᐳ"}}:::plan
+    Constant1766{{"Constant[1766∈0] ➊<br />ᐸ§{ x: 1, y: 3 }ᐳ"}}:::plan
+    Constant1767{{"Constant[1767∈0] ➊<br />ᐸ[ 'TEXT 2098288669218571759', 'TEXT 2098288669218571760', 'Tᐳ"}}:::plan
+    Constant1768{{"Constant[1768∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
+    Constant1775{{"Constant[1775∈0] ➊<br />ᐸ§{ start: §{ value: '50', inclusive: true }, end: §{ value: ᐳ"}}:::plan
+    Constant1776{{"Constant[1776∈0] ➊<br />ᐸ§{ start: §{ value: '1927-11-05', inclusive: false }, end: §ᐳ"}}:::plan
+    Constant1777{{"Constant[1777∈0] ➊<br />ᐸ§{ start: §{ value: undefined, inclusive: undefined }, end: ᐳ"}}:::plan
+    Constant1778{{"Constant[1778∈0] ➊<br />ᐸ[ §{ seconds: 2, minutes: 3, hours: 4, days: 5, months: 6, yᐳ"}}:::plan
+    Constant1779{{"Constant[1779∈0] ➊<br />ᐸ§{ a: §{ a: 456, b: 'def', c: 'blue', d: '79863dcf-0433-4c3dᐳ"}}:::plan
+    Constant1780{{"Constant[1780∈0] ➊<br />ᐸ[ §{ schedule: '2009-10-24 10:23:54+02', is_optimised: true ᐳ"}}:::plan
+    Constant1781{{"Constant[1781∈0] ➊<br />ᐸ[ §{ schedule: '2008-10-24 10:17:54+02', is_optimised: true ᐳ"}}:::plan
     PgInsertSingle116[["PgInsertSingle[116∈1] ➊<br />ᐸtypes(id,smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,cidr,macaddr,text_array_domain,int8_array_domain)ᐳ"]]:::sideeffectplan
-    Object119 & Constant1583 & Constant1584 & Constant1585 & Constant1586 & Constant1586 & Constant1053 & Constant1587 & Constant1588 & Constant1717 & Constant1590 & Constant1591 & Constant1718 & Constant1601 & Constant1602 & Constant1738 & Constant1739 & Constant1740 & Constant1608 & Constant1609 & Constant1610 & Constant1611 & Constant1612 & Constant1723 & Constant1741 & Constant1619 & Constant1726 & Constant1742 & Constant1729 & Constant1638 & Constant1639 & Constant1730 & Constant1731 --> PgInsertSingle116
+    Object119 & Constant1620 & Constant1621 & Constant1622 & Constant1623 & Constant1623 & Constant1053 & Constant1624 & Constant1625 & Constant1754 & Constant1627 & Constant1628 & Constant1755 & Constant1638 & Constant1639 & Constant1775 & Constant1776 & Constant1777 & Constant1645 & Constant1646 & Constant1647 & Constant1648 & Constant1649 & Constant1760 & Constant1778 & Constant1656 & Constant1763 & Constant1779 & Constant1766 & Constant1675 & Constant1676 & Constant1767 & Constant1768 --> PgInsertSingle116
     Object120{{"Object[120∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle116 --> Object120
-    Object1171{{"Object[1171∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1168 & Constant1169 & Constant1170 --> Object1171
-    Object1185{{"Object[1185∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1182 & Constant1183 & Constant1170 --> Object1185
-    Object1201{{"Object[1201∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1198 & Constant1199 & Constant1170 --> Object1201
-    Object1217{{"Object[1217∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1214 & Constant1215 & Constant1216 --> Object1217
-    Lambda1172{{"Lambda[1172∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1171 --> Lambda1172
-    Lambda1177{{"Lambda[1177∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1688 --> Lambda1177
-    Lambda1186{{"Lambda[1186∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1185 --> Lambda1186
-    Lambda1191{{"Lambda[1191∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1689 --> Lambda1191
-    Lambda1202{{"Lambda[1202∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1201 --> Lambda1202
-    Lambda1207{{"Lambda[1207∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1690 --> Lambda1207
-    Lambda1218{{"Lambda[1218∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1217 --> Lambda1218
-    Lambda1223{{"Lambda[1223∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1691 --> Lambda1223
+    Lambda265{{"Lambda[265∈2] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda265
     PgSelect222[["PgSelect[222∈3] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression221{{"PgClassExpression[221∈3] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object119 & PgClassExpression221 & Lambda1055 & Lambda1186 & Lambda1191 & Lambda1055 & Lambda1202 & Lambda1207 & Lambda1052 & Lambda1055 & Lambda1218 & Lambda1223 --> PgSelect222
+    Object119 & PgClassExpression221 & Access1056 & Lambda1196 & Lambda1201 & Access1056 & Lambda1213 & Lambda1218 & Lambda1052 & Access1056 & Lambda1230 & Lambda1235 --> PgSelect222
     PgSelect208[["PgSelect[208∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression207{{"PgClassExpression[207∈3] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object119 & PgClassExpression207 & Lambda1052 & Lambda1055 & Lambda1172 & Lambda1177 --> PgSelect208
+    Object119 & PgClassExpression207 & Lambda1052 & Access1056 & Lambda1181 & Lambda1186 --> PgSelect208
     List147{{"List[147∈3] ➊<br />ᐸ145,146ᐳ"}}:::plan
     PgClassExpression146{{"PgClassExpression[146∈3] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant145 & PgClassExpression146 --> List147
@@ -337,8 +539,8 @@ graph TD
     PgSelectSingle230{{"PgSelectSingle[230∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle225 --> PgSelectSingle230
     PgSelectSingle242{{"PgSelectSingle[242∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1208{{"RemapKeys[1208∈3] ➊<br />ᐸ225:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1208 --> PgSelectSingle242
+    RemapKeys1219{{"RemapKeys[1219∈3] ➊<br />ᐸ225:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1219 --> PgSelectSingle242
     PgClassExpression250{{"PgClassExpression[250∈3] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle225 --> PgClassExpression250
     PgClassExpression251{{"PgClassExpression[251∈3] ➊<br />ᐸ__types__.”point”ᐳ"}}:::plan
@@ -355,7 +557,7 @@ graph TD
     PgInsertSingle116 --> PgClassExpression260
     PgClassExpression262{{"PgClassExpression[262∈3] ➊<br />ᐸ__types__....ay_domain”ᐳ"}}:::plan
     PgInsertSingle116 --> PgClassExpression262
-    PgSelectSingle225 --> RemapKeys1208
+    PgSelectSingle225 --> RemapKeys1219
     __Item158[/"__Item[158∈4]<br />ᐸ157ᐳ"\]:::itemplan
     PgClassExpression157 ==> __Item158
     __Item162[/"__Item[162∈5]<br />ᐸ161ᐳ"\]:::itemplan
@@ -394,11 +596,9 @@ graph TD
     PgClassExpression260 ==> __Item261
     __Item263[/"__Item[263∈18]<br />ᐸ262ᐳ"\]:::itemplan
     PgClassExpression262 ==> __Item263
-    Lambda265{{"Lambda[265∈19] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda265
     PgInsertSingle278[["PgInsertSingle[278∈20] ➊<br />ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ"]]:::sideeffectplan
     Object281{{"Object[281∈20] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object281 & Constant1648 & Constant1649 & Constant1650 & Constant1651 & Access273 & Constant1652 & Constant1653 & Constant1654 --> PgInsertSingle278
+    Object281 & Constant1685 & Constant1686 & Constant1687 & Constant1688 & Access273 & Constant1689 & Constant1690 & Constant1691 --> PgInsertSingle278
     Access279{{"Access[279∈20] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access280{{"Access[280∈20] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access279 & Access280 --> Object281
@@ -408,49 +608,19 @@ graph TD
     PgInsertSingle278 --> Object282
     PgSelect309[["PgSelect[309∈21] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression308{{"PgClassExpression[308∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda1074{{"Lambda[1074∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1079{{"Lambda[1079∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1074 & Lambda1079 --> PgSelect309
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1076 & Lambda1081 --> PgSelect309
     PgSelect328[["PgSelect[328∈21] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1088{{"Lambda[1088∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1093{{"Lambda[1093∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1088 & Lambda1093 --> PgSelect328
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1091 & Lambda1096 --> PgSelect328
     PgSelect345[["PgSelect[345∈21] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1102{{"Lambda[1102∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1107{{"Lambda[1107∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1102 & Lambda1107 --> PgSelect345
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1106 & Lambda1111 --> PgSelect345
     PgSelect362[["PgSelect[362∈21] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1116{{"Lambda[1116∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1121{{"Lambda[1121∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1116 & Lambda1121 --> PgSelect362
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1121 & Lambda1126 --> PgSelect362
     PgSelect379[["PgSelect[379∈21] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1130{{"Lambda[1130∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1135{{"Lambda[1135∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1130 & Lambda1135 --> PgSelect379
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1136 & Lambda1141 --> PgSelect379
     PgSelect396[["PgSelect[396∈21] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1144{{"Lambda[1144∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1149{{"Lambda[1149∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1144 & Lambda1149 --> PgSelect396
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1151 & Lambda1156 --> PgSelect396
     PgSelect431[["PgSelect[431∈21] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1158{{"Lambda[1158∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1163{{"Lambda[1163∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object281 & PgClassExpression308 & Lambda1052 & Lambda1055 & Lambda1158 & Lambda1163 --> PgSelect431
-    Object1059{{"Object[1059∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1056 & Constant1057 & Constant1058 --> Object1059
-    Object1073{{"Object[1073∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1070 & Constant1071 & Constant1058 --> Object1073
-    Object1087{{"Object[1087∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1084 & Constant1085 & Constant1058 --> Object1087
-    Object1101{{"Object[1101∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1098 & Constant1099 & Constant1058 --> Object1101
-    Object1115{{"Object[1115∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1112 & Constant1113 & Constant1058 --> Object1115
-    Object1129{{"Object[1129∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1126 & Constant1127 & Constant1058 --> Object1129
-    Object1143{{"Object[1143∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1140 & Constant1141 & Constant1058 --> Object1143
-    Object1157{{"Object[1157∈21] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1154 & Constant1155 & Constant1058 --> Object1157
+    Object281 & PgClassExpression308 & Lambda1052 & Access1056 & Lambda1166 & Lambda1171 --> PgSelect431
     Edge316{{"Edge[316∈21] ➊"}}:::plan
     PgSelectSingle315{{"PgSelectSingle[315∈21] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor317{{"PgCursor[317∈21] ➊"}}:::plan
@@ -490,13 +660,28 @@ graph TD
     PgCursor437{{"PgCursor[437∈21] ➊"}}:::plan
     Connection433{{"Connection[433∈21] ➊<br />ᐸ431ᐳ"}}:::plan
     PgSelectSingle435 & PgCursor437 & Connection433 --> Edge436
+    List286{{"List[286∈21] ➊<br />ᐸ284,308ᐳ"}}:::plan
+    Constant284 & PgClassExpression308 --> List286
     List322{{"List[322∈21] ➊<br />ᐸ284,318ᐳ"}}:::plan
     PgClassExpression318{{"PgClassExpression[318∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant284 & PgClassExpression318 --> List322
+    List339{{"List[339∈21] ➊<br />ᐸ284,335ᐳ"}}:::plan
+    PgClassExpression335{{"PgClassExpression[335∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression335 --> List339
+    List356{{"List[356∈21] ➊<br />ᐸ284,352ᐳ"}}:::plan
+    PgClassExpression352{{"PgClassExpression[352∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression352 --> List356
+    List373{{"List[373∈21] ➊<br />ᐸ284,369ᐳ"}}:::plan
+    PgClassExpression369{{"PgClassExpression[369∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression369 --> List373
     List440{{"List[440∈21] ➊<br />ᐸ438,439ᐳ"}}:::plan
     PgClassExpression438{{"PgClassExpression[438∈21] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgClassExpression439{{"PgClassExpression[439∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgClassExpression438 & PgClassExpression439 --> List440
+    List443{{"List[443∈21] ➊<br />ᐸ284,439ᐳ"}}:::plan
+    Constant284 & PgClassExpression439 --> List443
+    Lambda287{{"Lambda[287∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List286 --> Lambda287
     PgInsertSingle278 --> PgClassExpression308
     First314{{"First[314∈21] ➊"}}:::plan
     PgSelect309 --> First314
@@ -512,25 +697,28 @@ graph TD
     First331 --> PgSelectSingle332
     List336{{"List[336∈21] ➊<br />ᐸ335ᐳ"}}:::plan
     List336 --> PgCursor334
-    PgClassExpression335{{"PgClassExpression[335∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle332 --> PgClassExpression335
     PgClassExpression335 --> List336
+    Lambda340{{"Lambda[340∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List339 --> Lambda340
     First348{{"First[348∈21] ➊"}}:::plan
     PgSelect345 --> First348
     First348 --> PgSelectSingle349
     List353{{"List[353∈21] ➊<br />ᐸ352ᐳ"}}:::plan
     List353 --> PgCursor351
-    PgClassExpression352{{"PgClassExpression[352∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle349 --> PgClassExpression352
     PgClassExpression352 --> List353
+    Lambda357{{"Lambda[357∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List356 --> Lambda357
     First365{{"First[365∈21] ➊"}}:::plan
     PgSelect362 --> First365
     First365 --> PgSelectSingle366
     List370{{"List[370∈21] ➊<br />ᐸ369ᐳ"}}:::plan
     List370 --> PgCursor368
-    PgClassExpression369{{"PgClassExpression[369∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle366 --> PgClassExpression369
     PgClassExpression369 --> List370
+    Lambda374{{"Lambda[374∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List373 --> Lambda374
     First382{{"First[382∈21] ➊"}}:::plan
     PgSelect379 --> First382
     First382 --> PgSelectSingle383
@@ -554,31 +742,13 @@ graph TD
     List440 --> PgCursor437
     PgSelectSingle435 --> PgClassExpression438
     PgSelectSingle435 --> PgClassExpression439
-    Lambda1060{{"Lambda[1060∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1059 --> Lambda1060
-    Lambda1065{{"Lambda[1065∈21] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1680 --> Lambda1065
-    Object1073 --> Lambda1074
-    Constant1681 --> Lambda1079
-    Object1087 --> Lambda1088
-    Constant1682 --> Lambda1093
-    Object1101 --> Lambda1102
-    Constant1683 --> Lambda1107
-    Object1115 --> Lambda1116
-    Constant1684 --> Lambda1121
-    Object1129 --> Lambda1130
-    Constant1685 --> Lambda1135
-    Object1143 --> Lambda1144
-    Constant1686 --> Lambda1149
-    Object1157 --> Lambda1158
-    Constant1687 --> Lambda1163
+    Lambda444{{"Lambda[444∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List443 --> Lambda444
+    Lambda447{{"Lambda[447∈21] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda447
     PgSelect298[["PgSelect[298∈22] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression297{{"PgClassExpression[297∈22] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object281 & PgClassExpression297 & Constant1655 & Lambda1052 & Lambda1055 & Lambda1060 & Lambda1065 --> PgSelect298
-    List286{{"List[286∈22] ➊<br />ᐸ284,308ᐳ"}}:::plan
-    Constant284 & PgClassExpression308 --> List286
-    Lambda287{{"Lambda[287∈22] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List286 --> Lambda287
+    Object281 & PgClassExpression297 & Constant1692 & Lambda1052 & Access1056 & Lambda1061 & Lambda1066 --> PgSelect298
     PgClassExpression289{{"PgClassExpression[289∈22] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgInsertSingle278 --> PgClassExpression289
     PgClassExpression290{{"PgClassExpression[290∈22] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -602,22 +772,10 @@ graph TD
     PgSelectSingle303 --> PgClassExpression305
     PgClassExpression324{{"PgClassExpression[324∈24] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle315 --> PgClassExpression324
-    List339{{"List[339∈25] ➊<br />ᐸ284,335ᐳ"}}:::plan
-    Constant284 & PgClassExpression335 --> List339
-    Lambda340{{"Lambda[340∈25] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List339 --> Lambda340
     PgClassExpression341{{"PgClassExpression[341∈26] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle332 --> PgClassExpression341
-    List356{{"List[356∈27] ➊<br />ᐸ284,352ᐳ"}}:::plan
-    Constant284 & PgClassExpression352 --> List356
-    Lambda357{{"Lambda[357∈27] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List356 --> Lambda357
     PgClassExpression358{{"PgClassExpression[358∈28] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle349 --> PgClassExpression358
-    List373{{"List[373∈29] ➊<br />ᐸ284,369ᐳ"}}:::plan
-    Constant284 & PgClassExpression369 --> List373
-    Lambda374{{"Lambda[374∈29] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List373 --> Lambda374
     PgClassExpression375{{"PgClassExpression[375∈30] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle366 --> PgClassExpression375
     List390{{"List[390∈32] ➊<br />ᐸ284,389ᐳ"}}:::plan
@@ -638,69 +796,33 @@ graph TD
     PgSelectSingle400 --> PgClassExpression409
     PgClassExpression426{{"PgClassExpression[426∈36] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle315 --> PgClassExpression426
-    List443{{"List[443∈37] ➊<br />ᐸ284,439ᐳ"}}:::plan
-    Constant284 & PgClassExpression439 --> List443
-    Lambda444{{"Lambda[444∈37] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List443 --> Lambda444
     PgClassExpression445{{"PgClassExpression[445∈38] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle435 --> PgClassExpression445
-    Lambda447{{"Lambda[447∈39] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda447
     PgInsertSingle460[["PgInsertSingle[460∈40] ➊<br />ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ"]]:::sideeffectplan
     Object463{{"Object[463∈40] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object463 & Constant1624 & Constant1657 & Constant1658 & Constant1659 & Constant144 & Constant1660 & Constant1638 & Constant1661 --> PgInsertSingle460
+    Object463 & Constant1661 & Constant1694 & Constant1695 & Constant1696 & Constant144 & Constant1697 & Constant1675 & Constant1698 --> PgInsertSingle460
     Access461{{"Access[461∈40] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access462{{"Access[462∈40] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access461 & Access462 --> Object463
     Object464{{"Object[464∈40] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgInsertSingle460 & Constant1656 --> Object464
+    PgInsertSingle460 & Constant1693 --> Object464
     __Value2 --> Access461
     __Value2 --> Access462
     PgSelect490[["PgSelect[490∈41] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression489{{"PgClassExpression[489∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda1246{{"Lambda[1246∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1251{{"Lambda[1251∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1246 & Lambda1251 --> PgSelect490
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1260 & Lambda1265 --> PgSelect490
     PgSelect509[["PgSelect[509∈41] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1260{{"Lambda[1260∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1265{{"Lambda[1265∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1260 & Lambda1265 --> PgSelect509
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1275 & Lambda1280 --> PgSelect509
     PgSelect526[["PgSelect[526∈41] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1274{{"Lambda[1274∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1279{{"Lambda[1279∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1274 & Lambda1279 --> PgSelect526
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1290 & Lambda1295 --> PgSelect526
     PgSelect543[["PgSelect[543∈41] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1288{{"Lambda[1288∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1293{{"Lambda[1293∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1288 & Lambda1293 --> PgSelect543
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1305 & Lambda1310 --> PgSelect543
     PgSelect560[["PgSelect[560∈41] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1302{{"Lambda[1302∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1307{{"Lambda[1307∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1302 & Lambda1307 --> PgSelect560
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1320 & Lambda1325 --> PgSelect560
     PgSelect577[["PgSelect[577∈41] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1316{{"Lambda[1316∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1321{{"Lambda[1321∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1316 & Lambda1321 --> PgSelect577
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1335 & Lambda1340 --> PgSelect577
     PgSelect612[["PgSelect[612∈41] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1330{{"Lambda[1330∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1335{{"Lambda[1335∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object463 & PgClassExpression489 & Lambda1052 & Lambda1055 & Lambda1330 & Lambda1335 --> PgSelect612
-    Object1231{{"Object[1231∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1228 & Constant1229 & Constant1058 --> Object1231
-    Object1245{{"Object[1245∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1242 & Constant1243 & Constant1058 --> Object1245
-    Object1259{{"Object[1259∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1256 & Constant1257 & Constant1058 --> Object1259
-    Object1273{{"Object[1273∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1270 & Constant1271 & Constant1058 --> Object1273
-    Object1287{{"Object[1287∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1284 & Constant1285 & Constant1058 --> Object1287
-    Object1301{{"Object[1301∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1298 & Constant1299 & Constant1058 --> Object1301
-    Object1315{{"Object[1315∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1312 & Constant1313 & Constant1058 --> Object1315
-    Object1329{{"Object[1329∈41] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1326 & Constant1327 & Constant1058 --> Object1329
+    Object463 & PgClassExpression489 & Lambda1052 & Access1056 & Lambda1350 & Lambda1355 --> PgSelect612
     Edge497{{"Edge[497∈41] ➊"}}:::plan
     PgSelectSingle496{{"PgSelectSingle[496∈41] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor498{{"PgCursor[498∈41] ➊"}}:::plan
@@ -740,13 +862,28 @@ graph TD
     PgCursor618{{"PgCursor[618∈41] ➊"}}:::plan
     Connection614{{"Connection[614∈41] ➊<br />ᐸ612ᐳ"}}:::plan
     PgSelectSingle616 & PgCursor618 & Connection614 --> Edge617
+    List467{{"List[467∈41] ➊<br />ᐸ284,489ᐳ"}}:::plan
+    Constant284 & PgClassExpression489 --> List467
     List503{{"List[503∈41] ➊<br />ᐸ284,499ᐳ"}}:::plan
     PgClassExpression499{{"PgClassExpression[499∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant284 & PgClassExpression499 --> List503
+    List520{{"List[520∈41] ➊<br />ᐸ284,516ᐳ"}}:::plan
+    PgClassExpression516{{"PgClassExpression[516∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression516 --> List520
+    List537{{"List[537∈41] ➊<br />ᐸ284,533ᐳ"}}:::plan
+    PgClassExpression533{{"PgClassExpression[533∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression533 --> List537
+    List554{{"List[554∈41] ➊<br />ᐸ284,550ᐳ"}}:::plan
+    PgClassExpression550{{"PgClassExpression[550∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression550 --> List554
     List621{{"List[621∈41] ➊<br />ᐸ619,620ᐳ"}}:::plan
     PgClassExpression619{{"PgClassExpression[619∈41] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgClassExpression620{{"PgClassExpression[620∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgClassExpression619 & PgClassExpression620 --> List621
+    List624{{"List[624∈41] ➊<br />ᐸ284,620ᐳ"}}:::plan
+    Constant284 & PgClassExpression620 --> List624
+    Lambda468{{"Lambda[468∈41] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List467 --> Lambda468
     PgInsertSingle460 --> PgClassExpression489
     First495{{"First[495∈41] ➊"}}:::plan
     PgSelect490 --> First495
@@ -762,25 +899,28 @@ graph TD
     First512 --> PgSelectSingle513
     List517{{"List[517∈41] ➊<br />ᐸ516ᐳ"}}:::plan
     List517 --> PgCursor515
-    PgClassExpression516{{"PgClassExpression[516∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle513 --> PgClassExpression516
     PgClassExpression516 --> List517
+    Lambda521{{"Lambda[521∈41] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List520 --> Lambda521
     First529{{"First[529∈41] ➊"}}:::plan
     PgSelect526 --> First529
     First529 --> PgSelectSingle530
     List534{{"List[534∈41] ➊<br />ᐸ533ᐳ"}}:::plan
     List534 --> PgCursor532
-    PgClassExpression533{{"PgClassExpression[533∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle530 --> PgClassExpression533
     PgClassExpression533 --> List534
+    Lambda538{{"Lambda[538∈41] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List537 --> Lambda538
     First546{{"First[546∈41] ➊"}}:::plan
     PgSelect543 --> First546
     First546 --> PgSelectSingle547
     List551{{"List[551∈41] ➊<br />ᐸ550ᐳ"}}:::plan
     List551 --> PgCursor549
-    PgClassExpression550{{"PgClassExpression[550∈41] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle547 --> PgClassExpression550
     PgClassExpression550 --> List551
+    Lambda555{{"Lambda[555∈41] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List554 --> Lambda555
     First563{{"First[563∈41] ➊"}}:::plan
     PgSelect560 --> First563
     First563 --> PgSelectSingle564
@@ -804,31 +944,13 @@ graph TD
     List621 --> PgCursor618
     PgSelectSingle616 --> PgClassExpression619
     PgSelectSingle616 --> PgClassExpression620
-    Lambda1232{{"Lambda[1232∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1231 --> Lambda1232
-    Lambda1237{{"Lambda[1237∈41] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1692 --> Lambda1237
-    Object1245 --> Lambda1246
-    Constant1693 --> Lambda1251
-    Object1259 --> Lambda1260
-    Constant1694 --> Lambda1265
-    Object1273 --> Lambda1274
-    Constant1695 --> Lambda1279
-    Object1287 --> Lambda1288
-    Constant1696 --> Lambda1293
-    Object1301 --> Lambda1302
-    Constant1697 --> Lambda1307
-    Object1315 --> Lambda1316
-    Constant1698 --> Lambda1321
-    Object1329 --> Lambda1330
-    Constant1699 --> Lambda1335
+    Lambda625{{"Lambda[625∈41] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List624 --> Lambda625
+    Lambda628{{"Lambda[628∈41] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda628
     PgSelect479[["PgSelect[479∈42] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression478{{"PgClassExpression[478∈42] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object463 & PgClassExpression478 & Constant1655 & Lambda1052 & Lambda1055 & Lambda1232 & Lambda1237 --> PgSelect479
-    List467{{"List[467∈42] ➊<br />ᐸ284,489ᐳ"}}:::plan
-    Constant284 & PgClassExpression489 --> List467
-    Lambda468{{"Lambda[468∈42] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List467 --> Lambda468
+    Object463 & PgClassExpression478 & Constant1692 & Lambda1052 & Access1056 & Lambda1245 & Lambda1250 --> PgSelect479
     PgClassExpression470{{"PgClassExpression[470∈42] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgInsertSingle460 --> PgClassExpression470
     PgClassExpression471{{"PgClassExpression[471∈42] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -852,22 +974,10 @@ graph TD
     PgSelectSingle484 --> PgClassExpression486
     PgClassExpression505{{"PgClassExpression[505∈44] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle496 --> PgClassExpression505
-    List520{{"List[520∈45] ➊<br />ᐸ284,516ᐳ"}}:::plan
-    Constant284 & PgClassExpression516 --> List520
-    Lambda521{{"Lambda[521∈45] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List520 --> Lambda521
     PgClassExpression522{{"PgClassExpression[522∈46] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle513 --> PgClassExpression522
-    List537{{"List[537∈47] ➊<br />ᐸ284,533ᐳ"}}:::plan
-    Constant284 & PgClassExpression533 --> List537
-    Lambda538{{"Lambda[538∈47] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List537 --> Lambda538
     PgClassExpression539{{"PgClassExpression[539∈48] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle530 --> PgClassExpression539
-    List554{{"List[554∈49] ➊<br />ᐸ284,550ᐳ"}}:::plan
-    Constant284 & PgClassExpression550 --> List554
-    Lambda555{{"Lambda[555∈49] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List554 --> Lambda555
     PgClassExpression556{{"PgClassExpression[556∈50] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle547 --> PgClassExpression556
     List571{{"List[571∈52] ➊<br />ᐸ284,570ᐳ"}}:::plan
@@ -888,38 +998,28 @@ graph TD
     PgSelectSingle581 --> PgClassExpression590
     PgClassExpression607{{"PgClassExpression[607∈56] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle496 --> PgClassExpression607
-    List624{{"List[624∈57] ➊<br />ᐸ284,620ᐳ"}}:::plan
-    Constant284 & PgClassExpression620 --> List624
-    Lambda625{{"Lambda[625∈57] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List624 --> Lambda625
     PgClassExpression626{{"PgClassExpression[626∈58] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle616 --> PgClassExpression626
-    Lambda628{{"Lambda[628∈59] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda628
     PgInsertSingle635[["PgInsertSingle[635∈60] ➊<br />ᐸcompound_key(person_id_2,person_id_1,extra)ᐳ"]]:::sideeffectplan
     Object638{{"Object[638∈60] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object638 & Constant1624 & Constant1648 & Constant1053 --> PgInsertSingle635
+    Object638 & Constant1661 & Constant1685 & Constant1053 --> PgInsertSingle635
     Access636{{"Access[636∈60] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access637{{"Access[637∈60] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access636 & Access637 --> Object638
     Object639{{"Object[639∈60] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgInsertSingle635 & Constant1662 --> Object639
+    PgInsertSingle635 & Constant1699 --> Object639
     __Value2 --> Access636
     __Value2 --> Access637
     PgSelect649[["PgSelect[649∈61] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression670{{"PgClassExpression[670∈61] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
-    Lambda1344{{"Lambda[1344∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1349{{"Lambda[1349∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object638 & PgClassExpression670 & Lambda1052 & Lambda1055 & Lambda1344 & Lambda1349 --> PgSelect649
+    Object638 & PgClassExpression670 & Lambda1052 & Access1056 & Lambda1365 & Lambda1370 --> PgSelect649
     PgSelect661[["PgSelect[661∈61] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression682{{"PgClassExpression[682∈61] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
-    Lambda1358{{"Lambda[1358∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1363{{"Lambda[1363∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object638 & PgClassExpression682 & Lambda1052 & Lambda1055 & Lambda1358 & Lambda1363 --> PgSelect661
-    Object1343{{"Object[1343∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1340 & Constant1341 & Constant1058 --> Object1343
-    Object1357{{"Object[1357∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1354 & Constant1355 & Constant1058 --> Object1357
+    Object638 & PgClassExpression682 & Lambda1052 & Access1056 & Lambda1380 & Lambda1385 --> PgSelect661
+    List643{{"List[643∈61] ➊<br />ᐸ640,670,682ᐳ"}}:::plan
+    Constant640 & PgClassExpression670 & PgClassExpression682 --> List643
+    Lambda644{{"Lambda[644∈61] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List643 --> Lambda644
     First653{{"First[653∈61] ➊"}}:::plan
     PgSelect649 --> First653
     PgSelectSingle654{{"PgSelectSingle[654∈61] ➊<br />ᐸpersonᐳ"}}:::plan
@@ -930,14 +1030,8 @@ graph TD
     First663 --> PgSelectSingle664
     PgInsertSingle635 --> PgClassExpression670
     PgInsertSingle635 --> PgClassExpression682
-    Object1343 --> Lambda1344
-    Constant1700 --> Lambda1349
-    Object1357 --> Lambda1358
-    Constant1701 --> Lambda1363
-    List643{{"List[643∈62] ➊<br />ᐸ640,670,682ᐳ"}}:::plan
-    Constant640 & PgClassExpression670 & PgClassExpression682 --> List643
-    Lambda644{{"Lambda[644∈62] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List643 --> Lambda644
+    Lambda693{{"Lambda[693∈61] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda693
     PgClassExpression647{{"PgClassExpression[647∈62] ➊<br />ᐸ__compound...__.”extra”ᐳ"}}:::plan
     PgInsertSingle635 --> PgClassExpression647
     List657{{"List[657∈63] ➊<br />ᐸ284,656ᐳ"}}:::plan
@@ -972,11 +1066,9 @@ graph TD
     List689 --> Lambda690
     PgClassExpression691{{"PgClassExpression[691∈66] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle664 --> PgClassExpression691
-    Lambda693{{"Lambda[693∈67] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda693
     PgInsertSingle698[["PgInsertSingle[698∈68] ➊<br />ᐸedge_case(not_null_has_default)ᐳ"]]:::sideeffectplan
     Object701{{"Object[701∈68] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object701 & Constant1604 --> PgInsertSingle698
+    Object701 & Constant1641 --> PgInsertSingle698
     Access699{{"Access[699∈68] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access700{{"Access[700∈68] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access699 & Access700 --> Object701
@@ -984,10 +1076,10 @@ graph TD
     __Value2 --> Access700
     Object702{{"Object[702∈68] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle698 --> Object702
+    Lambda705{{"Lambda[705∈69] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda705
     PgClassExpression703{{"PgClassExpression[703∈70] ➊<br />ᐸ__edge_cas...s_default”ᐳ"}}:::plan
     PgInsertSingle698 --> PgClassExpression703
-    Lambda705{{"Lambda[705∈71] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda705
     Object712{{"Object[712∈72] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access710{{"Access[710∈72] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access711{{"Access[711∈72] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -998,13 +1090,13 @@ graph TD
     __Value2 --> Access711
     Object713{{"Object[713∈72] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle709 --> Object713
+    Lambda716{{"Lambda[716∈73] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda716
     PgClassExpression714{{"PgClassExpression[714∈74] ➊<br />ᐸ__edge_cas...s_default”ᐳ"}}:::plan
     PgInsertSingle709 --> PgClassExpression714
-    Lambda716{{"Lambda[716∈75] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda716
     PgInsertSingle728[["PgInsertSingle[728∈76] ➊<br />ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ"]]:::sideeffectplan
     Object731{{"Object[731∈76] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object731 & Constant1663 & Constant1664 & Constant144 & Constant1665 & __InputDynamicScalar724 & Constant1666 & Constant1667 & Constant1668 --> PgInsertSingle728
+    Object731 & Constant1700 & Constant1701 & Constant144 & Constant1702 & __InputDynamicScalar724 & Constant1703 & Constant1704 & Constant1705 --> PgInsertSingle728
     Access729{{"Access[729∈76] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access730{{"Access[730∈76] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access729 & Access730 --> Object731
@@ -1014,49 +1106,19 @@ graph TD
     PgInsertSingle728 --> Object732
     PgSelect759[["PgSelect[759∈77] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression758{{"PgClassExpression[758∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda1386{{"Lambda[1386∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1391{{"Lambda[1391∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1386 & Lambda1391 --> PgSelect759
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1410 & Lambda1415 --> PgSelect759
     PgSelect778[["PgSelect[778∈77] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1400{{"Lambda[1400∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1405{{"Lambda[1405∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1400 & Lambda1405 --> PgSelect778
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1425 & Lambda1430 --> PgSelect778
     PgSelect795[["PgSelect[795∈77] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1414{{"Lambda[1414∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1419{{"Lambda[1419∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1414 & Lambda1419 --> PgSelect795
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1440 & Lambda1445 --> PgSelect795
     PgSelect812[["PgSelect[812∈77] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1428{{"Lambda[1428∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1433{{"Lambda[1433∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1428 & Lambda1433 --> PgSelect812
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1455 & Lambda1460 --> PgSelect812
     PgSelect829[["PgSelect[829∈77] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1442{{"Lambda[1442∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1447{{"Lambda[1447∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1442 & Lambda1447 --> PgSelect829
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1470 & Lambda1475 --> PgSelect829
     PgSelect846[["PgSelect[846∈77] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1456{{"Lambda[1456∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1461{{"Lambda[1461∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1456 & Lambda1461 --> PgSelect846
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1485 & Lambda1490 --> PgSelect846
     PgSelect881[["PgSelect[881∈77] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1470{{"Lambda[1470∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1475{{"Lambda[1475∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 & PgClassExpression758 & Lambda1052 & Lambda1055 & Lambda1470 & Lambda1475 --> PgSelect881
-    Object1371{{"Object[1371∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1368 & Constant1369 & Constant1058 --> Object1371
-    Object1385{{"Object[1385∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1382 & Constant1383 & Constant1058 --> Object1385
-    Object1399{{"Object[1399∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1396 & Constant1397 & Constant1058 --> Object1399
-    Object1413{{"Object[1413∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1410 & Constant1411 & Constant1058 --> Object1413
-    Object1427{{"Object[1427∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1424 & Constant1425 & Constant1058 --> Object1427
-    Object1441{{"Object[1441∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1438 & Constant1439 & Constant1058 --> Object1441
-    Object1455{{"Object[1455∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1452 & Constant1453 & Constant1058 --> Object1455
-    Object1469{{"Object[1469∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1466 & Constant1467 & Constant1058 --> Object1469
+    Object731 & PgClassExpression758 & Lambda1052 & Access1056 & Lambda1500 & Lambda1505 --> PgSelect881
     Edge766{{"Edge[766∈77] ➊"}}:::plan
     PgSelectSingle765{{"PgSelectSingle[765∈77] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor767{{"PgCursor[767∈77] ➊"}}:::plan
@@ -1096,13 +1158,28 @@ graph TD
     PgCursor887{{"PgCursor[887∈77] ➊"}}:::plan
     Connection883{{"Connection[883∈77] ➊<br />ᐸ881ᐳ"}}:::plan
     PgSelectSingle885 & PgCursor887 & Connection883 --> Edge886
+    List736{{"List[736∈77] ➊<br />ᐸ284,758ᐳ"}}:::plan
+    Constant284 & PgClassExpression758 --> List736
     List772{{"List[772∈77] ➊<br />ᐸ284,768ᐳ"}}:::plan
     PgClassExpression768{{"PgClassExpression[768∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant284 & PgClassExpression768 --> List772
+    List789{{"List[789∈77] ➊<br />ᐸ284,785ᐳ"}}:::plan
+    PgClassExpression785{{"PgClassExpression[785∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression785 --> List789
+    List806{{"List[806∈77] ➊<br />ᐸ284,802ᐳ"}}:::plan
+    PgClassExpression802{{"PgClassExpression[802∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression802 --> List806
+    List823{{"List[823∈77] ➊<br />ᐸ284,819ᐳ"}}:::plan
+    PgClassExpression819{{"PgClassExpression[819∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant284 & PgClassExpression819 --> List823
     List890{{"List[890∈77] ➊<br />ᐸ888,889ᐳ"}}:::plan
     PgClassExpression888{{"PgClassExpression[888∈77] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgClassExpression889{{"PgClassExpression[889∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgClassExpression888 & PgClassExpression889 --> List890
+    List893{{"List[893∈77] ➊<br />ᐸ284,889ᐳ"}}:::plan
+    Constant284 & PgClassExpression889 --> List893
+    Lambda737{{"Lambda[737∈77] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List736 --> Lambda737
     PgInsertSingle728 --> PgClassExpression758
     First764{{"First[764∈77] ➊"}}:::plan
     PgSelect759 --> First764
@@ -1118,25 +1195,28 @@ graph TD
     First781 --> PgSelectSingle782
     List786{{"List[786∈77] ➊<br />ᐸ785ᐳ"}}:::plan
     List786 --> PgCursor784
-    PgClassExpression785{{"PgClassExpression[785∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle782 --> PgClassExpression785
     PgClassExpression785 --> List786
+    Lambda790{{"Lambda[790∈77] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List789 --> Lambda790
     First798{{"First[798∈77] ➊"}}:::plan
     PgSelect795 --> First798
     First798 --> PgSelectSingle799
     List803{{"List[803∈77] ➊<br />ᐸ802ᐳ"}}:::plan
     List803 --> PgCursor801
-    PgClassExpression802{{"PgClassExpression[802∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle799 --> PgClassExpression802
     PgClassExpression802 --> List803
+    Lambda807{{"Lambda[807∈77] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List806 --> Lambda807
     First815{{"First[815∈77] ➊"}}:::plan
     PgSelect812 --> First815
     First815 --> PgSelectSingle816
     List820{{"List[820∈77] ➊<br />ᐸ819ᐳ"}}:::plan
     List820 --> PgCursor818
-    PgClassExpression819{{"PgClassExpression[819∈77] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle816 --> PgClassExpression819
     PgClassExpression819 --> List820
+    Lambda824{{"Lambda[824∈77] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List823 --> Lambda824
     First832{{"First[832∈77] ➊"}}:::plan
     PgSelect829 --> First832
     First832 --> PgSelectSingle833
@@ -1160,31 +1240,13 @@ graph TD
     List890 --> PgCursor887
     PgSelectSingle885 --> PgClassExpression888
     PgSelectSingle885 --> PgClassExpression889
-    Lambda1372{{"Lambda[1372∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1371 --> Lambda1372
-    Lambda1377{{"Lambda[1377∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1702 --> Lambda1377
-    Object1385 --> Lambda1386
-    Constant1703 --> Lambda1391
-    Object1399 --> Lambda1400
-    Constant1704 --> Lambda1405
-    Object1413 --> Lambda1414
-    Constant1705 --> Lambda1419
-    Object1427 --> Lambda1428
-    Constant1706 --> Lambda1433
-    Object1441 --> Lambda1442
-    Constant1707 --> Lambda1447
-    Object1455 --> Lambda1456
-    Constant1708 --> Lambda1461
-    Object1469 --> Lambda1470
-    Constant1709 --> Lambda1475
+    Lambda894{{"Lambda[894∈77] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List893 --> Lambda894
+    Lambda897{{"Lambda[897∈77] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant264 --> Lambda897
     PgSelect748[["PgSelect[748∈78] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression747{{"PgClassExpression[747∈78] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object731 & PgClassExpression747 & Constant1655 & Lambda1052 & Lambda1055 & Lambda1372 & Lambda1377 --> PgSelect748
-    List736{{"List[736∈78] ➊<br />ᐸ284,758ᐳ"}}:::plan
-    Constant284 & PgClassExpression758 --> List736
-    Lambda737{{"Lambda[737∈78] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List736 --> Lambda737
+    Object731 & PgClassExpression747 & Constant1692 & Lambda1052 & Access1056 & Lambda1395 & Lambda1400 --> PgSelect748
     PgClassExpression739{{"PgClassExpression[739∈78] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgInsertSingle728 --> PgClassExpression739
     PgClassExpression740{{"PgClassExpression[740∈78] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -1208,22 +1270,10 @@ graph TD
     PgSelectSingle753 --> PgClassExpression755
     PgClassExpression774{{"PgClassExpression[774∈80] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle765 --> PgClassExpression774
-    List789{{"List[789∈81] ➊<br />ᐸ284,785ᐳ"}}:::plan
-    Constant284 & PgClassExpression785 --> List789
-    Lambda790{{"Lambda[790∈81] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List789 --> Lambda790
     PgClassExpression791{{"PgClassExpression[791∈82] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle782 --> PgClassExpression791
-    List806{{"List[806∈83] ➊<br />ᐸ284,802ᐳ"}}:::plan
-    Constant284 & PgClassExpression802 --> List806
-    Lambda807{{"Lambda[807∈83] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List806 --> Lambda807
     PgClassExpression808{{"PgClassExpression[808∈84] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle799 --> PgClassExpression808
-    List823{{"List[823∈85] ➊<br />ᐸ284,819ᐳ"}}:::plan
-    Constant284 & PgClassExpression819 --> List823
-    Lambda824{{"Lambda[824∈85] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List823 --> Lambda824
     PgClassExpression825{{"PgClassExpression[825∈86] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle816 --> PgClassExpression825
     List840{{"List[840∈88] ➊<br />ᐸ284,839ᐳ"}}:::plan
@@ -1244,17 +1294,11 @@ graph TD
     PgSelectSingle850 --> PgClassExpression859
     PgClassExpression876{{"PgClassExpression[876∈92] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle765 --> PgClassExpression876
-    List893{{"List[893∈93] ➊<br />ᐸ284,889ᐳ"}}:::plan
-    Constant284 & PgClassExpression889 --> List893
-    Lambda894{{"Lambda[894∈93] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List893 --> Lambda894
     PgClassExpression895{{"PgClassExpression[895∈94] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle885 --> PgClassExpression895
-    Lambda897{{"Lambda[897∈95] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant264 --> Lambda897
     PgInsertSingle905[["PgInsertSingle[905∈96] ➊<br />ᐸperson(id,person_full_name,about,email)ᐳ"]]:::sideeffectplan
     Object908{{"Object[908∈96] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object908 & Constant1669 & Constant1670 & Constant144 & Constant1655 --> PgInsertSingle905
+    Object908 & Constant1706 & Constant1707 & Constant144 & Constant1692 --> PgInsertSingle905
     Access906{{"Access[906∈96] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access907{{"Access[907∈96] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access906 & Access907 --> Object908
@@ -1262,15 +1306,9 @@ graph TD
     __Value2 --> Access907
     Object909{{"Object[909∈96] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle905 --> Object909
-    Object1483{{"Object[1483∈97] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1480 & Constant1481 & Constant1058 --> Object1483
-    Lambda1484{{"Lambda[1484∈97] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1483 --> Lambda1484
-    Lambda1489{{"Lambda[1489∈97] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1710 --> Lambda1489
     PgSelect912[["PgSelect[912∈98] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression911{{"PgClassExpression[911∈98] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object908 & PgClassExpression911 & Constant1655 & Lambda1052 & Lambda1055 & Lambda1484 & Lambda1489 --> PgSelect912
+    Object908 & PgClassExpression911 & Constant1692 & Lambda1052 & Access1056 & Lambda1515 & Lambda1520 --> PgSelect912
     PgInsertSingle905 --> PgClassExpression911
     First916{{"First[916∈98] ➊"}}:::plan
     PgSelect912 --> First916
@@ -1280,7 +1318,7 @@ graph TD
     PgSelectSingle917 --> PgClassExpression919
     PgInsertSingle925[["PgInsertSingle[925∈99] ➊<br />ᐸdefault_value(id,null_value)ᐳ"]]:::sideeffectplan
     Object928{{"Object[928∈99] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object928 & Constant1671 & Constant144 --> PgInsertSingle925
+    Object928 & Constant1708 & Constant144 --> PgInsertSingle925
     Access926{{"Access[926∈99] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access927{{"Access[927∈99] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access926 & Access927 --> Object928
@@ -1294,7 +1332,7 @@ graph TD
     PgInsertSingle925 --> PgClassExpression931
     PgInsertSingle946[["PgInsertSingle[946∈102] ➊<br />ᐸpost(headline,comptypes)ᐳ"]]:::sideeffectplan
     Object949{{"Object[949∈102] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object949 & Constant1672 & Constant1743 --> PgInsertSingle946
+    Object949 & Constant1709 & Constant1780 --> PgInsertSingle946
     Access947{{"Access[947∈102] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access948{{"Access[948∈102] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access947 & Access948 --> Object949
@@ -1302,15 +1340,9 @@ graph TD
     __Value2 --> Access948
     Object950{{"Object[950∈102] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle946 --> Object950
-    Object1497{{"Object[1497∈103] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1494 & Constant1495 & Constant1496 --> Object1497
-    Lambda1498{{"Lambda[1498∈103] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1497 --> Lambda1498
-    Lambda1503{{"Lambda[1503∈103] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1711 --> Lambda1503
     PgSelect958[["PgSelect[958∈104] ➊<br />ᐸfrmcdc_comptypeᐳ"]]:::plan
     PgClassExpression957{{"PgClassExpression[957∈104] ➊<br />ᐸ__post__.”comptypes”ᐳ"}}:::plan
-    Object949 & PgClassExpression957 & Lambda1052 & Lambda1055 & Lambda1498 & Lambda1503 --> PgSelect958
+    Object949 & PgClassExpression957 & Lambda1052 & Access1056 & Lambda1530 & Lambda1535 --> PgSelect958
     PgClassExpression955{{"PgClassExpression[955∈104] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgInsertSingle946 --> PgClassExpression955
     PgClassExpression956{{"PgClassExpression[956∈104] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -1326,7 +1358,7 @@ graph TD
     PgSelectSingle963 --> PgClassExpression965
     PgInsertSingle981[["PgInsertSingle[981∈107] ➊<br />ᐸpost(headline,author_id,comptypes)ᐳ"]]:::sideeffectplan
     Object984{{"Object[984∈107] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object984 & Constant1676 & Constant1613 & Constant1744 --> PgInsertSingle981
+    Object984 & Constant1713 & Constant1650 & Constant1781 --> PgInsertSingle981
     Access982{{"Access[982∈107] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access983{{"Access[983∈107] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access982 & Access983 --> Object984
@@ -1336,32 +1368,14 @@ graph TD
     PgInsertSingle981 --> Object985
     PgSelect1016[["PgSelect[1016∈108] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1015{{"PgClassExpression[1015∈108] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Lambda1527{{"Lambda[1527∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1532{{"Lambda[1532∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1546{{"Lambda[1546∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1551{{"Lambda[1551∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1562{{"Lambda[1562∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1567{{"Lambda[1567∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object984 & PgClassExpression1015 & Lambda1055 & Lambda1527 & Lambda1532 & Lambda1055 & Lambda1546 & Lambda1551 & Lambda1052 & Lambda1055 & Lambda1562 & Lambda1567 --> PgSelect1016
+    Object984 & PgClassExpression1015 & Access1056 & Lambda1561 & Lambda1566 & Access1056 & Lambda1581 & Lambda1586 & Lambda1052 & Access1056 & Lambda1598 & Lambda1603 --> PgSelect1016
     PgSelect1002[["PgSelect[1002∈108] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression1044{{"PgClassExpression[1044∈108] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    Lambda1576{{"Lambda[1576∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1581{{"Lambda[1581∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object984 & PgClassExpression1044 & Lambda1052 & Lambda1055 & Lambda1576 & Lambda1581 --> PgSelect1002
-    Object1511{{"Object[1511∈108] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1508 & Constant1509 & Constant1496 --> Object1511
-    Object1526{{"Object[1526∈108] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1523 & Constant1524 & Constant1496 --> Object1526
-    Object1545{{"Object[1545∈108] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1542 & Constant1543 & Constant1058 --> Object1545
-    Object1561{{"Object[1561∈108] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1558 & Constant1559 & Constant1560 --> Object1561
-    Object1575{{"Object[1575∈108] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1052 & Constant1572 & Constant1573 & Constant1058 --> Object1575
-    Edge1518{{"Edge[1518∈108] ➊"}}:::plan
+    Object984 & PgClassExpression1044 & Lambda1052 & Access1056 & Lambda1613 & Lambda1618 --> PgSelect1002
+    Edge1551{{"Edge[1551∈108] ➊"}}:::plan
     PgSelectSingle1022{{"PgSelectSingle[1022∈108] ➊<br />ᐸpostᐳ"}}:::plan
     Connection1020{{"Connection[1020∈108] ➊<br />ᐸ1016ᐳ"}}:::plan
-    PgSelectSingle1022 & Connection1020 --> Edge1518
+    PgSelectSingle1022 & Connection1020 --> Edge1551
     First1004{{"First[1004∈108] ➊"}}:::plan
     PgSelect1002 --> First1004
     PgSelectSingle1005{{"PgSelectSingle[1005∈108] ➊<br />ᐸpersonᐳ"}}:::plan
@@ -1370,22 +1384,12 @@ graph TD
     First1021{{"First[1021∈108] ➊"}}:::plan
     PgSelect1016 --> First1021
     First1021 --> PgSelectSingle1022
+    PgClassExpression1025{{"PgClassExpression[1025∈108] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    PgSelectSingle1022 --> PgClassExpression1025
     PgInsertSingle981 --> PgClassExpression1044
-    Lambda1512{{"Lambda[1512∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1511 --> Lambda1512
-    Lambda1517{{"Lambda[1517∈108] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1712 --> Lambda1517
-    Object1526 --> Lambda1527
-    Constant1713 --> Lambda1532
-    Object1545 --> Lambda1546
-    Constant1714 --> Lambda1551
-    Object1561 --> Lambda1562
-    Constant1715 --> Lambda1567
-    Object1575 --> Lambda1576
-    Constant1716 --> Lambda1581
     PgSelect993[["PgSelect[993∈109] ➊<br />ᐸfrmcdc_comptypeᐳ"]]:::plan
     PgClassExpression992{{"PgClassExpression[992∈109] ➊<br />ᐸ__post__.”comptypes”ᐳ"}}:::plan
-    Object984 & PgClassExpression992 & Lambda1052 & Lambda1055 & Lambda1512 & Lambda1517 --> PgSelect993
+    Object984 & PgClassExpression992 & Lambda1052 & Access1056 & Lambda1545 & Lambda1550 --> PgSelect993
     PgClassExpression991{{"PgClassExpression[991∈109] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgInsertSingle981 --> PgClassExpression991
     PgInsertSingle981 --> PgClassExpression992
@@ -1401,22 +1405,20 @@ graph TD
     PgSelectSingle1005 --> PgClassExpression1006
     PgClassExpression1012{{"PgClassExpression[1012∈112] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgSelectSingle1005 --> PgClassExpression1012
-    PgClassExpression1025{{"PgClassExpression[1025∈113] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    PgSelectSingle1022 --> PgClassExpression1025
-    Object1536{{"Object[1536∈114] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access1534{{"Access[1534∈114] ➊<br />ᐸ1021.2ᐳ"}}:::plan
-    Access1534 & Constant144 & Constant144 & Lambda1052 & Constant1053 --> Object1536
+    Object1570{{"Object[1570∈114] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access1568{{"Access[1568∈114] ➊<br />ᐸ1021.2ᐳ"}}:::plan
+    Access1568 & Constant144 & Constant144 & Lambda1052 & Constant1053 --> Object1570
     PgClassExpression1028{{"PgClassExpression[1028∈114] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle1022 --> PgClassExpression1028
     PgSelectSingle1042{{"PgSelectSingle[1042∈114] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys1552{{"RemapKeys[1552∈114] ➊<br />ᐸ1022:{”0”:3}ᐳ"}}:::plan
-    RemapKeys1552 --> PgSelectSingle1042
-    First1021 --> Access1534
-    Lambda1537{{"Lambda[1537∈114] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object1536 --> Lambda1537
-    PgSelectSingle1022 --> RemapKeys1552
-    __Item1034[/"__Item[1034∈115]<br />ᐸ1537ᐳ"\]:::itemplan
-    Lambda1537 ==> __Item1034
+    RemapKeys1587{{"RemapKeys[1587∈114] ➊<br />ᐸ1022:{”0”:3}ᐳ"}}:::plan
+    RemapKeys1587 --> PgSelectSingle1042
+    First1021 --> Access1568
+    Lambda1571{{"Lambda[1571∈114] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object1570 --> Lambda1571
+    PgSelectSingle1022 --> RemapKeys1587
+    __Item1034[/"__Item[1034∈115]<br />ᐸ1571ᐳ"\]:::itemplan
+    Lambda1571 ==> __Item1034
     PgSelectSingle1035{{"PgSelectSingle[1035∈115]<br />ᐸfrmcdc_comptypeᐳ"}}:::plan
     __Item1034 --> PgSelectSingle1035
     PgClassExpression1036{{"PgClassExpression[1036∈116]<br />ᐸ__frmcdc_c...”schedule”ᐳ"}}:::plan
@@ -1433,16 +1435,16 @@ graph TD
     subgraph "Buckets for mutations/v4/mutation-create"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,Access117,Access118,Object119,Constant144,Constant145,Constant264,Access273,Constant284,Constant640,__InputDynamicScalar724,Lambda1052,Constant1053,Lambda1055,Constant1056,Constant1057,Constant1058,Constant1070,Constant1071,Constant1084,Constant1085,Constant1098,Constant1099,Constant1112,Constant1113,Constant1126,Constant1127,Constant1140,Constant1141,Constant1154,Constant1155,Constant1168,Constant1169,Constant1170,Constant1182,Constant1183,Constant1198,Constant1199,Constant1214,Constant1215,Constant1216,Constant1228,Constant1229,Constant1242,Constant1243,Constant1256,Constant1257,Constant1270,Constant1271,Constant1284,Constant1285,Constant1298,Constant1299,Constant1312,Constant1313,Constant1326,Constant1327,Constant1340,Constant1341,Constant1354,Constant1355,Constant1368,Constant1369,Constant1382,Constant1383,Constant1396,Constant1397,Constant1410,Constant1411,Constant1424,Constant1425,Constant1438,Constant1439,Constant1452,Constant1453,Constant1466,Constant1467,Constant1480,Constant1481,Constant1494,Constant1495,Constant1496,Constant1508,Constant1509,Constant1523,Constant1524,Constant1542,Constant1543,Constant1558,Constant1559,Constant1560,Constant1572,Constant1573,Constant1583,Constant1584,Constant1585,Constant1586,Constant1587,Constant1588,Constant1590,Constant1591,Constant1601,Constant1602,Constant1604,Constant1608,Constant1609,Constant1610,Constant1611,Constant1612,Constant1613,Constant1619,Constant1624,Constant1638,Constant1639,Constant1646,Constant1647,Constant1648,Constant1649,Constant1650,Constant1651,Constant1652,Constant1653,Constant1654,Constant1655,Constant1656,Constant1657,Constant1658,Constant1659,Constant1660,Constant1661,Constant1662,Constant1663,Constant1664,Constant1665,Constant1666,Constant1667,Constant1668,Constant1669,Constant1670,Constant1671,Constant1672,Constant1676,Constant1680,Constant1681,Constant1682,Constant1683,Constant1684,Constant1685,Constant1686,Constant1687,Constant1688,Constant1689,Constant1690,Constant1691,Constant1692,Constant1693,Constant1694,Constant1695,Constant1696,Constant1697,Constant1698,Constant1699,Constant1700,Constant1701,Constant1702,Constant1703,Constant1704,Constant1705,Constant1706,Constant1707,Constant1708,Constant1709,Constant1710,Constant1711,Constant1712,Constant1713,Constant1714,Constant1715,Constant1716,Constant1717,Constant1718,Constant1723,Constant1726,Constant1729,Constant1730,Constant1731,Constant1738,Constant1739,Constant1740,Constant1741,Constant1742,Constant1743,Constant1744 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 119, 1583, 1584, 1585, 1586, 1053, 1587, 1588, 1717, 1590, 1591, 1718, 1601, 1602, 1738, 1739, 1740, 1608, 1609, 1610, 1611, 1612, 1723, 1741, 1619, 1726, 1742, 1729, 1638, 1639, 1730, 1731, 1052, 1168, 1169, 1170, 1688, 1182, 1183, 1689, 1198, 1199, 1690, 1214, 1215, 1216, 1691, 145, 1055, 264, 4, 144<br /><br />1: PgInsertSingle[116]<br />2: <br />ᐳ: Object[120]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,Access117,Access118,Object119,Constant144,Constant145,Constant264,Access273,Constant284,Constant640,__InputDynamicScalar724,Lambda1052,Constant1053,Lambda1055,Access1056,Constant1057,Constant1058,Constant1059,Object1060,Lambda1061,Lambda1066,Constant1072,Constant1073,Object1075,Lambda1076,Lambda1081,Constant1087,Constant1088,Object1090,Lambda1091,Lambda1096,Constant1102,Constant1103,Object1105,Lambda1106,Lambda1111,Constant1117,Constant1118,Object1120,Lambda1121,Lambda1126,Constant1132,Constant1133,Object1135,Lambda1136,Lambda1141,Constant1147,Constant1148,Object1150,Lambda1151,Lambda1156,Constant1162,Constant1163,Object1165,Lambda1166,Lambda1171,Constant1177,Constant1178,Constant1179,Object1180,Lambda1181,Lambda1186,Constant1192,Constant1193,Object1195,Lambda1196,Lambda1201,Constant1209,Constant1210,Object1212,Lambda1213,Lambda1218,Constant1226,Constant1227,Constant1228,Object1229,Lambda1230,Lambda1235,Constant1241,Constant1242,Object1244,Lambda1245,Lambda1250,Constant1256,Constant1257,Object1259,Lambda1260,Lambda1265,Constant1271,Constant1272,Object1274,Lambda1275,Lambda1280,Constant1286,Constant1287,Object1289,Lambda1290,Lambda1295,Constant1301,Constant1302,Object1304,Lambda1305,Lambda1310,Constant1316,Constant1317,Object1319,Lambda1320,Lambda1325,Constant1331,Constant1332,Object1334,Lambda1335,Lambda1340,Constant1346,Constant1347,Object1349,Lambda1350,Lambda1355,Constant1361,Constant1362,Object1364,Lambda1365,Lambda1370,Constant1376,Constant1377,Object1379,Lambda1380,Lambda1385,Constant1391,Constant1392,Object1394,Lambda1395,Lambda1400,Constant1406,Constant1407,Object1409,Lambda1410,Lambda1415,Constant1421,Constant1422,Object1424,Lambda1425,Lambda1430,Constant1436,Constant1437,Object1439,Lambda1440,Lambda1445,Constant1451,Constant1452,Object1454,Lambda1455,Lambda1460,Constant1466,Constant1467,Object1469,Lambda1470,Lambda1475,Constant1481,Constant1482,Object1484,Lambda1485,Lambda1490,Constant1496,Constant1497,Object1499,Lambda1500,Lambda1505,Constant1511,Constant1512,Object1514,Lambda1515,Lambda1520,Constant1526,Constant1527,Constant1528,Object1529,Lambda1530,Lambda1535,Constant1541,Constant1542,Object1544,Lambda1545,Lambda1550,Constant1557,Constant1558,Object1560,Lambda1561,Lambda1566,Constant1577,Constant1578,Object1580,Lambda1581,Lambda1586,Constant1594,Constant1595,Constant1596,Object1597,Lambda1598,Lambda1603,Constant1609,Constant1610,Object1612,Lambda1613,Lambda1618,Constant1620,Constant1621,Constant1622,Constant1623,Constant1624,Constant1625,Constant1627,Constant1628,Constant1638,Constant1639,Constant1641,Constant1645,Constant1646,Constant1647,Constant1648,Constant1649,Constant1650,Constant1656,Constant1661,Constant1675,Constant1676,Constant1683,Constant1684,Constant1685,Constant1686,Constant1687,Constant1688,Constant1689,Constant1690,Constant1691,Constant1692,Constant1693,Constant1694,Constant1695,Constant1696,Constant1697,Constant1698,Constant1699,Constant1700,Constant1701,Constant1702,Constant1703,Constant1704,Constant1705,Constant1706,Constant1707,Constant1708,Constant1709,Constant1713,Constant1717,Constant1718,Constant1719,Constant1720,Constant1721,Constant1722,Constant1723,Constant1724,Constant1725,Constant1726,Constant1727,Constant1728,Constant1729,Constant1730,Constant1731,Constant1732,Constant1733,Constant1734,Constant1735,Constant1736,Constant1737,Constant1738,Constant1739,Constant1740,Constant1741,Constant1742,Constant1743,Constant1744,Constant1745,Constant1746,Constant1747,Constant1748,Constant1749,Constant1750,Constant1751,Constant1752,Constant1753,Constant1754,Constant1755,Constant1760,Constant1763,Constant1766,Constant1767,Constant1768,Constant1775,Constant1776,Constant1777,Constant1778,Constant1779,Constant1780,Constant1781 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 119, 1620, 1621, 1622, 1623, 1053, 1624, 1625, 1754, 1627, 1628, 1755, 1638, 1639, 1775, 1776, 1777, 1645, 1646, 1647, 1648, 1649, 1760, 1778, 1656, 1763, 1779, 1766, 1675, 1676, 1767, 1768, 264, 145, 1052, 1056, 1181, 1186, 1196, 1201, 1213, 1218, 1230, 1235, 4, 144<br /><br />1: PgInsertSingle[116]<br />2: <br />ᐳ: Object[120]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle116,Object120 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 1052, 1168, 1169, 1170, 1688, 1182, 1183, 1689, 1198, 1199, 1690, 1214, 1215, 1216, 1691, 120, 116, 145, 119, 1055, 264, 4, 144<br /><br />ROOT Object{1}ᐸ{result}ᐳ[120]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 264, 120, 116, 145, 119, 1052, 1056, 1181, 1186, 1196, 1201, 1213, 1218, 1230, 1235, 4, 144<br /><br />ROOT Object{1}ᐸ{result}ᐳ[120]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Object1171,Lambda1172,Lambda1177,Object1185,Lambda1186,Lambda1191,Object1201,Lambda1202,Lambda1207,Object1217,Lambda1218,Lambda1223 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 116, 145, 119, 1052, 1055, 1172, 1177, 1186, 1191, 1202, 1207, 1218, 1223<br /><br />ROOT PgInsertSingle{1}ᐸtypes(id,smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,cidr,macaddr,text_array_domain,int8_array_domain)ᐳ[116]<br />1: <br />ᐳ: 146, 150, 151, 152, 153, 154, 155, 156, 157, 159, 160, 161, 163, 164, 165, 172, 179, 186, 187, 188, 189, 190, 191, 198, 206, 207, 221, 251, 254, 257, 258, 259, 260, 262, 147, 148, 166, 169, 173, 176, 180, 183<br />2: PgSelect[208], PgSelect[222]<br />ᐳ: 212, 213, 214, 215, 216, 217, 218, 219, 220, 224, 225, 230, 250, 1208, 242"):::bucket
+    class Bucket2,Lambda265 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 116, 145, 119, 1052, 1056, 1181, 1186, 1196, 1201, 1213, 1218, 1230, 1235<br /><br />ROOT PgInsertSingle{1}ᐸtypes(id,smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,cidr,macaddr,text_array_domain,int8_array_domain)ᐳ[116]<br />1: <br />ᐳ: 146, 150, 151, 152, 153, 154, 155, 156, 157, 159, 160, 161, 163, 164, 165, 172, 179, 186, 187, 188, 189, 190, 191, 198, 206, 207, 221, 251, 254, 257, 258, 259, 260, 262, 147, 148, 166, 169, 173, 176, 180, 183<br />2: PgSelect[208], PgSelect[222]<br />ᐳ: 212, 213, 214, 215, 216, 217, 218, 219, 220, 224, 225, 230, 250, 1219, 242"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression146,List147,Lambda148,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156,PgClassExpression157,PgClassExpression159,PgClassExpression160,PgClassExpression161,PgClassExpression163,PgClassExpression164,PgClassExpression165,Access166,Access169,PgClassExpression172,Access173,Access176,PgClassExpression179,Access180,Access183,PgClassExpression186,PgClassExpression187,PgClassExpression188,PgClassExpression189,PgClassExpression190,PgClassExpression191,PgClassExpression198,PgClassExpression206,PgClassExpression207,PgSelect208,First212,PgSelectSingle213,PgClassExpression214,PgClassExpression215,PgClassExpression216,PgClassExpression217,PgClassExpression218,PgClassExpression219,PgClassExpression220,PgClassExpression221,PgSelect222,First224,PgSelectSingle225,PgSelectSingle230,PgSelectSingle242,PgClassExpression250,PgClassExpression251,PgClassExpression254,PgClassExpression257,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression262,RemapKeys1208 bucket3
+    class Bucket3,PgClassExpression146,List147,Lambda148,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156,PgClassExpression157,PgClassExpression159,PgClassExpression160,PgClassExpression161,PgClassExpression163,PgClassExpression164,PgClassExpression165,Access166,Access169,PgClassExpression172,Access173,Access176,PgClassExpression179,Access180,Access183,PgClassExpression186,PgClassExpression187,PgClassExpression188,PgClassExpression189,PgClassExpression190,PgClassExpression191,PgClassExpression198,PgClassExpression206,PgClassExpression207,PgSelect208,First212,PgSelectSingle213,PgClassExpression214,PgClassExpression215,PgClassExpression216,PgClassExpression217,PgClassExpression218,PgClassExpression219,PgClassExpression220,PgClassExpression221,PgSelect222,First224,PgSelectSingle225,PgSelectSingle230,PgSelectSingle242,PgClassExpression250,PgClassExpression251,PgClassExpression254,PgClassExpression257,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression262,RemapKeys1219 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ157ᐳ[158]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item158 bucket4
@@ -1488,39 +1490,39 @@ graph TD
     Bucket18("Bucket 18 (listItem)<br /><br />ROOT __Item{18}ᐸ262ᐳ[263]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,__Item263 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 4, 265<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,Lambda265 bucket19
-    Bucket20("Bucket 20 (mutationField)<br />Deps: 1648, 1649, 1650, 1651, 273, 1652, 1653, 1654, 2, 1052, 1055, 284, 1056, 1057, 1058, 1680, 1070, 1071, 1681, 1084, 1085, 1682, 1098, 1099, 1683, 1112, 1113, 1684, 1126, 1127, 1685, 1140, 1141, 1686, 1154, 1155, 1687, 1655, 264, 4, 144<br /><br />1: Access[279]<br />2: Access[280]<br />3: Object[281]<br />4: PgInsertSingle[278]<br />5: <br />ᐳ: Object[282]"):::bucket
+    class Bucket19 bucket19
+    Bucket20("Bucket 20 (mutationField)<br />Deps: 1685, 1686, 1687, 1688, 273, 1689, 1690, 1691, 2, 284, 1052, 1056, 1076, 1081, 1091, 1096, 1106, 1111, 1121, 1126, 1136, 1141, 1151, 1156, 1166, 1171, 264, 1692, 1061, 1066, 4, 144<br /><br />1: Access[279]<br />2: Access[280]<br />3: Object[281]<br />4: PgInsertSingle[278]<br />5: <br />ᐳ: Object[282]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20,PgInsertSingle278,Access279,Access280,Object281,Object282 bucket20
-    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 278, 281, 1052, 1055, 284, 1056, 1057, 1058, 1680, 1070, 1071, 1681, 1084, 1085, 1682, 1098, 1099, 1683, 1112, 1113, 1684, 1126, 1127, 1685, 1140, 1141, 1686, 1154, 1155, 1687, 282, 1655, 264, 4, 144<br /><br />ROOT Object{20}ᐸ{result}ᐳ[282]<br />1: <br />ᐳ: 308, 313, 330, 347, 364, 381, 398, 415, 433, 1059, 1065, 1073, 1079, 1087, 1093, 1101, 1107, 1115, 1121, 1129, 1135, 1143, 1149, 1157, 1163, 1060, 1074, 1088, 1102, 1116, 1130, 1144, 1158<br />2: 309, 328, 345, 362, 379, 396, 431<br />ᐳ: 314, 315, 318, 319, 322, 323, 331, 332, 335, 336, 348, 349, 352, 353, 365, 366, 369, 370, 382, 383, 386, 387, 399, 400, 403, 404, 419, 434, 435, 438, 439, 440, 317, 334, 351, 368, 385, 402, 418, 437, 316, 333, 350, 367, 384, 401, 436"):::bucket
+    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 284, 278, 281, 1052, 1056, 1076, 1081, 1091, 1096, 1106, 1111, 1121, 1126, 1136, 1141, 1151, 1156, 1166, 1171, 264, 282, 1692, 1061, 1066, 4, 144<br /><br />ROOT Object{20}ᐸ{result}ᐳ[282]<br />1: <br />ᐳ: 308, 313, 330, 347, 364, 381, 398, 415, 433, 447, 286, 287<br />2: 309, 328, 345, 362, 379, 396, 431<br />ᐳ: 314, 315, 318, 319, 322, 323, 331, 332, 335, 336, 339, 340, 348, 349, 352, 353, 356, 357, 365, 366, 369, 370, 373, 374, 382, 383, 386, 387, 399, 400, 403, 404, 419, 434, 435, 438, 439, 440, 443, 444, 317, 334, 351, 368, 385, 402, 418, 437, 316, 333, 350, 367, 384, 401, 436"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PgClassExpression308,PgSelect309,Connection313,First314,PgSelectSingle315,Edge316,PgCursor317,PgClassExpression318,List319,List322,Lambda323,PgSelect328,Connection330,First331,PgSelectSingle332,Edge333,PgCursor334,PgClassExpression335,List336,PgSelect345,Connection347,First348,PgSelectSingle349,Edge350,PgCursor351,PgClassExpression352,List353,PgSelect362,Connection364,First365,PgSelectSingle366,Edge367,PgCursor368,PgClassExpression369,List370,PgSelect379,Connection381,First382,PgSelectSingle383,Edge384,PgCursor385,PgClassExpression386,List387,PgSelect396,Connection398,First399,PgSelectSingle400,Edge401,PgCursor402,PgClassExpression403,List404,Connection415,Edge418,PgCursor419,PgSelect431,Connection433,First434,PgSelectSingle435,Edge436,PgCursor437,PgClassExpression438,PgClassExpression439,List440,Object1059,Lambda1060,Lambda1065,Object1073,Lambda1074,Lambda1079,Object1087,Lambda1088,Lambda1093,Object1101,Lambda1102,Lambda1107,Object1115,Lambda1116,Lambda1121,Object1129,Lambda1130,Lambda1135,Object1143,Lambda1144,Lambda1149,Object1157,Lambda1158,Lambda1163 bucket21
-    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 284, 308, 278, 281, 1655, 1052, 1055, 1060, 1065<br /><br />ROOT PgInsertSingle{20}ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ[278]<br />1: <br />ᐳ: 286, 289, 290, 291, 292, 293, 294, 295, 297, 287<br />2: PgSelect[298]<br />ᐳ: 302, 303, 305"):::bucket
+    class Bucket21,List286,Lambda287,PgClassExpression308,PgSelect309,Connection313,First314,PgSelectSingle315,Edge316,PgCursor317,PgClassExpression318,List319,List322,Lambda323,PgSelect328,Connection330,First331,PgSelectSingle332,Edge333,PgCursor334,PgClassExpression335,List336,List339,Lambda340,PgSelect345,Connection347,First348,PgSelectSingle349,Edge350,PgCursor351,PgClassExpression352,List353,List356,Lambda357,PgSelect362,Connection364,First365,PgSelectSingle366,Edge367,PgCursor368,PgClassExpression369,List370,List373,Lambda374,PgSelect379,Connection381,First382,PgSelectSingle383,Edge384,PgCursor385,PgClassExpression386,List387,PgSelect396,Connection398,First399,PgSelectSingle400,Edge401,PgCursor402,PgClassExpression403,List404,Connection415,Edge418,PgCursor419,PgSelect431,Connection433,First434,PgSelectSingle435,Edge436,PgCursor437,PgClassExpression438,PgClassExpression439,List440,List443,Lambda444,Lambda447 bucket21
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 278, 281, 1692, 1052, 1056, 1061, 1066, 287, 308<br /><br />ROOT PgInsertSingle{20}ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ[278]<br />1: <br />ᐳ: 289, 290, 291, 292, 293, 294, 295, 297<br />2: PgSelect[298]<br />ᐳ: 302, 303, 305"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,List286,Lambda287,PgClassExpression289,PgClassExpression290,PgClassExpression291,PgClassExpression292,PgClassExpression293,PgClassExpression294,PgClassExpression295,PgClassExpression297,PgSelect298,First302,PgSelectSingle303,PgClassExpression305 bucket22
+    class Bucket22,PgClassExpression289,PgClassExpression290,PgClassExpression291,PgClassExpression292,PgClassExpression293,PgClassExpression294,PgClassExpression295,PgClassExpression297,PgSelect298,First302,PgSelectSingle303,PgClassExpression305 bucket22
     Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 316, 315, 317, 323<br /><br />ROOT Edge{21}[316]"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23 bucket23
     Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 315, 323<br /><br />ROOT PgSelectSingle{21}ᐸpersonᐳ[315]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,PgClassExpression324 bucket24
-    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 284, 335, 333, 332, 334<br /><br />ROOT Edge{21}[333]"):::bucket
+    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 333, 332, 334, 340<br /><br />ROOT Edge{21}[333]"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,List339,Lambda340 bucket25
+    class Bucket25 bucket25
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 332, 340<br /><br />ROOT PgSelectSingle{21}ᐸpersonᐳ[332]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression341 bucket26
-    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 284, 352, 350, 349, 351<br /><br />ROOT Edge{21}[350]"):::bucket
+    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 350, 349, 351, 357<br /><br />ROOT Edge{21}[350]"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,List356,Lambda357 bucket27
+    class Bucket27 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 349, 357<br /><br />ROOT PgSelectSingle{21}ᐸpersonᐳ[349]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression358 bucket28
-    Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 284, 369, 367, 366, 368<br /><br />ROOT Edge{21}[367]"):::bucket
+    Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 367, 366, 368, 374<br /><br />ROOT Edge{21}[367]"):::bucket
     classDef bucket29 stroke:#4169e1
-    class Bucket29,List373,Lambda374 bucket29
+    class Bucket29 bucket29
     Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 366, 374<br /><br />ROOT PgSelectSingle{21}ᐸpersonᐳ[366]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,PgClassExpression375 bucket30
@@ -1542,45 +1544,45 @@ graph TD
     Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 315, 323<br /><br />ROOT PgSelectSingle{21}ᐸpersonᐳ[315]"):::bucket
     classDef bucket36 stroke:#7f007f
     class Bucket36,PgClassExpression426 bucket36
-    Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 284, 439, 436, 435, 437<br /><br />ROOT Edge{21}[436]"):::bucket
+    Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 436, 435, 437, 444<br /><br />ROOT Edge{21}[436]"):::bucket
     classDef bucket37 stroke:#ffa500
-    class Bucket37,List443,Lambda444 bucket37
+    class Bucket37 bucket37
     Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 435, 444<br /><br />ROOT PgSelectSingle{21}ᐸpersonᐳ[435]"):::bucket
     classDef bucket38 stroke:#0000ff
     class Bucket38,PgClassExpression445 bucket38
-    Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 4, 447<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket39 stroke:#7fff00
-    class Bucket39,Lambda447 bucket39
-    Bucket40("Bucket 40 (mutationField)<br />Deps: 1624, 1657, 1658, 1659, 144, 1660, 1638, 1661, 2, 1656, 1052, 1055, 284, 1228, 1229, 1058, 1692, 1242, 1243, 1693, 1256, 1257, 1694, 1270, 1271, 1695, 1284, 1285, 1696, 1298, 1299, 1697, 1312, 1313, 1698, 1326, 1327, 1699, 1655, 264, 4<br /><br />1: Access[461]<br />2: Access[462]<br />3: Object[463]<br />4: PgInsertSingle[460]<br />5: <br />ᐳ: Object[464]"):::bucket
+    class Bucket39 bucket39
+    Bucket40("Bucket 40 (mutationField)<br />Deps: 1661, 1694, 1695, 1696, 144, 1697, 1675, 1698, 2, 1693, 284, 1052, 1056, 1260, 1265, 1275, 1280, 1290, 1295, 1305, 1310, 1320, 1325, 1335, 1340, 1350, 1355, 264, 1692, 1245, 1250, 4<br /><br />1: Access[461]<br />2: Access[462]<br />3: Object[463]<br />4: PgInsertSingle[460]<br />5: <br />ᐳ: Object[464]"):::bucket
     classDef bucket40 stroke:#ff1493
     class Bucket40,PgInsertSingle460,Access461,Access462,Object463,Object464 bucket40
-    Bucket41("Bucket 41 (nullableBoundary)<br />Deps: 460, 463, 1052, 1055, 284, 1228, 1229, 1058, 1692, 1242, 1243, 1693, 1256, 1257, 1694, 1270, 1271, 1695, 1284, 1285, 1696, 1298, 1299, 1697, 1312, 1313, 1698, 1326, 1327, 1699, 464, 1655, 264, 4, 1656<br /><br />ROOT Object{40}ᐸ{result,clientMutationId}ᐳ[464]<br />1: <br />ᐳ: 489, 494, 511, 528, 545, 562, 579, 596, 614, 1231, 1237, 1245, 1251, 1259, 1265, 1273, 1279, 1287, 1293, 1301, 1307, 1315, 1321, 1329, 1335, 1232, 1246, 1260, 1274, 1288, 1302, 1316, 1330<br />2: 490, 509, 526, 543, 560, 577, 612<br />ᐳ: 495, 496, 499, 500, 503, 504, 512, 513, 516, 517, 529, 530, 533, 534, 546, 547, 550, 551, 563, 564, 567, 568, 580, 581, 584, 585, 600, 615, 616, 619, 620, 621, 498, 515, 532, 549, 566, 583, 599, 618, 497, 514, 531, 548, 565, 582, 617"):::bucket
+    Bucket41("Bucket 41 (nullableBoundary)<br />Deps: 284, 460, 463, 1052, 1056, 1260, 1265, 1275, 1280, 1290, 1295, 1305, 1310, 1320, 1325, 1335, 1340, 1350, 1355, 264, 464, 1692, 1245, 1250, 4, 1693<br /><br />ROOT Object{40}ᐸ{result,clientMutationId}ᐳ[464]<br />1: <br />ᐳ: 489, 494, 511, 528, 545, 562, 579, 596, 614, 628, 467, 468<br />2: 490, 509, 526, 543, 560, 577, 612<br />ᐳ: 495, 496, 499, 500, 503, 504, 512, 513, 516, 517, 520, 521, 529, 530, 533, 534, 537, 538, 546, 547, 550, 551, 554, 555, 563, 564, 567, 568, 580, 581, 584, 585, 600, 615, 616, 619, 620, 621, 624, 625, 498, 515, 532, 549, 566, 583, 599, 618, 497, 514, 531, 548, 565, 582, 617"):::bucket
     classDef bucket41 stroke:#808000
-    class Bucket41,PgClassExpression489,PgSelect490,Connection494,First495,PgSelectSingle496,Edge497,PgCursor498,PgClassExpression499,List500,List503,Lambda504,PgSelect509,Connection511,First512,PgSelectSingle513,Edge514,PgCursor515,PgClassExpression516,List517,PgSelect526,Connection528,First529,PgSelectSingle530,Edge531,PgCursor532,PgClassExpression533,List534,PgSelect543,Connection545,First546,PgSelectSingle547,Edge548,PgCursor549,PgClassExpression550,List551,PgSelect560,Connection562,First563,PgSelectSingle564,Edge565,PgCursor566,PgClassExpression567,List568,PgSelect577,Connection579,First580,PgSelectSingle581,Edge582,PgCursor583,PgClassExpression584,List585,Connection596,Edge599,PgCursor600,PgSelect612,Connection614,First615,PgSelectSingle616,Edge617,PgCursor618,PgClassExpression619,PgClassExpression620,List621,Object1231,Lambda1232,Lambda1237,Object1245,Lambda1246,Lambda1251,Object1259,Lambda1260,Lambda1265,Object1273,Lambda1274,Lambda1279,Object1287,Lambda1288,Lambda1293,Object1301,Lambda1302,Lambda1307,Object1315,Lambda1316,Lambda1321,Object1329,Lambda1330,Lambda1335 bucket41
-    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 284, 489, 460, 463, 1655, 1052, 1055, 1232, 1237<br /><br />ROOT PgInsertSingle{40}ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ[460]<br />1: <br />ᐳ: 467, 470, 471, 472, 473, 474, 475, 476, 478, 468<br />2: PgSelect[479]<br />ᐳ: 483, 484, 486"):::bucket
+    class Bucket41,List467,Lambda468,PgClassExpression489,PgSelect490,Connection494,First495,PgSelectSingle496,Edge497,PgCursor498,PgClassExpression499,List500,List503,Lambda504,PgSelect509,Connection511,First512,PgSelectSingle513,Edge514,PgCursor515,PgClassExpression516,List517,List520,Lambda521,PgSelect526,Connection528,First529,PgSelectSingle530,Edge531,PgCursor532,PgClassExpression533,List534,List537,Lambda538,PgSelect543,Connection545,First546,PgSelectSingle547,Edge548,PgCursor549,PgClassExpression550,List551,List554,Lambda555,PgSelect560,Connection562,First563,PgSelectSingle564,Edge565,PgCursor566,PgClassExpression567,List568,PgSelect577,Connection579,First580,PgSelectSingle581,Edge582,PgCursor583,PgClassExpression584,List585,Connection596,Edge599,PgCursor600,PgSelect612,Connection614,First615,PgSelectSingle616,Edge617,PgCursor618,PgClassExpression619,PgClassExpression620,List621,List624,Lambda625,Lambda628 bucket41
+    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 460, 463, 1692, 1052, 1056, 1245, 1250, 468, 489<br /><br />ROOT PgInsertSingle{40}ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ[460]<br />1: <br />ᐳ: 470, 471, 472, 473, 474, 475, 476, 478<br />2: PgSelect[479]<br />ᐳ: 483, 484, 486"):::bucket
     classDef bucket42 stroke:#dda0dd
-    class Bucket42,List467,Lambda468,PgClassExpression470,PgClassExpression471,PgClassExpression472,PgClassExpression473,PgClassExpression474,PgClassExpression475,PgClassExpression476,PgClassExpression478,PgSelect479,First483,PgSelectSingle484,PgClassExpression486 bucket42
+    class Bucket42,PgClassExpression470,PgClassExpression471,PgClassExpression472,PgClassExpression473,PgClassExpression474,PgClassExpression475,PgClassExpression476,PgClassExpression478,PgSelect479,First483,PgSelectSingle484,PgClassExpression486 bucket42
     Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 497, 496, 498, 504<br /><br />ROOT Edge{41}[497]"):::bucket
     classDef bucket43 stroke:#ff0000
     class Bucket43 bucket43
     Bucket44("Bucket 44 (nullableBoundary)<br />Deps: 496, 504<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[496]"):::bucket
     classDef bucket44 stroke:#ffff00
     class Bucket44,PgClassExpression505 bucket44
-    Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 284, 516, 514, 513, 515<br /><br />ROOT Edge{41}[514]"):::bucket
+    Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 514, 513, 515, 521<br /><br />ROOT Edge{41}[514]"):::bucket
     classDef bucket45 stroke:#00ffff
-    class Bucket45,List520,Lambda521 bucket45
+    class Bucket45 bucket45
     Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 513, 521<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[513]"):::bucket
     classDef bucket46 stroke:#4169e1
     class Bucket46,PgClassExpression522 bucket46
-    Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 284, 533, 531, 530, 532<br /><br />ROOT Edge{41}[531]"):::bucket
+    Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 531, 530, 532, 538<br /><br />ROOT Edge{41}[531]"):::bucket
     classDef bucket47 stroke:#3cb371
-    class Bucket47,List537,Lambda538 bucket47
+    class Bucket47 bucket47
     Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 530, 538<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[530]"):::bucket
     classDef bucket48 stroke:#a52a2a
     class Bucket48,PgClassExpression539 bucket48
-    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 284, 550, 548, 547, 549<br /><br />ROOT Edge{41}[548]"):::bucket
+    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 548, 547, 549, 555<br /><br />ROOT Edge{41}[548]"):::bucket
     classDef bucket49 stroke:#ff00ff
-    class Bucket49,List554,Lambda555 bucket49
+    class Bucket49 bucket49
     Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 547, 555<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[547]"):::bucket
     classDef bucket50 stroke:#f5deb3
     class Bucket50,PgClassExpression556 bucket50
@@ -1602,24 +1604,24 @@ graph TD
     Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 496, 504<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[496]"):::bucket
     classDef bucket56 stroke:#7fff00
     class Bucket56,PgClassExpression607 bucket56
-    Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 284, 620, 617, 616, 618<br /><br />ROOT Edge{41}[617]"):::bucket
+    Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 617, 616, 618, 625<br /><br />ROOT Edge{41}[617]"):::bucket
     classDef bucket57 stroke:#ff1493
-    class Bucket57,List624,Lambda625 bucket57
+    class Bucket57 bucket57
     Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 616, 625<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[616]"):::bucket
     classDef bucket58 stroke:#808000
     class Bucket58,PgClassExpression626 bucket58
-    Bucket59("Bucket 59 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket59("Bucket 59 (nullableBoundary)<br />Deps: 4, 628<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket59 stroke:#dda0dd
-    class Bucket59,Lambda628 bucket59
-    Bucket60("Bucket 60 (mutationField)<br />Deps: 1624, 1648, 1053, 2, 1662, 1052, 1055, 1340, 1341, 1058, 1700, 1354, 1355, 1701, 640, 284, 264, 4<br /><br />1: Access[636]<br />2: Access[637]<br />3: Object[638]<br />4: PgInsertSingle[635]<br />5: <br />ᐳ: Object[639]"):::bucket
+    class Bucket59 bucket59
+    Bucket60("Bucket 60 (mutationField)<br />Deps: 1661, 1685, 1053, 2, 1699, 640, 1052, 1056, 1365, 1370, 1380, 1385, 264, 284, 4<br /><br />1: Access[636]<br />2: Access[637]<br />3: Object[638]<br />4: PgInsertSingle[635]<br />5: <br />ᐳ: Object[639]"):::bucket
     classDef bucket60 stroke:#ff0000
     class Bucket60,PgInsertSingle635,Access636,Access637,Object638,Object639 bucket60
-    Bucket61("Bucket 61 (nullableBoundary)<br />Deps: 638, 1052, 1055, 635, 1340, 1341, 1058, 1700, 1354, 1355, 1701, 639, 640, 284, 264, 4, 1662<br /><br />ROOT Object{60}ᐸ{result,clientMutationId}ᐳ[639]<br />1: <br />ᐳ: 670, 682, 1343, 1349, 1357, 1363, 1344, 1358<br />2: PgSelect[649], PgSelect[661]<br />ᐳ: 653, 654, 663, 664"):::bucket
+    Bucket61("Bucket 61 (nullableBoundary)<br />Deps: 640, 638, 1052, 1056, 1365, 1370, 1380, 1385, 635, 264, 639, 284, 4, 1699<br /><br />ROOT Object{60}ᐸ{result,clientMutationId}ᐳ[639]<br />1: <br />ᐳ: 670, 682, 693, 643, 644<br />2: PgSelect[649], PgSelect[661]<br />ᐳ: 653, 654, 663, 664"):::bucket
     classDef bucket61 stroke:#ffff00
-    class Bucket61,PgSelect649,First653,PgSelectSingle654,PgSelect661,First663,PgSelectSingle664,PgClassExpression670,PgClassExpression682,Object1343,Lambda1344,Lambda1349,Object1357,Lambda1358,Lambda1363 bucket61
-    Bucket62("Bucket 62 (nullableBoundary)<br />Deps: 640, 670, 682, 635, 654, 284, 664<br /><br />ROOT PgInsertSingle{60}ᐸcompound_key(person_id_2,person_id_1,extra)ᐳ[635]"):::bucket
+    class Bucket61,List643,Lambda644,PgSelect649,First653,PgSelectSingle654,PgSelect661,First663,PgSelectSingle664,PgClassExpression670,PgClassExpression682,Lambda693 bucket61
+    Bucket62("Bucket 62 (nullableBoundary)<br />Deps: 635, 654, 284, 664, 644, 670, 682<br /><br />ROOT PgInsertSingle{60}ᐸcompound_key(person_id_2,person_id_1,extra)ᐳ[635]"):::bucket
     classDef bucket62 stroke:#00ffff
-    class Bucket62,List643,Lambda644,PgClassExpression647 bucket62
+    class Bucket62,PgClassExpression647 bucket62
     Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 654, 284<br /><br />ROOT PgSelectSingle{61}ᐸpersonᐳ[654]"):::bucket
     classDef bucket63 stroke:#4169e1
     class Bucket63,PgClassExpression656,List657,Lambda658,PgClassExpression659 bucket63
@@ -1632,63 +1634,63 @@ graph TD
     Bucket66("Bucket 66 (nullableBoundary)<br />Deps: 664, 284<br /><br />ROOT PgSelectSingle{61}ᐸpersonᐳ[664]"):::bucket
     classDef bucket66 stroke:#ff00ff
     class Bucket66,PgClassExpression688,List689,Lambda690,PgClassExpression691 bucket66
-    Bucket67("Bucket 67 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket67("Bucket 67 (nullableBoundary)<br />Deps: 4, 693<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket67 stroke:#f5deb3
-    class Bucket67,Lambda693 bucket67
-    Bucket68("Bucket 68 (mutationField)<br />Deps: 1604, 2, 264, 4<br /><br />1: Access[699]<br />2: Access[700]<br />3: Object[701]<br />4: PgInsertSingle[698]<br />5: <br />ᐳ: Object[702]"):::bucket
+    class Bucket67 bucket67
+    Bucket68("Bucket 68 (mutationField)<br />Deps: 1641, 2, 264, 4<br /><br />1: Access[699]<br />2: Access[700]<br />3: Object[701]<br />4: PgInsertSingle[698]<br />5: <br />ᐳ: Object[702]"):::bucket
     classDef bucket68 stroke:#696969
     class Bucket68,PgInsertSingle698,Access699,Access700,Object701,Object702 bucket68
-    Bucket69("Bucket 69 (nullableBoundary)<br />Deps: 702, 698, 264, 4<br /><br />ROOT Object{68}ᐸ{result}ᐳ[702]"):::bucket
+    Bucket69("Bucket 69 (nullableBoundary)<br />Deps: 264, 702, 698, 4<br /><br />ROOT Object{68}ᐸ{result}ᐳ[702]"):::bucket
     classDef bucket69 stroke:#00bfff
-    class Bucket69 bucket69
+    class Bucket69,Lambda705 bucket69
     Bucket70("Bucket 70 (nullableBoundary)<br />Deps: 698<br /><br />ROOT PgInsertSingle{68}ᐸedge_case(not_null_has_default)ᐳ[698]"):::bucket
     classDef bucket70 stroke:#7f007f
     class Bucket70,PgClassExpression703 bucket70
-    Bucket71("Bucket 71 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket71("Bucket 71 (nullableBoundary)<br />Deps: 4, 705<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket71 stroke:#ffa500
-    class Bucket71,Lambda705 bucket71
+    class Bucket71 bucket71
     Bucket72("Bucket 72 (mutationField)<br />Deps: 2, 264, 4<br /><br />1: Access[710]<br />2: Access[711]<br />3: Object[712]<br />4: PgInsertSingle[709]<br />5: <br />ᐳ: Object[713]"):::bucket
     classDef bucket72 stroke:#0000ff
     class Bucket72,PgInsertSingle709,Access710,Access711,Object712,Object713 bucket72
-    Bucket73("Bucket 73 (nullableBoundary)<br />Deps: 713, 709, 264, 4<br /><br />ROOT Object{72}ᐸ{result}ᐳ[713]"):::bucket
+    Bucket73("Bucket 73 (nullableBoundary)<br />Deps: 264, 713, 709, 4<br /><br />ROOT Object{72}ᐸ{result}ᐳ[713]"):::bucket
     classDef bucket73 stroke:#7fff00
-    class Bucket73 bucket73
+    class Bucket73,Lambda716 bucket73
     Bucket74("Bucket 74 (nullableBoundary)<br />Deps: 709<br /><br />ROOT PgInsertSingle{72}ᐸedge_case()ᐳ[709]"):::bucket
     classDef bucket74 stroke:#ff1493
     class Bucket74,PgClassExpression714 bucket74
-    Bucket75("Bucket 75 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket75("Bucket 75 (nullableBoundary)<br />Deps: 4, 716<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket75 stroke:#808000
-    class Bucket75,Lambda716 bucket75
-    Bucket76("Bucket 76 (mutationField)<br />Deps: 1663, 1664, 144, 1665, 724, 1666, 1667, 1668, 2, 1052, 1055, 284, 1368, 1369, 1058, 1702, 1382, 1383, 1703, 1396, 1397, 1704, 1410, 1411, 1705, 1424, 1425, 1706, 1438, 1439, 1707, 1452, 1453, 1708, 1466, 1467, 1709, 1655, 264, 4<br /><br />1: Access[729]<br />2: Access[730]<br />3: Object[731]<br />4: PgInsertSingle[728]<br />5: <br />ᐳ: Object[732]"):::bucket
+    class Bucket75 bucket75
+    Bucket76("Bucket 76 (mutationField)<br />Deps: 1700, 1701, 144, 1702, 724, 1703, 1704, 1705, 2, 284, 1052, 1056, 1410, 1415, 1425, 1430, 1440, 1445, 1455, 1460, 1470, 1475, 1485, 1490, 1500, 1505, 264, 1692, 1395, 1400, 4<br /><br />1: Access[729]<br />2: Access[730]<br />3: Object[731]<br />4: PgInsertSingle[728]<br />5: <br />ᐳ: Object[732]"):::bucket
     classDef bucket76 stroke:#dda0dd
     class Bucket76,PgInsertSingle728,Access729,Access730,Object731,Object732 bucket76
-    Bucket77("Bucket 77 (nullableBoundary)<br />Deps: 728, 731, 1052, 1055, 284, 1368, 1369, 1058, 1702, 1382, 1383, 1703, 1396, 1397, 1704, 1410, 1411, 1705, 1424, 1425, 1706, 1438, 1439, 1707, 1452, 1453, 1708, 1466, 1467, 1709, 732, 1655, 264, 4, 144<br /><br />ROOT Object{76}ᐸ{result}ᐳ[732]<br />1: <br />ᐳ: 758, 763, 780, 797, 814, 831, 848, 865, 883, 1371, 1377, 1385, 1391, 1399, 1405, 1413, 1419, 1427, 1433, 1441, 1447, 1455, 1461, 1469, 1475, 1372, 1386, 1400, 1414, 1428, 1442, 1456, 1470<br />2: 759, 778, 795, 812, 829, 846, 881<br />ᐳ: 764, 765, 768, 769, 772, 773, 781, 782, 785, 786, 798, 799, 802, 803, 815, 816, 819, 820, 832, 833, 836, 837, 849, 850, 853, 854, 869, 884, 885, 888, 889, 890, 767, 784, 801, 818, 835, 852, 868, 887, 766, 783, 800, 817, 834, 851, 886"):::bucket
+    Bucket77("Bucket 77 (nullableBoundary)<br />Deps: 284, 728, 731, 1052, 1056, 1410, 1415, 1425, 1430, 1440, 1445, 1455, 1460, 1470, 1475, 1485, 1490, 1500, 1505, 264, 732, 1692, 1395, 1400, 4, 144<br /><br />ROOT Object{76}ᐸ{result}ᐳ[732]<br />1: <br />ᐳ: 758, 763, 780, 797, 814, 831, 848, 865, 883, 897, 736, 737<br />2: 759, 778, 795, 812, 829, 846, 881<br />ᐳ: 764, 765, 768, 769, 772, 773, 781, 782, 785, 786, 789, 790, 798, 799, 802, 803, 806, 807, 815, 816, 819, 820, 823, 824, 832, 833, 836, 837, 849, 850, 853, 854, 869, 884, 885, 888, 889, 890, 893, 894, 767, 784, 801, 818, 835, 852, 868, 887, 766, 783, 800, 817, 834, 851, 886"):::bucket
     classDef bucket77 stroke:#ff0000
-    class Bucket77,PgClassExpression758,PgSelect759,Connection763,First764,PgSelectSingle765,Edge766,PgCursor767,PgClassExpression768,List769,List772,Lambda773,PgSelect778,Connection780,First781,PgSelectSingle782,Edge783,PgCursor784,PgClassExpression785,List786,PgSelect795,Connection797,First798,PgSelectSingle799,Edge800,PgCursor801,PgClassExpression802,List803,PgSelect812,Connection814,First815,PgSelectSingle816,Edge817,PgCursor818,PgClassExpression819,List820,PgSelect829,Connection831,First832,PgSelectSingle833,Edge834,PgCursor835,PgClassExpression836,List837,PgSelect846,Connection848,First849,PgSelectSingle850,Edge851,PgCursor852,PgClassExpression853,List854,Connection865,Edge868,PgCursor869,PgSelect881,Connection883,First884,PgSelectSingle885,Edge886,PgCursor887,PgClassExpression888,PgClassExpression889,List890,Object1371,Lambda1372,Lambda1377,Object1385,Lambda1386,Lambda1391,Object1399,Lambda1400,Lambda1405,Object1413,Lambda1414,Lambda1419,Object1427,Lambda1428,Lambda1433,Object1441,Lambda1442,Lambda1447,Object1455,Lambda1456,Lambda1461,Object1469,Lambda1470,Lambda1475 bucket77
-    Bucket78("Bucket 78 (nullableBoundary)<br />Deps: 284, 758, 728, 731, 1655, 1052, 1055, 1372, 1377<br /><br />ROOT PgInsertSingle{76}ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ[728]<br />1: <br />ᐳ: 736, 739, 740, 741, 742, 743, 744, 745, 747, 737<br />2: PgSelect[748]<br />ᐳ: 752, 753, 755"):::bucket
+    class Bucket77,List736,Lambda737,PgClassExpression758,PgSelect759,Connection763,First764,PgSelectSingle765,Edge766,PgCursor767,PgClassExpression768,List769,List772,Lambda773,PgSelect778,Connection780,First781,PgSelectSingle782,Edge783,PgCursor784,PgClassExpression785,List786,List789,Lambda790,PgSelect795,Connection797,First798,PgSelectSingle799,Edge800,PgCursor801,PgClassExpression802,List803,List806,Lambda807,PgSelect812,Connection814,First815,PgSelectSingle816,Edge817,PgCursor818,PgClassExpression819,List820,List823,Lambda824,PgSelect829,Connection831,First832,PgSelectSingle833,Edge834,PgCursor835,PgClassExpression836,List837,PgSelect846,Connection848,First849,PgSelectSingle850,Edge851,PgCursor852,PgClassExpression853,List854,Connection865,Edge868,PgCursor869,PgSelect881,Connection883,First884,PgSelectSingle885,Edge886,PgCursor887,PgClassExpression888,PgClassExpression889,List890,List893,Lambda894,Lambda897 bucket77
+    Bucket78("Bucket 78 (nullableBoundary)<br />Deps: 728, 731, 1692, 1052, 1056, 1395, 1400, 737, 758<br /><br />ROOT PgInsertSingle{76}ᐸperson(id,person_full_name,about,email,config,last_login_from_ip,last_login_from_subnet,user_mac)ᐳ[728]<br />1: <br />ᐳ: 739, 740, 741, 742, 743, 744, 745, 747<br />2: PgSelect[748]<br />ᐳ: 752, 753, 755"):::bucket
     classDef bucket78 stroke:#ffff00
-    class Bucket78,List736,Lambda737,PgClassExpression739,PgClassExpression740,PgClassExpression741,PgClassExpression742,PgClassExpression743,PgClassExpression744,PgClassExpression745,PgClassExpression747,PgSelect748,First752,PgSelectSingle753,PgClassExpression755 bucket78
+    class Bucket78,PgClassExpression739,PgClassExpression740,PgClassExpression741,PgClassExpression742,PgClassExpression743,PgClassExpression744,PgClassExpression745,PgClassExpression747,PgSelect748,First752,PgSelectSingle753,PgClassExpression755 bucket78
     Bucket79("Bucket 79 (nullableBoundary)<br />Deps: 766, 765, 767, 773<br /><br />ROOT Edge{77}[766]"):::bucket
     classDef bucket79 stroke:#00ffff
     class Bucket79 bucket79
     Bucket80("Bucket 80 (nullableBoundary)<br />Deps: 765, 773<br /><br />ROOT PgSelectSingle{77}ᐸpersonᐳ[765]"):::bucket
     classDef bucket80 stroke:#4169e1
     class Bucket80,PgClassExpression774 bucket80
-    Bucket81("Bucket 81 (nullableBoundary)<br />Deps: 284, 785, 783, 782, 784<br /><br />ROOT Edge{77}[783]"):::bucket
+    Bucket81("Bucket 81 (nullableBoundary)<br />Deps: 783, 782, 784, 790<br /><br />ROOT Edge{77}[783]"):::bucket
     classDef bucket81 stroke:#3cb371
-    class Bucket81,List789,Lambda790 bucket81
+    class Bucket81 bucket81
     Bucket82("Bucket 82 (nullableBoundary)<br />Deps: 782, 790<br /><br />ROOT PgSelectSingle{77}ᐸpersonᐳ[782]"):::bucket
     classDef bucket82 stroke:#a52a2a
     class Bucket82,PgClassExpression791 bucket82
-    Bucket83("Bucket 83 (nullableBoundary)<br />Deps: 284, 802, 800, 799, 801<br /><br />ROOT Edge{77}[800]"):::bucket
+    Bucket83("Bucket 83 (nullableBoundary)<br />Deps: 800, 799, 801, 807<br /><br />ROOT Edge{77}[800]"):::bucket
     classDef bucket83 stroke:#ff00ff
-    class Bucket83,List806,Lambda807 bucket83
+    class Bucket83 bucket83
     Bucket84("Bucket 84 (nullableBoundary)<br />Deps: 799, 807<br /><br />ROOT PgSelectSingle{77}ᐸpersonᐳ[799]"):::bucket
     classDef bucket84 stroke:#f5deb3
     class Bucket84,PgClassExpression808 bucket84
-    Bucket85("Bucket 85 (nullableBoundary)<br />Deps: 284, 819, 817, 816, 818<br /><br />ROOT Edge{77}[817]"):::bucket
+    Bucket85("Bucket 85 (nullableBoundary)<br />Deps: 817, 816, 818, 824<br /><br />ROOT Edge{77}[817]"):::bucket
     classDef bucket85 stroke:#696969
-    class Bucket85,List823,Lambda824 bucket85
+    class Bucket85 bucket85
     Bucket86("Bucket 86 (nullableBoundary)<br />Deps: 816, 824<br /><br />ROOT PgSelectSingle{77}ᐸpersonᐳ[816]"):::bucket
     classDef bucket86 stroke:#00bfff
     class Bucket86,PgClassExpression825 bucket86
@@ -1710,25 +1712,25 @@ graph TD
     Bucket92("Bucket 92 (nullableBoundary)<br />Deps: 765, 773<br /><br />ROOT PgSelectSingle{77}ᐸpersonᐳ[765]"):::bucket
     classDef bucket92 stroke:#808000
     class Bucket92,PgClassExpression876 bucket92
-    Bucket93("Bucket 93 (nullableBoundary)<br />Deps: 284, 889, 886, 885, 887<br /><br />ROOT Edge{77}[886]"):::bucket
+    Bucket93("Bucket 93 (nullableBoundary)<br />Deps: 886, 885, 887, 894<br /><br />ROOT Edge{77}[886]"):::bucket
     classDef bucket93 stroke:#dda0dd
-    class Bucket93,List893,Lambda894 bucket93
+    class Bucket93 bucket93
     Bucket94("Bucket 94 (nullableBoundary)<br />Deps: 885, 894<br /><br />ROOT PgSelectSingle{77}ᐸpersonᐳ[885]"):::bucket
     classDef bucket94 stroke:#ff0000
     class Bucket94,PgClassExpression895 bucket94
-    Bucket95("Bucket 95 (nullableBoundary)<br />Deps: 264, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket95("Bucket 95 (nullableBoundary)<br />Deps: 4, 897<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket95 stroke:#ffff00
-    class Bucket95,Lambda897 bucket95
-    Bucket96("Bucket 96 (mutationField)<br />Deps: 1669, 1670, 144, 1655, 2, 1052, 1480, 1481, 1058, 1710, 1055<br /><br />1: Access[906]<br />2: Access[907]<br />3: Object[908]<br />4: PgInsertSingle[905]<br />5: <br />ᐳ: Object[909]"):::bucket
+    class Bucket95 bucket95
+    Bucket96("Bucket 96 (mutationField)<br />Deps: 1706, 1707, 144, 1692, 2, 1052, 1056, 1515, 1520<br /><br />1: Access[906]<br />2: Access[907]<br />3: Object[908]<br />4: PgInsertSingle[905]<br />5: <br />ᐳ: Object[909]"):::bucket
     classDef bucket96 stroke:#00ffff
     class Bucket96,PgInsertSingle905,Access906,Access907,Object908,Object909 bucket96
-    Bucket97("Bucket 97 (nullableBoundary)<br />Deps: 1052, 1480, 1481, 1058, 1710, 909, 905, 908, 1655, 1055<br /><br />ROOT Object{96}ᐸ{result}ᐳ[909]"):::bucket
+    Bucket97("Bucket 97 (nullableBoundary)<br />Deps: 909, 905, 908, 1692, 1052, 1056, 1515, 1520<br /><br />ROOT Object{96}ᐸ{result}ᐳ[909]"):::bucket
     classDef bucket97 stroke:#4169e1
-    class Bucket97,Object1483,Lambda1484,Lambda1489 bucket97
-    Bucket98("Bucket 98 (nullableBoundary)<br />Deps: 905, 908, 1655, 1052, 1055, 1484, 1489<br /><br />ROOT PgInsertSingle{96}ᐸperson(id,person_full_name,about,email)ᐳ[905]<br />1: <br />ᐳ: PgClassExpression[911]<br />2: PgSelect[912]<br />ᐳ: 916, 917, 919"):::bucket
+    class Bucket97 bucket97
+    Bucket98("Bucket 98 (nullableBoundary)<br />Deps: 905, 908, 1692, 1052, 1056, 1515, 1520<br /><br />ROOT PgInsertSingle{96}ᐸperson(id,person_full_name,about,email)ᐳ[905]<br />1: <br />ᐳ: PgClassExpression[911]<br />2: PgSelect[912]<br />ᐳ: 916, 917, 919"):::bucket
     classDef bucket98 stroke:#3cb371
     class Bucket98,PgClassExpression911,PgSelect912,First916,PgSelectSingle917,PgClassExpression919 bucket98
-    Bucket99("Bucket 99 (mutationField)<br />Deps: 1671, 144, 2<br /><br />1: Access[926]<br />2: Access[927]<br />3: Object[928]<br />4: PgInsertSingle[925]<br />5: <br />ᐳ: Object[929]"):::bucket
+    Bucket99("Bucket 99 (mutationField)<br />Deps: 1708, 144, 2<br /><br />1: Access[926]<br />2: Access[927]<br />3: Object[928]<br />4: PgInsertSingle[925]<br />5: <br />ᐳ: Object[929]"):::bucket
     classDef bucket99 stroke:#a52a2a
     class Bucket99,PgInsertSingle925,Access926,Access927,Object928,Object929 bucket99
     Bucket100("Bucket 100 (nullableBoundary)<br />Deps: 929, 925<br /><br />ROOT Object{99}ᐸ{result}ᐳ[929]"):::bucket
@@ -1737,13 +1739,13 @@ graph TD
     Bucket101("Bucket 101 (nullableBoundary)<br />Deps: 925<br /><br />ROOT PgInsertSingle{99}ᐸdefault_value(id,null_value)ᐳ[925]"):::bucket
     classDef bucket101 stroke:#f5deb3
     class Bucket101,PgClassExpression930,PgClassExpression931 bucket101
-    Bucket102("Bucket 102 (mutationField)<br />Deps: 1672, 1743, 2, 1052, 1494, 1495, 1496, 1711, 1055<br /><br />1: Access[947]<br />2: Access[948]<br />3: Object[949]<br />4: PgInsertSingle[946]<br />5: <br />ᐳ: Object[950]"):::bucket
+    Bucket102("Bucket 102 (mutationField)<br />Deps: 1709, 1780, 2, 1052, 1056, 1530, 1535<br /><br />1: Access[947]<br />2: Access[948]<br />3: Object[949]<br />4: PgInsertSingle[946]<br />5: <br />ᐳ: Object[950]"):::bucket
     classDef bucket102 stroke:#696969
     class Bucket102,PgInsertSingle946,Access947,Access948,Object949,Object950 bucket102
-    Bucket103("Bucket 103 (nullableBoundary)<br />Deps: 1052, 1494, 1495, 1496, 1711, 950, 946, 949, 1055<br /><br />ROOT Object{102}ᐸ{result}ᐳ[950]"):::bucket
+    Bucket103("Bucket 103 (nullableBoundary)<br />Deps: 950, 946, 949, 1052, 1056, 1530, 1535<br /><br />ROOT Object{102}ᐸ{result}ᐳ[950]"):::bucket
     classDef bucket103 stroke:#00bfff
-    class Bucket103,Object1497,Lambda1498,Lambda1503 bucket103
-    Bucket104("Bucket 104 (nullableBoundary)<br />Deps: 946, 949, 1052, 1055, 1498, 1503<br /><br />ROOT PgInsertSingle{102}ᐸpost(headline,comptypes)ᐳ[946]<br />1: <br />ᐳ: 955, 956, 957<br />2: PgSelect[958]"):::bucket
+    class Bucket103 bucket103
+    Bucket104("Bucket 104 (nullableBoundary)<br />Deps: 946, 949, 1052, 1056, 1530, 1535<br /><br />ROOT PgInsertSingle{102}ᐸpost(headline,comptypes)ᐳ[946]<br />1: <br />ᐳ: 955, 956, 957<br />2: PgSelect[958]"):::bucket
     classDef bucket104 stroke:#7f007f
     class Bucket104,PgClassExpression955,PgClassExpression956,PgClassExpression957,PgSelect958 bucket104
     Bucket105("Bucket 105 (listItem)<br /><br />ROOT __Item{105}ᐸ958ᐳ[962]"):::bucket
@@ -1752,13 +1754,13 @@ graph TD
     Bucket106("Bucket 106 (nullableBoundary)<br />Deps: 963<br /><br />ROOT PgSelectSingle{105}ᐸfrmcdc_comptypeᐳ[963]"):::bucket
     classDef bucket106 stroke:#0000ff
     class Bucket106,PgClassExpression964,PgClassExpression965 bucket106
-    Bucket107("Bucket 107 (mutationField)<br />Deps: 1676, 1613, 1744, 2, 1052, 1055, 1508, 1509, 1496, 1712, 1523, 1524, 1713, 1542, 1543, 1058, 1714, 1558, 1559, 1560, 1715, 1572, 1573, 1716, 144, 1053<br /><br />1: Access[982]<br />2: Access[983]<br />3: Object[984]<br />4: PgInsertSingle[981]<br />5: <br />ᐳ: Object[985]"):::bucket
+    Bucket107("Bucket 107 (mutationField)<br />Deps: 1713, 1650, 1781, 2, 1052, 1056, 1613, 1618, 1561, 1566, 1581, 1586, 1598, 1603, 1545, 1550, 144, 1053<br /><br />1: Access[982]<br />2: Access[983]<br />3: Object[984]<br />4: PgInsertSingle[981]<br />5: <br />ᐳ: Object[985]"):::bucket
     classDef bucket107 stroke:#7fff00
     class Bucket107,PgInsertSingle981,Access982,Access983,Object984,Object985 bucket107
-    Bucket108("Bucket 108 (nullableBoundary)<br />Deps: 984, 1052, 1055, 981, 1508, 1509, 1496, 1712, 1523, 1524, 1713, 1542, 1543, 1058, 1714, 1558, 1559, 1560, 1715, 1572, 1573, 1716, 985, 144, 1053<br /><br />ROOT Object{107}ᐸ{result}ᐳ[985]<br />1: <br />ᐳ: 1015, 1020, 1044, 1511, 1517, 1526, 1532, 1545, 1551, 1561, 1567, 1575, 1581, 1512, 1527, 1546, 1562, 1576<br />2: PgSelect[1002], PgSelect[1016]<br />ᐳ: 1004, 1005, 1021, 1022, 1518"):::bucket
+    Bucket108("Bucket 108 (nullableBoundary)<br />Deps: 984, 1052, 1056, 1613, 1618, 981, 1561, 1566, 1581, 1586, 1598, 1603, 985, 1545, 1550, 144, 1053<br /><br />ROOT Object{107}ᐸ{result}ᐳ[985]<br />1: <br />ᐳ: 1015, 1020, 1044<br />2: PgSelect[1002], PgSelect[1016]<br />ᐳ: 1004, 1005, 1021, 1022, 1025, 1551"):::bucket
     classDef bucket108 stroke:#ff1493
-    class Bucket108,PgSelect1002,First1004,PgSelectSingle1005,PgClassExpression1015,PgSelect1016,Connection1020,First1021,PgSelectSingle1022,PgClassExpression1044,Object1511,Lambda1512,Lambda1517,Edge1518,Object1526,Lambda1527,Lambda1532,Object1545,Lambda1546,Lambda1551,Object1561,Lambda1562,Lambda1567,Object1575,Lambda1576,Lambda1581 bucket108
-    Bucket109("Bucket 109 (nullableBoundary)<br />Deps: 981, 984, 1052, 1055, 1512, 1517, 1005, 1015<br /><br />ROOT PgInsertSingle{107}ᐸpost(headline,author_id,comptypes)ᐳ[981]<br />1: <br />ᐳ: 991, 992<br />2: PgSelect[993]"):::bucket
+    class Bucket108,PgSelect1002,First1004,PgSelectSingle1005,PgClassExpression1015,PgSelect1016,Connection1020,First1021,PgSelectSingle1022,PgClassExpression1025,PgClassExpression1044,Edge1551 bucket108
+    Bucket109("Bucket 109 (nullableBoundary)<br />Deps: 981, 984, 1052, 1056, 1545, 1550, 1005, 1015<br /><br />ROOT PgInsertSingle{107}ᐸpost(headline,author_id,comptypes)ᐳ[981]<br />1: <br />ᐳ: 991, 992<br />2: PgSelect[993]"):::bucket
     classDef bucket109 stroke:#808000
     class Bucket109,PgClassExpression991,PgClassExpression992,PgSelect993 bucket109
     Bucket110("Bucket 110 (listItem)<br /><br />ROOT __Item{110}ᐸ993ᐳ[997]"):::bucket
@@ -1770,13 +1772,13 @@ graph TD
     Bucket112("Bucket 112 (nullableBoundary)<br />Deps: 1005<br /><br />ROOT PgSelectSingle{108}ᐸpersonᐳ[1005]"):::bucket
     classDef bucket112 stroke:#ffff00
     class Bucket112,PgClassExpression1006,PgClassExpression1012 bucket112
-    Bucket113("Bucket 113 (nullableBoundary)<br />Deps: 1022, 1518, 1021, 144, 1052, 1053<br /><br />ROOT Edge{108}[1518]"):::bucket
+    Bucket113("Bucket 113 (nullableBoundary)<br />Deps: 1551, 1022, 1021, 144, 1052, 1053, 1025<br /><br />ROOT Edge{108}[1551]"):::bucket
     classDef bucket113 stroke:#00ffff
-    class Bucket113,PgClassExpression1025 bucket113
+    class Bucket113 bucket113
     Bucket114("Bucket 114 (nullableBoundary)<br />Deps: 1022, 1021, 144, 1052, 1053, 1025<br /><br />ROOT PgSelectSingle{108}ᐸpostᐳ[1022]"):::bucket
     classDef bucket114 stroke:#4169e1
-    class Bucket114,PgClassExpression1028,PgSelectSingle1042,Access1534,Object1536,Lambda1537,RemapKeys1552 bucket114
-    Bucket115("Bucket 115 (listItem)<br /><br />ROOT __Item{115}ᐸ1537ᐳ[1034]"):::bucket
+    class Bucket114,PgClassExpression1028,PgSelectSingle1042,Access1568,Object1570,Lambda1571,RemapKeys1587 bucket114
+    Bucket115("Bucket 115 (listItem)<br /><br />ROOT __Item{115}ᐸ1571ᐳ[1034]"):::bucket
     classDef bucket115 stroke:#3cb371
     class Bucket115,__Item1034,PgSelectSingle1035 bucket115
     Bucket116("Bucket 116 (nullableBoundary)<br />Deps: 1035<br /><br />ROOT PgSelectSingle{115}ᐸfrmcdc_comptypeᐳ[1035]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-delete.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-delete.mermaid
@@ -9,24 +9,81 @@ graph TD
 
 
     %% plan dependencies
+    Object392{{"Object[392∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda384 & Constant389 & Constant390 & Constant391 --> Object392
+    Object407{{"Object[407∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant404{{"Constant[404∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda384 & Constant404 & Constant405 & Constant391 --> Object407
+    Object422{{"Object[422∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant419{{"Constant[419∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda384 & Constant419 & Constant420 & Constant391 --> Object422
+    Object437{{"Object[437∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda384 & Constant434 & Constant435 & Constant391 --> Object437
+    Object452{{"Object[452∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant449{{"Constant[449∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda384 & Constant449 & Constant450 & Constant391 --> Object452
+    Object467{{"Object[467∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 213ᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda384 & Constant464 & Constant465 & Constant391 --> Object467
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
     Lambda9{{"Lambda[9∈0] ➊<br />ᐸdecode_Post_base64JSONᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸ'WyJwb3N0cyIsMV0='ᐳ"}}:::plan
-    Constant468 --> Lambda9
+    Constant474{{"Constant[474∈0] ➊<br />ᐸ'WyJwb3N0cyIsMV0='ᐳ"}}:::plan
+    Constant474 --> Lambda9
     Access10{{"Access[10∈0] ➊<br />ᐸ9.1ᐳ"}}:::plan
     Lambda9 --> Access10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Lambda384{{"Lambda[384∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant469 --> Lambda384
+    Constant475{{"Constant[475∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant475 --> Lambda384
     Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant470 --> Lambda387
+    Constant476{{"Constant[476∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant476 --> Lambda387
+    Access388{{"Access[388∈0] ➊<br />ᐸ387.0ᐳ"}}:::plan
+    Lambda387 --> Access388
+    Lambda393{{"Lambda[393∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object392 --> Lambda393
+    Lambda398{{"Lambda[398∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant493{{"Constant[493∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant493 --> Lambda398
+    Lambda408{{"Lambda[408∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object407 --> Lambda408
+    Lambda413{{"Lambda[413∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant494 --> Lambda413
+    Lambda423{{"Lambda[423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object422 --> Lambda423
+    Lambda428{{"Lambda[428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant495{{"Constant[495∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant495 --> Lambda428
+    Lambda438{{"Lambda[438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object437 --> Lambda438
+    Lambda443{{"Lambda[443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant496{{"Constant[496∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant496 --> Lambda443
+    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object452 --> Lambda453
+    Lambda458{{"Lambda[458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant497{{"Constant[497∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant497 --> Lambda458
+    Lambda468{{"Lambda[468∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object467 --> Lambda468
+    Lambda473{{"Lambda[473∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant498{{"Constant[498∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
+    Constant498 --> Lambda473
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant17{{"Constant[17∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant18{{"Constant[18∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
@@ -34,41 +91,22 @@ graph TD
     Constant112{{"Constant[112∈0] ➊<br />ᐸ'types'ᐳ"}}:::plan
     Constant216{{"Constant[216∈0] ➊<br />ᐸ'compound_keys'ᐳ"}}:::plan
     Constant235{{"Constant[235∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant458{{"Constant[458∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 213ᐳ"}}:::plan
-    Constant459{{"Constant[459∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ'WyJwb3N0cyIsMl0='ᐳ"}}:::plan
-    Constant473{{"Constant[473∈0] ➊<br />ᐸ'WyJwb3N0cyIsMjAwMDAwMF0='ᐳ"}}:::plan
-    Constant474{{"Constant[474∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
-    Constant475{{"Constant[475∈0] ➊<br />ᐸ'WyJwb3N0cyIsM10='ᐳ"}}:::plan
-    Constant476{{"Constant[476∈0] ➊<br />ᐸ'throw error'ᐳ"}}:::plan
-    Constant477{{"Constant[477∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant478{{"Constant[478∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Constant479{{"Constant[479∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant480{{"Constant[480∈0] ➊<br />ᐸ2000000ᐳ"}}:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiw0LDNd'ᐳ"}}:::plan
-    Constant482{{"Constant[482∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant483{{"Constant[483∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant484{{"Constant[484∈0] ➊<br />ᐸ'budd.deey@email.com'ᐳ"}}:::plan
-    Constant485{{"Constant[485∈0] ➊<br />ᐸ'graphile-build.issue.27.exists@example.com'ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant487{{"Constant[487∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant488{{"Constant[488∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant489{{"Constant[489∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant490{{"Constant[490∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant491{{"Constant[491∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant492{{"Constant[492∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸ'WyJwb3N0cyIsMl0='ᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸ'WyJwb3N0cyIsMjAwMDAwMF0='ᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸ'WyJwb3N0cyIsM10='ᐳ"}}:::plan
+    Constant482{{"Constant[482∈0] ➊<br />ᐸ'throw error'ᐳ"}}:::plan
+    Constant483{{"Constant[483∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Constant484{{"Constant[484∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Constant485{{"Constant[485∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Constant486{{"Constant[486∈0] ➊<br />ᐸ2000000ᐳ"}}:::plan
+    Constant487{{"Constant[487∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiw0LDNd'ᐳ"}}:::plan
+    Constant488{{"Constant[488∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant489{{"Constant[489∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant490{{"Constant[490∈0] ➊<br />ᐸ'budd.deey@email.com'ᐳ"}}:::plan
+    Constant491{{"Constant[491∈0] ➊<br />ᐸ'graphile-build.issue.27.exists@example.com'ᐳ"}}:::plan
+    Constant492{{"Constant[492∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     PgDeleteSingle12[["PgDeleteSingle[12∈1] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object15 -->|rejectNull| PgDeleteSingle12
     Access10 --> PgDeleteSingle12
@@ -80,12 +118,12 @@ graph TD
     PgDeleteSingle12 --> PgClassExpression19
     Lambda21{{"Lambda[21∈2] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List20 --> Lambda21
+    Lambda30{{"Lambda[30∈2] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda30
     PgClassExpression27{{"PgClassExpression[27∈3] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle12 --> PgClassExpression27
     PgClassExpression28{{"PgClassExpression[28∈3] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle12 --> PgClassExpression28
-    Lambda30{{"Lambda[30∈4] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda30
     PgDeleteSingle37[["PgDeleteSingle[37∈5] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object40{{"Object[40∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access35{{"Access[35∈5] ➊<br />ᐸ34.1ᐳ"}}:::plan
@@ -95,9 +133,9 @@ graph TD
     Access39{{"Access[39∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access38 & Access39 --> Object40
     Object41{{"Object[41∈5] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgDeleteSingle37 & Constant471 --> Object41
+    PgDeleteSingle37 & Constant477 --> Object41
     Lambda34{{"Lambda[34∈5] ➊<br />ᐸdecode_Post_base64JSONᐳ"}}:::plan
-    Constant472 --> Lambda34
+    Constant478 --> Lambda34
     Lambda34 --> Access35
     __Value2 --> Access38
     __Value2 --> Access39
@@ -107,12 +145,12 @@ graph TD
     PgDeleteSingle37 --> PgClassExpression43
     Lambda45{{"Lambda[45∈6] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List44 --> Lambda45
+    Lambda54{{"Lambda[54∈6] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda54
     PgClassExpression51{{"PgClassExpression[51∈7] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle37 --> PgClassExpression51
     PgClassExpression52{{"PgClassExpression[52∈7] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle37 --> PgClassExpression52
-    Lambda54{{"Lambda[54∈8] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda54
     PgDeleteSingle61[["PgDeleteSingle[61∈9] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object64{{"Object[64∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access59{{"Access[59∈9] ➊<br />ᐸ58.1ᐳ"}}:::plan
@@ -122,7 +160,7 @@ graph TD
     Access63{{"Access[63∈9] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access62 & Access63 --> Object64
     Lambda58{{"Lambda[58∈9] ➊<br />ᐸdecode_Post_base64JSONᐳ"}}:::plan
-    Constant473 --> Lambda58
+    Constant479 --> Lambda58
     Lambda58 --> Access59
     __Value2 --> Access62
     __Value2 --> Access63
@@ -134,12 +172,12 @@ graph TD
     PgDeleteSingle61 --> PgClassExpression68
     Lambda70{{"Lambda[70∈10] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List69 --> Lambda70
+    Lambda79{{"Lambda[79∈10] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda79
     PgClassExpression76{{"PgClassExpression[76∈11] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle61 --> PgClassExpression76
     PgClassExpression77{{"PgClassExpression[77∈11] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle61 --> PgClassExpression77
-    Lambda79{{"Lambda[79∈12] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda79
     PgDeleteSingle86[["PgDeleteSingle[86∈13] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object89{{"Object[89∈13] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access84{{"Access[84∈13] ➊<br />ᐸ83.1ᐳ"}}:::plan
@@ -149,9 +187,9 @@ graph TD
     Access88{{"Access[88∈13] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access87 & Access88 --> Object89
     Object90{{"Object[90∈13] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgDeleteSingle86 & Constant474 --> Object90
+    PgDeleteSingle86 & Constant480 --> Object90
     Lambda83{{"Lambda[83∈13] ➊<br />ᐸdecode_Post_base64JSONᐳ"}}:::plan
-    Constant475 --> Lambda83
+    Constant481 --> Lambda83
     Lambda83 --> Access84
     __Value2 --> Access87
     __Value2 --> Access88
@@ -161,20 +199,20 @@ graph TD
     PgDeleteSingle86 --> PgClassExpression92
     Lambda94{{"Lambda[94∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List93 --> Lambda94
+    Lambda103{{"Lambda[103∈14] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda103
     PgClassExpression100{{"PgClassExpression[100∈15] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle86 --> PgClassExpression100
     PgClassExpression101{{"PgClassExpression[101∈15] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle86 --> PgClassExpression101
-    Lambda103{{"Lambda[103∈16] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda103
     PgDeleteSingle107[["PgDeleteSingle[107∈17] ➊<br />ᐸtypes(id)ᐳ"]]:::sideeffectplan
     Object110{{"Object[110∈17] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object110 & Constant477 --> PgDeleteSingle107
+    Object110 & Constant483 --> PgDeleteSingle107
     Access108{{"Access[108∈17] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access109{{"Access[109∈17] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access108 & Access109 --> Object110
     Object111{{"Object[111∈17] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgDeleteSingle107 & Constant476 --> Object111
+    PgDeleteSingle107 & Constant482 --> Object111
     __Value2 --> Access108
     __Value2 --> Access109
     List114{{"List[114∈18] ➊<br />ᐸ112,113ᐳ"}}:::plan
@@ -185,7 +223,7 @@ graph TD
     List114 --> Lambda115
     PgDeleteSingle119[["PgDeleteSingle[119∈19] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object122{{"Object[122∈19] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object122 & Constant478 --> PgDeleteSingle119
+    Object122 & Constant484 --> PgDeleteSingle119
     Access120{{"Access[120∈19] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access121{{"Access[121∈19] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access120 & Access121 --> Object122
@@ -199,20 +237,20 @@ graph TD
     PgDeleteSingle119 --> PgClassExpression126
     Lambda128{{"Lambda[128∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List127 --> Lambda128
+    Lambda137{{"Lambda[137∈20] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda137
     PgClassExpression134{{"PgClassExpression[134∈21] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle119 --> PgClassExpression134
     PgClassExpression135{{"PgClassExpression[135∈21] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle119 --> PgClassExpression135
-    Lambda137{{"Lambda[137∈22] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda137
     PgDeleteSingle141[["PgDeleteSingle[141∈23] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object144{{"Object[144∈23] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object144 & Constant479 --> PgDeleteSingle141
+    Object144 & Constant485 --> PgDeleteSingle141
     Access142{{"Access[142∈23] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access143{{"Access[143∈23] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access142 & Access143 --> Object144
     Object145{{"Object[145∈23] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgDeleteSingle141 & Constant471 --> Object145
+    PgDeleteSingle141 & Constant477 --> Object145
     __Value2 --> Access142
     __Value2 --> Access143
     List148{{"List[148∈24] ➊<br />ᐸ18,147ᐳ"}}:::plan
@@ -221,15 +259,15 @@ graph TD
     PgDeleteSingle141 --> PgClassExpression147
     Lambda149{{"Lambda[149∈24] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List148 --> Lambda149
+    Lambda158{{"Lambda[158∈24] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda158
     PgClassExpression155{{"PgClassExpression[155∈25] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle141 --> PgClassExpression155
     PgClassExpression156{{"PgClassExpression[156∈25] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle141 --> PgClassExpression156
-    Lambda158{{"Lambda[158∈26] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda158
     PgDeleteSingle162[["PgDeleteSingle[162∈27] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object165{{"Object[165∈27] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object165 & Constant480 --> PgDeleteSingle162
+    Object165 & Constant486 --> PgDeleteSingle162
     Access163{{"Access[163∈27] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access164{{"Access[164∈27] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access163 & Access164 --> Object165
@@ -243,20 +281,20 @@ graph TD
     PgDeleteSingle162 --> PgClassExpression169
     Lambda171{{"Lambda[171∈28] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List170 --> Lambda171
+    Lambda180{{"Lambda[180∈28] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda180
     PgClassExpression177{{"PgClassExpression[177∈29] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle162 --> PgClassExpression177
     PgClassExpression178{{"PgClassExpression[178∈29] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle162 --> PgClassExpression178
-    Lambda180{{"Lambda[180∈30] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda180
     PgDeleteSingle184[["PgDeleteSingle[184∈31] ➊<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object187{{"Object[187∈31] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object187 & Constant477 --> PgDeleteSingle184
+    Object187 & Constant483 --> PgDeleteSingle184
     Access185{{"Access[185∈31] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access186{{"Access[186∈31] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access185 & Access186 --> Object187
     Object188{{"Object[188∈31] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgDeleteSingle184 & Constant474 --> Object188
+    PgDeleteSingle184 & Constant480 --> Object188
     __Value2 --> Access185
     __Value2 --> Access186
     List191{{"List[191∈32] ➊<br />ᐸ18,190ᐳ"}}:::plan
@@ -265,12 +303,12 @@ graph TD
     PgDeleteSingle184 --> PgClassExpression190
     Lambda192{{"Lambda[192∈32] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List191 --> Lambda192
+    Lambda201{{"Lambda[201∈32] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda201
     PgClassExpression198{{"PgClassExpression[198∈33] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgDeleteSingle184 --> PgClassExpression198
     PgClassExpression199{{"PgClassExpression[199∈33] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgDeleteSingle184 --> PgClassExpression199
-    Lambda201{{"Lambda[201∈34] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda201
     PgDeleteSingle210[["PgDeleteSingle[210∈35] ➊<br />ᐸcompound_key(person_id_1,person_id_2)ᐳ"]]:::sideeffectplan
     Object213{{"Object[213∈35] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access206{{"Access[206∈35] ➊<br />ᐸ205.1ᐳ"}}:::plan
@@ -282,7 +320,7 @@ graph TD
     Access212{{"Access[212∈35] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access211 & Access212 --> Object213
     Lambda205{{"Lambda[205∈35] ➊<br />ᐸdecode_CompoundKey_base64JSONᐳ"}}:::plan
-    Constant481 --> Lambda205
+    Constant487 --> Lambda205
     Lambda205 --> Access206
     Lambda205 --> Access208
     __Value2 --> Access211
@@ -291,18 +329,10 @@ graph TD
     PgDeleteSingle210 --> Object214
     PgSelect229[["PgSelect[229∈36] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression217{{"PgClassExpression[217∈36] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
-    Lambda392{{"Lambda[392∈36] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda397{{"Lambda[397∈36] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object213 & PgClassExpression217 & Lambda384 & Lambda387 & Lambda392 & Lambda397 --> PgSelect229
+    Object213 & PgClassExpression217 & Lambda384 & Access388 & Lambda393 & Lambda398 --> PgSelect229
     PgSelect241[["PgSelect[241∈36] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression218{{"PgClassExpression[218∈36] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
-    Lambda406{{"Lambda[406∈36] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda411{{"Lambda[411∈36] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object213 & PgClassExpression218 & Lambda384 & Lambda387 & Lambda406 & Lambda411 --> PgSelect241
-    Object391{{"Object[391∈36] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda384 & Constant388 & Constant389 & Constant390 --> Object391
-    Object405{{"Object[405∈36] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda384 & Constant402 & Constant403 & Constant390 --> Object405
+    Object213 & PgClassExpression218 & Lambda384 & Access388 & Lambda408 & Lambda413 --> PgSelect241
     List219{{"List[219∈36] ➊<br />ᐸ216,217,218ᐳ"}}:::plan
     Constant216 & PgClassExpression217 & PgClassExpression218 --> List219
     PgDeleteSingle210 --> PgClassExpression217
@@ -317,10 +347,8 @@ graph TD
     PgSelect241 --> First243
     PgSelectSingle244{{"PgSelectSingle[244∈36] ➊<br />ᐸpersonᐳ"}}:::plan
     First243 --> PgSelectSingle244
-    Object391 --> Lambda392
-    Constant487 --> Lambda397
-    Object405 --> Lambda406
-    Constant488 --> Lambda411
+    Lambda251{{"Lambda[251∈36] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda251
     List237{{"List[237∈38] ➊<br />ᐸ235,236ᐳ"}}:::plan
     PgClassExpression236{{"PgClassExpression[236∈38] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant235 & PgClassExpression236 --> List237
@@ -337,11 +365,9 @@ graph TD
     List247 --> Lambda248
     PgClassExpression249{{"PgClassExpression[249∈39] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle244 --> PgClassExpression249
-    Lambda251{{"Lambda[251∈40] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda251
     PgDeleteSingle256[["PgDeleteSingle[256∈41] ➊<br />ᐸcompound_key(person_id_1,person_id_2)ᐳ"]]:::sideeffectplan
     Object259{{"Object[259∈41] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object259 & Constant482 & Constant483 --> PgDeleteSingle256
+    Object259 & Constant488 & Constant489 --> PgDeleteSingle256
     Access257{{"Access[257∈41] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access258{{"Access[258∈41] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access257 & Access258 --> Object259
@@ -351,18 +377,10 @@ graph TD
     PgDeleteSingle256 --> Object260
     PgSelect275[["PgSelect[275∈42] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression263{{"PgClassExpression[263∈42] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
-    Lambda420{{"Lambda[420∈42] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda425{{"Lambda[425∈42] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object259 & PgClassExpression263 & Lambda384 & Lambda387 & Lambda420 & Lambda425 --> PgSelect275
+    Object259 & PgClassExpression263 & Lambda384 & Access388 & Lambda423 & Lambda428 --> PgSelect275
     PgSelect287[["PgSelect[287∈42] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression264{{"PgClassExpression[264∈42] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
-    Lambda434{{"Lambda[434∈42] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda439{{"Lambda[439∈42] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object259 & PgClassExpression264 & Lambda384 & Lambda387 & Lambda434 & Lambda439 --> PgSelect287
-    Object419{{"Object[419∈42] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda384 & Constant416 & Constant417 & Constant390 --> Object419
-    Object433{{"Object[433∈42] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda384 & Constant430 & Constant431 & Constant390 --> Object433
+    Object259 & PgClassExpression264 & Lambda384 & Access388 & Lambda438 & Lambda443 --> PgSelect287
     List265{{"List[265∈42] ➊<br />ᐸ216,263,264ᐳ"}}:::plan
     Constant216 & PgClassExpression263 & PgClassExpression264 --> List265
     PgDeleteSingle256 --> PgClassExpression263
@@ -377,10 +395,8 @@ graph TD
     PgSelect287 --> First289
     PgSelectSingle290{{"PgSelectSingle[290∈42] ➊<br />ᐸpersonᐳ"}}:::plan
     First289 --> PgSelectSingle290
-    Object419 --> Lambda420
-    Constant489 --> Lambda425
-    Object433 --> Lambda434
-    Constant490 --> Lambda439
+    Lambda297{{"Lambda[297∈42] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda297
     List283{{"List[283∈44] ➊<br />ᐸ235,282ᐳ"}}:::plan
     PgClassExpression282{{"PgClassExpression[282∈44] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant235 & PgClassExpression282 --> List283
@@ -397,11 +413,9 @@ graph TD
     List293 --> Lambda294
     PgClassExpression295{{"PgClassExpression[295∈45] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle290 --> PgClassExpression295
-    Lambda297{{"Lambda[297∈46] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda297
     PgDeleteSingle301[["PgDeleteSingle[301∈47] ➊<br />ᐸperson(email)ᐳ"]]:::sideeffectplan
     Object304{{"Object[304∈47] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object304 & Constant484 --> PgDeleteSingle301
+    Object304 & Constant490 --> PgDeleteSingle301
     Access302{{"Access[302∈47] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access303{{"Access[303∈47] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access302 & Access303 --> Object304
@@ -415,11 +429,11 @@ graph TD
     PgDeleteSingle301 --> PgClassExpression308
     Lambda310{{"Lambda[310∈48] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List309 --> Lambda310
-    Lambda312{{"Lambda[312∈49] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Lambda312{{"Lambda[312∈48] ➊<br />ᐸrawEncodeᐳ"}}:::plan
     Constant29 --> Lambda312
     PgDeleteSingle316[["PgDeleteSingle[316∈50] ➊<br />ᐸperson(email)ᐳ"]]:::sideeffectplan
     Object319{{"Object[319∈50] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object319 & Constant485 --> PgDeleteSingle316
+    Object319 & Constant491 --> PgDeleteSingle316
     Access317{{"Access[317∈50] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access318{{"Access[318∈50] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access317 & Access318 --> Object319
@@ -427,21 +441,17 @@ graph TD
     __Value2 --> Access318
     Object320{{"Object[320∈50] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgDeleteSingle316 --> Object320
-    Object447{{"Object[447∈51] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda384 & Constant444 & Constant445 & Constant390 --> Object447
     List324{{"List[324∈51] ➊<br />ᐸ235,323ᐳ"}}:::plan
     PgClassExpression323{{"PgClassExpression[323∈51] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant235 & PgClassExpression323 --> List324
     PgDeleteSingle316 --> PgClassExpression323
     Lambda325{{"Lambda[325∈51] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List324 --> Lambda325
-    Lambda448{{"Lambda[448∈51] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object447 --> Lambda448
-    Lambda453{{"Lambda[453∈51] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant491 --> Lambda453
+    Lambda344{{"Lambda[344∈51] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda344
     PgSelect335[["PgSelect[335∈52] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression334{{"PgClassExpression[334∈52] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object319 & PgClassExpression334 & Constant485 & Lambda384 & Lambda387 & Lambda448 & Lambda453 --> PgSelect335
+    Object319 & PgClassExpression334 & Constant491 & Lambda384 & Access388 & Lambda453 & Lambda458 --> PgSelect335
     PgClassExpression331{{"PgClassExpression[331∈52] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgDeleteSingle316 --> PgClassExpression331
     PgClassExpression332{{"PgClassExpression[332∈52] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -453,11 +463,9 @@ graph TD
     First339 --> PgSelectSingle340
     PgClassExpression342{{"PgClassExpression[342∈52] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle340 --> PgClassExpression342
-    Lambda344{{"Lambda[344∈53] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda344
     PgDeleteSingle348[["PgDeleteSingle[348∈54] ➊<br />ᐸperson(id)ᐳ"]]:::sideeffectplan
     Object351{{"Object[351∈54] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object351 & Constant486 --> PgDeleteSingle348
+    Object351 & Constant492 --> PgDeleteSingle348
     Access349{{"Access[349∈54] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access350{{"Access[350∈54] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access349 & Access350 --> Object351
@@ -467,11 +475,7 @@ graph TD
     PgDeleteSingle348 --> Object352
     PgSelect361[["PgSelect[361∈55] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression360{{"PgClassExpression[360∈55] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Lambda462{{"Lambda[462∈55] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda467{{"Lambda[467∈55] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object351 & PgClassExpression360 & Lambda384 & Lambda387 & Lambda462 & Lambda467 --> PgSelect361
-    Object461{{"Object[461∈55] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda384 & Constant458 & Constant459 & Constant390 --> Object461
+    Object351 & PgClassExpression360 & Lambda384 & Access388 & Lambda468 & Lambda473 --> PgSelect361
     Edge368{{"Edge[368∈55] ➊"}}:::plan
     PgSelectSingle367{{"PgSelectSingle[367∈55] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor369{{"PgCursor[369∈55] ➊"}}:::plan
@@ -484,6 +488,8 @@ graph TD
     PgClassExpression370{{"PgClassExpression[370∈55] ➊<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgClassExpression371{{"PgClassExpression[371∈55] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgClassExpression370 & PgClassExpression371 --> List372
+    List377{{"List[377∈55] ➊<br />ᐸ235,371ᐳ"}}:::plan
+    Constant235 & PgClassExpression371 --> List377
     PgDeleteSingle348 --> PgClassExpression355
     Lambda357{{"Lambda[357∈55] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List356 --> Lambda357
@@ -494,131 +500,127 @@ graph TD
     List372 --> PgCursor369
     PgSelectSingle367 --> PgClassExpression370
     PgSelectSingle367 --> PgClassExpression371
-    Object461 --> Lambda462
-    Constant492 --> Lambda467
-    List377{{"List[377∈56] ➊<br />ᐸ235,371ᐳ"}}:::plan
-    Constant235 & PgClassExpression371 --> List377
-    Lambda378{{"Lambda[378∈56] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    Lambda378{{"Lambda[378∈55] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List377 --> Lambda378
+    Lambda381{{"Lambda[381∈55] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant29 --> Lambda381
     PgClassExpression379{{"PgClassExpression[379∈57] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgSelectSingle367 --> PgClassExpression379
-    Lambda381{{"Lambda[381∈58] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant29 --> Lambda381
 
     %% define steps
 
     subgraph "Buckets for mutations/v4/mutation-delete"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda9,Access10,Access13,Access14,Object15,Constant17,Constant18,Constant29,Constant112,Constant216,Constant235,Lambda384,Lambda387,Constant388,Constant389,Constant390,Constant402,Constant403,Constant416,Constant417,Constant430,Constant431,Constant444,Constant445,Constant458,Constant459,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483,Constant484,Constant485,Constant486,Constant487,Constant488,Constant489,Constant490,Constant491,Constant492 bucket0
+    class Bucket0,__Value2,__Value4,Lambda9,Access10,Access13,Access14,Object15,Constant17,Constant18,Constant29,Constant112,Constant216,Constant235,Lambda384,Lambda387,Access388,Constant389,Constant390,Constant391,Object392,Lambda393,Lambda398,Constant404,Constant405,Object407,Lambda408,Lambda413,Constant419,Constant420,Object422,Lambda423,Lambda428,Constant434,Constant435,Object437,Lambda438,Lambda443,Constant449,Constant450,Object452,Lambda453,Lambda458,Constant464,Constant465,Object467,Lambda468,Lambda473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483,Constant484,Constant485,Constant486,Constant487,Constant488,Constant489,Constant490,Constant491,Constant492,Constant493,Constant494,Constant495,Constant496,Constant497,Constant498 bucket0
     Bucket1("Bucket 1 (mutationField)<br />Deps: 15, 10, 18, 29, 4, 17<br /><br />1: PgDeleteSingle[12]<br />2: <br />ᐳ: Object[16]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgDeleteSingle12,Object16 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 18, 16, 29, 4, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[16]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 18, 29, 16, 4, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression19,List20,Lambda21 bucket2
+    class Bucket2,PgClassExpression19,List20,Lambda21,Lambda30 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 12, 21, 19<br /><br />ROOT PgDeleteSingle{1}ᐸpost(id)ᐳ[12]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression27,PgClassExpression28 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 4, 30<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Lambda30 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 472, 2, 471, 18, 29, 4<br /><br />1: Access[38]<br />2: Access[39]<br />3: Object[40]<br />4: Lambda[34]<br />5: Access[35]<br />6: PgDeleteSingle[37]<br />7: <br />ᐳ: Object[41]"):::bucket
+    class Bucket4 bucket4
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 478, 2, 477, 18, 29, 4<br /><br />1: Access[38]<br />2: Access[39]<br />3: Object[40]<br />4: Lambda[34]<br />5: Access[35]<br />6: PgDeleteSingle[37]<br />7: <br />ᐳ: Object[41]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,Lambda34,Access35,PgDeleteSingle37,Access38,Access39,Object40,Object41 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 37, 18, 41, 29, 4, 471<br /><br />ROOT Object{5}ᐸ{result,clientMutationId}ᐳ[41]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 37, 18, 29, 41, 4, 477<br /><br />ROOT Object{5}ᐸ{result,clientMutationId}ᐳ[41]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,List44,Lambda45 bucket6
+    class Bucket6,PgClassExpression43,List44,Lambda45,Lambda54 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 37, 45, 43<br /><br />ROOT PgDeleteSingle{5}ᐸpost(id)ᐳ[37]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression51,PgClassExpression52 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 4, 54<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,Lambda54 bucket8
-    Bucket9("Bucket 9 (mutationField)<br />Deps: 473, 2, 18, 29, 4, 17<br /><br />1: Access[62]<br />2: Access[63]<br />3: Object[64]<br />4: Lambda[58]<br />5: Access[59]<br />6: PgDeleteSingle[61]<br />7: <br />ᐳ: Object[65]"):::bucket
+    class Bucket8 bucket8
+    Bucket9("Bucket 9 (mutationField)<br />Deps: 479, 2, 18, 29, 4, 17<br /><br />1: Access[62]<br />2: Access[63]<br />3: Object[64]<br />4: Lambda[58]<br />5: Access[59]<br />6: PgDeleteSingle[61]<br />7: <br />ᐳ: Object[65]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,Lambda58,Access59,PgDeleteSingle61,Access62,Access63,Object64,Object65 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 61, 18, 65, 29, 4, 17<br /><br />ROOT Object{9}ᐸ{result}ᐳ[65]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 61, 18, 29, 65, 4, 17<br /><br />ROOT Object{9}ᐸ{result}ᐳ[65]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression68,List69,Lambda70 bucket10
+    class Bucket10,PgClassExpression68,List69,Lambda70,Lambda79 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 61, 70, 68<br /><br />ROOT PgDeleteSingle{9}ᐸpost(id)ᐳ[61]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression76,PgClassExpression77 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 4, 79<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,Lambda79 bucket12
-    Bucket13("Bucket 13 (mutationField)<br />Deps: 475, 2, 474, 18, 29, 4<br /><br />1: Access[87]<br />2: Access[88]<br />3: Object[89]<br />4: Lambda[83]<br />5: Access[84]<br />6: PgDeleteSingle[86]<br />7: <br />ᐳ: Object[90]"):::bucket
+    class Bucket12 bucket12
+    Bucket13("Bucket 13 (mutationField)<br />Deps: 481, 2, 480, 18, 29, 4<br /><br />1: Access[87]<br />2: Access[88]<br />3: Object[89]<br />4: Lambda[83]<br />5: Access[84]<br />6: PgDeleteSingle[86]<br />7: <br />ᐳ: Object[90]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,Lambda83,Access84,PgDeleteSingle86,Access87,Access88,Object89,Object90 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 86, 18, 90, 29, 4, 474<br /><br />ROOT Object{13}ᐸ{result,clientMutationId}ᐳ[90]"):::bucket
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 86, 18, 29, 90, 4, 480<br /><br />ROOT Object{13}ᐸ{result,clientMutationId}ᐳ[90]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression92,List93,Lambda94 bucket14
+    class Bucket14,PgClassExpression92,List93,Lambda94,Lambda103 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 86, 94, 92<br /><br />ROOT PgDeleteSingle{13}ᐸpost(id)ᐳ[86]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression100,PgClassExpression101 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 4, 103<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,Lambda103 bucket16
-    Bucket17("Bucket 17 (mutationField)<br />Deps: 477, 2, 476, 112<br /><br />1: Access[108]<br />2: Access[109]<br />3: Object[110]<br />4: PgDeleteSingle[107]<br />5: <br />ᐳ: Object[111]"):::bucket
+    class Bucket16 bucket16
+    Bucket17("Bucket 17 (mutationField)<br />Deps: 483, 2, 482, 112<br /><br />1: Access[108]<br />2: Access[109]<br />3: Object[110]<br />4: PgDeleteSingle[107]<br />5: <br />ᐳ: Object[111]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgDeleteSingle107,Access108,Access109,Object110,Object111 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 107, 112, 111, 476<br /><br />ROOT Object{17}ᐸ{result,clientMutationId}ᐳ[111]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 107, 112, 111, 482<br /><br />ROOT Object{17}ᐸ{result,clientMutationId}ᐳ[111]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,PgClassExpression113,List114,Lambda115 bucket18
-    Bucket19("Bucket 19 (mutationField)<br />Deps: 478, 2, 18, 29, 4, 17<br /><br />1: Access[120]<br />2: Access[121]<br />3: Object[122]<br />4: PgDeleteSingle[119]<br />5: <br />ᐳ: Object[123]"):::bucket
+    Bucket19("Bucket 19 (mutationField)<br />Deps: 484, 2, 18, 29, 4, 17<br /><br />1: Access[120]<br />2: Access[121]<br />3: Object[122]<br />4: PgDeleteSingle[119]<br />5: <br />ᐳ: Object[123]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgDeleteSingle119,Access120,Access121,Object122,Object123 bucket19
-    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 119, 18, 123, 29, 4, 17<br /><br />ROOT Object{19}ᐸ{result}ᐳ[123]"):::bucket
+    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 119, 18, 29, 123, 4, 17<br /><br />ROOT Object{19}ᐸ{result}ᐳ[123]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression126,List127,Lambda128 bucket20
+    class Bucket20,PgClassExpression126,List127,Lambda128,Lambda137 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 119, 128, 126<br /><br />ROOT PgDeleteSingle{19}ᐸpost(id)ᐳ[119]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression134,PgClassExpression135 bucket21
-    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 4, 137<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,Lambda137 bucket22
-    Bucket23("Bucket 23 (mutationField)<br />Deps: 479, 2, 471, 18, 29, 4<br /><br />1: Access[142]<br />2: Access[143]<br />3: Object[144]<br />4: PgDeleteSingle[141]<br />5: <br />ᐳ: Object[145]"):::bucket
+    class Bucket22 bucket22
+    Bucket23("Bucket 23 (mutationField)<br />Deps: 485, 2, 477, 18, 29, 4<br /><br />1: Access[142]<br />2: Access[143]<br />3: Object[144]<br />4: PgDeleteSingle[141]<br />5: <br />ᐳ: Object[145]"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23,PgDeleteSingle141,Access142,Access143,Object144,Object145 bucket23
-    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 141, 18, 145, 29, 4, 471<br /><br />ROOT Object{23}ᐸ{result,clientMutationId}ᐳ[145]"):::bucket
+    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 141, 18, 29, 145, 4, 477<br /><br />ROOT Object{23}ᐸ{result,clientMutationId}ᐳ[145]"):::bucket
     classDef bucket24 stroke:#808000
-    class Bucket24,PgClassExpression147,List148,Lambda149 bucket24
+    class Bucket24,PgClassExpression147,List148,Lambda149,Lambda158 bucket24
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 141, 149, 147<br /><br />ROOT PgDeleteSingle{23}ᐸpost(id)ᐳ[141]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgClassExpression155,PgClassExpression156 bucket25
-    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 4, 158<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,Lambda158 bucket26
-    Bucket27("Bucket 27 (mutationField)<br />Deps: 480, 2, 18, 29, 4, 17<br /><br />1: Access[163]<br />2: Access[164]<br />3: Object[165]<br />4: PgDeleteSingle[162]<br />5: <br />ᐳ: Object[166]"):::bucket
+    class Bucket26 bucket26
+    Bucket27("Bucket 27 (mutationField)<br />Deps: 486, 2, 18, 29, 4, 17<br /><br />1: Access[163]<br />2: Access[164]<br />3: Object[165]<br />4: PgDeleteSingle[162]<br />5: <br />ᐳ: Object[166]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgDeleteSingle162,Access163,Access164,Object165,Object166 bucket27
-    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 162, 18, 166, 29, 4, 17<br /><br />ROOT Object{27}ᐸ{result}ᐳ[166]"):::bucket
+    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 162, 18, 29, 166, 4, 17<br /><br />ROOT Object{27}ᐸ{result}ᐳ[166]"):::bucket
     classDef bucket28 stroke:#00ffff
-    class Bucket28,PgClassExpression169,List170,Lambda171 bucket28
+    class Bucket28,PgClassExpression169,List170,Lambda171,Lambda180 bucket28
     Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 162, 171, 169<br /><br />ROOT PgDeleteSingle{27}ᐸpost(id)ᐳ[162]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,PgClassExpression177,PgClassExpression178 bucket29
-    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 4, 180<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket30 stroke:#3cb371
-    class Bucket30,Lambda180 bucket30
-    Bucket31("Bucket 31 (mutationField)<br />Deps: 477, 2, 474, 18, 29, 4<br /><br />1: Access[185]<br />2: Access[186]<br />3: Object[187]<br />4: PgDeleteSingle[184]<br />5: <br />ᐳ: Object[188]"):::bucket
+    class Bucket30 bucket30
+    Bucket31("Bucket 31 (mutationField)<br />Deps: 483, 2, 480, 18, 29, 4<br /><br />1: Access[185]<br />2: Access[186]<br />3: Object[187]<br />4: PgDeleteSingle[184]<br />5: <br />ᐳ: Object[188]"):::bucket
     classDef bucket31 stroke:#a52a2a
     class Bucket31,PgDeleteSingle184,Access185,Access186,Object187,Object188 bucket31
-    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 184, 18, 188, 29, 4, 474<br /><br />ROOT Object{31}ᐸ{result,clientMutationId}ᐳ[188]"):::bucket
+    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 184, 18, 29, 188, 4, 480<br /><br />ROOT Object{31}ᐸ{result,clientMutationId}ᐳ[188]"):::bucket
     classDef bucket32 stroke:#ff00ff
-    class Bucket32,PgClassExpression190,List191,Lambda192 bucket32
+    class Bucket32,PgClassExpression190,List191,Lambda192,Lambda201 bucket32
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 184, 192, 190<br /><br />ROOT PgDeleteSingle{31}ᐸpost(id)ᐳ[184]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression198,PgClassExpression199 bucket33
-    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 4, 201<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,Lambda201 bucket34
-    Bucket35("Bucket 35 (mutationField)<br />Deps: 481, 2, 216, 384, 387, 388, 389, 390, 487, 402, 403, 488, 235, 29, 4, 17<br /><br />1: Access[211]<br />2: Access[212]<br />3: Object[213]<br />4: Lambda[205]<br />5: Access[206]<br />6: Access[208]<br />7: PgDeleteSingle[210]<br />8: <br />ᐳ: Object[214]"):::bucket
+    class Bucket34 bucket34
+    Bucket35("Bucket 35 (mutationField)<br />Deps: 487, 2, 216, 384, 388, 393, 398, 408, 413, 29, 235, 4, 17<br /><br />1: Access[211]<br />2: Access[212]<br />3: Object[213]<br />4: Lambda[205]<br />5: Access[206]<br />6: Access[208]<br />7: PgDeleteSingle[210]<br />8: <br />ᐳ: Object[214]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,Lambda205,Access206,Access208,PgDeleteSingle210,Access211,Access212,Object213,Object214 bucket35
-    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 210, 216, 213, 384, 387, 388, 389, 390, 487, 402, 403, 488, 214, 235, 29, 4, 17<br /><br />ROOT Object{35}ᐸ{result}ᐳ[214]<br />1: <br />ᐳ: 217, 218, 391, 397, 405, 411, 219, 220, 392, 406<br />2: PgSelect[229], PgSelect[241]<br />ᐳ: 233, 234, 243, 244"):::bucket
+    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 210, 216, 213, 384, 388, 393, 398, 408, 413, 29, 214, 235, 4, 17<br /><br />ROOT Object{35}ᐸ{result}ᐳ[214]<br />1: <br />ᐳ: 217, 218, 251, 219, 220<br />2: PgSelect[229], PgSelect[241]<br />ᐳ: 233, 234, 243, 244"):::bucket
     classDef bucket36 stroke:#7f007f
-    class Bucket36,PgClassExpression217,PgClassExpression218,List219,Lambda220,PgSelect229,First233,PgSelectSingle234,PgSelect241,First243,PgSelectSingle244,Object391,Lambda392,Lambda397,Object405,Lambda406,Lambda411 bucket36
+    class Bucket36,PgClassExpression217,PgClassExpression218,List219,Lambda220,PgSelect229,First233,PgSelectSingle234,PgSelect241,First243,PgSelectSingle244,Lambda251 bucket36
     Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 210, 234, 235, 244, 220, 217, 218<br /><br />ROOT PgDeleteSingle{35}ᐸcompound_key(person_id_1,person_id_2)ᐳ[210]"):::bucket
     classDef bucket37 stroke:#ffa500
     class Bucket37 bucket37
@@ -628,15 +630,15 @@ graph TD
     Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 244, 235<br /><br />ROOT PgSelectSingle{36}ᐸpersonᐳ[244]"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,PgClassExpression246,List247,Lambda248,PgClassExpression249 bucket39
-    Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 4, 251<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket40 stroke:#ff1493
-    class Bucket40,Lambda251 bucket40
-    Bucket41("Bucket 41 (mutationField)<br />Deps: 482, 483, 2, 216, 384, 387, 416, 417, 390, 489, 430, 431, 490, 235, 29, 4, 17<br /><br />1: Access[257]<br />2: Access[258]<br />3: Object[259]<br />4: PgDeleteSingle[256]<br />5: <br />ᐳ: Object[260]"):::bucket
+    class Bucket40 bucket40
+    Bucket41("Bucket 41 (mutationField)<br />Deps: 488, 489, 2, 216, 384, 388, 423, 428, 438, 443, 29, 235, 4, 17<br /><br />1: Access[257]<br />2: Access[258]<br />3: Object[259]<br />4: PgDeleteSingle[256]<br />5: <br />ᐳ: Object[260]"):::bucket
     classDef bucket41 stroke:#808000
     class Bucket41,PgDeleteSingle256,Access257,Access258,Object259,Object260 bucket41
-    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 256, 216, 259, 384, 387, 416, 417, 390, 489, 430, 431, 490, 260, 235, 29, 4, 17<br /><br />ROOT Object{41}ᐸ{result}ᐳ[260]<br />1: <br />ᐳ: 263, 264, 419, 425, 433, 439, 265, 266, 420, 434<br />2: PgSelect[275], PgSelect[287]<br />ᐳ: 279, 280, 289, 290"):::bucket
+    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 256, 216, 259, 384, 388, 423, 428, 438, 443, 29, 260, 235, 4, 17<br /><br />ROOT Object{41}ᐸ{result}ᐳ[260]<br />1: <br />ᐳ: 263, 264, 297, 265, 266<br />2: PgSelect[275], PgSelect[287]<br />ᐳ: 279, 280, 289, 290"):::bucket
     classDef bucket42 stroke:#dda0dd
-    class Bucket42,PgClassExpression263,PgClassExpression264,List265,Lambda266,PgSelect275,First279,PgSelectSingle280,PgSelect287,First289,PgSelectSingle290,Object419,Lambda420,Lambda425,Object433,Lambda434,Lambda439 bucket42
+    class Bucket42,PgClassExpression263,PgClassExpression264,List265,Lambda266,PgSelect275,First279,PgSelectSingle280,PgSelect287,First289,PgSelectSingle290,Lambda297 bucket42
     Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 256, 280, 235, 290, 266, 263, 264<br /><br />ROOT PgDeleteSingle{41}ᐸcompound_key(person_id_1,person_id_2)ᐳ[256]"):::bucket
     classDef bucket43 stroke:#ff0000
     class Bucket43 bucket43
@@ -646,45 +648,45 @@ graph TD
     Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 290, 235<br /><br />ROOT PgSelectSingle{42}ᐸpersonᐳ[290]"):::bucket
     classDef bucket45 stroke:#00ffff
     class Bucket45,PgClassExpression292,List293,Lambda294,PgClassExpression295 bucket45
-    Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 4, 297<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket46 stroke:#4169e1
-    class Bucket46,Lambda297 bucket46
-    Bucket47("Bucket 47 (mutationField)<br />Deps: 484, 2, 235, 29, 4, 17<br /><br />1: Access[302]<br />2: Access[303]<br />3: Object[304]<br />4: PgDeleteSingle[301]<br />5: <br />ᐳ: Object[305]"):::bucket
+    class Bucket46 bucket46
+    Bucket47("Bucket 47 (mutationField)<br />Deps: 490, 2, 235, 29, 4, 17<br /><br />1: Access[302]<br />2: Access[303]<br />3: Object[304]<br />4: PgDeleteSingle[301]<br />5: <br />ᐳ: Object[305]"):::bucket
     classDef bucket47 stroke:#3cb371
     class Bucket47,PgDeleteSingle301,Access302,Access303,Object304,Object305 bucket47
-    Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 301, 235, 305, 29, 4, 17<br /><br />ROOT Object{47}ᐸ{result}ᐳ[305]"):::bucket
+    Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 301, 235, 29, 305, 4, 17<br /><br />ROOT Object{47}ᐸ{result}ᐳ[305]"):::bucket
     classDef bucket48 stroke:#a52a2a
-    class Bucket48,PgClassExpression308,List309,Lambda310 bucket48
-    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket48,PgClassExpression308,List309,Lambda310,Lambda312 bucket48
+    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 4, 312<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket49 stroke:#ff00ff
-    class Bucket49,Lambda312 bucket49
-    Bucket50("Bucket 50 (mutationField)<br />Deps: 485, 2, 235, 384, 444, 445, 390, 491, 387, 29, 4, 17<br /><br />1: Access[317]<br />2: Access[318]<br />3: Object[319]<br />4: PgDeleteSingle[316]<br />5: <br />ᐳ: Object[320]"):::bucket
+    class Bucket49 bucket49
+    Bucket50("Bucket 50 (mutationField)<br />Deps: 491, 2, 235, 29, 384, 388, 453, 458, 4, 17<br /><br />1: Access[317]<br />2: Access[318]<br />3: Object[319]<br />4: PgDeleteSingle[316]<br />5: <br />ᐳ: Object[320]"):::bucket
     classDef bucket50 stroke:#f5deb3
     class Bucket50,PgDeleteSingle316,Access317,Access318,Object319,Object320 bucket50
-    Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 316, 235, 384, 444, 445, 390, 491, 320, 319, 485, 387, 29, 4, 17<br /><br />ROOT Object{50}ᐸ{result}ᐳ[320]"):::bucket
+    Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 316, 235, 29, 320, 319, 491, 384, 388, 453, 458, 4, 17<br /><br />ROOT Object{50}ᐸ{result}ᐳ[320]"):::bucket
     classDef bucket51 stroke:#696969
-    class Bucket51,PgClassExpression323,List324,Lambda325,Object447,Lambda448,Lambda453 bucket51
-    Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 316, 319, 485, 384, 387, 448, 453, 325, 323<br /><br />ROOT PgDeleteSingle{50}ᐸperson(email)ᐳ[316]<br />1: <br />ᐳ: 331, 332, 334<br />2: PgSelect[335]<br />ᐳ: 339, 340, 342"):::bucket
+    class Bucket51,PgClassExpression323,List324,Lambda325,Lambda344 bucket51
+    Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 316, 319, 491, 384, 388, 453, 458, 325, 323<br /><br />ROOT PgDeleteSingle{50}ᐸperson(email)ᐳ[316]<br />1: <br />ᐳ: 331, 332, 334<br />2: PgSelect[335]<br />ᐳ: 339, 340, 342"):::bucket
     classDef bucket52 stroke:#00bfff
     class Bucket52,PgClassExpression331,PgClassExpression332,PgClassExpression334,PgSelect335,First339,PgSelectSingle340,PgClassExpression342 bucket52
-    Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 4, 344<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket53 stroke:#7f007f
-    class Bucket53,Lambda344 bucket53
-    Bucket54("Bucket 54 (mutationField)<br />Deps: 486, 2, 235, 384, 387, 458, 459, 390, 492, 29, 4, 17<br /><br />1: Access[349]<br />2: Access[350]<br />3: Object[351]<br />4: PgDeleteSingle[348]<br />5: <br />ᐳ: Object[352]"):::bucket
+    class Bucket53 bucket53
+    Bucket54("Bucket 54 (mutationField)<br />Deps: 492, 2, 235, 384, 388, 468, 473, 29, 4, 17<br /><br />1: Access[349]<br />2: Access[350]<br />3: Object[351]<br />4: PgDeleteSingle[348]<br />5: <br />ᐳ: Object[352]"):::bucket
     classDef bucket54 stroke:#ffa500
     class Bucket54,PgDeleteSingle348,Access349,Access350,Object351,Object352 bucket54
-    Bucket55("Bucket 55 (nullableBoundary)<br />Deps: 348, 235, 351, 384, 387, 458, 459, 390, 492, 352, 29, 4, 17<br /><br />ROOT Object{54}ᐸ{result}ᐳ[352]<br />1: <br />ᐳ: 355, 360, 365, 461, 467, 356, 357, 462<br />2: PgSelect[361]<br />ᐳ: 366, 367, 370, 371, 372, 369, 368"):::bucket
+    Bucket55("Bucket 55 (nullableBoundary)<br />Deps: 348, 235, 351, 384, 388, 468, 473, 29, 352, 4, 17<br /><br />ROOT Object{54}ᐸ{result}ᐳ[352]<br />1: <br />ᐳ: 355, 360, 365, 381, 356, 357<br />2: PgSelect[361]<br />ᐳ: 366, 367, 370, 371, 372, 377, 378, 369, 368"):::bucket
     classDef bucket55 stroke:#0000ff
-    class Bucket55,PgClassExpression355,List356,Lambda357,PgClassExpression360,PgSelect361,Connection365,First366,PgSelectSingle367,Edge368,PgCursor369,PgClassExpression370,PgClassExpression371,List372,Object461,Lambda462,Lambda467 bucket55
-    Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 235, 371, 368, 367, 369, 370<br /><br />ROOT Edge{55}[368]"):::bucket
+    class Bucket55,PgClassExpression355,List356,Lambda357,PgClassExpression360,PgSelect361,Connection365,First366,PgSelectSingle367,Edge368,PgCursor369,PgClassExpression370,PgClassExpression371,List372,List377,Lambda378,Lambda381 bucket55
+    Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 368, 367, 369, 370, 371, 378<br /><br />ROOT Edge{55}[368]"):::bucket
     classDef bucket56 stroke:#7fff00
-    class Bucket56,List377,Lambda378 bucket56
+    class Bucket56 bucket56
     Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 367, 370, 371, 378<br /><br />ROOT PgSelectSingle{55}ᐸpersonᐳ[367]"):::bucket
     classDef bucket57 stroke:#ff1493
     class Bucket57,PgClassExpression379 bucket57
-    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 29, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 4, 381<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket58 stroke:#808000
-    class Bucket58,Lambda381 bucket58
+    class Bucket58 bucket58
     Bucket0 --> Bucket1 & Bucket5 & Bucket9 & Bucket13 & Bucket17 & Bucket19 & Bucket23 & Bucket27 & Bucket31 & Bucket35 & Bucket41 & Bucket47 & Bucket50 & Bucket54
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-return-types.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-return-types.mermaid
@@ -9,81 +9,111 @@ graph TD
 
 
     %% plan dependencies
-    Object275{{"Object[275∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object276{{"Object[276∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda268{{"Lambda[268∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸsql.identifier(”mutation_in_inout”)ᐳ"}}:::plan
-    Constant274{{"Constant[274∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda268 & Constant272 & Constant273 & Constant274 --> Object275
-    Object289{{"Object[289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸsql.identifier(”mutation_in_out”)ᐳ"}}:::plan
-    Lambda268 & Constant286 & Constant287 & Constant274 --> Object289
-    Object303{{"Object[303∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant300{{"Constant[300∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant301{{"Constant[301∈0] ➊<br />ᐸsql.identifier(”mutation_out”)ᐳ"}}:::plan
-    Lambda268 & Constant300 & Constant301 & Constant274 --> Object303
-    Object364{{"Object[364∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant361{{"Constant[361∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant362{{"Constant[362∈0] ➊<br />ᐸsql.identifier(”mutation_out_complex”)ᐳ"}}:::plan
-    Constant363{{"Constant[363∈0] ➊<br />ᐸRecordCodec(MutationOutComplexRecord)ᐳ"}}:::plan
-    Lambda268 & Constant361 & Constant362 & Constant363 --> Object364
-    Object425{{"Object[425∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant423{{"Constant[423∈0] ➊<br />ᐸsql.identifier(”mutation_out_complex_setof”)ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸRecordCodec(MutationOutComplexSetofRecord)ᐳ"}}:::plan
-    Lambda268 & Constant422 & Constant423 & Constant424 --> Object425
-    Object439{{"Object[439∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸsql.identifier(”mutation_out_out”)ᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸRecordCodec(MutationOutOutRecord)ᐳ"}}:::plan
-    Lambda268 & Constant436 & Constant437 & Constant438 --> Object439
-    Object467{{"Object[467∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸsql.identifier(”mutation_out_out_compound_type”)ᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸRecordCodec(MutationOutOutCompoundTypeRecord)ᐳ"}}:::plan
-    Lambda268 & Constant464 & Constant465 & Constant466 --> Object467
+    Constant273{{"Constant[273∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant274{{"Constant[274∈0] ➊<br />ᐸsql.identifier(”mutation_in_inout”)ᐳ"}}:::plan
+    Constant275{{"Constant[275∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda268 & Constant273 & Constant274 & Constant275 --> Object276
+    Object291{{"Object[291∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸsql.identifier(”mutation_in_out”)ᐳ"}}:::plan
+    Lambda268 & Constant288 & Constant289 & Constant275 --> Object291
+    Object306{{"Object[306∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant303{{"Constant[303∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant304{{"Constant[304∈0] ➊<br />ᐸsql.identifier(”mutation_out”)ᐳ"}}:::plan
+    Lambda268 & Constant303 & Constant304 & Constant275 --> Object306
+    Object321{{"Object[321∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant318{{"Constant[318∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant319{{"Constant[319∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant320{{"Constant[320∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda268 & Constant318 & Constant319 & Constant320 --> Object321
+    Object336{{"Object[336∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant333{{"Constant[333∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant334{{"Constant[334∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant335{{"Constant[335∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda268 & Constant333 & Constant334 & Constant335 --> Object336
+    Object356{{"Object[356∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant353{{"Constant[353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant354{{"Constant[354∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant355{{"Constant[355∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda268 & Constant353 & Constant354 & Constant355 --> Object356
+    Object371{{"Object[371∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant369{{"Constant[369∈0] ➊<br />ᐸsql.identifier(”mutation_out_complex”)ᐳ"}}:::plan
+    Constant370{{"Constant[370∈0] ➊<br />ᐸRecordCodec(MutationOutComplexRecord)ᐳ"}}:::plan
+    Lambda268 & Constant368 & Constant369 & Constant370 --> Object371
+    Object386{{"Object[386∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant384{{"Constant[384∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda268 & Constant383 & Constant384 & Constant320 --> Object386
+    Object401{{"Object[401∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda268 & Constant398 & Constant399 & Constant335 --> Object401
+    Object421{{"Object[421∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant419{{"Constant[419∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda268 & Constant418 & Constant419 & Constant355 --> Object421
+    Object436{{"Object[436∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸsql.identifier(”mutation_out_complex_setof”)ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸRecordCodec(MutationOutComplexSetofRecord)ᐳ"}}:::plan
+    Lambda268 & Constant433 & Constant434 & Constant435 --> Object436
+    Object451{{"Object[451∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant449{{"Constant[449∈0] ➊<br />ᐸsql.identifier(”mutation_out_out”)ᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸRecordCodec(MutationOutOutRecord)ᐳ"}}:::plan
+    Lambda268 & Constant448 & Constant449 & Constant450 --> Object451
+    Object466{{"Object[466∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda268 & Constant463 & Constant464 & Constant320 --> Object466
     Object481{{"Object[481∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant478{{"Constant[478∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant479{{"Constant[479∈0] ➊<br />ᐸsql.identifier(”mutation_out_out_setof”)ᐳ"}}:::plan
-    Constant480{{"Constant[480∈0] ➊<br />ᐸRecordCodec(MutationOutOutSetofRecord)ᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸsql.identifier(”mutation_out_out_compound_type”)ᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸRecordCodec(MutationOutOutCompoundTypeRecord)ᐳ"}}:::plan
     Lambda268 & Constant478 & Constant479 & Constant480 --> Object481
-    Object495{{"Object[495∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant492{{"Constant[492∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant493{{"Constant[493∈0] ➊<br />ᐸsql.identifier(”mutation_out_out_unnamed”)ᐳ"}}:::plan
-    Constant494{{"Constant[494∈0] ➊<br />ᐸRecordCodec(MutationOutOutUnnamedRecord)ᐳ"}}:::plan
-    Lambda268 & Constant492 & Constant493 & Constant494 --> Object495
-    Object509{{"Object[509∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant506{{"Constant[506∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant507{{"Constant[507∈0] ➊<br />ᐸsql.identifier(”mutation_out_setof”)ᐳ"}}:::plan
-    Lambda268 & Constant506 & Constant507 & Constant274 --> Object509
-    Object523{{"Object[523∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant520{{"Constant[520∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant521{{"Constant[521∈0] ➊<br />ᐸsql.identifier(”mutation_out_table”)ᐳ"}}:::plan
-    Constant349{{"Constant[349∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda268 & Constant520 & Constant521 & Constant349 --> Object523
-    Object537{{"Object[537∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant534{{"Constant[534∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant535{{"Constant[535∈0] ➊<br />ᐸsql.identifier(”mutation_out_table_setof”)ᐳ"}}:::plan
-    Lambda268 & Constant534 & Constant535 & Constant349 --> Object537
-    Object551{{"Object[551∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant548{{"Constant[548∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant549{{"Constant[549∈0] ➊<br />ᐸsql.identifier(”mutation_out_unnamed”)ᐳ"}}:::plan
-    Lambda268 & Constant548 & Constant549 & Constant274 --> Object551
-    Object565{{"Object[565∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant562{{"Constant[562∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant563{{"Constant[563∈0] ➊<br />ᐸsql.identifier(”mutation_out_unnamed_out_out_unnamed”)ᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸRecordCodec(MutationOutUnnamedOutOutUnnamedRecord)ᐳ"}}:::plan
-    Lambda268 & Constant562 & Constant563 & Constant564 --> Object565
-    Object579{{"Object[579∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant576{{"Constant[576∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant577{{"Constant[577∈0] ➊<br />ᐸsql.identifier(”mutation_returns_table_multi_col”)ᐳ"}}:::plan
-    Constant578{{"Constant[578∈0] ➊<br />ᐸRecordCodec(MutationReturnsTableMultiColRecord)ᐳ"}}:::plan
-    Lambda268 & Constant576 & Constant577 & Constant578 --> Object579
-    Object593{{"Object[593∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant590{{"Constant[590∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant591{{"Constant[591∈0] ➊<br />ᐸsql.identifier(”mutation_returns_table_one_col”)ᐳ"}}:::plan
-    Lambda268 & Constant590 & Constant591 & Constant274 --> Object593
+    Object496{{"Object[496∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant493{{"Constant[493∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸsql.identifier(”mutation_out_out_setof”)ᐳ"}}:::plan
+    Constant495{{"Constant[495∈0] ➊<br />ᐸRecordCodec(MutationOutOutSetofRecord)ᐳ"}}:::plan
+    Lambda268 & Constant493 & Constant494 & Constant495 --> Object496
+    Object511{{"Object[511∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant508{{"Constant[508∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant509{{"Constant[509∈0] ➊<br />ᐸsql.identifier(”mutation_out_out_unnamed”)ᐳ"}}:::plan
+    Constant510{{"Constant[510∈0] ➊<br />ᐸRecordCodec(MutationOutOutUnnamedRecord)ᐳ"}}:::plan
+    Lambda268 & Constant508 & Constant509 & Constant510 --> Object511
+    Object526{{"Object[526∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant523{{"Constant[523∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant524{{"Constant[524∈0] ➊<br />ᐸsql.identifier(”mutation_out_setof”)ᐳ"}}:::plan
+    Lambda268 & Constant523 & Constant524 & Constant275 --> Object526
+    Object541{{"Object[541∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant538{{"Constant[538∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant539{{"Constant[539∈0] ➊<br />ᐸsql.identifier(”mutation_out_table”)ᐳ"}}:::plan
+    Lambda268 & Constant538 & Constant539 & Constant355 --> Object541
+    Object556{{"Object[556∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant553{{"Constant[553∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant554{{"Constant[554∈0] ➊<br />ᐸsql.identifier(”mutation_out_table_setof”)ᐳ"}}:::plan
+    Lambda268 & Constant553 & Constant554 & Constant355 --> Object556
+    Object571{{"Object[571∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant568{{"Constant[568∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant569{{"Constant[569∈0] ➊<br />ᐸsql.identifier(”mutation_out_unnamed”)ᐳ"}}:::plan
+    Lambda268 & Constant568 & Constant569 & Constant275 --> Object571
+    Object586{{"Object[586∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant583{{"Constant[583∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant584{{"Constant[584∈0] ➊<br />ᐸsql.identifier(”mutation_out_unnamed_out_out_unnamed”)ᐳ"}}:::plan
+    Constant585{{"Constant[585∈0] ➊<br />ᐸRecordCodec(MutationOutUnnamedOutOutUnnamedRecord)ᐳ"}}:::plan
+    Lambda268 & Constant583 & Constant584 & Constant585 --> Object586
+    Object601{{"Object[601∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant598{{"Constant[598∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant599{{"Constant[599∈0] ➊<br />ᐸsql.identifier(”mutation_returns_table_multi_col”)ᐳ"}}:::plan
+    Constant600{{"Constant[600∈0] ➊<br />ᐸRecordCodec(MutationReturnsTableMultiColRecord)ᐳ"}}:::plan
+    Lambda268 & Constant598 & Constant599 & Constant600 --> Object601
+    Object616{{"Object[616∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant613{{"Constant[613∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant614{{"Constant[614∈0] ➊<br />ᐸsql.identifier(”mutation_returns_table_one_col”)ᐳ"}}:::plan
+    Lambda268 & Constant613 & Constant614 & Constant275 --> Object616
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -91,126 +121,140 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant605{{"Constant[605∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant605 --> Lambda268
+    Constant628{{"Constant[628∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant628 --> Lambda268
     Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant606{{"Constant[606∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant606 --> Lambda271
-    Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object275 --> Lambda276
-    Lambda281{{"Lambda[281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant607{{"Constant[607∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant607 --> Lambda281
-    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object289 --> Lambda290
-    Lambda295{{"Lambda[295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant608{{"Constant[608∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant608 --> Lambda295
-    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object303 --> Lambda304
-    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant609{{"Constant[609∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant609 --> Lambda309
-    Lambda365{{"Lambda[365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object364 --> Lambda365
-    Lambda370{{"Lambda[370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant613{{"Constant[613∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant613 --> Lambda370
-    Lambda426{{"Lambda[426∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object425 --> Lambda426
-    Lambda431{{"Lambda[431∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant617{{"Constant[617∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant617 --> Lambda431
-    Lambda440{{"Lambda[440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object439 --> Lambda440
-    Lambda445{{"Lambda[445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant618{{"Constant[618∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant618 --> Lambda445
-    Lambda468{{"Lambda[468∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object467 --> Lambda468
-    Lambda473{{"Lambda[473∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant620{{"Constant[620∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant620 --> Lambda473
+    Constant629{{"Constant[629∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant629 --> Lambda271
+    Access272{{"Access[272∈0] ➊<br />ᐸ271.0ᐳ"}}:::plan
+    Lambda271 --> Access272
+    Lambda277{{"Lambda[277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object276 --> Lambda277
+    Lambda282{{"Lambda[282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant630{{"Constant[630∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant630 --> Lambda282
+    Lambda292{{"Lambda[292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object291 --> Lambda292
+    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant631{{"Constant[631∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant631 --> Lambda297
+    Lambda307{{"Lambda[307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object306 --> Lambda307
+    Lambda312{{"Lambda[312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant632{{"Constant[632∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant632 --> Lambda312
+    Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object321 --> Lambda322
+    Lambda327{{"Lambda[327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant633{{"Constant[633∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant633 --> Lambda327
+    Lambda337{{"Lambda[337∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object336 --> Lambda337
+    Lambda342{{"Lambda[342∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant634{{"Constant[634∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant634 --> Lambda342
+    Lambda357{{"Lambda[357∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object356 --> Lambda357
+    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant635{{"Constant[635∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant635 --> Lambda362
+    Lambda372{{"Lambda[372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object371 --> Lambda372
+    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant636{{"Constant[636∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant636 --> Lambda377
+    Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object386 --> Lambda387
+    Lambda392{{"Lambda[392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant637{{"Constant[637∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant637 --> Lambda392
+    Lambda402{{"Lambda[402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object401 --> Lambda402
+    Lambda407{{"Lambda[407∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant638{{"Constant[638∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant638 --> Lambda407
+    Lambda422{{"Lambda[422∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object421 --> Lambda422
+    Lambda427{{"Lambda[427∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant639{{"Constant[639∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant639 --> Lambda427
+    Lambda437{{"Lambda[437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object436 --> Lambda437
+    Lambda442{{"Lambda[442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant640{{"Constant[640∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant640 --> Lambda442
+    Lambda452{{"Lambda[452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object451 --> Lambda452
+    Lambda457{{"Lambda[457∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant641{{"Constant[641∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant641 --> Lambda457
+    Lambda467{{"Lambda[467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object466 --> Lambda467
+    Lambda472{{"Lambda[472∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant642{{"Constant[642∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant642 --> Lambda472
     Lambda482{{"Lambda[482∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object481 --> Lambda482
     Lambda487{{"Lambda[487∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant621{{"Constant[621∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant621 --> Lambda487
-    Lambda496{{"Lambda[496∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object495 --> Lambda496
-    Lambda501{{"Lambda[501∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant622{{"Constant[622∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant622 --> Lambda501
-    Lambda510{{"Lambda[510∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object509 --> Lambda510
-    Lambda515{{"Lambda[515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant623{{"Constant[623∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant623 --> Lambda515
-    Lambda524{{"Lambda[524∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object523 --> Lambda524
-    Lambda529{{"Lambda[529∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant624{{"Constant[624∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant624 --> Lambda529
-    Lambda538{{"Lambda[538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object537 --> Lambda538
-    Lambda543{{"Lambda[543∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant625{{"Constant[625∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant625 --> Lambda543
-    Lambda552{{"Lambda[552∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object551 --> Lambda552
+    Constant643{{"Constant[643∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant643 --> Lambda487
+    Lambda497{{"Lambda[497∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object496 --> Lambda497
+    Lambda502{{"Lambda[502∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant644{{"Constant[644∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant644 --> Lambda502
+    Lambda512{{"Lambda[512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object511 --> Lambda512
+    Lambda517{{"Lambda[517∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant645{{"Constant[645∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant645 --> Lambda517
+    Lambda527{{"Lambda[527∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object526 --> Lambda527
+    Lambda532{{"Lambda[532∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant646{{"Constant[646∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant646 --> Lambda532
+    Lambda542{{"Lambda[542∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object541 --> Lambda542
+    Lambda547{{"Lambda[547∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant647{{"Constant[647∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant647 --> Lambda547
     Lambda557{{"Lambda[557∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant626{{"Constant[626∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant626 --> Lambda557
-    Lambda566{{"Lambda[566∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object565 --> Lambda566
-    Lambda571{{"Lambda[571∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant627{{"Constant[627∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant627 --> Lambda571
-    Lambda580{{"Lambda[580∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object579 --> Lambda580
-    Lambda585{{"Lambda[585∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant628{{"Constant[628∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant628 --> Lambda585
-    Lambda594{{"Lambda[594∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object593 --> Lambda594
-    Lambda599{{"Lambda[599∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant629{{"Constant[629∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant629 --> Lambda599
+    Object556 --> Lambda557
+    Lambda562{{"Lambda[562∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant648{{"Constant[648∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant648 --> Lambda562
+    Lambda572{{"Lambda[572∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object571 --> Lambda572
+    Lambda577{{"Lambda[577∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant649{{"Constant[649∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant649 --> Lambda577
+    Lambda587{{"Lambda[587∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object586 --> Lambda587
+    Lambda592{{"Lambda[592∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant650{{"Constant[650∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant650 --> Lambda592
+    Lambda602{{"Lambda[602∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object601 --> Lambda602
+    Lambda607{{"Lambda[607∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant651{{"Constant[651∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant651 --> Lambda607
+    Lambda617{{"Lambda[617∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object616 --> Lambda617
+    Lambda622{{"Lambda[622∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant652{{"Constant[652∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant652 --> Lambda622
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant66{{"Constant[66∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
     Constant82{{"Constant[82∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
     Constant266{{"Constant[266∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant269{{"Constant[269∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant314{{"Constant[314∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant315{{"Constant[315∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Constant328{{"Constant[328∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant329{{"Constant[329∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant330{{"Constant[330∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant348{{"Constant[348∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant376{{"Constant[376∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant408{{"Constant[408∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant409{{"Constant[409∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant451{{"Constant[451∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant600{{"Constant[600∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant601{{"Constant[601∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant602{{"Constant[602∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant603{{"Constant[603∈0] ➊<br />ᐸ'test'ᐳ"}}:::plan
-    Constant604{{"Constant[604∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant610{{"Constant[610∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant611{{"Constant[611∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant612{{"Constant[612∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant614{{"Constant[614∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant615{{"Constant[615∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant616{{"Constant[616∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant619{{"Constant[619∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant625{{"Constant[625∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant626{{"Constant[626∈0] ➊<br />ᐸ'test'ᐳ"}}:::plan
+    Constant627{{"Constant[627∈0] ➊<br />ᐸ20ᐳ"}}:::plan
     PgSelect10[["PgSelect[10∈1] ➊<br />ᐸmutation_in_inout(mutation)ᐳ"]]:::sideeffectplan
-    Object13 & Constant600 & Constant601 & Lambda268 & Lambda271 & Lambda276 & Lambda281 --> PgSelect10
+    Object13 & Constant623 & Constant624 & Lambda268 & Access272 & Lambda277 & Lambda282 --> PgSelect10
     First14{{"First[14∈1] ➊"}}:::plan
     PgSelect10 --> First14
     PgSelectSingle15{{"PgSelectSingle[15∈1] ➊<br />ᐸmutation_in_inoutᐳ"}}:::plan
@@ -221,7 +265,7 @@ graph TD
     PgClassExpression16 --> Object17
     PgSelect21[["PgSelect[21∈3] ➊<br />ᐸmutation_in_out(mutation)ᐳ"]]:::sideeffectplan
     Object24{{"Object[24∈3] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object24 & Constant600 & Lambda268 & Lambda271 & Lambda290 & Lambda295 --> PgSelect21
+    Object24 & Constant623 & Lambda268 & Access272 & Lambda292 & Lambda297 --> PgSelect21
     Access22{{"Access[22∈3] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access23{{"Access[23∈3] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access22 & Access23 --> Object24
@@ -237,7 +281,7 @@ graph TD
     PgClassExpression27 --> Object28
     PgSelect31[["PgSelect[31∈5] ➊<br />ᐸmutation_out(mutation)ᐳ"]]:::sideeffectplan
     Object34{{"Object[34∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object34 & Lambda268 & Lambda271 & Lambda304 & Lambda309 --> PgSelect31
+    Object34 & Lambda268 & Access272 & Lambda307 & Lambda312 --> PgSelect31
     Access32{{"Access[32∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access33{{"Access[33∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access32 & Access33 --> Object34
@@ -253,7 +297,7 @@ graph TD
     PgClassExpression37 --> Object38
     PgSelect43[["PgSelect[43∈7] ➊<br />ᐸmutation_out_complex(mutation)ᐳ"]]:::sideeffectplan
     Object46{{"Object[46∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object46 & Constant602 & Constant603 & Lambda268 & Lambda271 & Lambda365 & Lambda370 --> PgSelect43
+    Object46 & Constant625 & Constant626 & Lambda268 & Access272 & Lambda372 & Lambda377 --> PgSelect43
     Access44{{"Access[44∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access45{{"Access[45∈7] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access44 & Access45 --> Object46
@@ -265,30 +309,13 @@ graph TD
     First47 --> PgSelectSingle48
     Object49{{"Object[49∈7] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelectSingle48 --> Object49
-    Object317{{"Object[317∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant314 & Constant315 & Constant316 --> Object317
-    Object331{{"Object[331∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant328 & Constant329 & Constant330 --> Object331
-    Object350{{"Object[350∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant347 & Constant348 & Constant349 --> Object350
-    Lambda318{{"Lambda[318∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object317 --> Lambda318
-    Lambda323{{"Lambda[323∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant610 --> Lambda323
-    Lambda332{{"Lambda[332∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object331 --> Lambda332
-    Lambda337{{"Lambda[337∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant611 --> Lambda337
-    Lambda351{{"Lambda[351∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object350 --> Lambda351
-    Lambda356{{"Lambda[356∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant612 --> Lambda356
+    Connection78{{"Connection[78∈8] ➊<br />ᐸ74ᐳ"}}:::plan
     PgSelect62[["PgSelect[62∈9] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression61{{"PgClassExpression[61∈9] ➊<br />ᐸ__mutation...plex__.”z”ᐳ"}}:::plan
-    Object46 & PgClassExpression61 & Lambda271 & Lambda332 & Lambda337 & Lambda268 & Lambda271 & Lambda351 & Lambda356 --> PgSelect62
+    Object46 & PgClassExpression61 & Access272 & Lambda337 & Lambda342 & Lambda268 & Access272 & Lambda357 & Lambda362 --> PgSelect62
     PgSelect52[["PgSelect[52∈9] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression51{{"PgClassExpression[51∈9] ➊<br />ᐸ__mutation...plex__.”y”ᐳ"}}:::plan
-    Object46 & PgClassExpression51 & Lambda268 & Lambda271 & Lambda318 & Lambda323 --> PgSelect52
+    Object46 & PgClassExpression51 & Lambda268 & Access272 & Lambda322 & Lambda327 --> PgSelect52
     PgClassExpression50{{"PgClassExpression[50∈9] ➊<br />ᐸ__mutation...plex__.”x”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression50
     PgSelectSingle48 --> PgClassExpression51
@@ -301,16 +328,15 @@ graph TD
     PgSelect62 --> First64
     PgSelectSingle65{{"PgSelectSingle[65∈9] ➊<br />ᐸpersonᐳ"}}:::plan
     First64 --> PgSelectSingle65
-    Connection78{{"Connection[78∈9] ➊<br />ᐸ74ᐳ"}}:::plan
     PgClassExpression58{{"PgClassExpression[58∈10] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle57 --> PgClassExpression58
     PgClassExpression59{{"PgClassExpression[59∈10] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle57 --> PgClassExpression59
     PgClassExpression60{{"PgClassExpression[60∈10] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle57 --> PgClassExpression60
-    Object341{{"Object[341∈11] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access339{{"Access[339∈11] ➊<br />ᐸ64.0ᐳ"}}:::plan
-    Access339 & Constant266 & Constant266 & Lambda268 & Constant269 --> Object341
+    Object346{{"Object[346∈11] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access344{{"Access[344∈11] ➊<br />ᐸ64.0ᐳ"}}:::plan
+    Access344 & Constant266 & Constant266 & Lambda268 & Constant269 --> Object346
     List68{{"List[68∈11] ➊<br />ᐸ66,67ᐳ"}}:::plan
     PgClassExpression67{{"PgClassExpression[67∈11] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant66 & PgClassExpression67 --> List68
@@ -319,11 +345,11 @@ graph TD
     List68 --> Lambda69
     PgClassExpression70{{"PgClassExpression[70∈11] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle65 --> PgClassExpression70
-    First64 --> Access339
-    Lambda342{{"Lambda[342∈11] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object341 --> Lambda342
-    __Item80[/"__Item[80∈12]<br />ᐸ342ᐳ"\]:::itemplan
-    Lambda342 ==> __Item80
+    First64 --> Access344
+    Lambda347{{"Lambda[347∈11] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object346 --> Lambda347
+    __Item80[/"__Item[80∈12]<br />ᐸ347ᐳ"\]:::itemplan
+    Lambda347 ==> __Item80
     PgSelectSingle81{{"PgSelectSingle[81∈12]<br />ᐸpostᐳ"}}:::plan
     __Item80 --> PgSelectSingle81
     List84{{"List[84∈13]<br />ᐸ82,83ᐳ"}}:::plan
@@ -334,7 +360,7 @@ graph TD
     List84 --> Lambda85
     PgSelect89[["PgSelect[89∈14] ➊<br />ᐸmutation_out_complex_setof(mutation)ᐳ"]]:::sideeffectplan
     Object92{{"Object[92∈14] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object92 & Constant602 & Constant603 & Lambda268 & Lambda271 & Lambda426 & Lambda431 --> PgSelect89
+    Object92 & Constant625 & Constant626 & Lambda268 & Access272 & Lambda437 & Lambda442 --> PgSelect89
     Access90{{"Access[90∈14] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access91{{"Access[91∈14] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access90 & Access91 --> Object92
@@ -342,35 +368,17 @@ graph TD
     __Value2 --> Access91
     Object93{{"Object[93∈14] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelect89 --> Object93
-    Object378{{"Object[378∈15] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant375 & Constant376 & Constant316 --> Object378
-    Object392{{"Object[392∈15] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant389 & Constant390 & Constant330 --> Object392
-    Object411{{"Object[411∈15] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant408 & Constant409 & Constant349 --> Object411
-    Lambda379{{"Lambda[379∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object378 --> Lambda379
-    Lambda384{{"Lambda[384∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant614 --> Lambda384
-    Lambda393{{"Lambda[393∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object392 --> Lambda393
-    Lambda398{{"Lambda[398∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant615 --> Lambda398
-    Lambda412{{"Lambda[412∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object411 --> Lambda412
-    Lambda417{{"Lambda[417∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant616 --> Lambda417
+    Connection124{{"Connection[124∈15] ➊<br />ᐸ120ᐳ"}}:::plan
     __Item94[/"__Item[94∈16]<br />ᐸ89ᐳ"\]:::itemplan
     PgSelect89 ==> __Item94
     PgSelectSingle95{{"PgSelectSingle[95∈16]<br />ᐸmutation_out_complex_setofᐳ"}}:::plan
     __Item94 --> PgSelectSingle95
-    Connection124{{"Connection[124∈16] ➊<br />ᐸ120ᐳ"}}:::plan
     PgSelect108[["PgSelect[108∈17]<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression107{{"PgClassExpression[107∈17]<br />ᐸ__mutation...etof__.”z”ᐳ"}}:::plan
-    Object92 & PgClassExpression107 & Lambda271 & Lambda393 & Lambda398 & Lambda268 & Lambda271 & Lambda412 & Lambda417 --> PgSelect108
+    Object92 & PgClassExpression107 & Access272 & Lambda402 & Lambda407 & Lambda268 & Access272 & Lambda422 & Lambda427 --> PgSelect108
     PgSelect98[["PgSelect[98∈17]<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression97{{"PgClassExpression[97∈17]<br />ᐸ__mutation...etof__.”y”ᐳ"}}:::plan
-    Object92 & PgClassExpression97 & Lambda268 & Lambda271 & Lambda379 & Lambda384 --> PgSelect98
+    Object92 & PgClassExpression97 & Lambda268 & Access272 & Lambda387 & Lambda392 --> PgSelect98
     PgClassExpression96{{"PgClassExpression[96∈17]<br />ᐸ__mutation...etof__.”x”ᐳ"}}:::plan
     PgSelectSingle95 --> PgClassExpression96
     PgSelectSingle95 --> PgClassExpression97
@@ -389,9 +397,9 @@ graph TD
     PgSelectSingle103 --> PgClassExpression105
     PgClassExpression106{{"PgClassExpression[106∈18]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle103 --> PgClassExpression106
-    Object402{{"Object[402∈19]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access400{{"Access[400∈19]<br />ᐸ110.0ᐳ"}}:::plan
-    Access400 & Constant266 & Constant266 & Lambda268 & Constant269 --> Object402
+    Object411{{"Object[411∈19]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access409{{"Access[409∈19]<br />ᐸ110.0ᐳ"}}:::plan
+    Access409 & Constant266 & Constant266 & Lambda268 & Constant269 --> Object411
     List114{{"List[114∈19]<br />ᐸ66,113ᐳ"}}:::plan
     PgClassExpression113{{"PgClassExpression[113∈19]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant66 & PgClassExpression113 --> List114
@@ -400,11 +408,11 @@ graph TD
     List114 --> Lambda115
     PgClassExpression116{{"PgClassExpression[116∈19]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle111 --> PgClassExpression116
-    First110 --> Access400
-    Lambda403{{"Lambda[403∈19]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object402 --> Lambda403
-    __Item126[/"__Item[126∈20]<br />ᐸ403ᐳ"\]:::itemplan
-    Lambda403 ==> __Item126
+    First110 --> Access409
+    Lambda412{{"Lambda[412∈19]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object411 --> Lambda412
+    __Item126[/"__Item[126∈20]<br />ᐸ412ᐳ"\]:::itemplan
+    Lambda412 ==> __Item126
     PgSelectSingle127{{"PgSelectSingle[127∈20]<br />ᐸpostᐳ"}}:::plan
     __Item126 --> PgSelectSingle127
     List130{{"List[130∈21]<br />ᐸ82,129ᐳ"}}:::plan
@@ -415,7 +423,7 @@ graph TD
     List130 --> Lambda131
     PgSelect133[["PgSelect[133∈22] ➊<br />ᐸmutation_out_out(mutation)ᐳ"]]:::sideeffectplan
     Object136{{"Object[136∈22] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object136 & Lambda268 & Lambda271 & Lambda440 & Lambda445 --> PgSelect133
+    Object136 & Lambda268 & Access272 & Lambda452 & Lambda457 --> PgSelect133
     Access134{{"Access[134∈22] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access135{{"Access[135∈22] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access134 & Access135 --> Object136
@@ -433,7 +441,7 @@ graph TD
     PgSelectSingle138 --> PgClassExpression141
     PgSelect145[["PgSelect[145∈25] ➊<br />ᐸmutation_out_out_compound_type(mutation)ᐳ"]]:::sideeffectplan
     Object148{{"Object[148∈25] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object148 & Constant600 & Lambda268 & Lambda271 & Lambda468 & Lambda473 --> PgSelect145
+    Object148 & Constant623 & Lambda268 & Access272 & Lambda482 & Lambda487 --> PgSelect145
     Access146{{"Access[146∈25] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access147{{"Access[147∈25] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access146 & Access147 --> Object148
@@ -445,15 +453,9 @@ graph TD
     First149 --> PgSelectSingle150
     Object151{{"Object[151∈25] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelectSingle150 --> Object151
-    Object453{{"Object[453∈26] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda268 & Constant450 & Constant451 & Constant316 --> Object453
-    Lambda454{{"Lambda[454∈26] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object453 --> Lambda454
-    Lambda459{{"Lambda[459∈26] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant619 --> Lambda459
     PgSelect154[["PgSelect[154∈27] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression153{{"PgClassExpression[153∈27] ➊<br />ᐸ__mutation...ype__.”o2”ᐳ"}}:::plan
-    Object148 & PgClassExpression153 & Lambda268 & Lambda271 & Lambda454 & Lambda459 --> PgSelect154
+    Object148 & PgClassExpression153 & Lambda268 & Access272 & Lambda467 & Lambda472 --> PgSelect154
     PgClassExpression152{{"PgClassExpression[152∈27] ➊<br />ᐸ__mutation...ype__.”o1”ᐳ"}}:::plan
     PgSelectSingle150 --> PgClassExpression152
     PgSelectSingle150 --> PgClassExpression153
@@ -469,7 +471,7 @@ graph TD
     PgSelectSingle159 --> PgClassExpression162
     PgSelect165[["PgSelect[165∈29] ➊<br />ᐸmutation_out_out_setof(mutation)ᐳ"]]:::sideeffectplan
     Object168{{"Object[168∈29] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object168 & Lambda268 & Lambda271 & Lambda482 & Lambda487 --> PgSelect165
+    Object168 & Lambda268 & Access272 & Lambda497 & Lambda502 --> PgSelect165
     Access166{{"Access[166∈29] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access167{{"Access[167∈29] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access166 & Access167 --> Object168
@@ -487,7 +489,7 @@ graph TD
     PgSelectSingle171 --> PgClassExpression173
     PgSelect176[["PgSelect[176∈33] ➊<br />ᐸmutation_out_out_unnamed(mutation)ᐳ"]]:::sideeffectplan
     Object179{{"Object[179∈33] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object179 & Lambda268 & Lambda271 & Lambda496 & Lambda501 --> PgSelect176
+    Object179 & Lambda268 & Access272 & Lambda512 & Lambda517 --> PgSelect176
     Access177{{"Access[177∈33] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access178{{"Access[178∈33] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access177 & Access178 --> Object179
@@ -505,7 +507,7 @@ graph TD
     PgSelectSingle181 --> PgClassExpression184
     PgSelect187[["PgSelect[187∈36] ➊<br />ᐸmutation_out_setof(mutation)ᐳ"]]:::sideeffectplan
     Object190{{"Object[190∈36] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object190 & Lambda268 & Lambda271 & Lambda510 & Lambda515 --> PgSelect187
+    Object190 & Lambda268 & Access272 & Lambda527 & Lambda532 --> PgSelect187
     Access188{{"Access[188∈36] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access189{{"Access[189∈36] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access188 & Access189 --> Object190
@@ -521,7 +523,7 @@ graph TD
     PgSelectSingle193 --> PgClassExpression194
     PgSelect197[["PgSelect[197∈39] ➊<br />ᐸmutation_out_table(mutation)ᐳ"]]:::sideeffectplan
     Object200{{"Object[200∈39] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object200 & Lambda268 & Lambda271 & Lambda524 & Lambda529 --> PgSelect197
+    Object200 & Lambda268 & Access272 & Lambda542 & Lambda547 --> PgSelect197
     Access198{{"Access[198∈39] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access199{{"Access[199∈39] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access198 & Access199 --> Object200
@@ -541,7 +543,7 @@ graph TD
     List206 --> Lambda207
     PgSelect210[["PgSelect[210∈42] ➊<br />ᐸmutation_out_table_setof(mutation)ᐳ"]]:::sideeffectplan
     Object213{{"Object[213∈42] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object213 & Lambda268 & Lambda271 & Lambda538 & Lambda543 --> PgSelect210
+    Object213 & Lambda268 & Access272 & Lambda557 & Lambda562 --> PgSelect210
     Access211{{"Access[211∈42] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access212{{"Access[212∈42] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access211 & Access212 --> Object213
@@ -561,7 +563,7 @@ graph TD
     List219 --> Lambda220
     PgSelect223[["PgSelect[223∈46] ➊<br />ᐸmutation_out_unnamed(mutation)ᐳ"]]:::sideeffectplan
     Object226{{"Object[226∈46] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object226 & Lambda268 & Lambda271 & Lambda552 & Lambda557 --> PgSelect223
+    Object226 & Lambda268 & Access272 & Lambda572 & Lambda577 --> PgSelect223
     Access224{{"Access[224∈46] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access225{{"Access[225∈46] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access224 & Access225 --> Object226
@@ -577,7 +579,7 @@ graph TD
     PgClassExpression229 --> Object230
     PgSelect233[["PgSelect[233∈48] ➊<br />ᐸmutation_out_unnamed_out_out_unnamed(mutation)ᐳ"]]:::sideeffectplan
     Object236{{"Object[236∈48] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object236 & Lambda268 & Lambda271 & Lambda566 & Lambda571 --> PgSelect233
+    Object236 & Lambda268 & Access272 & Lambda587 & Lambda592 --> PgSelect233
     Access234{{"Access[234∈48] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access235{{"Access[235∈48] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access234 & Access235 --> Object236
@@ -597,7 +599,7 @@ graph TD
     PgSelectSingle238 --> PgClassExpression242
     PgSelect246[["PgSelect[246∈51] ➊<br />ᐸmutation_returns_table_multi_col(mutation)ᐳ"]]:::sideeffectplan
     Object249{{"Object[249∈51] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object249 & Constant604 & Lambda268 & Lambda271 & Lambda580 & Lambda585 --> PgSelect246
+    Object249 & Constant627 & Lambda268 & Access272 & Lambda602 & Lambda607 --> PgSelect246
     Access247{{"Access[247∈51] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access248{{"Access[248∈51] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access247 & Access248 --> Object249
@@ -615,7 +617,7 @@ graph TD
     PgSelectSingle252 --> PgClassExpression254
     PgSelect258[["PgSelect[258∈55] ➊<br />ᐸmutation_returns_table_one_col(mutation)ᐳ"]]:::sideeffectplan
     Object261{{"Object[261∈55] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object261 & Constant604 & Lambda268 & Lambda271 & Lambda594 & Lambda599 --> PgSelect258
+    Object261 & Constant627 & Lambda268 & Access272 & Lambda617 & Lambda622 --> PgSelect258
     Access259{{"Access[259∈55] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access260{{"Access[260∈55] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access259 & Access260 --> Object261
@@ -635,56 +637,56 @@ graph TD
     subgraph "Buckets for mutations/v4/mutation-return-types"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Constant66,Constant82,Constant266,Lambda268,Constant269,Lambda271,Constant272,Constant273,Constant274,Object275,Lambda276,Lambda281,Constant286,Constant287,Object289,Lambda290,Lambda295,Constant300,Constant301,Object303,Lambda304,Lambda309,Constant314,Constant315,Constant316,Constant328,Constant329,Constant330,Constant347,Constant348,Constant349,Constant361,Constant362,Constant363,Object364,Lambda365,Lambda370,Constant375,Constant376,Constant389,Constant390,Constant408,Constant409,Constant422,Constant423,Constant424,Object425,Lambda426,Lambda431,Constant436,Constant437,Constant438,Object439,Lambda440,Lambda445,Constant450,Constant451,Constant464,Constant465,Constant466,Object467,Lambda468,Lambda473,Constant478,Constant479,Constant480,Object481,Lambda482,Lambda487,Constant492,Constant493,Constant494,Object495,Lambda496,Lambda501,Constant506,Constant507,Object509,Lambda510,Lambda515,Constant520,Constant521,Object523,Lambda524,Lambda529,Constant534,Constant535,Object537,Lambda538,Lambda543,Constant548,Constant549,Object551,Lambda552,Lambda557,Constant562,Constant563,Constant564,Object565,Lambda566,Lambda571,Constant576,Constant577,Constant578,Object579,Lambda580,Lambda585,Constant590,Constant591,Object593,Lambda594,Lambda599,Constant600,Constant601,Constant602,Constant603,Constant604,Constant605,Constant606,Constant607,Constant608,Constant609,Constant610,Constant611,Constant612,Constant613,Constant614,Constant615,Constant616,Constant617,Constant618,Constant619,Constant620,Constant621,Constant622,Constant623,Constant624,Constant625,Constant626,Constant627,Constant628,Constant629 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 13, 600, 601, 268, 271, 276, 281<br /><br />1: PgSelect[10]<br />2: <br />ᐳ: 14, 15, 16, 17"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Constant66,Constant82,Constant266,Lambda268,Constant269,Lambda271,Access272,Constant273,Constant274,Constant275,Object276,Lambda277,Lambda282,Constant288,Constant289,Object291,Lambda292,Lambda297,Constant303,Constant304,Object306,Lambda307,Lambda312,Constant318,Constant319,Constant320,Object321,Lambda322,Lambda327,Constant333,Constant334,Constant335,Object336,Lambda337,Lambda342,Constant353,Constant354,Constant355,Object356,Lambda357,Lambda362,Constant368,Constant369,Constant370,Object371,Lambda372,Lambda377,Constant383,Constant384,Object386,Lambda387,Lambda392,Constant398,Constant399,Object401,Lambda402,Lambda407,Constant418,Constant419,Object421,Lambda422,Lambda427,Constant433,Constant434,Constant435,Object436,Lambda437,Lambda442,Constant448,Constant449,Constant450,Object451,Lambda452,Lambda457,Constant463,Constant464,Object466,Lambda467,Lambda472,Constant478,Constant479,Constant480,Object481,Lambda482,Lambda487,Constant493,Constant494,Constant495,Object496,Lambda497,Lambda502,Constant508,Constant509,Constant510,Object511,Lambda512,Lambda517,Constant523,Constant524,Object526,Lambda527,Lambda532,Constant538,Constant539,Object541,Lambda542,Lambda547,Constant553,Constant554,Object556,Lambda557,Lambda562,Constant568,Constant569,Object571,Lambda572,Lambda577,Constant583,Constant584,Constant585,Object586,Lambda587,Lambda592,Constant598,Constant599,Constant600,Object601,Lambda602,Lambda607,Constant613,Constant614,Object616,Lambda617,Lambda622,Constant623,Constant624,Constant625,Constant626,Constant627,Constant628,Constant629,Constant630,Constant631,Constant632,Constant633,Constant634,Constant635,Constant636,Constant637,Constant638,Constant639,Constant640,Constant641,Constant642,Constant643,Constant644,Constant645,Constant646,Constant647,Constant648,Constant649,Constant650,Constant651,Constant652 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 13, 623, 624, 268, 272, 277, 282<br /><br />1: PgSelect[10]<br />2: <br />ᐳ: 14, 15, 16, 17"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect10,First14,PgSelectSingle15,PgClassExpression16,Object17 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 16<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (mutationField)<br />Deps: 600, 268, 271, 290, 295, 2<br /><br />1: Access[22]<br />2: Access[23]<br />3: Object[24]<br />4: PgSelect[21]<br />5: <br />ᐳ: 25, 26, 27, 28"):::bucket
+    Bucket3("Bucket 3 (mutationField)<br />Deps: 623, 268, 272, 292, 297, 2<br /><br />1: Access[22]<br />2: Access[23]<br />3: Object[24]<br />4: PgSelect[21]<br />5: <br />ᐳ: 25, 26, 27, 28"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgSelect21,Access22,Access23,Object24,First25,PgSelectSingle26,PgClassExpression27,Object28 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 28, 27<br /><br />ROOT Object{3}ᐸ{result}ᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 268, 271, 304, 309, 2<br /><br />1: Access[32]<br />2: Access[33]<br />3: Object[34]<br />4: PgSelect[31]<br />5: <br />ᐳ: 35, 36, 37, 38"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 268, 272, 307, 312, 2<br /><br />1: Access[32]<br />2: Access[33]<br />3: Object[34]<br />4: PgSelect[31]<br />5: <br />ᐳ: 35, 36, 37, 38"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgSelect31,Access32,Access33,Object34,First35,PgSelectSingle36,PgClassExpression37,Object38 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 38, 37<br /><br />ROOT Object{5}ᐸ{result}ᐳ[38]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 602, 603, 268, 271, 365, 370, 2, 314, 315, 316, 610, 328, 329, 330, 611, 347, 348, 349, 612, 66, 266, 269, 82<br /><br />1: Access[44]<br />2: Access[45]<br />3: Object[46]<br />4: PgSelect[43]<br />5: <br />ᐳ: 47, 48, 49"):::bucket
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 625, 626, 268, 272, 372, 377, 2, 322, 327, 337, 342, 357, 362, 66, 266, 269, 82<br /><br />1: Access[44]<br />2: Access[45]<br />3: Object[46]<br />4: PgSelect[43]<br />5: <br />ᐳ: 47, 48, 49"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgSelect43,Access44,Access45,Object46,First47,PgSelectSingle48,Object49 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 268, 314, 315, 316, 610, 328, 329, 330, 611, 347, 348, 349, 612, 49, 48, 46, 271, 66, 266, 269, 82<br /><br />ROOT Object{7}ᐸ{result}ᐳ[49]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49, 48, 46, 268, 272, 322, 327, 337, 342, 357, 362, 66, 266, 269, 82<br /><br />ROOT Object{7}ᐸ{result}ᐳ[49]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,Object317,Lambda318,Lambda323,Object331,Lambda332,Lambda337,Object350,Lambda351,Lambda356 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48, 46, 268, 271, 318, 323, 332, 337, 351, 356, 66, 266, 269, 82<br /><br />ROOT PgSelectSingle{7}ᐸmutation_out_complexᐳ[48]<br />1: <br />ᐳ: 50, 51, 61, 78<br />2: PgSelect[52], PgSelect[62]<br />ᐳ: 56, 57, 64, 65"):::bucket
+    class Bucket8,Connection78 bucket8
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 48, 46, 268, 272, 322, 327, 337, 342, 357, 362, 66, 266, 269, 82, 78<br /><br />ROOT PgSelectSingle{7}ᐸmutation_out_complexᐳ[48]<br />1: <br />ᐳ: 50, 51, 61<br />2: PgSelect[52], PgSelect[62]<br />ᐳ: 56, 57, 64, 65"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression50,PgClassExpression51,PgSelect52,First56,PgSelectSingle57,PgClassExpression61,PgSelect62,First64,PgSelectSingle65,Connection78 bucket9
+    class Bucket9,PgClassExpression50,PgClassExpression51,PgSelect52,First56,PgSelectSingle57,PgClassExpression61,PgSelect62,First64,PgSelectSingle65 bucket9
     Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 57<br /><br />ROOT PgSelectSingle{9}ᐸfrmcdc_compoundTypeᐳ[57]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgClassExpression58,PgClassExpression59,PgClassExpression60 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 65, 66, 64, 266, 268, 269, 82, 78<br /><br />ROOT PgSelectSingle{9}ᐸpersonᐳ[65]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression67,List68,Lambda69,PgClassExpression70,Access339,Object341,Lambda342 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 82<br /><br />ROOT __Item{12}ᐸ342ᐳ[80]"):::bucket
+    class Bucket11,PgClassExpression67,List68,Lambda69,PgClassExpression70,Access344,Object346,Lambda347 bucket11
+    Bucket12("Bucket 12 (listItem)<br />Deps: 82<br /><br />ROOT __Item{12}ᐸ347ᐳ[80]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,__Item80,PgSelectSingle81 bucket12
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 81, 82<br /><br />ROOT PgSelectSingle{12}ᐸpostᐳ[81]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression83,List84,Lambda85 bucket13
-    Bucket14("Bucket 14 (mutationField)<br />Deps: 602, 603, 268, 271, 426, 431, 2, 375, 376, 316, 614, 389, 390, 330, 615, 408, 409, 349, 616, 66, 266, 269, 82<br /><br />1: Access[90]<br />2: Access[91]<br />3: Object[92]<br />4: PgSelect[89]<br />5: <br />ᐳ: Object[93]"):::bucket
+    Bucket14("Bucket 14 (mutationField)<br />Deps: 625, 626, 268, 272, 437, 442, 2, 387, 392, 402, 407, 422, 427, 66, 266, 269, 82<br /><br />1: Access[90]<br />2: Access[91]<br />3: Object[92]<br />4: PgSelect[89]<br />5: <br />ᐳ: Object[93]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgSelect89,Access90,Access91,Object92,Object93 bucket14
-    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 268, 375, 376, 316, 614, 389, 390, 330, 615, 408, 409, 349, 616, 93, 89, 92, 271, 66, 266, 269, 82<br /><br />ROOT Object{14}ᐸ{result}ᐳ[93]"):::bucket
+    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 93, 89, 92, 268, 272, 387, 392, 402, 407, 422, 427, 66, 266, 269, 82<br /><br />ROOT Object{14}ᐸ{result}ᐳ[93]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,Object378,Lambda379,Lambda384,Object392,Lambda393,Lambda398,Object411,Lambda412,Lambda417 bucket15
-    Bucket16("Bucket 16 (listItem)<br />Deps: 92, 268, 271, 379, 384, 393, 398, 412, 417, 66, 266, 269, 82<br /><br />ROOT __Item{16}ᐸ89ᐳ[94]"):::bucket
+    class Bucket15,Connection124 bucket15
+    Bucket16("Bucket 16 (listItem)<br />Deps: 92, 268, 272, 387, 392, 402, 407, 422, 427, 66, 266, 269, 82, 124<br /><br />ROOT __Item{16}ᐸ89ᐳ[94]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,__Item94,PgSelectSingle95,Connection124 bucket16
-    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 95, 92, 268, 271, 379, 384, 393, 398, 412, 417, 66, 266, 269, 82, 124<br /><br />ROOT PgSelectSingle{16}ᐸmutation_out_complex_setofᐳ[95]<br />1: <br />ᐳ: 96, 97, 107<br />2: PgSelect[98], PgSelect[108]<br />ᐳ: 102, 103, 110, 111"):::bucket
+    class Bucket16,__Item94,PgSelectSingle95 bucket16
+    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 95, 92, 268, 272, 387, 392, 402, 407, 422, 427, 66, 266, 269, 82, 124<br /><br />ROOT PgSelectSingle{16}ᐸmutation_out_complex_setofᐳ[95]<br />1: <br />ᐳ: 96, 97, 107<br />2: PgSelect[98], PgSelect[108]<br />ᐳ: 102, 103, 110, 111"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgClassExpression96,PgClassExpression97,PgSelect98,First102,PgSelectSingle103,PgClassExpression107,PgSelect108,First110,PgSelectSingle111 bucket17
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 103<br /><br />ROOT PgSelectSingle{17}ᐸfrmcdc_compoundTypeᐳ[103]"):::bucket
@@ -692,14 +694,14 @@ graph TD
     class Bucket18,PgClassExpression104,PgClassExpression105,PgClassExpression106 bucket18
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 111, 66, 110, 266, 268, 269, 82, 124<br /><br />ROOT PgSelectSingle{17}ᐸpersonᐳ[111]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgClassExpression113,List114,Lambda115,PgClassExpression116,Access400,Object402,Lambda403 bucket19
-    Bucket20("Bucket 20 (listItem)<br />Deps: 82<br /><br />ROOT __Item{20}ᐸ403ᐳ[126]"):::bucket
+    class Bucket19,PgClassExpression113,List114,Lambda115,PgClassExpression116,Access409,Object411,Lambda412 bucket19
+    Bucket20("Bucket 20 (listItem)<br />Deps: 82<br /><br />ROOT __Item{20}ᐸ412ᐳ[126]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20,__Item126,PgSelectSingle127 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 127, 82<br /><br />ROOT PgSelectSingle{20}ᐸpostᐳ[127]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression129,List130,Lambda131 bucket21
-    Bucket22("Bucket 22 (mutationField)<br />Deps: 268, 271, 440, 445, 2<br /><br />1: Access[134]<br />2: Access[135]<br />3: Object[136]<br />4: PgSelect[133]<br />5: <br />ᐳ: 137, 138, 139"):::bucket
+    Bucket22("Bucket 22 (mutationField)<br />Deps: 268, 272, 452, 457, 2<br /><br />1: Access[134]<br />2: Access[135]<br />3: Object[136]<br />4: PgSelect[133]<br />5: <br />ᐳ: 137, 138, 139"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22,PgSelect133,Access134,Access135,Object136,First137,PgSelectSingle138,Object139 bucket22
     Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 139, 138<br /><br />ROOT Object{22}ᐸ{result}ᐳ[139]"):::bucket
@@ -708,19 +710,19 @@ graph TD
     Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 138<br /><br />ROOT PgSelectSingle{22}ᐸmutation_out_outᐳ[138]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,PgClassExpression140,PgClassExpression141 bucket24
-    Bucket25("Bucket 25 (mutationField)<br />Deps: 600, 268, 271, 468, 473, 2, 450, 451, 316, 619<br /><br />1: Access[146]<br />2: Access[147]<br />3: Object[148]<br />4: PgSelect[145]<br />5: <br />ᐳ: 149, 150, 151"):::bucket
+    Bucket25("Bucket 25 (mutationField)<br />Deps: 623, 268, 272, 482, 487, 2, 467, 472<br /><br />1: Access[146]<br />2: Access[147]<br />3: Object[148]<br />4: PgSelect[145]<br />5: <br />ᐳ: 149, 150, 151"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgSelect145,Access146,Access147,Object148,First149,PgSelectSingle150,Object151 bucket25
-    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 268, 450, 451, 316, 619, 151, 150, 148, 271<br /><br />ROOT Object{25}ᐸ{result}ᐳ[151]"):::bucket
+    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 151, 150, 148, 268, 272, 467, 472<br /><br />ROOT Object{25}ᐸ{result}ᐳ[151]"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,Object453,Lambda454,Lambda459 bucket26
-    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 150, 148, 268, 271, 454, 459<br /><br />ROOT PgSelectSingle{25}ᐸmutation_out_out_compound_typeᐳ[150]<br />1: <br />ᐳ: 152, 153<br />2: PgSelect[154]<br />ᐳ: First[158], PgSelectSingle[159]"):::bucket
+    class Bucket26 bucket26
+    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 150, 148, 268, 272, 467, 472<br /><br />ROOT PgSelectSingle{25}ᐸmutation_out_out_compound_typeᐳ[150]<br />1: <br />ᐳ: 152, 153<br />2: PgSelect[154]<br />ᐳ: First[158], PgSelectSingle[159]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgClassExpression152,PgClassExpression153,PgSelect154,First158,PgSelectSingle159 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 159<br /><br />ROOT PgSelectSingle{27}ᐸfrmcdc_compoundTypeᐳ[159]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression160,PgClassExpression161,PgClassExpression162 bucket28
-    Bucket29("Bucket 29 (mutationField)<br />Deps: 268, 271, 482, 487, 2<br /><br />1: Access[166]<br />2: Access[167]<br />3: Object[168]<br />4: PgSelect[165]<br />5: <br />ᐳ: Object[169]"):::bucket
+    Bucket29("Bucket 29 (mutationField)<br />Deps: 268, 272, 497, 502, 2<br /><br />1: Access[166]<br />2: Access[167]<br />3: Object[168]<br />4: PgSelect[165]<br />5: <br />ᐳ: Object[169]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,PgSelect165,Access166,Access167,Object168,Object169 bucket29
     Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 169, 165<br /><br />ROOT Object{29}ᐸ{result}ᐳ[169]"):::bucket
@@ -732,7 +734,7 @@ graph TD
     Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 171<br /><br />ROOT PgSelectSingle{31}ᐸmutation_out_out_setofᐳ[171]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32,PgClassExpression172,PgClassExpression173 bucket32
-    Bucket33("Bucket 33 (mutationField)<br />Deps: 268, 271, 496, 501, 2<br /><br />1: Access[177]<br />2: Access[178]<br />3: Object[179]<br />4: PgSelect[176]<br />5: <br />ᐳ: 180, 181, 182"):::bucket
+    Bucket33("Bucket 33 (mutationField)<br />Deps: 268, 272, 512, 517, 2<br /><br />1: Access[177]<br />2: Access[178]<br />3: Object[179]<br />4: PgSelect[176]<br />5: <br />ᐳ: 180, 181, 182"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgSelect176,Access177,Access178,Object179,First180,PgSelectSingle181,Object182 bucket33
     Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 182, 181<br /><br />ROOT Object{33}ᐸ{result}ᐳ[182]"):::bucket
@@ -741,7 +743,7 @@ graph TD
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 181<br /><br />ROOT PgSelectSingle{33}ᐸmutation_out_out_unnamedᐳ[181]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression183,PgClassExpression184 bucket35
-    Bucket36("Bucket 36 (mutationField)<br />Deps: 268, 271, 510, 515, 2<br /><br />1: Access[188]<br />2: Access[189]<br />3: Object[190]<br />4: PgSelect[187]<br />5: <br />ᐳ: Object[191]"):::bucket
+    Bucket36("Bucket 36 (mutationField)<br />Deps: 268, 272, 527, 532, 2<br /><br />1: Access[188]<br />2: Access[189]<br />3: Object[190]<br />4: PgSelect[187]<br />5: <br />ᐳ: Object[191]"):::bucket
     classDef bucket36 stroke:#7f007f
     class Bucket36,PgSelect187,Access188,Access189,Object190,Object191 bucket36
     Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 191, 187<br /><br />ROOT Object{36}ᐸ{result}ᐳ[191]"):::bucket
@@ -750,7 +752,7 @@ graph TD
     Bucket38("Bucket 38 (listItem)<br /><br />ROOT __Item{38}ᐸ187ᐳ[192]"):::bucket
     classDef bucket38 stroke:#0000ff
     class Bucket38,__Item192,PgSelectSingle193,PgClassExpression194 bucket38
-    Bucket39("Bucket 39 (mutationField)<br />Deps: 268, 271, 524, 529, 2, 66<br /><br />1: Access[198]<br />2: Access[199]<br />3: Object[200]<br />4: PgSelect[197]<br />5: <br />ᐳ: 201, 202, 203"):::bucket
+    Bucket39("Bucket 39 (mutationField)<br />Deps: 268, 272, 542, 547, 2, 66<br /><br />1: Access[198]<br />2: Access[199]<br />3: Object[200]<br />4: PgSelect[197]<br />5: <br />ᐳ: 201, 202, 203"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,PgSelect197,Access198,Access199,Object200,First201,PgSelectSingle202,Object203 bucket39
     Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 203, 202, 66<br /><br />ROOT Object{39}ᐸ{result}ᐳ[203]"):::bucket
@@ -759,7 +761,7 @@ graph TD
     Bucket41("Bucket 41 (nullableBoundary)<br />Deps: 202, 66<br /><br />ROOT PgSelectSingle{39}ᐸmutation_out_tableᐳ[202]"):::bucket
     classDef bucket41 stroke:#808000
     class Bucket41,PgClassExpression205,List206,Lambda207 bucket41
-    Bucket42("Bucket 42 (mutationField)<br />Deps: 268, 271, 538, 543, 2, 66<br /><br />1: Access[211]<br />2: Access[212]<br />3: Object[213]<br />4: PgSelect[210]<br />5: <br />ᐳ: Object[214]"):::bucket
+    Bucket42("Bucket 42 (mutationField)<br />Deps: 268, 272, 557, 562, 2, 66<br /><br />1: Access[211]<br />2: Access[212]<br />3: Object[213]<br />4: PgSelect[210]<br />5: <br />ᐳ: Object[214]"):::bucket
     classDef bucket42 stroke:#dda0dd
     class Bucket42,PgSelect210,Access211,Access212,Object213,Object214 bucket42
     Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 214, 210, 66<br /><br />ROOT Object{42}ᐸ{result}ᐳ[214]"):::bucket
@@ -771,13 +773,13 @@ graph TD
     Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 216, 66<br /><br />ROOT PgSelectSingle{44}ᐸmutation_out_table_setofᐳ[216]"):::bucket
     classDef bucket45 stroke:#00ffff
     class Bucket45,PgClassExpression218,List219,Lambda220 bucket45
-    Bucket46("Bucket 46 (mutationField)<br />Deps: 268, 271, 552, 557, 2<br /><br />1: Access[224]<br />2: Access[225]<br />3: Object[226]<br />4: PgSelect[223]<br />5: <br />ᐳ: 227, 228, 229, 230"):::bucket
+    Bucket46("Bucket 46 (mutationField)<br />Deps: 268, 272, 572, 577, 2<br /><br />1: Access[224]<br />2: Access[225]<br />3: Object[226]<br />4: PgSelect[223]<br />5: <br />ᐳ: 227, 228, 229, 230"):::bucket
     classDef bucket46 stroke:#4169e1
     class Bucket46,PgSelect223,Access224,Access225,Object226,First227,PgSelectSingle228,PgClassExpression229,Object230 bucket46
     Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 230, 229<br /><br />ROOT Object{46}ᐸ{result}ᐳ[230]"):::bucket
     classDef bucket47 stroke:#3cb371
     class Bucket47 bucket47
-    Bucket48("Bucket 48 (mutationField)<br />Deps: 268, 271, 566, 571, 2<br /><br />1: Access[234]<br />2: Access[235]<br />3: Object[236]<br />4: PgSelect[233]<br />5: <br />ᐳ: 237, 238, 239"):::bucket
+    Bucket48("Bucket 48 (mutationField)<br />Deps: 268, 272, 587, 592, 2<br /><br />1: Access[234]<br />2: Access[235]<br />3: Object[236]<br />4: PgSelect[233]<br />5: <br />ᐳ: 237, 238, 239"):::bucket
     classDef bucket48 stroke:#a52a2a
     class Bucket48,PgSelect233,Access234,Access235,Object236,First237,PgSelectSingle238,Object239 bucket48
     Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 239, 238<br /><br />ROOT Object{48}ᐸ{result}ᐳ[239]"):::bucket
@@ -786,7 +788,7 @@ graph TD
     Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 238<br /><br />ROOT PgSelectSingle{48}ᐸmutation_out_unnamed_out_out_unnamedᐳ[238]"):::bucket
     classDef bucket50 stroke:#f5deb3
     class Bucket50,PgClassExpression240,PgClassExpression241,PgClassExpression242 bucket50
-    Bucket51("Bucket 51 (mutationField)<br />Deps: 604, 268, 271, 580, 585, 2<br /><br />1: Access[247]<br />2: Access[248]<br />3: Object[249]<br />4: PgSelect[246]<br />5: <br />ᐳ: Object[250]"):::bucket
+    Bucket51("Bucket 51 (mutationField)<br />Deps: 627, 268, 272, 602, 607, 2<br /><br />1: Access[247]<br />2: Access[248]<br />3: Object[249]<br />4: PgSelect[246]<br />5: <br />ᐳ: Object[250]"):::bucket
     classDef bucket51 stroke:#696969
     class Bucket51,PgSelect246,Access247,Access248,Object249,Object250 bucket51
     Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 250, 246<br /><br />ROOT Object{51}ᐸ{result}ᐳ[250]"):::bucket
@@ -798,7 +800,7 @@ graph TD
     Bucket54("Bucket 54 (nullableBoundary)<br />Deps: 252<br /><br />ROOT PgSelectSingle{53}ᐸmutation_returns_table_multi_colᐳ[252]"):::bucket
     classDef bucket54 stroke:#ffa500
     class Bucket54,PgClassExpression253,PgClassExpression254 bucket54
-    Bucket55("Bucket 55 (mutationField)<br />Deps: 604, 268, 271, 594, 599, 2<br /><br />1: Access[259]<br />2: Access[260]<br />3: Object[261]<br />4: PgSelect[258]<br />5: <br />ᐳ: Object[262]"):::bucket
+    Bucket55("Bucket 55 (mutationField)<br />Deps: 627, 268, 272, 617, 622, 2<br /><br />1: Access[259]<br />2: Access[260]<br />3: Object[261]<br />4: PgSelect[258]<br />5: <br />ᐳ: Object[262]"):::bucket
     classDef bucket55 stroke:#0000ff
     class Bucket55,PgSelect258,Access259,Access260,Object261,Object262 bucket55
     Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 262, 258<br /><br />ROOT Object{55}ᐸ{result}ᐳ[262]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-update.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-update.mermaid
@@ -9,153 +9,269 @@ graph TD
 
 
     %% plan dependencies
+    Object518{{"Object[518∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda510{{"Lambda[510∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant515{{"Constant[515∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant516{{"Constant[516∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant517{{"Constant[517∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda510 & Constant515 & Constant516 & Constant517 --> Object518
+    Object533{{"Object[533∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant530{{"Constant[530∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant531{{"Constant[531∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant530 & Constant531 & Constant517 --> Object533
+    Object548{{"Object[548∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant545{{"Constant[545∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant546{{"Constant[546∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant545 & Constant546 & Constant517 --> Object548
+    Object563{{"Object[563∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant560{{"Constant[560∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant561{{"Constant[561∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant560 & Constant561 & Constant517 --> Object563
+    Object578{{"Object[578∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant575{{"Constant[575∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant576{{"Constant[576∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant575 & Constant576 & Constant517 --> Object578
+    Object593{{"Object[593∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant590{{"Constant[590∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant591{{"Constant[591∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant590 & Constant591 & Constant517 --> Object593
+    Object608{{"Object[608∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant605{{"Constant[605∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant606{{"Constant[606∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant605 & Constant606 & Constant517 --> Object608
+    Object623{{"Object[623∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant620{{"Constant[620∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant621{{"Constant[621∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant620 & Constant621 & Constant517 --> Object623
+    Object638{{"Object[638∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant635{{"Constant[635∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant636{{"Constant[636∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant635 & Constant636 & Constant517 --> Object638
+    Object653{{"Object[653∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant650{{"Constant[650∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant651{{"Constant[651∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant650 & Constant651 & Constant517 --> Object653
+    Object668{{"Object[668∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant665{{"Constant[665∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant666{{"Constant[666∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant665 & Constant666 & Constant517 --> Object668
+    Object683{{"Object[683∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant680{{"Constant[680∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant681{{"Constant[681∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant680 & Constant681 & Constant517 --> Object683
+    Object698{{"Object[698∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant695{{"Constant[695∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant696{{"Constant[696∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant695 & Constant696 & Constant517 --> Object698
+    Object713{{"Object[713∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant710{{"Constant[710∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant711{{"Constant[711∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant710 & Constant711 & Constant517 --> Object713
+    Object728{{"Object[728∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant725{{"Constant[725∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant726{{"Constant[726∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant725 & Constant726 & Constant517 --> Object728
+    Object743{{"Object[743∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant740{{"Constant[740∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant741{{"Constant[741∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant740 & Constant741 & Constant517 --> Object743
+    Object758{{"Object[758∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant755{{"Constant[755∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant756{{"Constant[756∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant755 & Constant756 & Constant517 --> Object758
+    Object773{{"Object[773∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant770{{"Constant[770∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant771{{"Constant[771∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant770 & Constant771 & Constant517 --> Object773
+    Object788{{"Object[788∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant785{{"Constant[785∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant786{{"Constant[786∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant785 & Constant786 & Constant517 --> Object788
+    Object803{{"Object[803∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant800{{"Constant[800∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant801{{"Constant[801∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda510 & Constant800 & Constant801 & Constant517 --> Object803
     Object18{{"Object[18∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access16 & Access17 --> Object18
     Lambda12{{"Lambda[12∈0] ➊<br />ᐸdecode_Person_base64JSONᐳ"}}:::plan
-    Constant790{{"Constant[790∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDFd'ᐳ"}}:::plan
-    Constant790 --> Lambda12
+    Constant810{{"Constant[810∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDFd'ᐳ"}}:::plan
+    Constant810 --> Lambda12
     Access13{{"Access[13∈0] ➊<br />ᐸ12.1ᐳ"}}:::plan
     Lambda12 --> Access13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access16
     __Value2 --> Access17
-    Lambda510{{"Lambda[510∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant793{{"Constant[793∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant793 --> Lambda510
+    Constant813{{"Constant[813∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant813 --> Lambda510
     Lambda513{{"Lambda[513∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant794{{"Constant[794∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant794 --> Lambda513
+    Constant814{{"Constant[814∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant814 --> Lambda513
+    Access514{{"Access[514∈0] ➊<br />ᐸ513.0ᐳ"}}:::plan
+    Lambda513 --> Access514
+    Lambda519{{"Lambda[519∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object518 --> Lambda519
+    Lambda524{{"Lambda[524∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant834{{"Constant[834∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant834 --> Lambda524
+    Lambda534{{"Lambda[534∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object533 --> Lambda534
+    Lambda539{{"Lambda[539∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant835{{"Constant[835∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant835 --> Lambda539
+    Lambda549{{"Lambda[549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object548 --> Lambda549
+    Lambda554{{"Lambda[554∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant836{{"Constant[836∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant836 --> Lambda554
+    Lambda564{{"Lambda[564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object563 --> Lambda564
+    Lambda569{{"Lambda[569∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant837{{"Constant[837∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant837 --> Lambda569
+    Lambda579{{"Lambda[579∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object578 --> Lambda579
+    Lambda584{{"Lambda[584∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant838{{"Constant[838∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant838 --> Lambda584
+    Lambda594{{"Lambda[594∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object593 --> Lambda594
+    Lambda599{{"Lambda[599∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant839{{"Constant[839∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant839 --> Lambda599
+    Lambda609{{"Lambda[609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object608 --> Lambda609
+    Lambda614{{"Lambda[614∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant840{{"Constant[840∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant840 --> Lambda614
+    Lambda624{{"Lambda[624∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object623 --> Lambda624
+    Lambda629{{"Lambda[629∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant841{{"Constant[841∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant841 --> Lambda629
+    Lambda639{{"Lambda[639∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object638 --> Lambda639
+    Lambda644{{"Lambda[644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant842{{"Constant[842∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant842 --> Lambda644
+    Lambda654{{"Lambda[654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object653 --> Lambda654
+    Lambda659{{"Lambda[659∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant843{{"Constant[843∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant843 --> Lambda659
+    Lambda669{{"Lambda[669∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object668 --> Lambda669
+    Lambda674{{"Lambda[674∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant844{{"Constant[844∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant844 --> Lambda674
+    Lambda684{{"Lambda[684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object683 --> Lambda684
+    Lambda689{{"Lambda[689∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant845{{"Constant[845∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant845 --> Lambda689
+    Lambda699{{"Lambda[699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object698 --> Lambda699
+    Lambda704{{"Lambda[704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant846{{"Constant[846∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant846 --> Lambda704
+    Lambda714{{"Lambda[714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object713 --> Lambda714
+    Lambda719{{"Lambda[719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant847{{"Constant[847∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant847 --> Lambda719
+    Lambda729{{"Lambda[729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object728 --> Lambda729
+    Lambda734{{"Lambda[734∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant848{{"Constant[848∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant848 --> Lambda734
+    Lambda744{{"Lambda[744∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object743 --> Lambda744
+    Lambda749{{"Lambda[749∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant849{{"Constant[849∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant849 --> Lambda749
+    Lambda759{{"Lambda[759∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object758 --> Lambda759
+    Lambda764{{"Lambda[764∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant850{{"Constant[850∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant850 --> Lambda764
+    Lambda774{{"Lambda[774∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object773 --> Lambda774
+    Lambda779{{"Lambda[779∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant851{{"Constant[851∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant851 --> Lambda779
+    Lambda789{{"Lambda[789∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object788 --> Lambda789
+    Lambda794{{"Lambda[794∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant852{{"Constant[852∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant852 --> Lambda794
+    Lambda804{{"Lambda[804∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object803 --> Lambda804
+    Lambda809{{"Lambda[809∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant853{{"Constant[853∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant853 --> Lambda809
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant20{{"Constant[20∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant21{{"Constant[21∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
     Constant57{{"Constant[57∈0] ➊<br />ᐸ'query'ᐳ"}}:::plan
     Constant332{{"Constant[332∈0] ➊<br />ᐸ'compound_keys'ᐳ"}}:::plan
     Constant511{{"Constant[511∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant514{{"Constant[514∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant515{{"Constant[515∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant516{{"Constant[516∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant528{{"Constant[528∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant529{{"Constant[529∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant542{{"Constant[542∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant570{{"Constant[570∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant571{{"Constant[571∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant584{{"Constant[584∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant585{{"Constant[585∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant598{{"Constant[598∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant599{{"Constant[599∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant612{{"Constant[612∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant613{{"Constant[613∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant626{{"Constant[626∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant627{{"Constant[627∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant640{{"Constant[640∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant641{{"Constant[641∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant654{{"Constant[654∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant655{{"Constant[655∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant668{{"Constant[668∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant669{{"Constant[669∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant682{{"Constant[682∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant683{{"Constant[683∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant696{{"Constant[696∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant697{{"Constant[697∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant710{{"Constant[710∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant711{{"Constant[711∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant724{{"Constant[724∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant725{{"Constant[725∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant738{{"Constant[738∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant739{{"Constant[739∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant752{{"Constant[752∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant753{{"Constant[753∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant766{{"Constant[766∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant767{{"Constant[767∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant780{{"Constant[780∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant781{{"Constant[781∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant791{{"Constant[791∈0] ➊<br />ᐸ'John Smith Sr.'ᐳ"}}:::plan
-    Constant792{{"Constant[792∈0] ➊<br />ᐸ'An older John Smith'ᐳ"}}:::plan
-    Constant795{{"Constant[795∈0] ➊<br />ᐸ'graphile-build.issue.27.exists@example.com'ᐳ"}}:::plan
-    Constant796{{"Constant[796∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
-    Constant797{{"Constant[797∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDJd'ᐳ"}}:::plan
-    Constant798{{"Constant[798∈0] ➊<br />ᐸ'Sarah Smith'ᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸ'sarah.smith@email.com'ᐳ"}}:::plan
-    Constant800{{"Constant[800∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
-    Constant801{{"Constant[801∈0] ➊<br />ᐸ'Now with an “H.”'ᐳ"}}:::plan
-    Constant802{{"Constant[802∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant803{{"Constant[803∈0] ➊<br />ᐸ'Best Pal'ᐳ"}}:::plan
-    Constant804{{"Constant[804∈0] ➊<br />ᐸ'I have taken over Budd’s account. Hehehe.'ᐳ"}}:::plan
-    Constant805{{"Constant[805∈0] ➊<br />ᐸ'kathryn.ramirez@email.com'ᐳ"}}:::plan
-    Constant806{{"Constant[806∈0] ➊<br />ᐸ'Make art not friends.'ᐳ"}}:::plan
-    Constant807{{"Constant[807∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwxLDJd'ᐳ"}}:::plan
-    Constant808{{"Constant[808∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant809{{"Constant[809∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant810{{"Constant[810∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant811{{"Constant[811∈0] ➊<br />ᐸ'somethingelse@example.com'ᐳ"}}:::plan
-    Constant812{{"Constant[812∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant813{{"Constant[813∈0] ➊<br />ᐸ'New String'ᐳ"}}:::plan
-    Constant814{{"Constant[814∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant815{{"Constant[815∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant816{{"Constant[816∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant817{{"Constant[817∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant818{{"Constant[818∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant819{{"Constant[819∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant820{{"Constant[820∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant821{{"Constant[821∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant822{{"Constant[822∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant823{{"Constant[823∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant824{{"Constant[824∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant825{{"Constant[825∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant826{{"Constant[826∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant827{{"Constant[827∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant828{{"Constant[828∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant829{{"Constant[829∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant830{{"Constant[830∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant831{{"Constant[831∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant832{{"Constant[832∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant833{{"Constant[833∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant811{{"Constant[811∈0] ➊<br />ᐸ'John Smith Sr.'ᐳ"}}:::plan
+    Constant812{{"Constant[812∈0] ➊<br />ᐸ'An older John Smith'ᐳ"}}:::plan
+    Constant815{{"Constant[815∈0] ➊<br />ᐸ'graphile-build.issue.27.exists@example.com'ᐳ"}}:::plan
+    Constant816{{"Constant[816∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
+    Constant817{{"Constant[817∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDJd'ᐳ"}}:::plan
+    Constant818{{"Constant[818∈0] ➊<br />ᐸ'Sarah Smith'ᐳ"}}:::plan
+    Constant819{{"Constant[819∈0] ➊<br />ᐸ'sarah.smith@email.com'ᐳ"}}:::plan
+    Constant820{{"Constant[820∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
+    Constant821{{"Constant[821∈0] ➊<br />ᐸ'Now with an “H.”'ᐳ"}}:::plan
+    Constant822{{"Constant[822∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant823{{"Constant[823∈0] ➊<br />ᐸ'Best Pal'ᐳ"}}:::plan
+    Constant824{{"Constant[824∈0] ➊<br />ᐸ'I have taken over Budd’s account. Hehehe.'ᐳ"}}:::plan
+    Constant825{{"Constant[825∈0] ➊<br />ᐸ'kathryn.ramirez@email.com'ᐳ"}}:::plan
+    Constant826{{"Constant[826∈0] ➊<br />ᐸ'Make art not friends.'ᐳ"}}:::plan
+    Constant827{{"Constant[827∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwxLDJd'ᐳ"}}:::plan
+    Constant828{{"Constant[828∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant829{{"Constant[829∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant830{{"Constant[830∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant831{{"Constant[831∈0] ➊<br />ᐸ'somethingelse@example.com'ᐳ"}}:::plan
+    Constant832{{"Constant[832∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant833{{"Constant[833∈0] ➊<br />ᐸ'New String'ᐳ"}}:::plan
     PgUpdateSingle15[["PgUpdateSingle[15∈1] ➊<br />ᐸperson(id;person_full_name,about)ᐳ"]]:::sideeffectplan
     Object18 -->|rejectNull| PgUpdateSingle15
-    Access13 & Constant791 & Constant792 --> PgUpdateSingle15
+    Access13 & Constant811 & Constant812 --> PgUpdateSingle15
     Object19{{"Object[19∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle15 --> Object19
     PgSelect42[["PgSelect[42∈2] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression41{{"PgClassExpression[41∈2] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda532{{"Lambda[532∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda537{{"Lambda[537∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object18 & PgClassExpression41 & Lambda510 & Lambda513 & Lambda532 & Lambda537 --> PgSelect42
-    Object517{{"Object[517∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant514 & Constant515 & Constant516 --> Object517
-    Object531{{"Object[531∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant528 & Constant529 & Constant516 --> Object531
+    Object18 & PgClassExpression41 & Lambda510 & Access514 & Lambda534 & Lambda539 --> PgSelect42
     Edge49{{"Edge[49∈2] ➊"}}:::plan
     PgSelectSingle48{{"PgSelectSingle[48∈2] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor50{{"PgCursor[50∈2] ➊"}}:::plan
     Connection46{{"Connection[46∈2] ➊<br />ᐸ42ᐳ"}}:::plan
     PgSelectSingle48 & PgCursor50 & Connection46 --> Edge49
+    List23{{"List[23∈2] ➊<br />ᐸ21,41ᐳ"}}:::plan
+    Constant21 & PgClassExpression41 --> List23
+    List55{{"List[55∈2] ➊<br />ᐸ21,51ᐳ"}}:::plan
+    PgClassExpression51{{"PgClassExpression[51∈2] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression51 --> List55
+    Lambda24{{"Lambda[24∈2] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List23 --> Lambda24
     PgUpdateSingle15 --> PgClassExpression41
     First47{{"First[47∈2] ➊"}}:::plan
     PgSelect42 --> First47
     First47 --> PgSelectSingle48
     List52{{"List[52∈2] ➊<br />ᐸ51ᐳ"}}:::plan
     List52 --> PgCursor50
-    PgClassExpression51{{"PgClassExpression[51∈2] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression51
     PgClassExpression51 --> List52
-    Lambda518{{"Lambda[518∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object517 --> Lambda518
-    Lambda523{{"Lambda[523∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant814 --> Lambda523
-    Object531 --> Lambda532
-    Constant815 --> Lambda537
+    Lambda56{{"Lambda[56∈2] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List55 --> Lambda56
+    Lambda58{{"Lambda[58∈2] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda58
     PgSelect31[["PgSelect[31∈3] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object18 & PgClassExpression30 & Constant795 & Lambda510 & Lambda513 & Lambda518 & Lambda523 --> PgSelect31
-    List23{{"List[23∈3] ➊<br />ᐸ21,41ᐳ"}}:::plan
-    Constant21 & PgClassExpression41 --> List23
-    Lambda24{{"Lambda[24∈3] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List23 --> Lambda24
+    Object18 & PgClassExpression30 & Constant815 & Lambda510 & Access514 & Lambda519 & Lambda524 --> PgSelect31
     PgClassExpression26{{"PgClassExpression[26∈3] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle15 --> PgClassExpression26
     PgClassExpression27{{"PgClassExpression[27∈3] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -169,63 +285,51 @@ graph TD
     First35 --> PgSelectSingle36
     PgClassExpression38{{"PgClassExpression[38∈3] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle36 --> PgClassExpression38
-    List55{{"List[55∈4] ➊<br />ᐸ21,51ᐳ"}}:::plan
-    Constant21 & PgClassExpression51 --> List55
-    Lambda56{{"Lambda[56∈4] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List55 --> Lambda56
-    Lambda58{{"Lambda[58∈6] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda58
     PgUpdateSingle69[["PgUpdateSingle[69∈7] ➊<br />ᐸperson(id;person_full_name,email)ᐳ"]]:::sideeffectplan
     Object72{{"Object[72∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access67{{"Access[67∈7] ➊<br />ᐸ66.1ᐳ"}}:::plan
     Object72 -->|rejectNull| PgUpdateSingle69
-    Access67 & Constant798 & Constant799 --> PgUpdateSingle69
+    Access67 & Constant818 & Constant819 --> PgUpdateSingle69
     Access70{{"Access[70∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access71{{"Access[71∈7] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access70 & Access71 --> Object72
     Object73{{"Object[73∈7] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgUpdateSingle69 & Constant796 --> Object73
+    PgUpdateSingle69 & Constant816 --> Object73
     Lambda66{{"Lambda[66∈7] ➊<br />ᐸdecode_Person_base64JSONᐳ"}}:::plan
-    Constant797 --> Lambda66
+    Constant817 --> Lambda66
     Lambda66 --> Access67
     __Value2 --> Access70
     __Value2 --> Access71
     PgSelect95[["PgSelect[95∈8] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression94{{"PgClassExpression[94∈8] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda560{{"Lambda[560∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda565{{"Lambda[565∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object72 & PgClassExpression94 & Lambda510 & Lambda513 & Lambda560 & Lambda565 --> PgSelect95
-    Object545{{"Object[545∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant542 & Constant543 & Constant516 --> Object545
-    Object559{{"Object[559∈8] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant556 & Constant557 & Constant516 --> Object559
+    Object72 & PgClassExpression94 & Lambda510 & Access514 & Lambda564 & Lambda569 --> PgSelect95
     Edge102{{"Edge[102∈8] ➊"}}:::plan
     PgSelectSingle101{{"PgSelectSingle[101∈8] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor103{{"PgCursor[103∈8] ➊"}}:::plan
     Connection99{{"Connection[99∈8] ➊<br />ᐸ95ᐳ"}}:::plan
     PgSelectSingle101 & PgCursor103 & Connection99 --> Edge102
+    List76{{"List[76∈8] ➊<br />ᐸ21,94ᐳ"}}:::plan
+    Constant21 & PgClassExpression94 --> List76
+    List108{{"List[108∈8] ➊<br />ᐸ21,104ᐳ"}}:::plan
+    PgClassExpression104{{"PgClassExpression[104∈8] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression104 --> List108
+    Lambda77{{"Lambda[77∈8] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List76 --> Lambda77
     PgUpdateSingle69 --> PgClassExpression94
     First100{{"First[100∈8] ➊"}}:::plan
     PgSelect95 --> First100
     First100 --> PgSelectSingle101
     List105{{"List[105∈8] ➊<br />ᐸ104ᐳ"}}:::plan
     List105 --> PgCursor103
-    PgClassExpression104{{"PgClassExpression[104∈8] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle101 --> PgClassExpression104
     PgClassExpression104 --> List105
-    Lambda546{{"Lambda[546∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object545 --> Lambda546
-    Lambda551{{"Lambda[551∈8] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant816 --> Lambda551
-    Object559 --> Lambda560
-    Constant817 --> Lambda565
+    Lambda109{{"Lambda[109∈8] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List108 --> Lambda109
+    Lambda111{{"Lambda[111∈8] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda111
     PgSelect84[["PgSelect[84∈9] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression83{{"PgClassExpression[83∈9] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object72 & PgClassExpression83 & Constant795 & Lambda510 & Lambda513 & Lambda546 & Lambda551 --> PgSelect84
-    List76{{"List[76∈9] ➊<br />ᐸ21,94ᐳ"}}:::plan
-    Constant21 & PgClassExpression94 --> List76
-    Lambda77{{"Lambda[77∈9] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List76 --> Lambda77
+    Object72 & PgClassExpression83 & Constant815 & Lambda510 & Access514 & Lambda549 & Lambda554 --> PgSelect84
     PgClassExpression79{{"PgClassExpression[79∈9] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle69 --> PgClassExpression79
     PgClassExpression80{{"PgClassExpression[80∈9] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -239,63 +343,51 @@ graph TD
     First88 --> PgSelectSingle89
     PgClassExpression91{{"PgClassExpression[91∈9] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle89 --> PgClassExpression91
-    List108{{"List[108∈10] ➊<br />ᐸ21,104ᐳ"}}:::plan
-    Constant21 & PgClassExpression104 --> List108
-    Lambda109{{"Lambda[109∈10] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List108 --> Lambda109
-    Lambda111{{"Lambda[111∈12] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda111
     PgUpdateSingle121[["PgUpdateSingle[121∈13] ➊<br />ᐸperson(id;about)ᐳ"]]:::sideeffectplan
     Object124{{"Object[124∈13] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access119{{"Access[119∈13] ➊<br />ᐸ118.1ᐳ"}}:::plan
     Object124 -->|rejectNull| PgUpdateSingle121
-    Access119 & Constant801 --> PgUpdateSingle121
+    Access119 & Constant821 --> PgUpdateSingle121
     Access122{{"Access[122∈13] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access123{{"Access[123∈13] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access122 & Access123 --> Object124
     Object125{{"Object[125∈13] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgUpdateSingle121 & Constant800 --> Object125
+    PgUpdateSingle121 & Constant820 --> Object125
     Lambda118{{"Lambda[118∈13] ➊<br />ᐸdecode_Person_base64JSONᐳ"}}:::plan
-    Constant797 --> Lambda118
+    Constant817 --> Lambda118
     Lambda118 --> Access119
     __Value2 --> Access122
     __Value2 --> Access123
     PgSelect147[["PgSelect[147∈14] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression146{{"PgClassExpression[146∈14] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda588{{"Lambda[588∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda593{{"Lambda[593∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object124 & PgClassExpression146 & Lambda510 & Lambda513 & Lambda588 & Lambda593 --> PgSelect147
-    Object573{{"Object[573∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant570 & Constant571 & Constant516 --> Object573
-    Object587{{"Object[587∈14] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant584 & Constant585 & Constant516 --> Object587
+    Object124 & PgClassExpression146 & Lambda510 & Access514 & Lambda594 & Lambda599 --> PgSelect147
     Edge154{{"Edge[154∈14] ➊"}}:::plan
     PgSelectSingle153{{"PgSelectSingle[153∈14] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor155{{"PgCursor[155∈14] ➊"}}:::plan
     Connection151{{"Connection[151∈14] ➊<br />ᐸ147ᐳ"}}:::plan
     PgSelectSingle153 & PgCursor155 & Connection151 --> Edge154
+    List128{{"List[128∈14] ➊<br />ᐸ21,146ᐳ"}}:::plan
+    Constant21 & PgClassExpression146 --> List128
+    List160{{"List[160∈14] ➊<br />ᐸ21,156ᐳ"}}:::plan
+    PgClassExpression156{{"PgClassExpression[156∈14] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression156 --> List160
+    Lambda129{{"Lambda[129∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List128 --> Lambda129
     PgUpdateSingle121 --> PgClassExpression146
     First152{{"First[152∈14] ➊"}}:::plan
     PgSelect147 --> First152
     First152 --> PgSelectSingle153
     List157{{"List[157∈14] ➊<br />ᐸ156ᐳ"}}:::plan
     List157 --> PgCursor155
-    PgClassExpression156{{"PgClassExpression[156∈14] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle153 --> PgClassExpression156
     PgClassExpression156 --> List157
-    Lambda574{{"Lambda[574∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object573 --> Lambda574
-    Lambda579{{"Lambda[579∈14] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant818 --> Lambda579
-    Object587 --> Lambda588
-    Constant819 --> Lambda593
+    Lambda161{{"Lambda[161∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List160 --> Lambda161
+    Lambda163{{"Lambda[163∈14] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda163
     PgSelect136[["PgSelect[136∈15] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression135{{"PgClassExpression[135∈15] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object124 & PgClassExpression135 & Constant795 & Lambda510 & Lambda513 & Lambda574 & Lambda579 --> PgSelect136
-    List128{{"List[128∈15] ➊<br />ᐸ21,146ᐳ"}}:::plan
-    Constant21 & PgClassExpression146 --> List128
-    Lambda129{{"Lambda[129∈15] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List128 --> Lambda129
+    Object124 & PgClassExpression135 & Constant815 & Lambda510 & Access514 & Lambda579 & Lambda584 --> PgSelect136
     PgClassExpression131{{"PgClassExpression[131∈15] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle121 --> PgClassExpression131
     PgClassExpression132{{"PgClassExpression[132∈15] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -309,12 +401,6 @@ graph TD
     First140 --> PgSelectSingle141
     PgClassExpression143{{"PgClassExpression[143∈15] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle141 --> PgClassExpression143
-    List160{{"List[160∈16] ➊<br />ᐸ21,156ᐳ"}}:::plan
-    Constant21 & PgClassExpression156 --> List160
-    Lambda161{{"Lambda[161∈16] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List160 --> Lambda161
-    Lambda163{{"Lambda[163∈18] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda163
     PgUpdateSingle172[["PgUpdateSingle[172∈19] ➊<br />ᐸperson(id;about)ᐳ"]]:::sideeffectplan
     Object175{{"Object[175∈19] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access170{{"Access[170∈19] ➊<br />ᐸ169.1ᐳ"}}:::plan
@@ -324,7 +410,7 @@ graph TD
     Access174{{"Access[174∈19] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access173 & Access174 --> Object175
     Lambda169{{"Lambda[169∈19] ➊<br />ᐸdecode_Person_base64JSONᐳ"}}:::plan
-    Constant797 --> Lambda169
+    Constant817 --> Lambda169
     Lambda169 --> Access170
     __Value2 --> Access173
     __Value2 --> Access174
@@ -332,40 +418,34 @@ graph TD
     PgUpdateSingle172 --> Object176
     PgSelect199[["PgSelect[199∈20] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression198{{"PgClassExpression[198∈20] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda616{{"Lambda[616∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda621{{"Lambda[621∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object175 & PgClassExpression198 & Lambda510 & Lambda513 & Lambda616 & Lambda621 --> PgSelect199
-    Object601{{"Object[601∈20] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant598 & Constant599 & Constant516 --> Object601
-    Object615{{"Object[615∈20] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant612 & Constant613 & Constant516 --> Object615
+    Object175 & PgClassExpression198 & Lambda510 & Access514 & Lambda624 & Lambda629 --> PgSelect199
     Edge206{{"Edge[206∈20] ➊"}}:::plan
     PgSelectSingle205{{"PgSelectSingle[205∈20] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor207{{"PgCursor[207∈20] ➊"}}:::plan
     Connection203{{"Connection[203∈20] ➊<br />ᐸ199ᐳ"}}:::plan
     PgSelectSingle205 & PgCursor207 & Connection203 --> Edge206
+    List180{{"List[180∈20] ➊<br />ᐸ21,198ᐳ"}}:::plan
+    Constant21 & PgClassExpression198 --> List180
+    List212{{"List[212∈20] ➊<br />ᐸ21,208ᐳ"}}:::plan
+    PgClassExpression208{{"PgClassExpression[208∈20] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression208 --> List212
+    Lambda181{{"Lambda[181∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List180 --> Lambda181
     PgUpdateSingle172 --> PgClassExpression198
     First204{{"First[204∈20] ➊"}}:::plan
     PgSelect199 --> First204
     First204 --> PgSelectSingle205
     List209{{"List[209∈20] ➊<br />ᐸ208ᐳ"}}:::plan
     List209 --> PgCursor207
-    PgClassExpression208{{"PgClassExpression[208∈20] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle205 --> PgClassExpression208
     PgClassExpression208 --> List209
-    Lambda602{{"Lambda[602∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object601 --> Lambda602
-    Lambda607{{"Lambda[607∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant820 --> Lambda607
-    Object615 --> Lambda616
-    Constant821 --> Lambda621
+    Lambda213{{"Lambda[213∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List212 --> Lambda213
+    Lambda215{{"Lambda[215∈20] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda215
     PgSelect188[["PgSelect[188∈21] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression187{{"PgClassExpression[187∈21] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object175 & PgClassExpression187 & Constant795 & Lambda510 & Lambda513 & Lambda602 & Lambda607 --> PgSelect188
-    List180{{"List[180∈21] ➊<br />ᐸ21,198ᐳ"}}:::plan
-    Constant21 & PgClassExpression198 --> List180
-    Lambda181{{"Lambda[181∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List180 --> Lambda181
+    Object175 & PgClassExpression187 & Constant815 & Lambda510 & Access514 & Lambda609 & Lambda614 --> PgSelect188
     PgClassExpression183{{"PgClassExpression[183∈21] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle172 --> PgClassExpression183
     PgClassExpression184{{"PgClassExpression[184∈21] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -379,15 +459,9 @@ graph TD
     First192 --> PgSelectSingle193
     PgClassExpression195{{"PgClassExpression[195∈21] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle193 --> PgClassExpression195
-    List212{{"List[212∈22] ➊<br />ᐸ21,208ᐳ"}}:::plan
-    Constant21 & PgClassExpression208 --> List212
-    Lambda213{{"Lambda[213∈22] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List212 --> Lambda213
-    Lambda215{{"Lambda[215∈24] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda215
     PgUpdateSingle222[["PgUpdateSingle[222∈25] ➊<br />ᐸperson(id;person_full_name,about)ᐳ"]]:::sideeffectplan
     Object225{{"Object[225∈25] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object225 & Constant802 & Constant803 & Constant804 --> PgUpdateSingle222
+    Object225 & Constant822 & Constant823 & Constant824 --> PgUpdateSingle222
     Access223{{"Access[223∈25] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access224{{"Access[224∈25] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access223 & Access224 --> Object225
@@ -397,40 +471,34 @@ graph TD
     PgUpdateSingle222 --> Object226
     PgSelect249[["PgSelect[249∈26] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression248{{"PgClassExpression[248∈26] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda644{{"Lambda[644∈26] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda649{{"Lambda[649∈26] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object225 & PgClassExpression248 & Lambda510 & Lambda513 & Lambda644 & Lambda649 --> PgSelect249
-    Object629{{"Object[629∈26] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant626 & Constant627 & Constant516 --> Object629
-    Object643{{"Object[643∈26] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant640 & Constant641 & Constant516 --> Object643
+    Object225 & PgClassExpression248 & Lambda510 & Access514 & Lambda654 & Lambda659 --> PgSelect249
     Edge256{{"Edge[256∈26] ➊"}}:::plan
     PgSelectSingle255{{"PgSelectSingle[255∈26] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor257{{"PgCursor[257∈26] ➊"}}:::plan
     Connection253{{"Connection[253∈26] ➊<br />ᐸ249ᐳ"}}:::plan
     PgSelectSingle255 & PgCursor257 & Connection253 --> Edge256
+    List230{{"List[230∈26] ➊<br />ᐸ21,248ᐳ"}}:::plan
+    Constant21 & PgClassExpression248 --> List230
+    List262{{"List[262∈26] ➊<br />ᐸ21,258ᐳ"}}:::plan
+    PgClassExpression258{{"PgClassExpression[258∈26] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression258 --> List262
+    Lambda231{{"Lambda[231∈26] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List230 --> Lambda231
     PgUpdateSingle222 --> PgClassExpression248
     First254{{"First[254∈26] ➊"}}:::plan
     PgSelect249 --> First254
     First254 --> PgSelectSingle255
     List259{{"List[259∈26] ➊<br />ᐸ258ᐳ"}}:::plan
     List259 --> PgCursor257
-    PgClassExpression258{{"PgClassExpression[258∈26] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle255 --> PgClassExpression258
     PgClassExpression258 --> List259
-    Lambda630{{"Lambda[630∈26] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object629 --> Lambda630
-    Lambda635{{"Lambda[635∈26] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant822 --> Lambda635
-    Object643 --> Lambda644
-    Constant823 --> Lambda649
+    Lambda263{{"Lambda[263∈26] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List262 --> Lambda263
+    Lambda265{{"Lambda[265∈26] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda265
     PgSelect238[["PgSelect[238∈27] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression237{{"PgClassExpression[237∈27] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object225 & PgClassExpression237 & Constant795 & Lambda510 & Lambda513 & Lambda630 & Lambda635 --> PgSelect238
-    List230{{"List[230∈27] ➊<br />ᐸ21,248ᐳ"}}:::plan
-    Constant21 & PgClassExpression248 --> List230
-    Lambda231{{"Lambda[231∈27] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List230 --> Lambda231
+    Object225 & PgClassExpression237 & Constant815 & Lambda510 & Access514 & Lambda639 & Lambda644 --> PgSelect238
     PgClassExpression233{{"PgClassExpression[233∈27] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle222 --> PgClassExpression233
     PgClassExpression234{{"PgClassExpression[234∈27] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -444,15 +512,9 @@ graph TD
     First242 --> PgSelectSingle243
     PgClassExpression245{{"PgClassExpression[245∈27] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle243 --> PgClassExpression245
-    List262{{"List[262∈28] ➊<br />ᐸ21,258ᐳ"}}:::plan
-    Constant21 & PgClassExpression258 --> List262
-    Lambda263{{"Lambda[263∈28] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List262 --> Lambda263
-    Lambda265{{"Lambda[265∈30] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda265
     PgUpdateSingle271[["PgUpdateSingle[271∈31] ➊<br />ᐸperson(email;about)ᐳ"]]:::sideeffectplan
     Object274{{"Object[274∈31] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object274 & Constant805 & Constant806 --> PgUpdateSingle271
+    Object274 & Constant825 & Constant826 --> PgUpdateSingle271
     Access272{{"Access[272∈31] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access273{{"Access[273∈31] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access272 & Access273 --> Object274
@@ -462,40 +524,34 @@ graph TD
     PgUpdateSingle271 --> Object275
     PgSelect298[["PgSelect[298∈32] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression297{{"PgClassExpression[297∈32] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda672{{"Lambda[672∈32] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda677{{"Lambda[677∈32] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object274 & PgClassExpression297 & Lambda510 & Lambda513 & Lambda672 & Lambda677 --> PgSelect298
-    Object657{{"Object[657∈32] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant654 & Constant655 & Constant516 --> Object657
-    Object671{{"Object[671∈32] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant668 & Constant669 & Constant516 --> Object671
+    Object274 & PgClassExpression297 & Lambda510 & Access514 & Lambda684 & Lambda689 --> PgSelect298
     Edge305{{"Edge[305∈32] ➊"}}:::plan
     PgSelectSingle304{{"PgSelectSingle[304∈32] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor306{{"PgCursor[306∈32] ➊"}}:::plan
     Connection302{{"Connection[302∈32] ➊<br />ᐸ298ᐳ"}}:::plan
     PgSelectSingle304 & PgCursor306 & Connection302 --> Edge305
+    List279{{"List[279∈32] ➊<br />ᐸ21,297ᐳ"}}:::plan
+    Constant21 & PgClassExpression297 --> List279
+    List311{{"List[311∈32] ➊<br />ᐸ21,307ᐳ"}}:::plan
+    PgClassExpression307{{"PgClassExpression[307∈32] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression307 --> List311
+    Lambda280{{"Lambda[280∈32] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List279 --> Lambda280
     PgUpdateSingle271 --> PgClassExpression297
     First303{{"First[303∈32] ➊"}}:::plan
     PgSelect298 --> First303
     First303 --> PgSelectSingle304
     List308{{"List[308∈32] ➊<br />ᐸ307ᐳ"}}:::plan
     List308 --> PgCursor306
-    PgClassExpression307{{"PgClassExpression[307∈32] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle304 --> PgClassExpression307
     PgClassExpression307 --> List308
-    Lambda658{{"Lambda[658∈32] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object657 --> Lambda658
-    Lambda663{{"Lambda[663∈32] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant824 --> Lambda663
-    Object671 --> Lambda672
-    Constant825 --> Lambda677
+    Lambda312{{"Lambda[312∈32] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List311 --> Lambda312
+    Lambda314{{"Lambda[314∈32] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda314
     PgSelect287[["PgSelect[287∈33] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression286{{"PgClassExpression[286∈33] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object274 & PgClassExpression286 & Constant795 & Lambda510 & Lambda513 & Lambda658 & Lambda663 --> PgSelect287
-    List279{{"List[279∈33] ➊<br />ᐸ21,297ᐳ"}}:::plan
-    Constant21 & PgClassExpression297 --> List279
-    Lambda280{{"Lambda[280∈33] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List279 --> Lambda280
+    Object274 & PgClassExpression286 & Constant815 & Lambda510 & Access514 & Lambda669 & Lambda674 --> PgSelect287
     PgClassExpression282{{"PgClassExpression[282∈33] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle271 --> PgClassExpression282
     PgClassExpression283{{"PgClassExpression[283∈33] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -509,48 +565,32 @@ graph TD
     First291 --> PgSelectSingle292
     PgClassExpression294{{"PgClassExpression[294∈33] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle292 --> PgClassExpression294
-    List311{{"List[311∈34] ➊<br />ᐸ21,307ᐳ"}}:::plan
-    Constant21 & PgClassExpression307 --> List311
-    Lambda312{{"Lambda[312∈34] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List311 --> Lambda312
-    Lambda314{{"Lambda[314∈36] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda314
     PgUpdateSingle326[["PgUpdateSingle[326∈37] ➊<br />ᐸcompound_key(person_id_1,person_id_2;person_id_1,extra)ᐳ"]]:::sideeffectplan
     Object329{{"Object[329∈37] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access322{{"Access[322∈37] ➊<br />ᐸ321.1ᐳ"}}:::plan
     Access324{{"Access[324∈37] ➊<br />ᐸ321.2ᐳ"}}:::plan
     Object329 -->|rejectNull| PgUpdateSingle326
     Access322 -->|rejectNull| PgUpdateSingle326
-    Access324 & Constant808 & Constant809 --> PgUpdateSingle326
+    Access324 & Constant828 & Constant829 --> PgUpdateSingle326
     Access327{{"Access[327∈37] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access328{{"Access[328∈37] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access327 & Access328 --> Object329
     Lambda321{{"Lambda[321∈37] ➊<br />ᐸdecode_CompoundKey_base64JSONᐳ"}}:::plan
-    Constant807 --> Lambda321
+    Constant827 --> Lambda321
     Lambda321 --> Access322
     Lambda321 --> Access324
     __Value2 --> Access327
     __Value2 --> Access328
     Object330{{"Object[330∈37] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle326 --> Object330
-    Object685{{"Object[685∈38] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant682 & Constant683 & Constant516 --> Object685
-    Object699{{"Object[699∈38] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant696 & Constant697 & Constant516 --> Object699
-    Lambda686{{"Lambda[686∈38] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object685 --> Lambda686
-    Lambda691{{"Lambda[691∈38] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant826 --> Lambda691
-    Lambda700{{"Lambda[700∈38] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object699 --> Lambda700
-    Lambda705{{"Lambda[705∈38] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant827 --> Lambda705
+    Lambda357{{"Lambda[357∈38] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda357
     PgSelect341[["PgSelect[341∈39] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression333{{"PgClassExpression[333∈39] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
-    Object329 & PgClassExpression333 & Lambda510 & Lambda513 & Lambda686 & Lambda691 --> PgSelect341
+    Object329 & PgClassExpression333 & Lambda510 & Access514 & Lambda699 & Lambda704 --> PgSelect341
     PgSelect350[["PgSelect[350∈39] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression334{{"PgClassExpression[334∈39] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
-    Object329 & PgClassExpression334 & Lambda510 & Lambda513 & Lambda700 & Lambda705 --> PgSelect350
+    Object329 & PgClassExpression334 & Lambda510 & Access514 & Lambda714 & Lambda719 --> PgSelect350
     List335{{"List[335∈39] ➊<br />ᐸ332,333,334ᐳ"}}:::plan
     Constant332 & PgClassExpression333 & PgClassExpression334 --> List335
     PgUpdateSingle326 --> PgClassExpression333
@@ -575,36 +615,24 @@ graph TD
     PgSelectSingle353 --> PgClassExpression354
     PgClassExpression355{{"PgClassExpression[355∈41] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle353 --> PgClassExpression355
-    Lambda357{{"Lambda[357∈42] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda357
     PgUpdateSingle366[["PgUpdateSingle[366∈43] ➊<br />ᐸcompound_key(person_id_1,person_id_2;person_id_1,extra)ᐳ"]]:::sideeffectplan
     Object369{{"Object[369∈43] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object369 & Constant808 & Constant808 & Constant802 & Constant511 --> PgUpdateSingle366
+    Object369 & Constant828 & Constant828 & Constant822 & Constant511 --> PgUpdateSingle366
     Access367{{"Access[367∈43] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access368{{"Access[368∈43] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access367 & Access368 --> Object369
     Object370{{"Object[370∈43] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgUpdateSingle366 & Constant796 --> Object370
+    PgUpdateSingle366 & Constant816 --> Object370
     __Value2 --> Access367
     __Value2 --> Access368
-    Object713{{"Object[713∈44] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant710 & Constant711 & Constant516 --> Object713
-    Object727{{"Object[727∈44] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant724 & Constant725 & Constant516 --> Object727
-    Lambda714{{"Lambda[714∈44] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object713 --> Lambda714
-    Lambda719{{"Lambda[719∈44] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant828 --> Lambda719
-    Lambda728{{"Lambda[728∈44] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object727 --> Lambda728
-    Lambda733{{"Lambda[733∈44] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant829 --> Lambda733
+    Lambda396{{"Lambda[396∈44] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda396
     PgSelect380[["PgSelect[380∈45] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression372{{"PgClassExpression[372∈45] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
-    Object369 & PgClassExpression372 & Lambda510 & Lambda513 & Lambda714 & Lambda719 --> PgSelect380
+    Object369 & PgClassExpression372 & Lambda510 & Access514 & Lambda729 & Lambda734 --> PgSelect380
     PgSelect389[["PgSelect[389∈45] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression373{{"PgClassExpression[373∈45] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
-    Object369 & PgClassExpression373 & Lambda510 & Lambda513 & Lambda728 & Lambda733 --> PgSelect389
+    Object369 & PgClassExpression373 & Lambda510 & Access514 & Lambda744 & Lambda749 --> PgSelect389
     List374{{"List[374∈45] ➊<br />ᐸ332,372,373ᐳ"}}:::plan
     Constant332 & PgClassExpression372 & PgClassExpression373 --> List374
     PgUpdateSingle366 --> PgClassExpression372
@@ -629,36 +657,24 @@ graph TD
     PgSelectSingle392 --> PgClassExpression393
     PgClassExpression394{{"PgClassExpression[394∈47] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle392 --> PgClassExpression394
-    Lambda396{{"Lambda[396∈48] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda396
     PgUpdateSingle404[["PgUpdateSingle[404∈49] ➊<br />ᐸcompound_key(person_id_1,person_id_2;extra)ᐳ"]]:::sideeffectplan
     Object407{{"Object[407∈49] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object407 & Constant810 & Constant802 & Constant511 --> PgUpdateSingle404
+    Object407 & Constant830 & Constant822 & Constant511 --> PgUpdateSingle404
     Access405{{"Access[405∈49] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access406{{"Access[406∈49] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access405 & Access406 --> Object407
     Object408{{"Object[408∈49] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
-    PgUpdateSingle404 & Constant800 --> Object408
+    PgUpdateSingle404 & Constant820 --> Object408
     __Value2 --> Access405
     __Value2 --> Access406
-    Object741{{"Object[741∈50] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant738 & Constant739 & Constant516 --> Object741
-    Object755{{"Object[755∈50] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant752 & Constant753 & Constant516 --> Object755
-    Lambda742{{"Lambda[742∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object741 --> Lambda742
-    Lambda747{{"Lambda[747∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant830 --> Lambda747
-    Lambda756{{"Lambda[756∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object755 --> Lambda756
-    Lambda761{{"Lambda[761∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant831 --> Lambda761
+    Lambda434{{"Lambda[434∈50] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda434
     PgSelect418[["PgSelect[418∈51] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression410{{"PgClassExpression[410∈51] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
-    Object407 & PgClassExpression410 & Lambda510 & Lambda513 & Lambda742 & Lambda747 --> PgSelect418
+    Object407 & PgClassExpression410 & Lambda510 & Access514 & Lambda759 & Lambda764 --> PgSelect418
     PgSelect427[["PgSelect[427∈51] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression411{{"PgClassExpression[411∈51] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
-    Object407 & PgClassExpression411 & Lambda510 & Lambda513 & Lambda756 & Lambda761 --> PgSelect427
+    Object407 & PgClassExpression411 & Lambda510 & Access514 & Lambda774 & Lambda779 --> PgSelect427
     List412{{"List[412∈51] ➊<br />ᐸ332,410,411ᐳ"}}:::plan
     Constant332 & PgClassExpression410 & PgClassExpression411 --> List412
     PgUpdateSingle404 --> PgClassExpression410
@@ -683,11 +699,9 @@ graph TD
     PgSelectSingle430 --> PgClassExpression431
     PgClassExpression432{{"PgClassExpression[432∈53] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle430 --> PgClassExpression432
-    Lambda434{{"Lambda[434∈54] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda434
     PgUpdateSingle440[["PgUpdateSingle[440∈55] ➊<br />ᐸperson(email;email)ᐳ"]]:::sideeffectplan
     Object443{{"Object[443∈55] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object443 & Constant795 & Constant811 --> PgUpdateSingle440
+    Object443 & Constant815 & Constant831 --> PgUpdateSingle440
     Access441{{"Access[441∈55] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access442{{"Access[442∈55] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access441 & Access442 --> Object443
@@ -697,40 +711,34 @@ graph TD
     PgUpdateSingle440 --> Object444
     PgSelect467[["PgSelect[467∈56] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression466{{"PgClassExpression[466∈56] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Lambda784{{"Lambda[784∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda789{{"Lambda[789∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object443 & PgClassExpression466 & Lambda510 & Lambda513 & Lambda784 & Lambda789 --> PgSelect467
-    Object769{{"Object[769∈56] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant766 & Constant767 & Constant516 --> Object769
-    Object783{{"Object[783∈56] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda510 & Constant780 & Constant781 & Constant516 --> Object783
+    Object443 & PgClassExpression466 & Lambda510 & Access514 & Lambda804 & Lambda809 --> PgSelect467
     Edge474{{"Edge[474∈56] ➊"}}:::plan
     PgSelectSingle473{{"PgSelectSingle[473∈56] ➊<br />ᐸpersonᐳ"}}:::plan
     PgCursor475{{"PgCursor[475∈56] ➊"}}:::plan
     Connection471{{"Connection[471∈56] ➊<br />ᐸ467ᐳ"}}:::plan
     PgSelectSingle473 & PgCursor475 & Connection471 --> Edge474
+    List448{{"List[448∈56] ➊<br />ᐸ21,466ᐳ"}}:::plan
+    Constant21 & PgClassExpression466 --> List448
+    List480{{"List[480∈56] ➊<br />ᐸ21,476ᐳ"}}:::plan
+    PgClassExpression476{{"PgClassExpression[476∈56] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant21 & PgClassExpression476 --> List480
+    Lambda449{{"Lambda[449∈56] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List448 --> Lambda449
     PgUpdateSingle440 --> PgClassExpression466
     First472{{"First[472∈56] ➊"}}:::plan
     PgSelect467 --> First472
     First472 --> PgSelectSingle473
     List477{{"List[477∈56] ➊<br />ᐸ476ᐳ"}}:::plan
     List477 --> PgCursor475
-    PgClassExpression476{{"PgClassExpression[476∈56] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle473 --> PgClassExpression476
     PgClassExpression476 --> List477
-    Lambda770{{"Lambda[770∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object769 --> Lambda770
-    Lambda775{{"Lambda[775∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant832 --> Lambda775
-    Object783 --> Lambda784
-    Constant833 --> Lambda789
+    Lambda481{{"Lambda[481∈56] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List480 --> Lambda481
+    Lambda483{{"Lambda[483∈56] ➊<br />ᐸrawEncodeᐳ"}}:::plan
+    Constant57 --> Lambda483
     PgSelect456[["PgSelect[456∈57] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression455{{"PgClassExpression[455∈57] ➊<br />ᐸ__person__ᐳ"}}:::plan
-    Object443 & PgClassExpression455 & Constant795 & Lambda510 & Lambda513 & Lambda770 & Lambda775 --> PgSelect456
-    List448{{"List[448∈57] ➊<br />ᐸ21,466ᐳ"}}:::plan
-    Constant21 & PgClassExpression466 --> List448
-    Lambda449{{"Lambda[449∈57] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List448 --> Lambda449
+    Object443 & PgClassExpression455 & Constant815 & Lambda510 & Access514 & Lambda789 & Lambda794 --> PgSelect456
     PgClassExpression451{{"PgClassExpression[451∈57] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgUpdateSingle440 --> PgClassExpression451
     PgClassExpression452{{"PgClassExpression[452∈57] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -744,15 +752,9 @@ graph TD
     First460 --> PgSelectSingle461
     PgClassExpression463{{"PgClassExpression[463∈57] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle461 --> PgClassExpression463
-    List480{{"List[480∈58] ➊<br />ᐸ21,476ᐳ"}}:::plan
-    Constant21 & PgClassExpression476 --> List480
-    Lambda481{{"Lambda[481∈58] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List480 --> Lambda481
-    Lambda483{{"Lambda[483∈60] ➊<br />ᐸrawEncodeᐳ"}}:::plan
-    Constant57 --> Lambda483
     PgUpdateSingle489[["PgUpdateSingle[489∈61] ➊<br />ᐸdefault_value(id;null_value)ᐳ"]]:::sideeffectplan
     Object492{{"Object[492∈61] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object492 & Constant812 & Constant20 --> PgUpdateSingle489
+    Object492 & Constant832 & Constant20 --> PgUpdateSingle489
     Access490{{"Access[490∈61] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access491{{"Access[491∈61] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access490 & Access491 --> Object492
@@ -766,7 +768,7 @@ graph TD
     PgUpdateSingle489 --> PgClassExpression495
     PgUpdateSingle501[["PgUpdateSingle[501∈64] ➊<br />ᐸno_primary_key(id;str)ᐳ"]]:::sideeffectplan
     Object504{{"Object[504∈64] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object504 & Constant812 & Constant813 --> PgUpdateSingle501
+    Object504 & Constant832 & Constant833 --> PgUpdateSingle501
     Access502{{"Access[502∈64] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access503{{"Access[503∈64] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access502 & Access503 --> Object504
@@ -784,122 +786,122 @@ graph TD
     subgraph "Buckets for mutations/v4/mutation-update"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Constant20,Constant21,Constant57,Constant332,Lambda510,Constant511,Lambda513,Constant514,Constant515,Constant516,Constant528,Constant529,Constant542,Constant543,Constant556,Constant557,Constant570,Constant571,Constant584,Constant585,Constant598,Constant599,Constant612,Constant613,Constant626,Constant627,Constant640,Constant641,Constant654,Constant655,Constant668,Constant669,Constant682,Constant683,Constant696,Constant697,Constant710,Constant711,Constant724,Constant725,Constant738,Constant739,Constant752,Constant753,Constant766,Constant767,Constant780,Constant781,Constant790,Constant791,Constant792,Constant793,Constant794,Constant795,Constant796,Constant797,Constant798,Constant799,Constant800,Constant801,Constant802,Constant803,Constant804,Constant805,Constant806,Constant807,Constant808,Constant809,Constant810,Constant811,Constant812,Constant813,Constant814,Constant815,Constant816,Constant817,Constant818,Constant819,Constant820,Constant821,Constant822,Constant823,Constant824,Constant825,Constant826,Constant827,Constant828,Constant829,Constant830,Constant831,Constant832,Constant833 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 791, 792, 510, 513, 514, 515, 516, 814, 528, 529, 815, 21, 795, 57, 4, 20<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Constant20,Constant21,Constant57,Constant332,Lambda510,Constant511,Lambda513,Access514,Constant515,Constant516,Constant517,Object518,Lambda519,Lambda524,Constant530,Constant531,Object533,Lambda534,Lambda539,Constant545,Constant546,Object548,Lambda549,Lambda554,Constant560,Constant561,Object563,Lambda564,Lambda569,Constant575,Constant576,Object578,Lambda579,Lambda584,Constant590,Constant591,Object593,Lambda594,Lambda599,Constant605,Constant606,Object608,Lambda609,Lambda614,Constant620,Constant621,Object623,Lambda624,Lambda629,Constant635,Constant636,Object638,Lambda639,Lambda644,Constant650,Constant651,Object653,Lambda654,Lambda659,Constant665,Constant666,Object668,Lambda669,Lambda674,Constant680,Constant681,Object683,Lambda684,Lambda689,Constant695,Constant696,Object698,Lambda699,Lambda704,Constant710,Constant711,Object713,Lambda714,Lambda719,Constant725,Constant726,Object728,Lambda729,Lambda734,Constant740,Constant741,Object743,Lambda744,Lambda749,Constant755,Constant756,Object758,Lambda759,Lambda764,Constant770,Constant771,Object773,Lambda774,Lambda779,Constant785,Constant786,Object788,Lambda789,Lambda794,Constant800,Constant801,Object803,Lambda804,Lambda809,Constant810,Constant811,Constant812,Constant813,Constant814,Constant815,Constant816,Constant817,Constant818,Constant819,Constant820,Constant821,Constant822,Constant823,Constant824,Constant825,Constant826,Constant827,Constant828,Constant829,Constant830,Constant831,Constant832,Constant833,Constant834,Constant835,Constant836,Constant837,Constant838,Constant839,Constant840,Constant841,Constant842,Constant843,Constant844,Constant845,Constant846,Constant847,Constant848,Constant849,Constant850,Constant851,Constant852,Constant853 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 811, 812, 21, 510, 514, 534, 539, 57, 815, 519, 524, 4, 20<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle15,Object19 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 15, 18, 510, 513, 514, 515, 516, 814, 528, 529, 815, 19, 21, 795, 57, 4, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]<br />1: <br />ᐳ: 41, 46, 517, 523, 531, 537, 518, 532<br />2: PgSelect[42]<br />ᐳ: 47, 48, 51, 52, 50, 49"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 15, 18, 510, 514, 534, 539, 57, 19, 815, 519, 524, 4, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]<br />1: <br />ᐳ: 41, 46, 58, 23, 24<br />2: PgSelect[42]<br />ᐳ: 47, 48, 51, 52, 55, 56, 50, 49"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression41,PgSelect42,Connection46,First47,PgSelectSingle48,Edge49,PgCursor50,PgClassExpression51,List52,Object517,Lambda518,Lambda523,Object531,Lambda532,Lambda537 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 41, 15, 18, 795, 510, 513, 518, 523<br /><br />ROOT PgUpdateSingle{1}ᐸperson(id;person_full_name,about)ᐳ[15]<br />1: <br />ᐳ: 23, 26, 27, 28, 30, 24<br />2: PgSelect[31]<br />ᐳ: 35, 36, 38"):::bucket
+    class Bucket2,List23,Lambda24,PgClassExpression41,PgSelect42,Connection46,First47,PgSelectSingle48,Edge49,PgCursor50,PgClassExpression51,List52,List55,Lambda56,Lambda58 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 18, 815, 510, 514, 519, 524, 24, 41<br /><br />ROOT PgUpdateSingle{1}ᐸperson(id;person_full_name,about)ᐳ[15]<br />1: <br />ᐳ: 26, 27, 28, 30<br />2: PgSelect[31]<br />ᐳ: 35, 36, 38"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,List23,Lambda24,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression30,PgSelect31,First35,PgSelectSingle36,PgClassExpression38 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 21, 51, 49, 48, 50<br /><br />ROOT Edge{2}[49]"):::bucket
+    class Bucket3,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression30,PgSelect31,First35,PgSelectSingle36,PgClassExpression38 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 49, 48, 50, 56, 51<br /><br />ROOT Edge{2}[49]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,List55,Lambda56 bucket4
+    class Bucket4 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 48, 56, 51<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[48]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 4, 58<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Lambda58 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 797, 798, 799, 2, 796, 510, 513, 542, 543, 516, 816, 556, 557, 817, 21, 795, 57, 4<br /><br />1: Access[70]<br />2: Access[71]<br />3: Object[72]<br />4: Lambda[66]<br />5: Access[67]<br />6: PgUpdateSingle[69]<br />7: <br />ᐳ: Object[73]"):::bucket
+    class Bucket6 bucket6
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 817, 818, 819, 2, 816, 21, 510, 514, 564, 569, 57, 815, 549, 554, 4<br /><br />1: Access[70]<br />2: Access[71]<br />3: Object[72]<br />4: Lambda[66]<br />5: Access[67]<br />6: PgUpdateSingle[69]<br />7: <br />ᐳ: Object[73]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,Lambda66,Access67,PgUpdateSingle69,Access70,Access71,Object72,Object73 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 69, 72, 510, 513, 542, 543, 516, 816, 556, 557, 817, 73, 21, 795, 57, 4, 796<br /><br />ROOT Object{7}ᐸ{result,clientMutationId}ᐳ[73]<br />1: <br />ᐳ: 94, 99, 545, 551, 559, 565, 546, 560<br />2: PgSelect[95]<br />ᐳ: 100, 101, 104, 105, 103, 102"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 21, 69, 72, 510, 514, 564, 569, 57, 73, 815, 549, 554, 4, 816<br /><br />ROOT Object{7}ᐸ{result,clientMutationId}ᐳ[73]<br />1: <br />ᐳ: 94, 99, 111, 76, 77<br />2: PgSelect[95]<br />ᐳ: 100, 101, 104, 105, 108, 109, 103, 102"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression94,PgSelect95,Connection99,First100,PgSelectSingle101,Edge102,PgCursor103,PgClassExpression104,List105,Object545,Lambda546,Lambda551,Object559,Lambda560,Lambda565 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 21, 94, 69, 72, 795, 510, 513, 546, 551<br /><br />ROOT PgUpdateSingle{7}ᐸperson(id;person_full_name,email)ᐳ[69]<br />1: <br />ᐳ: 76, 79, 80, 81, 83, 77<br />2: PgSelect[84]<br />ᐳ: 88, 89, 91"):::bucket
+    class Bucket8,List76,Lambda77,PgClassExpression94,PgSelect95,Connection99,First100,PgSelectSingle101,Edge102,PgCursor103,PgClassExpression104,List105,List108,Lambda109,Lambda111 bucket8
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 69, 72, 815, 510, 514, 549, 554, 77, 94<br /><br />ROOT PgUpdateSingle{7}ᐸperson(id;person_full_name,email)ᐳ[69]<br />1: <br />ᐳ: 79, 80, 81, 83<br />2: PgSelect[84]<br />ᐳ: 88, 89, 91"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,List76,Lambda77,PgClassExpression79,PgClassExpression80,PgClassExpression81,PgClassExpression83,PgSelect84,First88,PgSelectSingle89,PgClassExpression91 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 21, 104, 102, 101, 103<br /><br />ROOT Edge{8}[102]"):::bucket
+    class Bucket9,PgClassExpression79,PgClassExpression80,PgClassExpression81,PgClassExpression83,PgSelect84,First88,PgSelectSingle89,PgClassExpression91 bucket9
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 102, 101, 103, 109, 104<br /><br />ROOT Edge{8}[102]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,List108,Lambda109 bucket10
+    class Bucket10 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 101, 109, 104<br /><br />ROOT PgSelectSingle{8}ᐸpersonᐳ[101]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 4, 111<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,Lambda111 bucket12
-    Bucket13("Bucket 13 (mutationField)<br />Deps: 797, 801, 2, 800, 510, 513, 570, 571, 516, 818, 584, 585, 819, 21, 795, 57, 4<br /><br />1: Access[122]<br />2: Access[123]<br />3: Object[124]<br />4: Lambda[118]<br />5: Access[119]<br />6: PgUpdateSingle[121]<br />7: <br />ᐳ: Object[125]"):::bucket
+    class Bucket12 bucket12
+    Bucket13("Bucket 13 (mutationField)<br />Deps: 817, 821, 2, 820, 21, 510, 514, 594, 599, 57, 815, 579, 584, 4<br /><br />1: Access[122]<br />2: Access[123]<br />3: Object[124]<br />4: Lambda[118]<br />5: Access[119]<br />6: PgUpdateSingle[121]<br />7: <br />ᐳ: Object[125]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,Lambda118,Access119,PgUpdateSingle121,Access122,Access123,Object124,Object125 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 121, 124, 510, 513, 570, 571, 516, 818, 584, 585, 819, 125, 21, 795, 57, 4, 800<br /><br />ROOT Object{13}ᐸ{result,clientMutationId}ᐳ[125]<br />1: <br />ᐳ: 146, 151, 573, 579, 587, 593, 574, 588<br />2: PgSelect[147]<br />ᐳ: 152, 153, 156, 157, 155, 154"):::bucket
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 21, 121, 124, 510, 514, 594, 599, 57, 125, 815, 579, 584, 4, 820<br /><br />ROOT Object{13}ᐸ{result,clientMutationId}ᐳ[125]<br />1: <br />ᐳ: 146, 151, 163, 128, 129<br />2: PgSelect[147]<br />ᐳ: 152, 153, 156, 157, 160, 161, 155, 154"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression146,PgSelect147,Connection151,First152,PgSelectSingle153,Edge154,PgCursor155,PgClassExpression156,List157,Object573,Lambda574,Lambda579,Object587,Lambda588,Lambda593 bucket14
-    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 21, 146, 121, 124, 795, 510, 513, 574, 579<br /><br />ROOT PgUpdateSingle{13}ᐸperson(id;about)ᐳ[121]<br />1: <br />ᐳ: 128, 131, 132, 133, 135, 129<br />2: PgSelect[136]<br />ᐳ: 140, 141, 143"):::bucket
+    class Bucket14,List128,Lambda129,PgClassExpression146,PgSelect147,Connection151,First152,PgSelectSingle153,Edge154,PgCursor155,PgClassExpression156,List157,List160,Lambda161,Lambda163 bucket14
+    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 121, 124, 815, 510, 514, 579, 584, 129, 146<br /><br />ROOT PgUpdateSingle{13}ᐸperson(id;about)ᐳ[121]<br />1: <br />ᐳ: 131, 132, 133, 135<br />2: PgSelect[136]<br />ᐳ: 140, 141, 143"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,List128,Lambda129,PgClassExpression131,PgClassExpression132,PgClassExpression133,PgClassExpression135,PgSelect136,First140,PgSelectSingle141,PgClassExpression143 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 21, 156, 154, 153, 155<br /><br />ROOT Edge{14}[154]"):::bucket
+    class Bucket15,PgClassExpression131,PgClassExpression132,PgClassExpression133,PgClassExpression135,PgSelect136,First140,PgSelectSingle141,PgClassExpression143 bucket15
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 154, 153, 155, 161, 156<br /><br />ROOT Edge{14}[154]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,List160,Lambda161 bucket16
+    class Bucket16 bucket16
     Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 153, 161, 156<br /><br />ROOT PgSelectSingle{14}ᐸpersonᐳ[153]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 4, 163<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,Lambda163 bucket18
-    Bucket19("Bucket 19 (mutationField)<br />Deps: 797, 20, 2, 510, 513, 598, 599, 516, 820, 612, 613, 821, 21, 795, 57, 4<br /><br />1: Access[173]<br />2: Access[174]<br />3: Object[175]<br />4: Lambda[169]<br />5: Access[170]<br />6: PgUpdateSingle[172]<br />7: <br />ᐳ: Object[176]"):::bucket
+    class Bucket18 bucket18
+    Bucket19("Bucket 19 (mutationField)<br />Deps: 817, 20, 2, 21, 510, 514, 624, 629, 57, 815, 609, 614, 4<br /><br />1: Access[173]<br />2: Access[174]<br />3: Object[175]<br />4: Lambda[169]<br />5: Access[170]<br />6: PgUpdateSingle[172]<br />7: <br />ᐳ: Object[176]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,Lambda169,Access170,PgUpdateSingle172,Access173,Access174,Object175,Object176 bucket19
-    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 172, 175, 510, 513, 598, 599, 516, 820, 612, 613, 821, 176, 21, 795, 57, 4, 20<br /><br />ROOT Object{19}ᐸ{result}ᐳ[176]<br />1: <br />ᐳ: 198, 203, 601, 607, 615, 621, 602, 616<br />2: PgSelect[199]<br />ᐳ: 204, 205, 208, 209, 207, 206"):::bucket
+    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 21, 172, 175, 510, 514, 624, 629, 57, 176, 815, 609, 614, 4, 20<br /><br />ROOT Object{19}ᐸ{result}ᐳ[176]<br />1: <br />ᐳ: 198, 203, 215, 180, 181<br />2: PgSelect[199]<br />ᐳ: 204, 205, 208, 209, 212, 213, 207, 206"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression198,PgSelect199,Connection203,First204,PgSelectSingle205,Edge206,PgCursor207,PgClassExpression208,List209,Object601,Lambda602,Lambda607,Object615,Lambda616,Lambda621 bucket20
-    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 21, 198, 172, 175, 795, 510, 513, 602, 607<br /><br />ROOT PgUpdateSingle{19}ᐸperson(id;about)ᐳ[172]<br />1: <br />ᐳ: 180, 183, 184, 185, 187, 181<br />2: PgSelect[188]<br />ᐳ: 192, 193, 195"):::bucket
+    class Bucket20,List180,Lambda181,PgClassExpression198,PgSelect199,Connection203,First204,PgSelectSingle205,Edge206,PgCursor207,PgClassExpression208,List209,List212,Lambda213,Lambda215 bucket20
+    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 172, 175, 815, 510, 514, 609, 614, 181, 198<br /><br />ROOT PgUpdateSingle{19}ᐸperson(id;about)ᐳ[172]<br />1: <br />ᐳ: 183, 184, 185, 187<br />2: PgSelect[188]<br />ᐳ: 192, 193, 195"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,List180,Lambda181,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression187,PgSelect188,First192,PgSelectSingle193,PgClassExpression195 bucket21
-    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 21, 208, 206, 205, 207<br /><br />ROOT Edge{20}[206]"):::bucket
+    class Bucket21,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression187,PgSelect188,First192,PgSelectSingle193,PgClassExpression195 bucket21
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 206, 205, 207, 213, 208<br /><br />ROOT Edge{20}[206]"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,List212,Lambda213 bucket22
+    class Bucket22 bucket22
     Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 205, 213, 208<br /><br />ROOT PgSelectSingle{20}ᐸpersonᐳ[205]"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23 bucket23
-    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 4, 215<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket24 stroke:#808000
-    class Bucket24,Lambda215 bucket24
-    Bucket25("Bucket 25 (mutationField)<br />Deps: 802, 803, 804, 2, 510, 513, 626, 627, 516, 822, 640, 641, 823, 21, 795, 57, 4, 20<br /><br />1: Access[223]<br />2: Access[224]<br />3: Object[225]<br />4: PgUpdateSingle[222]<br />5: <br />ᐳ: Object[226]"):::bucket
+    class Bucket24 bucket24
+    Bucket25("Bucket 25 (mutationField)<br />Deps: 822, 823, 824, 2, 21, 510, 514, 654, 659, 57, 815, 639, 644, 4, 20<br /><br />1: Access[223]<br />2: Access[224]<br />3: Object[225]<br />4: PgUpdateSingle[222]<br />5: <br />ᐳ: Object[226]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgUpdateSingle222,Access223,Access224,Object225,Object226 bucket25
-    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 222, 225, 510, 513, 626, 627, 516, 822, 640, 641, 823, 226, 21, 795, 57, 4, 20<br /><br />ROOT Object{25}ᐸ{result}ᐳ[226]<br />1: <br />ᐳ: 248, 253, 629, 635, 643, 649, 630, 644<br />2: PgSelect[249]<br />ᐳ: 254, 255, 258, 259, 257, 256"):::bucket
+    Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 21, 222, 225, 510, 514, 654, 659, 57, 226, 815, 639, 644, 4, 20<br /><br />ROOT Object{25}ᐸ{result}ᐳ[226]<br />1: <br />ᐳ: 248, 253, 265, 230, 231<br />2: PgSelect[249]<br />ᐳ: 254, 255, 258, 259, 262, 263, 257, 256"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,PgClassExpression248,PgSelect249,Connection253,First254,PgSelectSingle255,Edge256,PgCursor257,PgClassExpression258,List259,Object629,Lambda630,Lambda635,Object643,Lambda644,Lambda649 bucket26
-    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 21, 248, 222, 225, 795, 510, 513, 630, 635<br /><br />ROOT PgUpdateSingle{25}ᐸperson(id;person_full_name,about)ᐳ[222]<br />1: <br />ᐳ: 230, 233, 234, 235, 237, 231<br />2: PgSelect[238]<br />ᐳ: 242, 243, 245"):::bucket
+    class Bucket26,List230,Lambda231,PgClassExpression248,PgSelect249,Connection253,First254,PgSelectSingle255,Edge256,PgCursor257,PgClassExpression258,List259,List262,Lambda263,Lambda265 bucket26
+    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 222, 225, 815, 510, 514, 639, 644, 231, 248<br /><br />ROOT PgUpdateSingle{25}ᐸperson(id;person_full_name,about)ᐳ[222]<br />1: <br />ᐳ: 233, 234, 235, 237<br />2: PgSelect[238]<br />ᐳ: 242, 243, 245"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,List230,Lambda231,PgClassExpression233,PgClassExpression234,PgClassExpression235,PgClassExpression237,PgSelect238,First242,PgSelectSingle243,PgClassExpression245 bucket27
-    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 21, 258, 256, 255, 257<br /><br />ROOT Edge{26}[256]"):::bucket
+    class Bucket27,PgClassExpression233,PgClassExpression234,PgClassExpression235,PgClassExpression237,PgSelect238,First242,PgSelectSingle243,PgClassExpression245 bucket27
+    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 256, 255, 257, 263, 258<br /><br />ROOT Edge{26}[256]"):::bucket
     classDef bucket28 stroke:#00ffff
-    class Bucket28,List262,Lambda263 bucket28
+    class Bucket28 bucket28
     Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 255, 263, 258<br /><br />ROOT PgSelectSingle{26}ᐸpersonᐳ[255]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29 bucket29
-    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 4, 265<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket30 stroke:#3cb371
-    class Bucket30,Lambda265 bucket30
-    Bucket31("Bucket 31 (mutationField)<br />Deps: 805, 806, 2, 510, 513, 654, 655, 516, 824, 668, 669, 825, 21, 795, 57, 4, 20<br /><br />1: Access[272]<br />2: Access[273]<br />3: Object[274]<br />4: PgUpdateSingle[271]<br />5: <br />ᐳ: Object[275]"):::bucket
+    class Bucket30 bucket30
+    Bucket31("Bucket 31 (mutationField)<br />Deps: 825, 826, 2, 21, 510, 514, 684, 689, 57, 815, 669, 674, 4, 20<br /><br />1: Access[272]<br />2: Access[273]<br />3: Object[274]<br />4: PgUpdateSingle[271]<br />5: <br />ᐳ: Object[275]"):::bucket
     classDef bucket31 stroke:#a52a2a
     class Bucket31,PgUpdateSingle271,Access272,Access273,Object274,Object275 bucket31
-    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 271, 274, 510, 513, 654, 655, 516, 824, 668, 669, 825, 275, 21, 795, 57, 4, 20<br /><br />ROOT Object{31}ᐸ{result}ᐳ[275]<br />1: <br />ᐳ: 297, 302, 657, 663, 671, 677, 658, 672<br />2: PgSelect[298]<br />ᐳ: 303, 304, 307, 308, 306, 305"):::bucket
+    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 21, 271, 274, 510, 514, 684, 689, 57, 275, 815, 669, 674, 4, 20<br /><br />ROOT Object{31}ᐸ{result}ᐳ[275]<br />1: <br />ᐳ: 297, 302, 314, 279, 280<br />2: PgSelect[298]<br />ᐳ: 303, 304, 307, 308, 311, 312, 306, 305"):::bucket
     classDef bucket32 stroke:#ff00ff
-    class Bucket32,PgClassExpression297,PgSelect298,Connection302,First303,PgSelectSingle304,Edge305,PgCursor306,PgClassExpression307,List308,Object657,Lambda658,Lambda663,Object671,Lambda672,Lambda677 bucket32
-    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 21, 297, 271, 274, 795, 510, 513, 658, 663<br /><br />ROOT PgUpdateSingle{31}ᐸperson(email;about)ᐳ[271]<br />1: <br />ᐳ: 279, 282, 283, 284, 286, 280<br />2: PgSelect[287]<br />ᐳ: 291, 292, 294"):::bucket
+    class Bucket32,List279,Lambda280,PgClassExpression297,PgSelect298,Connection302,First303,PgSelectSingle304,Edge305,PgCursor306,PgClassExpression307,List308,List311,Lambda312,Lambda314 bucket32
+    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 271, 274, 815, 510, 514, 669, 674, 280, 297<br /><br />ROOT PgUpdateSingle{31}ᐸperson(email;about)ᐳ[271]<br />1: <br />ᐳ: 282, 283, 284, 286<br />2: PgSelect[287]<br />ᐳ: 291, 292, 294"):::bucket
     classDef bucket33 stroke:#f5deb3
-    class Bucket33,List279,Lambda280,PgClassExpression282,PgClassExpression283,PgClassExpression284,PgClassExpression286,PgSelect287,First291,PgSelectSingle292,PgClassExpression294 bucket33
-    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 21, 307, 305, 304, 306<br /><br />ROOT Edge{32}[305]"):::bucket
+    class Bucket33,PgClassExpression282,PgClassExpression283,PgClassExpression284,PgClassExpression286,PgSelect287,First291,PgSelectSingle292,PgClassExpression294 bucket33
+    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 305, 304, 306, 312, 307<br /><br />ROOT Edge{32}[305]"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,List311,Lambda312 bucket34
+    class Bucket34 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 304, 312, 307<br /><br />ROOT PgSelectSingle{32}ᐸpersonᐳ[304]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35 bucket35
-    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 4, 314<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket36 stroke:#7f007f
-    class Bucket36,Lambda314 bucket36
-    Bucket37("Bucket 37 (mutationField)<br />Deps: 807, 808, 809, 2, 510, 682, 683, 516, 826, 696, 697, 827, 332, 513, 57, 4, 20<br /><br />1: Access[327]<br />2: Access[328]<br />3: Object[329]<br />4: Lambda[321]<br />5: Access[322]<br />6: Access[324]<br />7: PgUpdateSingle[326]<br />8: <br />ᐳ: Object[330]"):::bucket
+    class Bucket36 bucket36
+    Bucket37("Bucket 37 (mutationField)<br />Deps: 827, 828, 829, 2, 57, 332, 510, 514, 699, 704, 714, 719, 4, 20<br /><br />1: Access[327]<br />2: Access[328]<br />3: Object[329]<br />4: Lambda[321]<br />5: Access[322]<br />6: Access[324]<br />7: PgUpdateSingle[326]<br />8: <br />ᐳ: Object[330]"):::bucket
     classDef bucket37 stroke:#ffa500
     class Bucket37,Lambda321,Access322,Access324,PgUpdateSingle326,Access327,Access328,Object329,Object330 bucket37
-    Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 510, 682, 683, 516, 826, 696, 697, 827, 330, 326, 332, 329, 513, 57, 4, 20<br /><br />ROOT Object{37}ᐸ{result}ᐳ[330]"):::bucket
+    Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 57, 330, 326, 332, 329, 510, 514, 699, 704, 714, 719, 4, 20<br /><br />ROOT Object{37}ᐸ{result}ᐳ[330]"):::bucket
     classDef bucket38 stroke:#0000ff
-    class Bucket38,Object685,Lambda686,Lambda691,Object699,Lambda700,Lambda705 bucket38
-    Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 326, 332, 329, 510, 513, 686, 691, 700, 705<br /><br />ROOT PgUpdateSingle{37}ᐸcompound_key(person_id_1,person_id_2;person_id_1,extra)ᐳ[326]<br />1: <br />ᐳ: 333, 334, 339, 335, 336<br />2: PgSelect[341], PgSelect[350]<br />ᐳ: 345, 346, 352, 353"):::bucket
+    class Bucket38,Lambda357 bucket38
+    Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 326, 332, 329, 510, 514, 699, 704, 714, 719<br /><br />ROOT PgUpdateSingle{37}ᐸcompound_key(person_id_1,person_id_2;person_id_1,extra)ᐳ[326]<br />1: <br />ᐳ: 333, 334, 339, 335, 336<br />2: PgSelect[341], PgSelect[350]<br />ᐳ: 345, 346, 352, 353"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,PgClassExpression333,PgClassExpression334,List335,Lambda336,PgClassExpression339,PgSelect341,First345,PgSelectSingle346,PgSelect350,First352,PgSelectSingle353 bucket39
     Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 346<br /><br />ROOT PgSelectSingle{39}ᐸpersonᐳ[346]"):::bucket
@@ -908,16 +910,16 @@ graph TD
     Bucket41("Bucket 41 (nullableBoundary)<br />Deps: 353<br /><br />ROOT PgSelectSingle{39}ᐸpersonᐳ[353]"):::bucket
     classDef bucket41 stroke:#808000
     class Bucket41,PgClassExpression354,PgClassExpression355 bucket41
-    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 4, 357<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket42 stroke:#dda0dd
-    class Bucket42,Lambda357 bucket42
-    Bucket43("Bucket 43 (mutationField)<br />Deps: 808, 802, 511, 2, 796, 510, 710, 711, 516, 828, 724, 725, 829, 332, 513, 57, 4<br /><br />1: Access[367]<br />2: Access[368]<br />3: Object[369]<br />4: PgUpdateSingle[366]<br />5: <br />ᐳ: Object[370]"):::bucket
+    class Bucket42 bucket42
+    Bucket43("Bucket 43 (mutationField)<br />Deps: 828, 822, 511, 2, 816, 57, 332, 510, 514, 729, 734, 744, 749, 4<br /><br />1: Access[367]<br />2: Access[368]<br />3: Object[369]<br />4: PgUpdateSingle[366]<br />5: <br />ᐳ: Object[370]"):::bucket
     classDef bucket43 stroke:#ff0000
     class Bucket43,PgUpdateSingle366,Access367,Access368,Object369,Object370 bucket43
-    Bucket44("Bucket 44 (nullableBoundary)<br />Deps: 510, 710, 711, 516, 828, 724, 725, 829, 370, 366, 332, 369, 513, 57, 4, 796<br /><br />ROOT Object{43}ᐸ{result,clientMutationId}ᐳ[370]"):::bucket
+    Bucket44("Bucket 44 (nullableBoundary)<br />Deps: 57, 370, 366, 332, 369, 510, 514, 729, 734, 744, 749, 4, 816<br /><br />ROOT Object{43}ᐸ{result,clientMutationId}ᐳ[370]"):::bucket
     classDef bucket44 stroke:#ffff00
-    class Bucket44,Object713,Lambda714,Lambda719,Object727,Lambda728,Lambda733 bucket44
-    Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 366, 332, 369, 510, 513, 714, 719, 728, 733<br /><br />ROOT PgUpdateSingle{43}ᐸcompound_key(person_id_1,person_id_2;person_id_1,extra)ᐳ[366]<br />1: <br />ᐳ: 372, 373, 378, 374, 375<br />2: PgSelect[380], PgSelect[389]<br />ᐳ: 384, 385, 391, 392"):::bucket
+    class Bucket44,Lambda396 bucket44
+    Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 366, 332, 369, 510, 514, 729, 734, 744, 749<br /><br />ROOT PgUpdateSingle{43}ᐸcompound_key(person_id_1,person_id_2;person_id_1,extra)ᐳ[366]<br />1: <br />ᐳ: 372, 373, 378, 374, 375<br />2: PgSelect[380], PgSelect[389]<br />ᐳ: 384, 385, 391, 392"):::bucket
     classDef bucket45 stroke:#00ffff
     class Bucket45,PgClassExpression372,PgClassExpression373,List374,Lambda375,PgClassExpression378,PgSelect380,First384,PgSelectSingle385,PgSelect389,First391,PgSelectSingle392 bucket45
     Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 385<br /><br />ROOT PgSelectSingle{45}ᐸpersonᐳ[385]"):::bucket
@@ -926,16 +928,16 @@ graph TD
     Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 392<br /><br />ROOT PgSelectSingle{45}ᐸpersonᐳ[392]"):::bucket
     classDef bucket47 stroke:#3cb371
     class Bucket47,PgClassExpression393,PgClassExpression394 bucket47
-    Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 4, 396<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket48 stroke:#a52a2a
-    class Bucket48,Lambda396 bucket48
-    Bucket49("Bucket 49 (mutationField)<br />Deps: 810, 802, 511, 2, 800, 510, 738, 739, 516, 830, 752, 753, 831, 332, 513, 57, 4<br /><br />1: Access[405]<br />2: Access[406]<br />3: Object[407]<br />4: PgUpdateSingle[404]<br />5: <br />ᐳ: Object[408]"):::bucket
+    class Bucket48 bucket48
+    Bucket49("Bucket 49 (mutationField)<br />Deps: 830, 822, 511, 2, 820, 57, 332, 510, 514, 759, 764, 774, 779, 4<br /><br />1: Access[405]<br />2: Access[406]<br />3: Object[407]<br />4: PgUpdateSingle[404]<br />5: <br />ᐳ: Object[408]"):::bucket
     classDef bucket49 stroke:#ff00ff
     class Bucket49,PgUpdateSingle404,Access405,Access406,Object407,Object408 bucket49
-    Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 510, 738, 739, 516, 830, 752, 753, 831, 408, 404, 332, 407, 513, 57, 4, 800<br /><br />ROOT Object{49}ᐸ{result,clientMutationId}ᐳ[408]"):::bucket
+    Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 57, 408, 404, 332, 407, 510, 514, 759, 764, 774, 779, 4, 820<br /><br />ROOT Object{49}ᐸ{result,clientMutationId}ᐳ[408]"):::bucket
     classDef bucket50 stroke:#f5deb3
-    class Bucket50,Object741,Lambda742,Lambda747,Object755,Lambda756,Lambda761 bucket50
-    Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 404, 332, 407, 510, 513, 742, 747, 756, 761<br /><br />ROOT PgUpdateSingle{49}ᐸcompound_key(person_id_1,person_id_2;extra)ᐳ[404]<br />1: <br />ᐳ: 410, 411, 416, 412, 413<br />2: PgSelect[418], PgSelect[427]<br />ᐳ: 422, 423, 429, 430"):::bucket
+    class Bucket50,Lambda434 bucket50
+    Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 404, 332, 407, 510, 514, 759, 764, 774, 779<br /><br />ROOT PgUpdateSingle{49}ᐸcompound_key(person_id_1,person_id_2;extra)ᐳ[404]<br />1: <br />ᐳ: 410, 411, 416, 412, 413<br />2: PgSelect[418], PgSelect[427]<br />ᐳ: 422, 423, 429, 430"):::bucket
     classDef bucket51 stroke:#696969
     class Bucket51,PgClassExpression410,PgClassExpression411,List412,Lambda413,PgClassExpression416,PgSelect418,First422,PgSelectSingle423,PgSelect427,First429,PgSelectSingle430 bucket51
     Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 423<br /><br />ROOT PgSelectSingle{51}ᐸpersonᐳ[423]"):::bucket
@@ -944,28 +946,28 @@ graph TD
     Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 430<br /><br />ROOT PgSelectSingle{51}ᐸpersonᐳ[430]"):::bucket
     classDef bucket53 stroke:#7f007f
     class Bucket53,PgClassExpression431,PgClassExpression432 bucket53
-    Bucket54("Bucket 54 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket54("Bucket 54 (nullableBoundary)<br />Deps: 4, 434<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket54 stroke:#ffa500
-    class Bucket54,Lambda434 bucket54
-    Bucket55("Bucket 55 (mutationField)<br />Deps: 795, 811, 2, 510, 513, 766, 767, 516, 832, 780, 781, 833, 21, 57, 4, 20<br /><br />1: Access[441]<br />2: Access[442]<br />3: Object[443]<br />4: PgUpdateSingle[440]<br />5: <br />ᐳ: Object[444]"):::bucket
+    class Bucket54 bucket54
+    Bucket55("Bucket 55 (mutationField)<br />Deps: 815, 831, 2, 21, 510, 514, 804, 809, 57, 789, 794, 4, 20<br /><br />1: Access[441]<br />2: Access[442]<br />3: Object[443]<br />4: PgUpdateSingle[440]<br />5: <br />ᐳ: Object[444]"):::bucket
     classDef bucket55 stroke:#0000ff
     class Bucket55,PgUpdateSingle440,Access441,Access442,Object443,Object444 bucket55
-    Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 440, 443, 510, 513, 766, 767, 516, 832, 780, 781, 833, 444, 21, 795, 57, 4, 20<br /><br />ROOT Object{55}ᐸ{result}ᐳ[444]<br />1: <br />ᐳ: 466, 471, 769, 775, 783, 789, 770, 784<br />2: PgSelect[467]<br />ᐳ: 472, 473, 476, 477, 475, 474"):::bucket
+    Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 21, 440, 443, 510, 514, 804, 809, 57, 444, 815, 789, 794, 4, 20<br /><br />ROOT Object{55}ᐸ{result}ᐳ[444]<br />1: <br />ᐳ: 466, 471, 483, 448, 449<br />2: PgSelect[467]<br />ᐳ: 472, 473, 476, 477, 480, 481, 475, 474"):::bucket
     classDef bucket56 stroke:#7fff00
-    class Bucket56,PgClassExpression466,PgSelect467,Connection471,First472,PgSelectSingle473,Edge474,PgCursor475,PgClassExpression476,List477,Object769,Lambda770,Lambda775,Object783,Lambda784,Lambda789 bucket56
-    Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 21, 466, 440, 443, 795, 510, 513, 770, 775<br /><br />ROOT PgUpdateSingle{55}ᐸperson(email;email)ᐳ[440]<br />1: <br />ᐳ: 448, 451, 452, 453, 455, 449<br />2: PgSelect[456]<br />ᐳ: 460, 461, 463"):::bucket
+    class Bucket56,List448,Lambda449,PgClassExpression466,PgSelect467,Connection471,First472,PgSelectSingle473,Edge474,PgCursor475,PgClassExpression476,List477,List480,Lambda481,Lambda483 bucket56
+    Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 440, 443, 815, 510, 514, 789, 794, 449, 466<br /><br />ROOT PgUpdateSingle{55}ᐸperson(email;email)ᐳ[440]<br />1: <br />ᐳ: 451, 452, 453, 455<br />2: PgSelect[456]<br />ᐳ: 460, 461, 463"):::bucket
     classDef bucket57 stroke:#ff1493
-    class Bucket57,List448,Lambda449,PgClassExpression451,PgClassExpression452,PgClassExpression453,PgClassExpression455,PgSelect456,First460,PgSelectSingle461,PgClassExpression463 bucket57
-    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 21, 476, 474, 473, 475<br /><br />ROOT Edge{56}[474]"):::bucket
+    class Bucket57,PgClassExpression451,PgClassExpression452,PgClassExpression453,PgClassExpression455,PgSelect456,First460,PgSelectSingle461,PgClassExpression463 bucket57
+    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 474, 473, 475, 481, 476<br /><br />ROOT Edge{56}[474]"):::bucket
     classDef bucket58 stroke:#808000
-    class Bucket58,List480,Lambda481 bucket58
+    class Bucket58 bucket58
     Bucket59("Bucket 59 (nullableBoundary)<br />Deps: 473, 481, 476<br /><br />ROOT PgSelectSingle{56}ᐸpersonᐳ[473]"):::bucket
     classDef bucket59 stroke:#dda0dd
     class Bucket59 bucket59
-    Bucket60("Bucket 60 (nullableBoundary)<br />Deps: 57, 4<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    Bucket60("Bucket 60 (nullableBoundary)<br />Deps: 4, 483<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket60 stroke:#ff0000
-    class Bucket60,Lambda483 bucket60
-    Bucket61("Bucket 61 (mutationField)<br />Deps: 812, 20, 2<br /><br />1: Access[490]<br />2: Access[491]<br />3: Object[492]<br />4: PgUpdateSingle[489]<br />5: <br />ᐳ: Object[493]"):::bucket
+    class Bucket60 bucket60
+    Bucket61("Bucket 61 (mutationField)<br />Deps: 832, 20, 2<br /><br />1: Access[490]<br />2: Access[491]<br />3: Object[492]<br />4: PgUpdateSingle[489]<br />5: <br />ᐳ: Object[493]"):::bucket
     classDef bucket61 stroke:#ffff00
     class Bucket61,PgUpdateSingle489,Access490,Access491,Object492,Object493 bucket61
     Bucket62("Bucket 62 (nullableBoundary)<br />Deps: 493, 489<br /><br />ROOT Object{61}ᐸ{result}ᐳ[493]"):::bucket
@@ -974,7 +976,7 @@ graph TD
     Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 489<br /><br />ROOT PgUpdateSingle{61}ᐸdefault_value(id;null_value)ᐳ[489]"):::bucket
     classDef bucket63 stroke:#4169e1
     class Bucket63,PgClassExpression494,PgClassExpression495 bucket63
-    Bucket64("Bucket 64 (mutationField)<br />Deps: 812, 813, 2<br /><br />1: Access[502]<br />2: Access[503]<br />3: Object[504]<br />4: PgUpdateSingle[501]<br />5: <br />ᐳ: Object[505]"):::bucket
+    Bucket64("Bucket 64 (mutationField)<br />Deps: 832, 833, 2<br /><br />1: Access[502]<br />2: Access[503]<br />3: Object[504]<br />4: PgUpdateSingle[501]<br />5: <br />ᐳ: Object[505]"):::bucket
     classDef bucket64 stroke:#3cb371
     class Bucket64,PgUpdateSingle501,Access502,Access503,Object504,Object505 bucket64
     Bucket65("Bucket 65 (nullableBoundary)<br />Deps: 505, 501<br /><br />ROOT Object{64}ᐸ{result}ᐳ[505]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.createT.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.createT.mermaid
@@ -9,11 +9,11 @@ graph TD
 
 
     %% plan dependencies
-    List153{{"List[153∈0] ➊<br />ᐸ57,122,185,185,185,185,185,185ᐳ"}}:::plan
+    List153{{"List[153∈0] ➊<br />ᐸ57,122,186,186,186,186,186,186ᐳ"}}:::plan
     List57{{"List[57∈0] ➊<br />ᐸ32ᐳ"}}:::plan
     List122{{"List[122∈0] ➊<br />ᐸ67,97ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    List57 & List122 & Constant185 & Constant185 & Constant185 & Constant185 & Constant185 & Constant185 --> List153
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    List57 & List122 & Constant186 & Constant186 & Constant186 & Constant186 & Constant186 & Constant186 --> List153
     Object32{{"Object[32∈0] ➊<br />ᐸ{from_hours,from_minutes,to_hours,to_minutes}ᐳ"}}:::plan
     Access37{{"Access[37∈0] ➊<br />ᐸ0.input.t.v.0.0.fromHoursᐳ"}}:::plan
     Access43{{"Access[43∈0] ➊<br />ᐸ0.input.t.v.0.0.fromMinutesᐳ"}}:::plan
@@ -32,6 +32,12 @@ graph TD
     Access114{{"Access[114∈0] ➊<br />ᐸ0.input.t.v.1.1.toHoursᐳ"}}:::plan
     Access120{{"Access[120∈0] ➊<br />ᐸ0.input.t.v.1.1.toMinutesᐳ"}}:::plan
     Access102 & Access108 & Access114 & Access120 --> Object97
+    Object179{{"Object[179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”frmcdc_work_hour”)ᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸDomainCodecᐸworkHourPartsᐳ(workHour)ᐳ"}}:::plan
+    Lambda171 & Constant176 & Constant177 & Constant178 --> Object179
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -54,34 +60,30 @@ graph TD
     __Value0 --> Access108
     __Value0 --> Access114
     __Value0 --> Access120
-    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant186 --> Lambda171
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸsql.identifier(”frmcdc_work_hour”)ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸDomainCodecᐸworkHourPartsᐳ(workHour)ᐳ"}}:::plan
     Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant187 --> Lambda171
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant188 --> Lambda174
+    Access175{{"Access[175∈0] ➊<br />ᐸ174.0ᐳ"}}:::plan
+    Lambda174 --> Access175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object179 --> Lambda180
+    Lambda185{{"Lambda[185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant189 --> Lambda185
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgInsertSingle8[["PgInsertSingle[8∈1] ➊<br />ᐸt(v)ᐳ"]]:::sideeffectplan
     Object11 & List153 --> PgInsertSingle8
     Object12{{"Object[12∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle8 --> Object12
-    Object178{{"Object[178∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda171 & Constant175 & Constant176 & Constant177 --> Object178
-    Lambda174{{"Lambda[174∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant187 --> Lambda174
-    Lambda179{{"Lambda[179∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object178 --> Lambda179
-    Lambda184{{"Lambda[184∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant188 --> Lambda184
     PgClassExpression154{{"PgClassExpression[154∈3] ➊<br />ᐸ__t__.”k”ᐳ"}}:::plan
     PgInsertSingle8 --> PgClassExpression154
     PgClassExpression155{{"PgClassExpression[155∈3] ➊<br />ᐸ__t__.”v”ᐳ"}}:::plan
     PgInsertSingle8 --> PgClassExpression155
     PgSelect159[["PgSelect[159∈5]<br />ᐸfrmcdc_workHourᐳ"]]:::plan
     __Item158[/"__Item[158∈5]<br />ᐸ155ᐳ"\]:::itemplan
-    Object11 & __Item158 & Lambda171 & Lambda174 & Lambda179 & Lambda184 --> PgSelect159
+    Object11 & __Item158 & Lambda171 & Access175 & Lambda180 & Lambda185 --> PgSelect159
     PgClassExpression155 ==> __Item158
     __Item163[/"__Item[163∈6]<br />ᐸ159ᐳ"\]:::itemplan
     PgSelect159 ==> __Item163
@@ -101,17 +103,17 @@ graph TD
     subgraph "Buckets for mutations/v4/nested_arrays.createT"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,Access9,Access10,Object11,Object32,Access37,Access43,Access49,Access55,List57,Object67,Access72,Access78,Access84,Access90,Object97,Access102,Access108,Access114,Access120,List122,List153,Lambda171,Constant175,Constant176,Constant177,Constant185,Constant186,Constant187,Constant188 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 153, 187, 171, 175, 176, 177, 188<br /><br />1: PgInsertSingle[8]<br />2: <br />ᐳ: Object[12]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,Access9,Access10,Object11,Object32,Access37,Access43,Access49,Access55,List57,Object67,Access72,Access78,Access84,Access90,Object97,Access102,Access108,Access114,Access120,List122,List153,Lambda171,Lambda174,Access175,Constant176,Constant177,Constant178,Object179,Lambda180,Lambda185,Constant186,Constant187,Constant188,Constant189 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 153, 171, 175, 180, 185<br /><br />1: PgInsertSingle[8]<br />2: <br />ᐳ: Object[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle8,Object12 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 187, 171, 175, 176, 177, 188, 12, 8, 11<br /><br />ROOT Object{1}ᐸ{result}ᐳ[12]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 8, 11, 171, 175, 180, 185<br /><br />ROOT Object{1}ᐸ{result}ᐳ[12]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda174,Object178,Lambda179,Lambda184 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 8, 11, 171, 174, 179, 184<br /><br />ROOT PgInsertSingle{1}ᐸt(v)ᐳ[8]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 8, 11, 171, 175, 180, 185<br /><br />ROOT PgInsertSingle{1}ᐸt(v)ᐳ[8]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression154,PgClassExpression155 bucket3
-    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 171, 174, 179, 184<br /><br />ROOT __Item{5}ᐸ155ᐳ[158]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 11, 171, 175, 180, 185<br /><br />ROOT __Item{5}ᐸ155ᐳ[158]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item158,PgSelect159 bucket5
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ159ᐳ[163]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.updateT.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/nested_arrays.updateT.mermaid
@@ -9,11 +9,11 @@ graph TD
 
 
     %% plan dependencies
-    List157{{"List[157∈0] ➊<br />ᐸ61,126,189,189,189,189,189,189ᐳ"}}:::plan
+    List157{{"List[157∈0] ➊<br />ᐸ61,126,190,190,190,190,190,190ᐳ"}}:::plan
     List61{{"List[61∈0] ➊<br />ᐸ36ᐳ"}}:::plan
     List126{{"List[126∈0] ➊<br />ᐸ71,101ᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    List61 & List126 & Constant189 & Constant189 & Constant189 & Constant189 & Constant189 & Constant189 --> List157
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    List61 & List126 & Constant190 & Constant190 & Constant190 & Constant190 & Constant190 & Constant190 --> List157
     Object36{{"Object[36∈0] ➊<br />ᐸ{from_hours,from_minutes,to_hours,to_minutes}ᐳ"}}:::plan
     Access41{{"Access[41∈0] ➊<br />ᐸ0.input.tPatch.v.0.0.fromHoursᐳ"}}:::plan
     Access47{{"Access[47∈0] ➊<br />ᐸ0.input.tPatch.v.0.0.fromMinutesᐳ"}}:::plan
@@ -32,6 +32,12 @@ graph TD
     Access118{{"Access[118∈0] ➊<br />ᐸ0.input.tPatch.v.1.1.toHoursᐳ"}}:::plan
     Access124{{"Access[124∈0] ➊<br />ᐸ0.input.tPatch.v.1.1.toMinutesᐳ"}}:::plan
     Access106 & Access112 & Access118 & Access124 --> Object101
+    Object183{{"Object[183∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸsql.identifier(”frmcdc_work_hour”)ᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸDomainCodecᐸworkHourPartsᐳ(workHour)ᐳ"}}:::plan
+    Lambda175 & Constant180 & Constant181 & Constant182 --> Object183
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -56,34 +62,30 @@ graph TD
     __Value0 --> Access112
     __Value0 --> Access118
     __Value0 --> Access124
-    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant190 --> Lambda175
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸsql.identifier(”frmcdc_work_hour”)ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸDomainCodecᐸworkHourPartsᐳ(workHour)ᐳ"}}:::plan
     Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant191 --> Lambda175
+    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant192 --> Lambda178
+    Access179{{"Access[179∈0] ➊<br />ᐸ178.0ᐳ"}}:::plan
+    Lambda178 --> Access179
+    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object183 --> Lambda184
+    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant193 --> Lambda189
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgUpdateSingle10[["PgUpdateSingle[10∈1] ➊<br />ᐸt(k;v)ᐳ"]]:::sideeffectplan
     Object13 & Access8 & List157 --> PgUpdateSingle10
     Object14{{"Object[14∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle10 --> Object14
-    Object182{{"Object[182∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda175 & Constant179 & Constant180 & Constant181 --> Object182
-    Lambda178{{"Lambda[178∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant191 --> Lambda178
-    Lambda183{{"Lambda[183∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object182 --> Lambda183
-    Lambda188{{"Lambda[188∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant192 --> Lambda188
     PgClassExpression158{{"PgClassExpression[158∈3] ➊<br />ᐸ__t__.”k”ᐳ"}}:::plan
     PgUpdateSingle10 --> PgClassExpression158
     PgClassExpression159{{"PgClassExpression[159∈3] ➊<br />ᐸ__t__.”v”ᐳ"}}:::plan
     PgUpdateSingle10 --> PgClassExpression159
     PgSelect163[["PgSelect[163∈5]<br />ᐸfrmcdc_workHourᐳ"]]:::plan
     __Item162[/"__Item[162∈5]<br />ᐸ159ᐳ"\]:::itemplan
-    Object13 & __Item162 & Lambda175 & Lambda178 & Lambda183 & Lambda188 --> PgSelect163
+    Object13 & __Item162 & Lambda175 & Access179 & Lambda184 & Lambda189 --> PgSelect163
     PgClassExpression159 ==> __Item162
     __Item167[/"__Item[167∈6]<br />ᐸ163ᐳ"\]:::itemplan
     PgSelect163 ==> __Item167
@@ -103,17 +105,17 @@ graph TD
     subgraph "Buckets for mutations/v4/nested_arrays.updateT"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,Access8,Access11,Access12,Object13,Object36,Access41,Access47,Access53,Access59,List61,Object71,Access76,Access82,Access88,Access94,Object101,Access106,Access112,Access118,Access124,List126,List157,Lambda175,Constant179,Constant180,Constant181,Constant189,Constant190,Constant191,Constant192 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 13, 8, 157, 191, 175, 179, 180, 181, 192<br /><br />1: PgUpdateSingle[10]<br />2: <br />ᐳ: Object[14]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,Access8,Access11,Access12,Object13,Object36,Access41,Access47,Access53,Access59,List61,Object71,Access76,Access82,Access88,Access94,Object101,Access106,Access112,Access118,Access124,List126,List157,Lambda175,Lambda178,Access179,Constant180,Constant181,Constant182,Object183,Lambda184,Lambda189,Constant190,Constant191,Constant192,Constant193 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 13, 8, 157, 175, 179, 184, 189<br /><br />1: PgUpdateSingle[10]<br />2: <br />ᐳ: Object[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle10,Object14 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 191, 175, 179, 180, 181, 192, 14, 10, 13<br /><br />ROOT Object{1}ᐸ{result}ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 10, 13, 175, 179, 184, 189<br /><br />ROOT Object{1}ᐸ{result}ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda178,Object182,Lambda183,Lambda188 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 10, 13, 175, 178, 183, 188<br /><br />ROOT PgUpdateSingle{1}ᐸt(k;v)ᐳ[10]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 10, 13, 175, 179, 184, 189<br /><br />ROOT PgUpdateSingle{1}ᐸt(k;v)ᐳ[10]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression158,PgClassExpression159 bucket3
-    Bucket5("Bucket 5 (listItem)<br />Deps: 13, 175, 178, 183, 188<br /><br />ROOT __Item{5}ᐸ159ᐳ[162]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 13, 175, 179, 184, 189<br /><br />ROOT __Item{5}ᐸ159ᐳ[162]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item162,PgSelect163 bucket5
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ163ᐳ[167]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/normal.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/normal.mermaid
@@ -9,12 +9,12 @@ graph TD
 
 
     %% plan dependencies
-    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object33{{"Object[33∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”authenticate”)ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
-    Lambda25 & Constant29 & Constant30 & Constant31 --> Object32
+    Constant30{{"Constant[30∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸsql.identifier(”authenticate”)ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
+    Lambda25 & Constant30 & Constant31 & Constant32 --> Object33
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,22 +22,24 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant42 --> Lambda25
-    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
     Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant43 --> Lambda28
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object32 --> Lambda33
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
-    Constant44 --> Lambda38
+    Constant43 --> Lambda25
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant44 --> Lambda28
+    Access29{{"Access[29∈0] ➊<br />ᐸ28.0ᐳ"}}:::plan
+    Lambda28 --> Access29
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object33 --> Lambda34
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
+    Constant45 --> Lambda39
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ'2'ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ'3'ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ'2'ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ'3'ᐳ"}}:::plan
     PgSelect11[["PgSelect[11∈1] ➊<br />ᐸauthenticate(mutation)ᐳ"]]:::sideeffectplan
-    Object14 & Constant39 & Constant40 & Constant41 & Lambda25 & Lambda28 & Lambda33 & Lambda38 --> PgSelect11
+    Object14 & Constant40 & Constant41 & Constant42 & Lambda25 & Access29 & Lambda34 & Lambda39 --> PgSelect11
     First15{{"First[15∈1] ➊"}}:::plan
     PgSelect11 --> First15
     PgSelectSingle16{{"PgSelectSingle[16∈1] ➊<br />ᐸauthenticateᐳ"}}:::plan
@@ -60,8 +62,8 @@ graph TD
     subgraph "Buckets for mutations/v4/normal"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda25,Lambda28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42,Constant43,Constant44 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 39, 40, 41, 25, 28, 33, 38<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda25,Lambda28,Access29,Constant30,Constant31,Constant32,Object33,Lambda34,Lambda39,Constant40,Constant41,Constant42,Constant43,Constant44,Constant45 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 40, 41, 42, 25, 29, 34, 39<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect11,First15,PgSelectSingle16,Object17 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 16<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.mermaid
@@ -9,6 +9,16 @@ graph TD
 
 
     %% plan dependencies
+    Object63{{"Object[63∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda55 & Constant60 & Constant61 & Constant62 --> Object63
+    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Lambda55 & Constant75 & Constant76 & Constant62 --> Object78
     Object16{{"Object[16∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,38 +26,36 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access14
     __Value2 --> Access15
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant88 --> Lambda55
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant90 --> Lambda55
     Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant89 --> Lambda58
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant91 --> Lambda58
+    Access59{{"Access[59∈0] ➊<br />ᐸ58.0ᐳ"}}:::plan
+    Lambda58 --> Access59
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object63 --> Lambda64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant92 --> Lambda69
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object78 --> Lambda79
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant93 --> Lambda84
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ'2023-05-24T07:43:00Z'ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ'temp'ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ12.7ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ13ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ'2023-05-24T07:43:00Z'ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ'temp'ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ12.7ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ13ᐳ"}}:::plan
     PgInsertSingle13[["PgInsertSingle[13∈1] ➊<br />ᐸmeasurements(timestamp,key,value,user_id)ᐳ"]]:::sideeffectplan
-    Object16 & Constant83 & Constant84 & Constant85 & Constant86 --> PgInsertSingle13
+    Object16 & Constant85 & Constant86 & Constant87 & Constant88 --> PgInsertSingle13
     Object17{{"Object[17∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle13 --> Object17
-    Object62{{"Object[62∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda55 & Constant59 & Constant60 & Constant61 --> Object62
-    Lambda63{{"Lambda[63∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object62 --> Lambda63
-    Lambda68{{"Lambda[68∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant90 --> Lambda68
     PgSelect22[["PgSelect[22∈3] ➊<br />ᐸusersᐳ"]]:::plan
     PgClassExpression21{{"PgClassExpression[21∈3] ➊<br />ᐸ__measurem....”user_id”ᐳ"}}:::plan
-    Object16 & PgClassExpression21 & Lambda55 & Lambda58 & Lambda63 & Lambda68 --> PgSelect22
+    Object16 & PgClassExpression21 & Lambda55 & Access59 & Lambda64 & Lambda69 --> PgSelect22
     PgClassExpression18{{"PgClassExpression[18∈3] ➊<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
     PgInsertSingle13 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3] ➊<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
@@ -65,7 +73,7 @@ graph TD
     PgSelectSingle27 --> PgClassExpression29
     PgUpdateSingle36[["PgUpdateSingle[36∈5] ➊<br />ᐸmeasurements(timestamp,key;value)ᐳ"]]:::sideeffectplan
     Object39{{"Object[39∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object39 & Constant83 & Constant84 & Constant87 --> PgUpdateSingle36
+    Object39 & Constant85 & Constant86 & Constant89 --> PgUpdateSingle36
     Access37{{"Access[37∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access38{{"Access[38∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access37 & Access38 --> Object39
@@ -73,15 +81,9 @@ graph TD
     __Value2 --> Access38
     Object40{{"Object[40∈5] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle36 --> Object40
-    Object76{{"Object[76∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda55 & Constant73 & Constant74 & Constant61 --> Object76
-    Lambda77{{"Lambda[77∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object76 --> Lambda77
-    Lambda82{{"Lambda[82∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant91 --> Lambda82
     PgSelect45[["PgSelect[45∈7] ➊<br />ᐸusersᐳ"]]:::plan
     PgClassExpression44{{"PgClassExpression[44∈7] ➊<br />ᐸ__measurem....”user_id”ᐳ"}}:::plan
-    Object39 & PgClassExpression44 & Lambda55 & Lambda58 & Lambda77 & Lambda82 --> PgSelect45
+    Object39 & PgClassExpression44 & Lambda55 & Access59 & Lambda79 & Lambda84 --> PgSelect45
     PgClassExpression41{{"PgClassExpression[41∈7] ➊<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
     PgUpdateSingle36 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈7] ➊<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
@@ -103,26 +105,26 @@ graph TD
     subgraph "Buckets for mutations/v4/partitions.unqualified"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access14,Access15,Object16,Lambda55,Lambda58,Constant59,Constant60,Constant61,Constant73,Constant74,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 16, 83, 84, 85, 86, 55, 59, 60, 61, 90, 58<br /><br />1: PgInsertSingle[13]<br />2: <br />ᐳ: Object[17]"):::bucket
+    class Bucket0,__Value2,__Value4,Access14,Access15,Object16,Lambda55,Lambda58,Access59,Constant60,Constant61,Constant62,Object63,Lambda64,Lambda69,Constant75,Constant76,Object78,Lambda79,Lambda84,Constant85,Constant86,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92,Constant93 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 16, 85, 86, 87, 88, 55, 59, 64, 69<br /><br />1: PgInsertSingle[13]<br />2: <br />ᐳ: Object[17]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle13,Object17 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 55, 59, 60, 61, 90, 17, 13, 16, 58<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 13, 16, 55, 59, 64, 69<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Object62,Lambda63,Lambda68 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 16, 55, 58, 63, 68<br /><br />ROOT PgInsertSingle{1}ᐸmeasurements(timestamp,key,value,user_id)ᐳ[13]<br />1: <br />ᐳ: 18, 19, 20, 21<br />2: PgSelect[22]<br />ᐳ: First[26], PgSelectSingle[27]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 16, 55, 59, 64, 69<br /><br />ROOT PgInsertSingle{1}ᐸmeasurements(timestamp,key,value,user_id)ᐳ[13]<br />1: <br />ᐳ: 18, 19, 20, 21<br />2: PgSelect[22]<br />ᐳ: First[26], PgSelectSingle[27]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgSelect22,First26,PgSelectSingle27 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 27<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[27]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression28,PgClassExpression29 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 83, 84, 87, 2, 55, 73, 74, 61, 91, 58<br /><br />1: Access[37]<br />2: Access[38]<br />3: Object[39]<br />4: PgUpdateSingle[36]<br />5: <br />ᐳ: Object[40]"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 85, 86, 89, 2, 55, 59, 79, 84<br /><br />1: Access[37]<br />2: Access[38]<br />3: Object[39]<br />4: PgUpdateSingle[36]<br />5: <br />ᐳ: Object[40]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgUpdateSingle36,Access37,Access38,Object39,Object40 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 55, 73, 74, 61, 91, 40, 36, 39, 58<br /><br />ROOT Object{5}ᐸ{result}ᐳ[40]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 40, 36, 39, 55, 59, 79, 84<br /><br />ROOT Object{5}ᐸ{result}ᐳ[40]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Object76,Lambda77,Lambda82 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 36, 39, 55, 58, 77, 82<br /><br />ROOT PgUpdateSingle{5}ᐸmeasurements(timestamp,key;value)ᐳ[36]<br />1: <br />ᐳ: 41, 42, 43, 44<br />2: PgSelect[45]<br />ᐳ: First[49], PgSelectSingle[50]"):::bucket
+    class Bucket6 bucket6
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 36, 39, 55, 59, 79, 84<br /><br />ROOT PgUpdateSingle{5}ᐸmeasurements(timestamp,key;value)ᐳ[36]<br />1: <br />ᐳ: 41, 42, 43, 44<br />2: PgSelect[45]<br />ᐳ: First[49], PgSelectSingle[50]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44,PgSelect45,First49,PgSelectSingle50 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 50<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[50]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/pg11.types.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/pg11.types.mermaid
@@ -9,6 +9,16 @@ graph TD
 
 
     %% plan dependencies
+    Object91{{"Object[91∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸDomainCodecᐸcompoundTypeᐳ(domainConstrainedCompoundType)ᐳ"}}:::plan
+    Lambda83 & Constant88 & Constant89 & Constant90 --> Object91
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
+    Lambda83 & Constant103 & Constant104 & Constant90 --> Object106
     Object21{{"Object[21∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access19{{"Access[19∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access20{{"Access[20∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,40 +26,38 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access19
     __Value2 --> Access20
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant120 --> Lambda83
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant122 --> Lambda83
     Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant121 --> Lambda86
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant123 --> Lambda86
+    Access87{{"Access[87∈0] ➊<br />ᐸ86.0ᐳ"}}:::plan
+    Lambda86 --> Access87
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object91 --> Lambda92
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant124 --> Lambda97
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object106 --> Lambda107
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant125 --> Lambda112
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸDomainCodecᐸcompoundTypeᐳ(domainConstrainedCompoundType)ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ'postgraphile_test_authenticator'ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ'pg11'ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ'postgraphile_test_visitor'ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ'c'ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ'postgraphile_test_authenticator'ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'pg11'ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ'postgraphile_test_visitor'ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ'c'ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
     PgUpdateSingle18[["PgUpdateSingle[18∈1] ➊<br />ᐸtypes(id;regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ"]]:::sideeffectplan
-    Object21 & Constant111 & Constant112 & Constant113 & Constant124 & Constant125 --> PgUpdateSingle18
+    Object21 & Constant113 & Constant114 & Constant115 & Constant126 & Constant127 --> PgUpdateSingle18
     Object22{{"Object[22∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle18 --> Object22
-    Object90{{"Object[90∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant87 & Constant88 & Constant89 --> Object90
-    Lambda91{{"Lambda[91∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object90 --> Lambda91
-    Lambda96{{"Lambda[96∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant122 --> Lambda96
     PgSelect31[["PgSelect[31∈3] ➊<br />ᐸfrmcdc_domainConstrainedCompoundTypeᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object21 & PgClassExpression30 & Lambda83 & Lambda86 & Lambda91 & Lambda96 --> PgSelect31
+    Object21 & PgClassExpression30 & Lambda83 & Access87 & Lambda92 & Lambda97 --> PgSelect31
     PgClassExpression25{{"PgClassExpression[25∈3] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     PgUpdateSingle18 --> PgClassExpression25
     PgClassExpression26{{"PgClassExpression[26∈3] ➊<br />ᐸ__types__.”regrole”ᐳ"}}:::plan
@@ -81,7 +89,7 @@ graph TD
     PgSelectSingle36 --> PgClassExpression43
     PgInsertSingle55[["PgInsertSingle[55∈6] ➊<br />ᐸtypes(regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ"]]:::sideeffectplan
     Object58{{"Object[58∈6] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object58 & Constant118 & Constant119 & Constant124 & Constant125 --> PgInsertSingle55
+    Object58 & Constant120 & Constant121 & Constant126 & Constant127 --> PgInsertSingle55
     Access56{{"Access[56∈6] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access57{{"Access[57∈6] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access56 & Access57 --> Object58
@@ -89,15 +97,9 @@ graph TD
     __Value2 --> Access57
     Object59{{"Object[59∈6] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle55 --> Object59
-    Object104{{"Object[104∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda83 & Constant101 & Constant102 & Constant89 --> Object104
-    Lambda105{{"Lambda[105∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 --> Lambda105
-    Lambda110{{"Lambda[110∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant123 --> Lambda110
     PgSelect68[["PgSelect[68∈8] ➊<br />ᐸfrmcdc_domainConstrainedCompoundTypeᐳ"]]:::plan
     PgClassExpression67{{"PgClassExpression[67∈8] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object58 & PgClassExpression67 & Lambda83 & Lambda86 & Lambda105 & Lambda110 --> PgSelect68
+    Object58 & PgClassExpression67 & Lambda83 & Access87 & Lambda107 & Lambda112 --> PgSelect68
     PgClassExpression62{{"PgClassExpression[62∈8] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     PgInsertSingle55 --> PgClassExpression62
     PgClassExpression63{{"PgClassExpression[63∈8] ➊<br />ᐸ__types__.”regrole”ᐳ"}}:::plan
@@ -133,14 +135,14 @@ graph TD
     subgraph "Buckets for mutations/v4/pg11.types"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access19,Access20,Object21,Lambda83,Lambda86,Constant87,Constant88,Constant89,Constant101,Constant102,Constant111,Constant112,Constant113,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 21, 111, 112, 113, 124, 125, 83, 87, 88, 89, 122, 86<br /><br />1: PgUpdateSingle[18]<br />2: <br />ᐳ: Object[22]"):::bucket
+    class Bucket0,__Value2,__Value4,Access19,Access20,Object21,Lambda83,Lambda86,Access87,Constant88,Constant89,Constant90,Object91,Lambda92,Lambda97,Constant103,Constant104,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125,Constant126,Constant127 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 21, 113, 114, 115, 126, 127, 83, 87, 92, 97<br /><br />1: PgUpdateSingle[18]<br />2: <br />ᐳ: Object[22]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle18,Object22 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 83, 87, 88, 89, 122, 22, 18, 21, 86<br /><br />ROOT Object{1}ᐸ{result}ᐳ[22]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 22, 18, 21, 83, 87, 92, 97<br /><br />ROOT Object{1}ᐸ{result}ᐳ[22]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Object90,Lambda91,Lambda96 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 21, 83, 86, 91, 96<br /><br />ROOT PgUpdateSingle{1}ᐸtypes(id;regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ[18]<br />1: <br />ᐳ: 25, 26, 27, 28, 30<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 21, 83, 87, 92, 97<br /><br />ROOT PgUpdateSingle{1}ᐸtypes(id;regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ[18]<br />1: <br />ᐳ: 25, 26, 27, 28, 30<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression25,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression30,PgSelect31,First35,PgSelectSingle36 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
@@ -149,13 +151,13 @@ graph TD
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_domainConstrainedCompoundTypeᐳ[36]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43 bucket5
-    Bucket6("Bucket 6 (mutationField)<br />Deps: 118, 119, 124, 125, 2, 83, 101, 102, 89, 123, 86<br /><br />1: Access[56]<br />2: Access[57]<br />3: Object[58]<br />4: PgInsertSingle[55]<br />5: <br />ᐳ: Object[59]"):::bucket
+    Bucket6("Bucket 6 (mutationField)<br />Deps: 120, 121, 126, 127, 2, 83, 87, 107, 112<br /><br />1: Access[56]<br />2: Access[57]<br />3: Object[58]<br />4: PgInsertSingle[55]<br />5: <br />ᐳ: Object[59]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgInsertSingle55,Access56,Access57,Object58,Object59 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 83, 101, 102, 89, 123, 59, 55, 58, 86<br /><br />ROOT Object{6}ᐸ{result}ᐳ[59]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 59, 55, 58, 83, 87, 107, 112<br /><br />ROOT Object{6}ᐸ{result}ᐳ[59]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Object104,Lambda105,Lambda110 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 55, 58, 83, 86, 105, 110<br /><br />ROOT PgInsertSingle{6}ᐸtypes(regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ[55]<br />1: <br />ᐳ: 62, 63, 64, 65, 67<br />2: PgSelect[68]<br />ᐳ: First[72], PgSelectSingle[73]"):::bucket
+    class Bucket7 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 55, 58, 83, 87, 107, 112<br /><br />ROOT PgInsertSingle{6}ᐸtypes(regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ[55]<br />1: <br />ᐳ: 62, 63, 64, 65, 67<br />2: PgSelect[68]<br />ᐳ: First[72], PgSelectSingle[73]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgClassExpression67,PgSelect68,First72,PgSelectSingle73 bucket8
     Bucket9("Bucket 9 (listItem)<br /><br />ROOT __Item{9}ᐸ65ᐳ[66]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/pgJwtTypeIdentifier-bigNumbers.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/pgJwtTypeIdentifier-bigNumbers.mermaid
@@ -9,12 +9,12 @@ graph TD
 
 
     %% plan dependencies
-    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object29{{"Object[29∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”authenticate”)ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
-    Lambda21 & Constant25 & Constant26 & Constant27 --> Object28
+    Constant26{{"Constant[26∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸsql.identifier(”authenticate”)ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
+    Lambda21 & Constant26 & Constant27 & Constant28 --> Object29
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,22 +22,24 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda21
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant39 --> Lambda24
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object28 --> Lambda29
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
-    Constant40 --> Lambda34
+    Constant39 --> Lambda21
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant40 --> Lambda24
+    Access25{{"Access[25∈0] ➊<br />ᐸ24.0ᐳ"}}:::plan
+    Lambda24 --> Access25
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object29 --> Lambda30
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
+    Constant41 --> Lambda35
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ'1234567890123456789.123456789'ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ'987654321098765432'ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ'1234567890123456789.123456789'ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ'987654321098765432'ᐳ"}}:::plan
     PgSelect11[["PgSelect[11∈1] ➊<br />ᐸauthenticate(mutation)ᐳ"]]:::sideeffectplan
-    Object14 & Constant35 & Constant36 & Constant37 & Lambda21 & Lambda24 & Lambda29 & Lambda34 --> PgSelect11
+    Object14 & Constant36 & Constant37 & Constant38 & Lambda21 & Access25 & Lambda30 & Lambda35 --> PgSelect11
     First15{{"First[15∈1] ➊"}}:::plan
     PgSelect11 --> First15
     PgSelectSingle16{{"PgSelectSingle[16∈1] ➊<br />ᐸauthenticateᐳ"}}:::plan
@@ -52,8 +54,8 @@ graph TD
     subgraph "Buckets for mutations/v4/pgJwtTypeIdentifier-bigNumbers"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda21,Lambda24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37,Constant38,Constant39,Constant40 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 35, 36, 37, 21, 24, 29, 34<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda21,Lambda24,Access25,Constant26,Constant27,Constant28,Object29,Lambda30,Lambda35,Constant36,Constant37,Constant38,Constant39,Constant40,Constant41 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 36, 37, 38, 21, 25, 30, 35<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect11,First15,PgSelectSingle16,Object17 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/pgJwtTypeIdentifier-withPayload.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/pgJwtTypeIdentifier-withPayload.mermaid
@@ -9,12 +9,22 @@ graph TD
 
 
     %% plan dependencies
-    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”authenticate_payload”)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(authPayload)ᐳ"}}:::plan
-    Lambda45 & Constant77 & Constant78 & Constant79 --> Object80
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”frmcdc_jwt_token”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”authenticate_payload”)ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(authPayload)ᐳ"}}:::plan
+    Lambda45 & Constant80 & Constant81 & Constant82 --> Object83
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,30 +32,34 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant90 --> Lambda45
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant93 --> Lambda45
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant91 --> Lambda48
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object80 --> Lambda81
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
-    Constant94 --> Lambda86
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant95 --> Lambda59
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant96 --> Lambda74
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object83 --> Lambda84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
+    Constant97 --> Lambda89
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”frmcdc_jwt_token”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ'2'ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ'3'ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ'2'ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ'3'ᐳ"}}:::plan
     PgSelect11[["PgSelect[11∈1] ➊<br />ᐸauthenticate_payload(mutation)ᐳ"]]:::sideeffectplan
-    Object14 & Constant87 & Constant88 & Constant89 & Lambda45 & Lambda48 & Lambda81 & Lambda86 --> PgSelect11
+    Object14 & Constant90 & Constant91 & Constant92 & Lambda45 & Access49 & Lambda84 & Lambda89 --> PgSelect11
     First15{{"First[15∈1] ➊"}}:::plan
     PgSelect11 --> First15
     PgSelectSingle16{{"PgSelectSingle[16∈1] ➊<br />ᐸauthenticate_payloadᐳ"}}:::plan
@@ -54,27 +68,15 @@ graph TD
     PgSelectSingle16 --> Object17
     PgSelect28[["PgSelect[28∈2] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression34{{"PgClassExpression[34∈2] ➊<br />ᐸ__authenti...oad__.”id”ᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & PgClassExpression34 & Lambda45 & Lambda48 & Lambda67 & Lambda72 --> PgSelect28
-    Object52{{"Object[52∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object66{{"Object[66∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant63 & Constant64 & Constant65 --> Object66
+    Object14 & PgClassExpression34 & Lambda45 & Access49 & Lambda69 & Lambda74 --> PgSelect28
     First30{{"First[30∈2] ➊"}}:::plan
     PgSelect28 --> First30
     PgSelectSingle31{{"PgSelectSingle[31∈2] ➊<br />ᐸpersonᐳ"}}:::plan
     First30 --> PgSelectSingle31
     PgSelectSingle16 --> PgClassExpression34
-    Lambda53{{"Lambda[53∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant92 --> Lambda58
-    Object66 --> Lambda67
-    Constant93 --> Lambda72
     PgSelect19[["PgSelect[19∈3] ➊<br />ᐸfrmcdc_jwtTokenᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3] ➊<br />ᐸ__authenti...ad__.”jwt”ᐳ"}}:::plan
-    Object14 & PgClassExpression18 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect19
+    Object14 & PgClassExpression18 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect19
     PgSelectSingle16 --> PgClassExpression18
     First23{{"First[23∈3] ➊"}}:::plan
     PgSelect19 --> First23
@@ -98,14 +100,14 @@ graph TD
     subgraph "Buckets for mutations/v4/pgJwtTypeIdentifier-withPayload"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda45,Lambda48,Constant49,Constant50,Constant51,Constant63,Constant64,Constant65,Constant77,Constant78,Constant79,Object80,Lambda81,Lambda86,Constant87,Constant88,Constant89,Constant90,Constant91,Constant92,Constant93,Constant94 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 87, 88, 89, 45, 48, 81, 86, 49, 50, 51, 92, 63, 64, 65, 93<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant90,Constant91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 90, 91, 92, 45, 49, 84, 89, 69, 74, 54, 59<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect11,First15,PgSelectSingle16,Object17 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 45, 48, 16, 49, 50, 51, 92, 63, 64, 65, 93, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]<br />1: <br />ᐳ: 34, 52, 58, 66, 72, 53, 67<br />2: PgSelect[28]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14, 45, 49, 69, 74, 16, 17, 54, 59<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]<br />1: <br />ᐳ: PgClassExpression[34]<br />2: PgSelect[28]<br />ᐳ: First[30], PgSelectSingle[31]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect28,First30,PgSelectSingle31,PgClassExpression34,Object52,Lambda53,Lambda58,Object66,Lambda67,Lambda72 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 14, 45, 48, 53, 58, 31, 34<br /><br />ROOT PgSelectSingle{1}ᐸauthenticate_payloadᐳ[16]<br />1: <br />ᐳ: 18, 27<br />2: PgSelect[19]<br />ᐳ: 23, 24, 25"):::bucket
+    class Bucket2,PgSelect28,First30,PgSelectSingle31,PgClassExpression34 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 14, 45, 49, 54, 59, 31, 34<br /><br />ROOT PgSelectSingle{1}ᐸauthenticate_payloadᐳ[16]<br />1: <br />ᐳ: 18, 27<br />2: PgSelect[19]<br />ᐳ: 23, 24, 25"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect19,First23,PgSelectSingle24,PgClassExpression25,PgClassExpression27 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[31]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/pgJwtTypeIdentifier.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/pgJwtTypeIdentifier.mermaid
@@ -9,12 +9,12 @@ graph TD
 
 
     %% plan dependencies
-    Object28{{"Object[28∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object29{{"Object[29∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸsql.identifier(”authenticate”)ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
-    Lambda21 & Constant25 & Constant26 & Constant27 --> Object28
+    Constant26{{"Constant[26∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸsql.identifier(”authenticate”)ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸRecordCodec(jwtToken)ᐳ"}}:::plan
+    Lambda21 & Constant26 & Constant27 & Constant28 --> Object29
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,22 +22,24 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda21
-    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant39 --> Lambda24
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object28 --> Lambda29
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
-    Constant40 --> Lambda34
+    Constant39 --> Lambda21
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant40 --> Lambda24
+    Access25{{"Access[25∈0] ➊<br />ᐸ24.0ᐳ"}}:::plan
+    Lambda24 --> Access25
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object29 --> Lambda30
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”authenᐳ"}}:::plan
+    Constant41 --> Lambda35
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ'2'ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ'3'ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ'2'ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ'3'ᐳ"}}:::plan
     PgSelect11[["PgSelect[11∈1] ➊<br />ᐸauthenticate(mutation)ᐳ"]]:::sideeffectplan
-    Object14 & Constant35 & Constant36 & Constant37 & Lambda21 & Lambda24 & Lambda29 & Lambda34 --> PgSelect11
+    Object14 & Constant36 & Constant37 & Constant38 & Lambda21 & Access25 & Lambda30 & Lambda35 --> PgSelect11
     First15{{"First[15∈1] ➊"}}:::plan
     PgSelect11 --> First15
     PgSelectSingle16{{"PgSelectSingle[16∈1] ➊<br />ᐸauthenticateᐳ"}}:::plan
@@ -52,8 +54,8 @@ graph TD
     subgraph "Buckets for mutations/v4/pgJwtTypeIdentifier"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda21,Lambda24,Constant25,Constant26,Constant27,Object28,Lambda29,Lambda34,Constant35,Constant36,Constant37,Constant38,Constant39,Constant40 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 35, 36, 37, 21, 24, 29, 34<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Lambda21,Lambda24,Access25,Constant26,Constant27,Constant28,Object29,Lambda30,Lambda35,Constant36,Constant37,Constant38,Constant39,Constant40,Constant41 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 36, 37, 38, 21, 25, 30, 35<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: 15, 16, 17"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect11,First15,PgSelectSingle16,Object17 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.custom_delete.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.custom_delete.mermaid
@@ -9,116 +9,128 @@ graph TD
 
 
     %% plan dependencies
-    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”custom_delete_relational_item”)ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸCodec(bool)ᐳ"}}:::plan
-    Lambda108 & Constant112 & Constant113 & Constant114 --> Object115
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
-    Lambda108 & Constant126 & Constant127 & Constant128 --> Object129
-    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
-    Lambda108 & Constant140 & Constant141 & Constant142 --> Object143
-    Object157{{"Object[157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
-    Lambda108 & Constant154 & Constant155 & Constant156 --> Object157
-    Object171{{"Object[171∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
-    Lambda108 & Constant168 & Constant169 & Constant170 --> Object171
-    Object185{{"Object[185∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
-    Lambda108 & Constant182 & Constant183 & Constant184 --> Object185
-    Object199{{"Object[199∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
-    Lambda108 & Constant196 & Constant197 & Constant198 --> Object199
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”custom_delete_relational_item”)ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸCodec(bool)ᐳ"}}:::plan
+    Lambda108 & Constant113 & Constant114 & Constant115 --> Object116
+    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
+    Lambda108 & Constant128 & Constant129 & Constant130 --> Object131
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
+    Lambda108 & Constant143 & Constant144 & Constant145 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
+    Lambda108 & Constant158 & Constant159 & Constant160 --> Object161
+    Object176{{"Object[176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
+    Lambda108 & Constant173 & Constant174 & Constant175 --> Object176
+    Object191{{"Object[191∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
+    Lambda108 & Constant188 & Constant189 & Constant190 --> Object191
+    Object206{{"Object[206∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
+    Lambda108 & Constant203 & Constant204 & Constant205 --> Object206
+    Object221{{"Object[221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda214{{"Lambda[214∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda214 & Constant218 & Constant219 & Constant130 --> Object221
     Object38{{"Object[38∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access36{{"Access[36∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access37{{"Access[37∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access36 & Access37 --> Object38
     Lambda9{{"Lambda[9∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMV0='ᐳ"}}:::plan
-    Constant221 --> Lambda9
-    List14{{"List[14∈0] ➊<br />ᐸ220ᐳ"}}:::plan
-    Access220{{"Access[220∈0] ➊<br />ᐸ9.base64JSON.1ᐳ"}}:::plan
-    Access220 --> List14
+    Constant229{{"Constant[229∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMV0='ᐳ"}}:::plan
+    Constant229 --> Lambda9
+    List14{{"List[14∈0] ➊<br />ᐸ228ᐳ"}}:::plan
+    Access228{{"Access[228∈0] ➊<br />ᐸ9.base64JSON.1ᐳ"}}:::plan
+    Access228 --> List14
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access36
     __Value2 --> Access37
-    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant223 --> Lambda108
+    Constant231{{"Constant[231∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant231 --> Lambda108
     Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant224 --> Lambda111
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object115 --> Lambda116
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”customᐳ"}}:::plan
-    Constant225 --> Lambda121
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object129 --> Lambda130
-    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant226 --> Lambda135
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object143 --> Lambda144
-    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant227 --> Lambda149
-    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object157 --> Lambda158
-    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant228 --> Lambda163
-    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object171 --> Lambda172
+    Constant232{{"Constant[232∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant232 --> Lambda111
+    Access112{{"Access[112∈0] ➊<br />ᐸ111.0ᐳ"}}:::plan
+    Lambda111 --> Access112
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object116 --> Lambda117
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant233{{"Constant[233∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”customᐳ"}}:::plan
+    Constant233 --> Lambda122
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object131 --> Lambda132
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant234 --> Lambda137
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object146 --> Lambda147
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant235{{"Constant[235∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant235 --> Lambda152
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object161 --> Lambda162
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant236{{"Constant[236∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant236 --> Lambda167
     Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant229{{"Constant[229∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant229 --> Lambda177
-    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object185 --> Lambda186
-    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant230{{"Constant[230∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant230 --> Lambda191
-    Lambda200{{"Lambda[200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object199 --> Lambda200
-    Lambda205{{"Lambda[205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant231{{"Constant[231∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant231 --> Lambda205
-    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant233{{"Constant[233∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant233 --> Lambda207
-    Lambda9 --> Access220
+    Object176 --> Lambda177
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant237{{"Constant[237∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant237 --> Lambda182
+    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object191 --> Lambda192
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant238 --> Lambda197
+    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object206 --> Lambda207
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant239 --> Lambda212
+    Constant241{{"Constant[241∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant241 --> Lambda214
+    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant242 --> Lambda216
+    Access217{{"Access[217∈0] ➊<br />ᐸ216.0ᐳ"}}:::plan
+    Lambda216 --> Access217
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object221 --> Lambda222
+    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant240 --> Lambda227
+    Lambda9 --> Access228
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant69{{"Constant[69∈0] ➊<br />ᐸ'relational_topics'ᐳ"}}:::plan
     Constant78{{"Constant[78∈0] ➊<br />ᐸ'relational_posts'ᐳ"}}:::plan
     Constant86{{"Constant[86∈0] ➊<br />ᐸ'relational_dividers'ᐳ"}}:::plan
     Constant94{{"Constant[94∈0] ➊<br />ᐸ'relational_checklists'ᐳ"}}:::plan
     Constant102{{"Constant[102∈0] ➊<br />ᐸ'relational_checklist_items'ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant211{{"Constant[211∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant232{{"Constant[232∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant230{{"Constant[230∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     PgSelect35[["PgSelect[35∈1] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     Access34{{"Access[34∈1] ➊<br />ᐸ33.0ᐳ"}}:::plan
-    Object38 & Access34 & Lambda108 & Lambda111 & Lambda130 & Lambda135 --> PgSelect35
+    Object38 & Access34 & Lambda108 & Access112 & Lambda132 & Lambda137 --> PgSelect35
     PgSelect42[["PgSelect[42∈1] ➊<br />ᐸcustom_delete_relational_item(mutation)ᐳ"]]:::sideeffectplan
     PgClassExpression41{{"PgClassExpression[41∈1] ➊<br />ᐸ__relational_items__ᐳ"}}:::plan
-    Object38 & PgClassExpression41 & Lambda108 & Lambda111 & Lambda116 & Lambda121 --> PgSelect42
+    Object38 & PgClassExpression41 & Lambda108 & Access112 & Lambda117 & Lambda122 --> PgSelect42
     List32{{"List[32∈1] ➊<br />ᐸ15,19,23,27,31ᐳ"}}:::plan
     Object15{{"Object[15∈1] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
     Object19{{"Object[19∈1] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
@@ -157,33 +169,25 @@ graph TD
     PgSelectSingle47 --> PgClassExpression48
     Object49{{"Object[49∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgClassExpression48 --> Object49
-    Object213{{"Object[213∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda207 & Constant210 & Constant211 & Constant128 --> Object213
     Connection58{{"Connection[58∈2] ➊<br />ᐸ54ᐳ"}}:::plan
-    Constant222 --> Connection58
-    Lambda209{{"Lambda[209∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant234 --> Lambda209
-    Lambda214{{"Lambda[214∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object213 --> Lambda214
-    Lambda219{{"Lambda[219∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant232 --> Lambda219
+    Constant230 --> Connection58
     PgSelect59[["PgSelect[59∈4] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Object38 & Connection58 & Constant222 & Lambda207 & Lambda209 & Lambda214 & Lambda219 --> PgSelect59
+    Object38 & Connection58 & Constant230 & Lambda214 & Access217 & Lambda222 & Lambda227 --> PgSelect59
     __Item60[/"__Item[60∈5]<br />ᐸ59ᐳ"\]:::itemplan
     PgSelect59 ==> __Item60
     PgSelectSingle61{{"PgSelectSingle[61∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item60 --> PgSelectSingle61
     PgSelect63[["PgSelect[63∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression62{{"PgClassExpression[62∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object38 & PgClassExpression62 & Lambda108 & Lambda111 & Lambda144 & Lambda149 --> PgSelect63
+    Object38 & PgClassExpression62 & Lambda108 & Access112 & Lambda147 & Lambda152 --> PgSelect63
     PgSelect74[["PgSelect[74∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object38 & PgClassExpression62 & Lambda108 & Lambda111 & Lambda158 & Lambda163 --> PgSelect74
+    Object38 & PgClassExpression62 & Lambda108 & Access112 & Lambda162 & Lambda167 --> PgSelect74
     PgSelect82[["PgSelect[82∈6]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object38 & PgClassExpression62 & Lambda108 & Lambda111 & Lambda172 & Lambda177 --> PgSelect82
+    Object38 & PgClassExpression62 & Lambda108 & Access112 & Lambda177 & Lambda182 --> PgSelect82
     PgSelect90[["PgSelect[90∈6]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object38 & PgClassExpression62 & Lambda108 & Lambda111 & Lambda186 & Lambda191 --> PgSelect90
+    Object38 & PgClassExpression62 & Lambda108 & Access112 & Lambda192 & Lambda197 --> PgSelect90
     PgSelect98[["PgSelect[98∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object38 & PgClassExpression62 & Lambda108 & Lambda111 & Lambda200 & Lambda205 --> PgSelect98
+    Object38 & PgClassExpression62 & Lambda108 & Access112 & Lambda207 & Lambda212 --> PgSelect98
     List71{{"List[71∈6]<br />ᐸ69,70ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression70{{"PgClassExpression[70∈6]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant69 & PgClassExpression70 --> List71
@@ -243,23 +247,23 @@ graph TD
     subgraph "Buckets for mutations/v4/polymorphic.relay.custom_delete"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda9,List14,Access36,Access37,Object38,Constant69,Constant78,Constant86,Constant94,Constant102,Lambda108,Lambda111,Constant112,Constant113,Constant114,Object115,Lambda116,Lambda121,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant140,Constant141,Constant142,Object143,Lambda144,Lambda149,Constant154,Constant155,Constant156,Object157,Lambda158,Lambda163,Constant168,Constant169,Constant170,Object171,Lambda172,Lambda177,Constant182,Constant183,Constant184,Object185,Lambda186,Lambda191,Constant196,Constant197,Constant198,Object199,Lambda200,Lambda205,Lambda207,Constant210,Constant211,Access220,Constant221,Constant222,Constant223,Constant224,Constant225,Constant226,Constant227,Constant228,Constant229,Constant230,Constant231,Constant232,Constant233,Constant234 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 9, 14, 38, 108, 111, 130, 135, 116, 121, 222, 234, 207, 210, 211, 128, 232, 4, 144, 149, 69, 158, 163, 78, 172, 177, 86, 186, 191, 94, 200, 205, 102<br /><br />1: Lambda[13]<br />2: Object[15]<br />3: Lambda[17]<br />4: Object[19]<br />5: Lambda[21]<br />6: Object[23]<br />7: Lambda[25]<br />8: Object[27]<br />9: Lambda[29]<br />10: Object[31]<br />11: List[32]<br />12: Lambda[33]<br />13: Access[34]<br />14: PgSelect[35]<br />15: First[39]<br />16: PgSelectSingle[40]<br />17: PgClassExpression[41]<br />18: PgSelect[42]<br />19: <br />ᐳ: 46, 47, 48, 49"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda9,List14,Access36,Access37,Object38,Constant69,Constant78,Constant86,Constant94,Constant102,Lambda108,Lambda111,Access112,Constant113,Constant114,Constant115,Object116,Lambda117,Lambda122,Constant128,Constant129,Constant130,Object131,Lambda132,Lambda137,Constant143,Constant144,Constant145,Object146,Lambda147,Lambda152,Constant158,Constant159,Constant160,Object161,Lambda162,Lambda167,Constant173,Constant174,Constant175,Object176,Lambda177,Lambda182,Constant188,Constant189,Constant190,Object191,Lambda192,Lambda197,Constant203,Constant204,Constant205,Object206,Lambda207,Lambda212,Lambda214,Lambda216,Access217,Constant218,Constant219,Object221,Lambda222,Lambda227,Access228,Constant229,Constant230,Constant231,Constant232,Constant233,Constant234,Constant235,Constant236,Constant237,Constant238,Constant239,Constant240,Constant241,Constant242 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 9, 14, 38, 108, 112, 132, 137, 117, 122, 230, 4, 214, 217, 222, 227, 147, 152, 69, 162, 167, 78, 177, 182, 86, 192, 197, 94, 207, 212, 102<br /><br />1: Lambda[13]<br />2: Object[15]<br />3: Lambda[17]<br />4: Object[19]<br />5: Lambda[21]<br />6: Object[23]<br />7: Lambda[25]<br />8: Object[27]<br />9: Lambda[29]<br />10: Object[31]<br />11: List[32]<br />12: Lambda[33]<br />13: Access[34]<br />14: PgSelect[35]<br />15: First[39]<br />16: PgSelectSingle[40]<br />17: PgClassExpression[41]<br />18: PgSelect[42]<br />19: <br />ᐳ: 46, 47, 48, 49"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,Lambda13,Object15,Lambda17,Object19,Lambda21,Object23,Lambda25,Object27,Lambda29,Object31,List32,Lambda33,Access34,PgSelect35,First39,PgSelectSingle40,PgClassExpression41,PgSelect42,First46,PgSelectSingle47,PgClassExpression48,Object49 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 222, 234, 207, 210, 211, 128, 232, 49, 4, 38, 108, 111, 144, 149, 69, 158, 163, 78, 172, 177, 86, 186, 191, 94, 200, 205, 102, 48<br /><br />ROOT Object{1}ᐸ{result}ᐳ[49]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 230, 49, 4, 38, 214, 217, 222, 227, 108, 112, 147, 152, 69, 162, 167, 78, 177, 182, 86, 192, 197, 94, 207, 212, 102, 48<br /><br />ROOT Object{1}ᐸ{result}ᐳ[49]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Connection58,Lambda209,Object213,Lambda214,Lambda219 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 38, 58, 222, 207, 209, 214, 219, 108, 111, 144, 149, 69, 158, 163, 78, 172, 177, 86, 186, 191, 94, 200, 205, 102<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,Connection58 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 38, 58, 230, 214, 217, 222, 227, 108, 112, 147, 152, 69, 162, 167, 78, 177, 182, 86, 192, 197, 94, 207, 212, 102<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38, 58, 222, 207, 209, 214, 219, 108, 111, 144, 149, 69, 158, 163, 78, 172, 177, 86, 186, 191, 94, 200, 205, 102<br /><br />ROOT Connection{2}ᐸ54ᐳ[58]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38, 58, 230, 214, 217, 222, 227, 108, 112, 147, 152, 69, 162, 167, 78, 177, 182, 86, 192, 197, 94, 207, 212, 102<br /><br />ROOT Connection{2}ᐸ54ᐳ[58]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgSelect59 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 38, 108, 111, 144, 149, 69, 158, 163, 78, 172, 177, 86, 186, 191, 94, 200, 205, 102<br /><br />ROOT __Item{5}ᐸ59ᐳ[60]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 38, 108, 112, 147, 152, 69, 162, 167, 78, 177, 182, 86, 192, 197, 94, 207, 212, 102<br /><br />ROOT __Item{5}ᐸ59ᐳ[60]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item60,PgSelectSingle61 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 61, 38, 108, 111, 144, 149, 69, 158, 163, 78, 172, 177, 86, 186, 191, 94, 200, 205, 102<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 62, 73<br />2: 63, 74, 82, 90, 98<br />ᐳ: 67, 68, 70, 71, 72, 76, 77, 79, 80, 81, 84, 85, 87, 88, 89, 92, 93, 95, 96, 97, 100, 101, 103, 104, 105"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 61, 38, 108, 112, 147, 152, 69, 162, 167, 78, 177, 182, 86, 192, 197, 94, 207, 212, 102<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 62, 73<br />2: 63, 74, 82, 90, 98<br />ᐳ: 67, 68, 70, 71, 72, 76, 77, 79, 80, 81, 84, 85, 87, 88, 89, 92, 93, 95, 96, 97, 100, 101, 103, 104, 105"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression62,PgSelect63,First67,PgSelectSingle68,PgClassExpression70,List71,Lambda72,PgClassExpression73,PgSelect74,First76,PgSelectSingle77,PgClassExpression79,List80,Lambda81,PgSelect82,First84,PgSelectSingle85,PgClassExpression87,List88,Lambda89,PgSelect90,First92,PgSelectSingle93,PgClassExpression95,List96,Lambda97,PgSelect98,First100,PgSelectSingle101,PgClassExpression103,List104,Lambda105 bucket6
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.mermaid
@@ -9,92 +9,126 @@ graph TD
 
 
     %% plan dependencies
-    Object597{{"Object[597∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object598{{"Object[598∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda590{{"Lambda[590∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant594{{"Constant[594∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant595{{"Constant[595∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant596{{"Constant[596∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
-    Lambda590 & Constant594 & Constant595 & Constant596 --> Object597
-    Object611{{"Object[611∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant608{{"Constant[608∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant609{{"Constant[609∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant610{{"Constant[610∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
-    Lambda590 & Constant608 & Constant609 & Constant610 --> Object611
-    Object625{{"Object[625∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant622{{"Constant[622∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant623{{"Constant[623∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant624{{"Constant[624∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
-    Lambda590 & Constant622 & Constant623 & Constant624 --> Object625
-    Object639{{"Object[639∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant636{{"Constant[636∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant637{{"Constant[637∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant638{{"Constant[638∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
-    Lambda590 & Constant636 & Constant637 & Constant638 --> Object639
-    Object653{{"Object[653∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant650{{"Constant[650∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant651{{"Constant[651∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant652{{"Constant[652∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
-    Lambda590 & Constant650 & Constant651 & Constant652 --> Object653
-    Object681{{"Object[681∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant678{{"Constant[678∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant679{{"Constant[679∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda590 & Constant678 & Constant679 & Constant596 --> Object681
-    Object695{{"Object[695∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant692{{"Constant[692∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant693{{"Constant[693∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda590 & Constant692 & Constant693 & Constant610 --> Object695
-    Object709{{"Object[709∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant706{{"Constant[706∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant707{{"Constant[707∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda590 & Constant706 & Constant707 & Constant624 --> Object709
-    Object723{{"Object[723∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant720{{"Constant[720∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant721{{"Constant[721∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda590 & Constant720 & Constant721 & Constant638 --> Object723
-    Object737{{"Object[737∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant734{{"Constant[734∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant735{{"Constant[735∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda590 & Constant734 & Constant735 & Constant652 --> Object737
-    Object765{{"Object[765∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant762{{"Constant[762∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant763{{"Constant[763∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda590 & Constant762 & Constant763 & Constant596 --> Object765
-    Object779{{"Object[779∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant776{{"Constant[776∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant777{{"Constant[777∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda590 & Constant776 & Constant777 & Constant610 --> Object779
+    Constant595{{"Constant[595∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant596{{"Constant[596∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant597{{"Constant[597∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
+    Lambda590 & Constant595 & Constant596 & Constant597 --> Object598
+    Object613{{"Object[613∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant610{{"Constant[610∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant611{{"Constant[611∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant612{{"Constant[612∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
+    Lambda590 & Constant610 & Constant611 & Constant612 --> Object613
+    Object628{{"Object[628∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant625{{"Constant[625∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant626{{"Constant[626∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant627{{"Constant[627∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
+    Lambda590 & Constant625 & Constant626 & Constant627 --> Object628
+    Object643{{"Object[643∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant640{{"Constant[640∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant641{{"Constant[641∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant642{{"Constant[642∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
+    Lambda590 & Constant640 & Constant641 & Constant642 --> Object643
+    Object658{{"Object[658∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant655{{"Constant[655∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant656{{"Constant[656∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant657{{"Constant[657∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
+    Lambda590 & Constant655 & Constant656 & Constant657 --> Object658
+    Object673{{"Object[673∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant670{{"Constant[670∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant671{{"Constant[671∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant672{{"Constant[672∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
+    Lambda590 & Constant670 & Constant671 & Constant672 --> Object673
+    Object688{{"Object[688∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant685{{"Constant[685∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant686{{"Constant[686∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda590 & Constant685 & Constant686 & Constant597 --> Object688
+    Object703{{"Object[703∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant700{{"Constant[700∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant701{{"Constant[701∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda590 & Constant700 & Constant701 & Constant612 --> Object703
+    Object718{{"Object[718∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant715{{"Constant[715∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant716{{"Constant[716∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda590 & Constant715 & Constant716 & Constant627 --> Object718
+    Object733{{"Object[733∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant730{{"Constant[730∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant731{{"Constant[731∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda590 & Constant730 & Constant731 & Constant642 --> Object733
+    Object748{{"Object[748∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant745{{"Constant[745∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant746{{"Constant[746∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda590 & Constant745 & Constant746 & Constant657 --> Object748
+    Object763{{"Object[763∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant760{{"Constant[760∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant761{{"Constant[761∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda590 & Constant760 & Constant761 & Constant672 --> Object763
+    Object778{{"Object[778∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant775{{"Constant[775∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant776{{"Constant[776∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda590 & Constant775 & Constant776 & Constant597 --> Object778
     Object793{{"Object[793∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant790{{"Constant[790∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant791{{"Constant[791∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda590 & Constant790 & Constant791 & Constant624 --> Object793
-    Object807{{"Object[807∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant804{{"Constant[804∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant805{{"Constant[805∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda590 & Constant804 & Constant805 & Constant638 --> Object807
-    Object821{{"Object[821∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant818{{"Constant[818∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant819{{"Constant[819∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda590 & Constant818 & Constant819 & Constant652 --> Object821
-    Object849{{"Object[849∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant846{{"Constant[846∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant847{{"Constant[847∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda590 & Constant846 & Constant847 & Constant596 --> Object849
-    Object863{{"Object[863∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant860{{"Constant[860∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant861{{"Constant[861∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda590 & Constant860 & Constant861 & Constant610 --> Object863
-    Object877{{"Object[877∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant874{{"Constant[874∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant875{{"Constant[875∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda590 & Constant874 & Constant875 & Constant624 --> Object877
-    Object891{{"Object[891∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant888{{"Constant[888∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant889{{"Constant[889∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda590 & Constant888 & Constant889 & Constant638 --> Object891
-    Object905{{"Object[905∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant902{{"Constant[902∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant903{{"Constant[903∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda590 & Constant902 & Constant903 & Constant652 --> Object905
+    Constant791{{"Constant[791∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda590 & Constant790 & Constant791 & Constant612 --> Object793
+    Object808{{"Object[808∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant805{{"Constant[805∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant806{{"Constant[806∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda590 & Constant805 & Constant806 & Constant627 --> Object808
+    Object823{{"Object[823∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant820{{"Constant[820∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant821{{"Constant[821∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda590 & Constant820 & Constant821 & Constant642 --> Object823
+    Object838{{"Object[838∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant835{{"Constant[835∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant836{{"Constant[836∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda590 & Constant835 & Constant836 & Constant657 --> Object838
+    Object853{{"Object[853∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant850{{"Constant[850∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant851{{"Constant[851∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda590 & Constant850 & Constant851 & Constant672 --> Object853
+    Object868{{"Object[868∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant865{{"Constant[865∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant866{{"Constant[866∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda590 & Constant865 & Constant866 & Constant597 --> Object868
+    Object883{{"Object[883∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant880{{"Constant[880∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant881{{"Constant[881∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda590 & Constant880 & Constant881 & Constant612 --> Object883
+    Object898{{"Object[898∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant895{{"Constant[895∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant896{{"Constant[896∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda590 & Constant895 & Constant896 & Constant627 --> Object898
+    Object913{{"Object[913∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant910{{"Constant[910∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant911{{"Constant[911∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda590 & Constant910 & Constant911 & Constant642 --> Object913
+    Object928{{"Object[928∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant925{{"Constant[925∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant926{{"Constant[926∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda590 & Constant925 & Constant926 & Constant657 --> Object928
+    Object943{{"Object[943∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant940{{"Constant[940∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant941{{"Constant[941∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda590 & Constant940 & Constant941 & Constant672 --> Object943
+    Object958{{"Object[958∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant955{{"Constant[955∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant956{{"Constant[956∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant957{{"Constant[957∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
+    Lambda590 & Constant955 & Constant956 & Constant957 --> Object958
+    Object973{{"Object[973∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant970{{"Constant[970∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant971{{"Constant[971∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda590 & Constant970 & Constant971 & Constant957 --> Object973
+    Object988{{"Object[988∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant985{{"Constant[985∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant986{{"Constant[986∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda590 & Constant985 & Constant986 & Constant957 --> Object988
+    Object1003{{"Object[1003∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1000{{"Constant[1000∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1001{{"Constant[1001∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda590 & Constant1000 & Constant1001 & Constant957 --> Object1003
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -103,128 +137,170 @@ graph TD
     __Value2 --> Access12
     __Value2 --> Access13
     Condition16{{"Condition[16∈0] ➊<br />ᐸexistsᐳ"}}:::plan
-    Constant983{{"Constant[983∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMV0='ᐳ"}}:::plan
-    Constant983 --> Condition16
+    Constant1011{{"Constant[1011∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMV0='ᐳ"}}:::plan
+    Constant1011 --> Condition16
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant983 --> Lambda17
-    List22{{"List[22∈0] ➊<br />ᐸ982ᐳ"}}:::plan
-    Access982{{"Access[982∈0] ➊<br />ᐸ17.base64JSON.1ᐳ"}}:::plan
-    Access982 --> List22
+    Constant1011 --> Lambda17
+    List22{{"List[22∈0] ➊<br />ᐸ1010ᐳ"}}:::plan
+    Access1010{{"Access[1010∈0] ➊<br />ᐸ17.base64JSON.1ᐳ"}}:::plan
+    Access1010 --> List22
     Condition45{{"Condition[45∈0] ➊<br />ᐸexistsᐳ"}}:::plan
-    Constant985{{"Constant[985∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMl0='ᐳ"}}:::plan
-    Constant985 --> Condition45
+    Constant1013{{"Constant[1013∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMl0='ᐳ"}}:::plan
+    Constant1013 --> Condition45
     Lambda46{{"Lambda[46∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant985 --> Lambda46
-    List51{{"List[51∈0] ➊<br />ᐸ984ᐳ"}}:::plan
-    Access984{{"Access[984∈0] ➊<br />ᐸ46.base64JSON.1ᐳ"}}:::plan
-    Access984 --> List51
-    Constant994{{"Constant[994∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant994 --> Lambda590
+    Constant1013 --> Lambda46
+    List51{{"List[51∈0] ➊<br />ᐸ1012ᐳ"}}:::plan
+    Access1012{{"Access[1012∈0] ➊<br />ᐸ46.base64JSON.1ᐳ"}}:::plan
+    Access1012 --> List51
+    Constant1022{{"Constant[1022∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1022 --> Lambda590
     Lambda593{{"Lambda[593∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant995{{"Constant[995∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant995 --> Lambda593
-    Lambda598{{"Lambda[598∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object597 --> Lambda598
-    Lambda603{{"Lambda[603∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant996{{"Constant[996∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant996 --> Lambda603
-    Lambda612{{"Lambda[612∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object611 --> Lambda612
-    Lambda617{{"Lambda[617∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant997{{"Constant[997∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant997 --> Lambda617
-    Lambda626{{"Lambda[626∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object625 --> Lambda626
-    Lambda631{{"Lambda[631∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant998{{"Constant[998∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant998 --> Lambda631
-    Lambda640{{"Lambda[640∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object639 --> Lambda640
-    Lambda645{{"Lambda[645∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant999{{"Constant[999∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant999 --> Lambda645
-    Lambda654{{"Lambda[654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object653 --> Lambda654
+    Constant1023{{"Constant[1023∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1023 --> Lambda593
+    Access594{{"Access[594∈0] ➊<br />ᐸ593.0ᐳ"}}:::plan
+    Lambda593 --> Access594
+    Lambda599{{"Lambda[599∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object598 --> Lambda599
+    Lambda604{{"Lambda[604∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1024{{"Constant[1024∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1024 --> Lambda604
+    Lambda614{{"Lambda[614∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object613 --> Lambda614
+    Lambda619{{"Lambda[619∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1025{{"Constant[1025∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1025 --> Lambda619
+    Lambda629{{"Lambda[629∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object628 --> Lambda629
+    Lambda634{{"Lambda[634∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1026{{"Constant[1026∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1026 --> Lambda634
+    Lambda644{{"Lambda[644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object643 --> Lambda644
+    Lambda649{{"Lambda[649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1027{{"Constant[1027∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1027 --> Lambda649
     Lambda659{{"Lambda[659∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1000{{"Constant[1000∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1000 --> Lambda659
-    Lambda682{{"Lambda[682∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object681 --> Lambda682
-    Lambda687{{"Lambda[687∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1002{{"Constant[1002∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1002 --> Lambda687
-    Lambda696{{"Lambda[696∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object695 --> Lambda696
-    Lambda701{{"Lambda[701∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1003{{"Constant[1003∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1003 --> Lambda701
-    Lambda710{{"Lambda[710∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object709 --> Lambda710
-    Lambda715{{"Lambda[715∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1004{{"Constant[1004∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1004 --> Lambda715
+    Object658 --> Lambda659
+    Lambda664{{"Lambda[664∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1028{{"Constant[1028∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1028 --> Lambda664
+    Lambda674{{"Lambda[674∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object673 --> Lambda674
+    Lambda679{{"Lambda[679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1029{{"Constant[1029∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1029 --> Lambda679
+    Lambda689{{"Lambda[689∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object688 --> Lambda689
+    Lambda694{{"Lambda[694∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1030{{"Constant[1030∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1030 --> Lambda694
+    Lambda704{{"Lambda[704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object703 --> Lambda704
+    Lambda709{{"Lambda[709∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1031{{"Constant[1031∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1031 --> Lambda709
+    Lambda719{{"Lambda[719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object718 --> Lambda719
     Lambda724{{"Lambda[724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object723 --> Lambda724
-    Lambda729{{"Lambda[729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1005{{"Constant[1005∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1005 --> Lambda729
-    Lambda738{{"Lambda[738∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object737 --> Lambda738
-    Lambda743{{"Lambda[743∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1006{{"Constant[1006∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1006 --> Lambda743
-    Lambda766{{"Lambda[766∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object765 --> Lambda766
-    Lambda771{{"Lambda[771∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1008{{"Constant[1008∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1008 --> Lambda771
-    Lambda780{{"Lambda[780∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object779 --> Lambda780
-    Lambda785{{"Lambda[785∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1009{{"Constant[1009∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1009 --> Lambda785
+    Constant1032{{"Constant[1032∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1032 --> Lambda724
+    Lambda734{{"Lambda[734∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object733 --> Lambda734
+    Lambda739{{"Lambda[739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1033{{"Constant[1033∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1033 --> Lambda739
+    Lambda749{{"Lambda[749∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object748 --> Lambda749
+    Lambda754{{"Lambda[754∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1034{{"Constant[1034∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1034 --> Lambda754
+    Lambda764{{"Lambda[764∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object763 --> Lambda764
+    Lambda769{{"Lambda[769∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1035{{"Constant[1035∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1035 --> Lambda769
+    Lambda779{{"Lambda[779∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object778 --> Lambda779
+    Lambda784{{"Lambda[784∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1036{{"Constant[1036∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1036 --> Lambda784
     Lambda794{{"Lambda[794∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object793 --> Lambda794
     Lambda799{{"Lambda[799∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1010{{"Constant[1010∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1010 --> Lambda799
-    Lambda808{{"Lambda[808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object807 --> Lambda808
-    Lambda813{{"Lambda[813∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1011{{"Constant[1011∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1011 --> Lambda813
-    Lambda822{{"Lambda[822∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object821 --> Lambda822
-    Lambda827{{"Lambda[827∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1012{{"Constant[1012∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1012 --> Lambda827
-    Lambda850{{"Lambda[850∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object849 --> Lambda850
-    Lambda855{{"Lambda[855∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1014{{"Constant[1014∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1014 --> Lambda855
-    Lambda864{{"Lambda[864∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object863 --> Lambda864
+    Constant1037{{"Constant[1037∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1037 --> Lambda799
+    Lambda809{{"Lambda[809∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object808 --> Lambda809
+    Lambda814{{"Lambda[814∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1038{{"Constant[1038∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1038 --> Lambda814
+    Lambda824{{"Lambda[824∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object823 --> Lambda824
+    Lambda829{{"Lambda[829∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1039{{"Constant[1039∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1039 --> Lambda829
+    Lambda839{{"Lambda[839∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object838 --> Lambda839
+    Lambda844{{"Lambda[844∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1040{{"Constant[1040∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1040 --> Lambda844
+    Lambda854{{"Lambda[854∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object853 --> Lambda854
+    Lambda859{{"Lambda[859∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1041{{"Constant[1041∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1041 --> Lambda859
     Lambda869{{"Lambda[869∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1015{{"Constant[1015∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1015 --> Lambda869
-    Lambda878{{"Lambda[878∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object877 --> Lambda878
-    Lambda883{{"Lambda[883∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1016{{"Constant[1016∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1016 --> Lambda883
-    Lambda892{{"Lambda[892∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object891 --> Lambda892
-    Lambda897{{"Lambda[897∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1017{{"Constant[1017∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1017 --> Lambda897
-    Lambda906{{"Lambda[906∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object905 --> Lambda906
-    Lambda911{{"Lambda[911∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1018{{"Constant[1018∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1018 --> Lambda911
-    Lambda17 --> Access982
-    Lambda46 --> Access984
+    Object868 --> Lambda869
+    Lambda874{{"Lambda[874∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1042{{"Constant[1042∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1042 --> Lambda874
+    Lambda884{{"Lambda[884∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object883 --> Lambda884
+    Lambda889{{"Lambda[889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1043{{"Constant[1043∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1043 --> Lambda889
+    Lambda899{{"Lambda[899∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object898 --> Lambda899
+    Lambda904{{"Lambda[904∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1044{{"Constant[1044∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1044 --> Lambda904
+    Lambda914{{"Lambda[914∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object913 --> Lambda914
+    Lambda919{{"Lambda[919∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1045{{"Constant[1045∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1045 --> Lambda919
+    Lambda929{{"Lambda[929∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object928 --> Lambda929
+    Lambda934{{"Lambda[934∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1046{{"Constant[1046∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1046 --> Lambda934
+    Lambda944{{"Lambda[944∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object943 --> Lambda944
+    Lambda949{{"Lambda[949∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1047{{"Constant[1047∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1047 --> Lambda949
+    Lambda959{{"Lambda[959∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object958 --> Lambda959
+    Lambda964{{"Lambda[964∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1048{{"Constant[1048∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1048 --> Lambda964
+    Lambda974{{"Lambda[974∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object973 --> Lambda974
+    Lambda979{{"Lambda[979∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1049{{"Constant[1049∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1049 --> Lambda979
+    Lambda989{{"Lambda[989∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object988 --> Lambda989
+    Lambda994{{"Lambda[994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1050{{"Constant[1050∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1050 --> Lambda994
+    Lambda1004{{"Lambda[1004∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1003 --> Lambda1004
+    Lambda1009{{"Lambda[1009∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1051{{"Constant[1051∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1051 --> Lambda1009
+    Lambda17 --> Access1010
+    Lambda46 --> Access1012
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant74{{"Constant[74∈0] ➊<br />ᐸ'relational_item_relations'ᐳ"}}:::plan
     Constant92{{"Constant[92∈0] ➊<br />ᐸ'relational_topics'ᐳ"}}:::plan
@@ -240,34 +316,8 @@ graph TD
     Constant441{{"Constant[441∈0] ➊<br />ᐸ'SingleTableChecklist'ᐳ"}}:::plan
     Constant444{{"Constant[444∈0] ➊<br />ᐸ'SingleTableChecklistItem'ᐳ"}}:::plan
     Constant537{{"Constant[537∈0] ➊<br />ᐸ'single_table_item_relation_composite_pks'ᐳ"}}:::plan
-    Constant664{{"Constant[664∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant665{{"Constant[665∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant666{{"Constant[666∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
-    Constant748{{"Constant[748∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant749{{"Constant[749∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant832{{"Constant[832∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant833{{"Constant[833∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant916{{"Constant[916∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant917{{"Constant[917∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant930{{"Constant[930∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant931{{"Constant[931∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant932{{"Constant[932∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
-    Constant944{{"Constant[944∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant945{{"Constant[945∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant958{{"Constant[958∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant959{{"Constant[959∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant972{{"Constant[972∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant973{{"Constant[973∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant989{{"Constant[989∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwxXQ=='ᐳ"}}:::plan
-    Constant991{{"Constant[991∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwyXQ=='ᐳ"}}:::plan
-    Constant1001{{"Constant[1001∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1007{{"Constant[1007∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1013{{"Constant[1013∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1019{{"Constant[1019∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1020{{"Constant[1020∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant1021{{"Constant[1021∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant1022{{"Constant[1022∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant1023{{"Constant[1023∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1017{{"Constant[1017∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwxXQ=='ᐳ"}}:::plan
+    Constant1019{{"Constant[1019∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwyXQ=='ᐳ"}}:::plan
     List40{{"List[40∈1] ➊<br />ᐸ23,27,31,35,39ᐳ"}}:::plan
     Object23{{"Object[23∈1] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
     Object27{{"Object[27∈1] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
@@ -332,24 +382,12 @@ graph TD
     Access71{{"Access[71∈1] ➊<br />ᐸ70.0ᐳ"}}:::plan
     Lambda70 --> Access71
     Access71 --> __Flag72
-    Object667{{"Object[667∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant664 & Constant665 & Constant666 --> Object667
-    Object751{{"Object[751∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant748 & Constant749 & Constant666 --> Object751
-    Lambda668{{"Lambda[668∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object667 --> Lambda668
-    Lambda673{{"Lambda[673∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1001 --> Lambda673
-    Lambda752{{"Lambda[752∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object751 --> Lambda752
-    Lambda757{{"Lambda[757∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1007 --> Lambda757
     PgSelect79[["PgSelect[79∈3] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression78{{"PgClassExpression[78∈3] ➊<br />ᐸ__relation...”child_id”ᐳ"}}:::plan
-    Object14 & PgClassExpression78 & Lambda590 & Lambda593 & Lambda668 & Lambda673 --> PgSelect79
+    Object14 & PgClassExpression78 & Lambda590 & Access594 & Lambda674 & Lambda679 --> PgSelect79
     PgSelect130[["PgSelect[130∈3] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression129{{"PgClassExpression[129∈3] ➊<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
-    Object14 & PgClassExpression129 & Lambda590 & Lambda593 & Lambda752 & Lambda757 --> PgSelect130
+    Object14 & PgClassExpression129 & Lambda590 & Access594 & Lambda764 & Lambda769 --> PgSelect130
     List76{{"List[76∈3] ➊<br />ᐸ74,75ᐳ"}}:::plan
     PgClassExpression75{{"PgClassExpression[75∈3] ➊<br />ᐸ__relation...ons__.”id”ᐳ"}}:::plan
     Constant74 & PgClassExpression75 --> List76
@@ -368,15 +406,15 @@ graph TD
     First132 --> PgSelectSingle133
     PgSelect86[["PgSelect[86∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression85{{"PgClassExpression[85∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object14 & PgClassExpression85 & Lambda590 & Lambda593 & Lambda598 & Lambda603 --> PgSelect86
+    Object14 & PgClassExpression85 & Lambda590 & Access594 & Lambda599 & Lambda604 --> PgSelect86
     PgSelect97[["PgSelect[97∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object14 & PgClassExpression85 & Lambda590 & Lambda593 & Lambda612 & Lambda617 --> PgSelect97
+    Object14 & PgClassExpression85 & Lambda590 & Access594 & Lambda614 & Lambda619 --> PgSelect97
     PgSelect105[["PgSelect[105∈4] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object14 & PgClassExpression85 & Lambda590 & Lambda593 & Lambda626 & Lambda631 --> PgSelect105
+    Object14 & PgClassExpression85 & Lambda590 & Access594 & Lambda629 & Lambda634 --> PgSelect105
     PgSelect113[["PgSelect[113∈4] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object14 & PgClassExpression85 & Lambda590 & Lambda593 & Lambda640 & Lambda645 --> PgSelect113
+    Object14 & PgClassExpression85 & Lambda590 & Access594 & Lambda644 & Lambda649 --> PgSelect113
     PgSelect121[["PgSelect[121∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object14 & PgClassExpression85 & Lambda590 & Lambda593 & Lambda654 & Lambda659 --> PgSelect121
+    Object14 & PgClassExpression85 & Lambda590 & Access594 & Lambda659 & Lambda664 --> PgSelect121
     List94{{"List[94∈4] ➊<br />ᐸ92,93ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression93{{"PgClassExpression[93∈4] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant92 & PgClassExpression93 --> List94
@@ -432,15 +470,15 @@ graph TD
     List127 --> Lambda128
     PgSelect135[["PgSelect[135∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression134{{"PgClassExpression[134∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object14 & PgClassExpression134 & Lambda590 & Lambda593 & Lambda682 & Lambda687 --> PgSelect135
+    Object14 & PgClassExpression134 & Lambda590 & Access594 & Lambda689 & Lambda694 --> PgSelect135
     PgSelect146[["PgSelect[146∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object14 & PgClassExpression134 & Lambda590 & Lambda593 & Lambda696 & Lambda701 --> PgSelect146
+    Object14 & PgClassExpression134 & Lambda590 & Access594 & Lambda704 & Lambda709 --> PgSelect146
     PgSelect154[["PgSelect[154∈5] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object14 & PgClassExpression134 & Lambda590 & Lambda593 & Lambda710 & Lambda715 --> PgSelect154
+    Object14 & PgClassExpression134 & Lambda590 & Access594 & Lambda719 & Lambda724 --> PgSelect154
     PgSelect162[["PgSelect[162∈5] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object14 & PgClassExpression134 & Lambda590 & Lambda593 & Lambda724 & Lambda729 --> PgSelect162
+    Object14 & PgClassExpression134 & Lambda590 & Access594 & Lambda734 & Lambda739 --> PgSelect162
     PgSelect170[["PgSelect[170∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object14 & PgClassExpression134 & Lambda590 & Lambda593 & Lambda738 & Lambda743 --> PgSelect170
+    Object14 & PgClassExpression134 & Lambda590 & Access594 & Lambda749 & Lambda754 --> PgSelect170
     List143{{"List[143∈5] ➊<br />ᐸ92,142ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression142{{"PgClassExpression[142∈5] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant92 & PgClassExpression142 --> List143
@@ -517,7 +555,7 @@ graph TD
     Access185{{"Access[185∈6] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access184 & Access185 --> Object186
     Lambda193[["Lambda[193∈6] ➊"]]:::unbatchedplan
-    List194{{"List[194∈6] ➊<br />ᐸ986ᐳ"}}:::plan
+    List194{{"List[194∈6] ➊<br />ᐸ1014ᐳ"}}:::plan
     Lambda193 & List194 --> Object195
     Lambda197[["Lambda[197∈6] ➊"]]:::unbatchedplan
     Lambda197 & List194 --> Object199
@@ -531,7 +569,7 @@ graph TD
     Condition188{{"Condition[188∈6] ➊<br />ᐸexistsᐳ"}}:::plan
     __Flag215 & Condition188 --> __Flag216
     Lambda222[["Lambda[222∈6] ➊"]]:::unbatchedplan
-    List223{{"List[223∈6] ➊<br />ᐸ987ᐳ"}}:::plan
+    List223{{"List[223∈6] ➊<br />ᐸ1015ᐳ"}}:::plan
     Lambda222 & List223 --> Object224
     Lambda226[["Lambda[226∈6] ➊"]]:::unbatchedplan
     Lambda226 & List223 --> Object228
@@ -548,12 +586,12 @@ graph TD
     __Value2 --> Access185
     Object187{{"Object[187∈6] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle183 --> Object187
-    Constant983 --> Condition188
+    Constant1011 --> Condition188
     Lambda189{{"Lambda[189∈6] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant983 --> Lambda189
+    Constant1011 --> Lambda189
     Lambda189 --> Lambda193
-    Access986{{"Access[986∈6] ➊<br />ᐸ189.base64JSON.1ᐳ"}}:::plan
-    Access986 --> List194
+    Access1014{{"Access[1014∈6] ➊<br />ᐸ189.base64JSON.1ᐳ"}}:::plan
+    Access1014 --> List194
     Lambda189 --> Lambda197
     Lambda189 --> Lambda201
     Lambda189 --> Lambda205
@@ -563,12 +601,12 @@ graph TD
     Access214{{"Access[214∈6] ➊<br />ᐸ213.0ᐳ"}}:::plan
     Lambda213 --> Access214
     Access214 --> __Flag215
-    Constant985 --> Condition217
+    Constant1013 --> Condition217
     Lambda218{{"Lambda[218∈6] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant985 --> Lambda218
+    Constant1013 --> Lambda218
     Lambda218 --> Lambda222
-    Access987{{"Access[987∈6] ➊<br />ᐸ218.base64JSON.1ᐳ"}}:::plan
-    Access987 --> List223
+    Access1015{{"Access[1015∈6] ➊<br />ᐸ218.base64JSON.1ᐳ"}}:::plan
+    Access1015 --> List223
     Lambda218 --> Lambda226
     Lambda218 --> Lambda230
     Lambda218 --> Lambda234
@@ -578,26 +616,14 @@ graph TD
     Access243{{"Access[243∈6] ➊<br />ᐸ242.0ᐳ"}}:::plan
     Lambda242 --> Access243
     Access243 --> __Flag244
-    Lambda189 --> Access986
-    Lambda218 --> Access987
-    Object835{{"Object[835∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant832 & Constant833 & Constant666 --> Object835
-    Object919{{"Object[919∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant916 & Constant917 & Constant666 --> Object919
-    Lambda836{{"Lambda[836∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object835 --> Lambda836
-    Lambda841{{"Lambda[841∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1013 --> Lambda841
-    Lambda920{{"Lambda[920∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object919 --> Lambda920
-    Lambda925{{"Lambda[925∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1019 --> Lambda925
+    Lambda189 --> Access1014
+    Lambda218 --> Access1015
     PgSelect252[["PgSelect[252∈8] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression248{{"PgClassExpression[248∈8] ➊<br />ᐸ__relation...”child_id”ᐳ"}}:::plan
-    Object186 & PgClassExpression248 & Lambda590 & Lambda593 & Lambda920 & Lambda925 --> PgSelect252
+    Object186 & PgClassExpression248 & Lambda590 & Access594 & Lambda944 & Lambda949 --> PgSelect252
     PgSelect303[["PgSelect[303∈8] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression247{{"PgClassExpression[247∈8] ➊<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
-    Object186 & PgClassExpression247 & Lambda590 & Lambda593 & Lambda836 & Lambda841 --> PgSelect303
+    Object186 & PgClassExpression247 & Lambda590 & Access594 & Lambda854 & Lambda859 --> PgSelect303
     List249{{"List[249∈8] ➊<br />ᐸ246,247,248ᐳ"}}:::plan
     Constant246 & PgClassExpression247 & PgClassExpression248 --> List249
     PgInsertSingle183 --> PgClassExpression247
@@ -614,15 +640,15 @@ graph TD
     First305 --> PgSelectSingle306
     PgSelect259[["PgSelect[259∈9] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression258{{"PgClassExpression[258∈9] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object186 & PgClassExpression258 & Lambda590 & Lambda593 & Lambda850 & Lambda855 --> PgSelect259
+    Object186 & PgClassExpression258 & Lambda590 & Access594 & Lambda869 & Lambda874 --> PgSelect259
     PgSelect270[["PgSelect[270∈9] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object186 & PgClassExpression258 & Lambda590 & Lambda593 & Lambda864 & Lambda869 --> PgSelect270
+    Object186 & PgClassExpression258 & Lambda590 & Access594 & Lambda884 & Lambda889 --> PgSelect270
     PgSelect278[["PgSelect[278∈9] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object186 & PgClassExpression258 & Lambda590 & Lambda593 & Lambda878 & Lambda883 --> PgSelect278
+    Object186 & PgClassExpression258 & Lambda590 & Access594 & Lambda899 & Lambda904 --> PgSelect278
     PgSelect286[["PgSelect[286∈9] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object186 & PgClassExpression258 & Lambda590 & Lambda593 & Lambda892 & Lambda897 --> PgSelect286
+    Object186 & PgClassExpression258 & Lambda590 & Access594 & Lambda914 & Lambda919 --> PgSelect286
     PgSelect294[["PgSelect[294∈9] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object186 & PgClassExpression258 & Lambda590 & Lambda593 & Lambda906 & Lambda911 --> PgSelect294
+    Object186 & PgClassExpression258 & Lambda590 & Access594 & Lambda929 & Lambda934 --> PgSelect294
     List267{{"List[267∈9] ➊<br />ᐸ92,266ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression266{{"PgClassExpression[266∈9] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant92 & PgClassExpression266 --> List267
@@ -678,15 +704,15 @@ graph TD
     List300 --> Lambda301
     PgSelect308[["PgSelect[308∈10] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression307{{"PgClassExpression[307∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object186 & PgClassExpression307 & Lambda590 & Lambda593 & Lambda766 & Lambda771 --> PgSelect308
+    Object186 & PgClassExpression307 & Lambda590 & Access594 & Lambda779 & Lambda784 --> PgSelect308
     PgSelect319[["PgSelect[319∈10] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object186 & PgClassExpression307 & Lambda590 & Lambda593 & Lambda780 & Lambda785 --> PgSelect319
+    Object186 & PgClassExpression307 & Lambda590 & Access594 & Lambda794 & Lambda799 --> PgSelect319
     PgSelect327[["PgSelect[327∈10] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object186 & PgClassExpression307 & Lambda590 & Lambda593 & Lambda794 & Lambda799 --> PgSelect327
+    Object186 & PgClassExpression307 & Lambda590 & Access594 & Lambda809 & Lambda814 --> PgSelect327
     PgSelect335[["PgSelect[335∈10] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object186 & PgClassExpression307 & Lambda590 & Lambda593 & Lambda808 & Lambda813 --> PgSelect335
+    Object186 & PgClassExpression307 & Lambda590 & Access594 & Lambda824 & Lambda829 --> PgSelect335
     PgSelect343[["PgSelect[343∈10] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object186 & PgClassExpression307 & Lambda590 & Lambda593 & Lambda822 & Lambda827 --> PgSelect343
+    Object186 & PgClassExpression307 & Lambda590 & Access594 & Lambda839 & Lambda844 --> PgSelect343
     List316{{"List[316∈10] ➊<br />ᐸ92,315ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression315{{"PgClassExpression[315∈10] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant92 & PgClassExpression315 --> List316
@@ -763,7 +789,7 @@ graph TD
     Access358{{"Access[358∈11] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access357 & Access358 --> Object359
     Lambda366[["Lambda[366∈11] ➊"]]:::unbatchedplan
-    List367{{"List[367∈11] ➊<br />ᐸ988ᐳ"}}:::plan
+    List367{{"List[367∈11] ➊<br />ᐸ1016ᐳ"}}:::plan
     Lambda366 & List367 --> Object368
     Lambda370[["Lambda[370∈11] ➊"]]:::unbatchedplan
     Lambda370 & List367 --> Object372
@@ -777,7 +803,7 @@ graph TD
     Condition361{{"Condition[361∈11] ➊<br />ᐸexistsᐳ"}}:::plan
     __Flag388 & Condition361 --> __Flag389
     Lambda395[["Lambda[395∈11] ➊"]]:::unbatchedplan
-    List396{{"List[396∈11] ➊<br />ᐸ990ᐳ"}}:::plan
+    List396{{"List[396∈11] ➊<br />ᐸ1018ᐳ"}}:::plan
     Lambda395 & List396 --> Object397
     Lambda399[["Lambda[399∈11] ➊"]]:::unbatchedplan
     Lambda399 & List396 --> Object401
@@ -794,12 +820,12 @@ graph TD
     __Value2 --> Access358
     Object360{{"Object[360∈11] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle356 --> Object360
-    Constant989 --> Condition361
+    Constant1017 --> Condition361
     Lambda362{{"Lambda[362∈11] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant989 --> Lambda362
+    Constant1017 --> Lambda362
     Lambda362 --> Lambda366
-    Access988{{"Access[988∈11] ➊<br />ᐸ362.base64JSON.1ᐳ"}}:::plan
-    Access988 --> List367
+    Access1016{{"Access[1016∈11] ➊<br />ᐸ362.base64JSON.1ᐳ"}}:::plan
+    Access1016 --> List367
     Lambda362 --> Lambda370
     Lambda362 --> Lambda374
     Lambda362 --> Lambda378
@@ -809,12 +835,12 @@ graph TD
     Access387{{"Access[387∈11] ➊<br />ᐸ386.0ᐳ"}}:::plan
     Lambda386 --> Access387
     Access387 --> __Flag388
-    Constant991 --> Condition390
+    Constant1019 --> Condition390
     Lambda391{{"Lambda[391∈11] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant991 --> Lambda391
+    Constant1019 --> Lambda391
     Lambda391 --> Lambda395
-    Access990{{"Access[990∈11] ➊<br />ᐸ391.base64JSON.1ᐳ"}}:::plan
-    Access990 --> List396
+    Access1018{{"Access[1018∈11] ➊<br />ᐸ391.base64JSON.1ᐳ"}}:::plan
+    Access1018 --> List396
     Lambda391 --> Lambda399
     Lambda391 --> Lambda403
     Lambda391 --> Lambda407
@@ -824,26 +850,14 @@ graph TD
     Access416{{"Access[416∈11] ➊<br />ᐸ415.0ᐳ"}}:::plan
     Lambda415 --> Access416
     Access416 --> __Flag417
-    Lambda362 --> Access988
-    Lambda391 --> Access990
-    Object933{{"Object[933∈12] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant930 & Constant931 & Constant932 --> Object933
-    Object947{{"Object[947∈12] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant944 & Constant945 & Constant932 --> Object947
-    Lambda934{{"Lambda[934∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object933 --> Lambda934
-    Lambda939{{"Lambda[939∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1020 --> Lambda939
-    Lambda948{{"Lambda[948∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object947 --> Lambda948
-    Lambda953{{"Lambda[953∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1021 --> Lambda953
+    Lambda362 --> Access1016
+    Lambda391 --> Access1018
     PgSelect424[["PgSelect[424∈13] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression423{{"PgClassExpression[423∈13] ➊<br />ᐸ__single_t...”child_id”ᐳ"}}:::plan
-    Object359 & PgClassExpression423 & Lambda590 & Lambda593 & Lambda934 & Lambda939 --> PgSelect424
+    Object359 & PgClassExpression423 & Lambda590 & Access594 & Lambda959 & Lambda964 --> PgSelect424
     PgSelect448[["PgSelect[448∈13] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression447{{"PgClassExpression[447∈13] ➊<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
-    Object359 & PgClassExpression447 & Lambda590 & Lambda593 & Lambda948 & Lambda953 --> PgSelect448
+    Object359 & PgClassExpression447 & Lambda590 & Access594 & Lambda974 & Lambda979 --> PgSelect448
     List421{{"List[421∈13] ➊<br />ᐸ419,420ᐳ"}}:::plan
     PgClassExpression420{{"PgClassExpression[420∈13] ➊<br />ᐸ__single_t...ons__.”id”ᐳ"}}:::plan
     Constant419 & PgClassExpression420 --> List421
@@ -931,7 +945,7 @@ graph TD
     Access476{{"Access[476∈16] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access475 & Access476 --> Object477
     Lambda484[["Lambda[484∈16] ➊"]]:::unbatchedplan
-    List485{{"List[485∈16] ➊<br />ᐸ992ᐳ"}}:::plan
+    List485{{"List[485∈16] ➊<br />ᐸ1020ᐳ"}}:::plan
     Lambda484 & List485 --> Object486
     Lambda488[["Lambda[488∈16] ➊"]]:::unbatchedplan
     Lambda488 & List485 --> Object490
@@ -945,7 +959,7 @@ graph TD
     Condition479{{"Condition[479∈16] ➊<br />ᐸexistsᐳ"}}:::plan
     __Flag506 & Condition479 --> __Flag507
     Lambda513[["Lambda[513∈16] ➊"]]:::unbatchedplan
-    List514{{"List[514∈16] ➊<br />ᐸ993ᐳ"}}:::plan
+    List514{{"List[514∈16] ➊<br />ᐸ1021ᐳ"}}:::plan
     Lambda513 & List514 --> Object515
     Lambda517[["Lambda[517∈16] ➊"]]:::unbatchedplan
     Lambda517 & List514 --> Object519
@@ -962,12 +976,12 @@ graph TD
     __Value2 --> Access476
     Object478{{"Object[478∈16] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle474 --> Object478
-    Constant989 --> Condition479
+    Constant1017 --> Condition479
     Lambda480{{"Lambda[480∈16] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant989 --> Lambda480
+    Constant1017 --> Lambda480
     Lambda480 --> Lambda484
-    Access992{{"Access[992∈16] ➊<br />ᐸ480.base64JSON.1ᐳ"}}:::plan
-    Access992 --> List485
+    Access1020{{"Access[1020∈16] ➊<br />ᐸ480.base64JSON.1ᐳ"}}:::plan
+    Access1020 --> List485
     Lambda480 --> Lambda488
     Lambda480 --> Lambda492
     Lambda480 --> Lambda496
@@ -977,12 +991,12 @@ graph TD
     Access505{{"Access[505∈16] ➊<br />ᐸ504.0ᐳ"}}:::plan
     Lambda504 --> Access505
     Access505 --> __Flag506
-    Constant991 --> Condition508
+    Constant1019 --> Condition508
     Lambda509{{"Lambda[509∈16] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant991 --> Lambda509
+    Constant1019 --> Lambda509
     Lambda509 --> Lambda513
-    Access993{{"Access[993∈16] ➊<br />ᐸ509.base64JSON.1ᐳ"}}:::plan
-    Access993 --> List514
+    Access1021{{"Access[1021∈16] ➊<br />ᐸ509.base64JSON.1ᐳ"}}:::plan
+    Access1021 --> List514
     Lambda509 --> Lambda517
     Lambda509 --> Lambda521
     Lambda509 --> Lambda525
@@ -992,26 +1006,14 @@ graph TD
     Access534{{"Access[534∈16] ➊<br />ᐸ533.0ᐳ"}}:::plan
     Lambda533 --> Access534
     Access534 --> __Flag535
-    Lambda480 --> Access992
-    Lambda509 --> Access993
-    Object961{{"Object[961∈17] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant958 & Constant959 & Constant932 --> Object961
-    Object975{{"Object[975∈17] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda590 & Constant972 & Constant973 & Constant932 --> Object975
-    Lambda962{{"Lambda[962∈17] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object961 --> Lambda962
-    Lambda967{{"Lambda[967∈17] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1022 --> Lambda967
-    Lambda976{{"Lambda[976∈17] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object975 --> Lambda976
-    Lambda981{{"Lambda[981∈17] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1023 --> Lambda981
+    Lambda480 --> Access1020
+    Lambda509 --> Access1021
     PgSelect543[["PgSelect[543∈18] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression539{{"PgClassExpression[539∈18] ➊<br />ᐸ__single_t...”child_id”ᐳ"}}:::plan
-    Object477 & PgClassExpression539 & Lambda590 & Lambda593 & Lambda976 & Lambda981 --> PgSelect543
+    Object477 & PgClassExpression539 & Lambda590 & Access594 & Lambda1004 & Lambda1009 --> PgSelect543
     PgSelect567[["PgSelect[567∈18] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression538{{"PgClassExpression[538∈18] ➊<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
-    Object477 & PgClassExpression538 & Lambda590 & Lambda593 & Lambda962 & Lambda967 --> PgSelect567
+    Object477 & PgClassExpression538 & Lambda590 & Access594 & Lambda989 & Lambda994 --> PgSelect567
     List540{{"List[540∈18] ➊<br />ᐸ537,538,539ᐳ"}}:::plan
     Constant537 & PgClassExpression538 & PgClassExpression539 --> List540
     PgInsertSingle474 --> PgClassExpression538
@@ -1080,44 +1082,44 @@ graph TD
     subgraph "Buckets for mutations/v4/polymorphic.relay"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Condition16,Lambda17,List22,Condition45,Lambda46,List51,Constant74,Constant92,Constant101,Constant109,Constant117,Constant125,Constant246,Constant419,Constant430,Constant435,Constant438,Constant441,Constant444,Constant537,Lambda590,Lambda593,Constant594,Constant595,Constant596,Object597,Lambda598,Lambda603,Constant608,Constant609,Constant610,Object611,Lambda612,Lambda617,Constant622,Constant623,Constant624,Object625,Lambda626,Lambda631,Constant636,Constant637,Constant638,Object639,Lambda640,Lambda645,Constant650,Constant651,Constant652,Object653,Lambda654,Lambda659,Constant664,Constant665,Constant666,Constant678,Constant679,Object681,Lambda682,Lambda687,Constant692,Constant693,Object695,Lambda696,Lambda701,Constant706,Constant707,Object709,Lambda710,Lambda715,Constant720,Constant721,Object723,Lambda724,Lambda729,Constant734,Constant735,Object737,Lambda738,Lambda743,Constant748,Constant749,Constant762,Constant763,Object765,Lambda766,Lambda771,Constant776,Constant777,Object779,Lambda780,Lambda785,Constant790,Constant791,Object793,Lambda794,Lambda799,Constant804,Constant805,Object807,Lambda808,Lambda813,Constant818,Constant819,Object821,Lambda822,Lambda827,Constant832,Constant833,Constant846,Constant847,Object849,Lambda850,Lambda855,Constant860,Constant861,Object863,Lambda864,Lambda869,Constant874,Constant875,Object877,Lambda878,Lambda883,Constant888,Constant889,Object891,Lambda892,Lambda897,Constant902,Constant903,Object905,Lambda906,Lambda911,Constant916,Constant917,Constant930,Constant931,Constant932,Constant944,Constant945,Constant958,Constant959,Constant972,Constant973,Access982,Constant983,Access984,Constant985,Constant989,Constant991,Constant994,Constant995,Constant996,Constant997,Constant998,Constant999,Constant1000,Constant1001,Constant1002,Constant1003,Constant1004,Constant1005,Constant1006,Constant1007,Constant1008,Constant1009,Constant1010,Constant1011,Constant1012,Constant1013,Constant1014,Constant1015,Constant1016,Constant1017,Constant1018,Constant1019,Constant1020,Constant1021,Constant1022,Constant1023 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 17, 22, 16, 46, 51, 45, 590, 664, 665, 666, 1001, 748, 749, 1007, 74, 593, 598, 603, 92, 612, 617, 101, 626, 631, 109, 640, 645, 117, 654, 659, 125, 682, 687, 696, 701, 710, 715, 724, 729, 738, 743<br /><br />1: Lambda[21]<br />2: Object[23]<br />3: Lambda[25]<br />4: Object[27]<br />5: Lambda[29]<br />6: Object[31]<br />7: Lambda[33]<br />8: Object[35]<br />9: Lambda[37]<br />10: Object[39]<br />11: List[40]<br />12: Lambda[41]<br />13: Access[42]<br />14: __Flag[43]<br />15: __Flag[44]<br />16: Lambda[50]<br />17: Object[52]<br />18: Lambda[54]<br />19: Object[56]<br />20: Lambda[58]<br />21: Object[60]<br />22: Lambda[62]<br />23: Object[64]<br />24: Lambda[66]<br />25: Object[68]<br />26: List[69]<br />27: Lambda[70]<br />28: Access[71]<br />29: __Flag[72]<br />30: __Flag[73]<br />31: PgInsertSingle[11]<br />32: <br />ᐳ: Object[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Condition16,Lambda17,List22,Condition45,Lambda46,List51,Constant74,Constant92,Constant101,Constant109,Constant117,Constant125,Constant246,Constant419,Constant430,Constant435,Constant438,Constant441,Constant444,Constant537,Lambda590,Lambda593,Access594,Constant595,Constant596,Constant597,Object598,Lambda599,Lambda604,Constant610,Constant611,Constant612,Object613,Lambda614,Lambda619,Constant625,Constant626,Constant627,Object628,Lambda629,Lambda634,Constant640,Constant641,Constant642,Object643,Lambda644,Lambda649,Constant655,Constant656,Constant657,Object658,Lambda659,Lambda664,Constant670,Constant671,Constant672,Object673,Lambda674,Lambda679,Constant685,Constant686,Object688,Lambda689,Lambda694,Constant700,Constant701,Object703,Lambda704,Lambda709,Constant715,Constant716,Object718,Lambda719,Lambda724,Constant730,Constant731,Object733,Lambda734,Lambda739,Constant745,Constant746,Object748,Lambda749,Lambda754,Constant760,Constant761,Object763,Lambda764,Lambda769,Constant775,Constant776,Object778,Lambda779,Lambda784,Constant790,Constant791,Object793,Lambda794,Lambda799,Constant805,Constant806,Object808,Lambda809,Lambda814,Constant820,Constant821,Object823,Lambda824,Lambda829,Constant835,Constant836,Object838,Lambda839,Lambda844,Constant850,Constant851,Object853,Lambda854,Lambda859,Constant865,Constant866,Object868,Lambda869,Lambda874,Constant880,Constant881,Object883,Lambda884,Lambda889,Constant895,Constant896,Object898,Lambda899,Lambda904,Constant910,Constant911,Object913,Lambda914,Lambda919,Constant925,Constant926,Object928,Lambda929,Lambda934,Constant940,Constant941,Object943,Lambda944,Lambda949,Constant955,Constant956,Constant957,Object958,Lambda959,Lambda964,Constant970,Constant971,Object973,Lambda974,Lambda979,Constant985,Constant986,Object988,Lambda989,Lambda994,Constant1000,Constant1001,Object1003,Lambda1004,Lambda1009,Access1010,Constant1011,Access1012,Constant1013,Constant1017,Constant1019,Constant1022,Constant1023,Constant1024,Constant1025,Constant1026,Constant1027,Constant1028,Constant1029,Constant1030,Constant1031,Constant1032,Constant1033,Constant1034,Constant1035,Constant1036,Constant1037,Constant1038,Constant1039,Constant1040,Constant1041,Constant1042,Constant1043,Constant1044,Constant1045,Constant1046,Constant1047,Constant1048,Constant1049,Constant1050,Constant1051 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 17, 22, 16, 46, 51, 45, 74, 590, 594, 674, 679, 764, 769, 599, 604, 92, 614, 619, 101, 629, 634, 109, 644, 649, 117, 659, 664, 125, 689, 694, 704, 709, 719, 724, 734, 739, 749, 754<br /><br />1: Lambda[21]<br />2: Object[23]<br />3: Lambda[25]<br />4: Object[27]<br />5: Lambda[29]<br />6: Object[31]<br />7: Lambda[33]<br />8: Object[35]<br />9: Lambda[37]<br />10: Object[39]<br />11: List[40]<br />12: Lambda[41]<br />13: Access[42]<br />14: __Flag[43]<br />15: __Flag[44]<br />16: Lambda[50]<br />17: Object[52]<br />18: Lambda[54]<br />19: Object[56]<br />20: Lambda[58]<br />21: Object[60]<br />22: Lambda[62]<br />23: Object[64]<br />24: Lambda[66]<br />25: Object[68]<br />26: List[69]<br />27: Lambda[70]<br />28: Access[71]<br />29: __Flag[72]<br />30: __Flag[73]<br />31: PgInsertSingle[11]<br />32: <br />ᐳ: Object[15]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle11,Object15,Lambda21,Object23,Lambda25,Object27,Lambda29,Object31,Lambda33,Object35,Lambda37,Object39,List40,Lambda41,Access42,__Flag43,__Flag44,Lambda50,Object52,Lambda54,Object56,Lambda58,Object60,Lambda62,Object64,Lambda66,Object68,List69,Lambda70,Access71,__Flag72,__Flag73 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 590, 664, 665, 666, 1001, 748, 749, 1007, 15, 11, 74, 14, 593, 598, 603, 92, 612, 617, 101, 626, 631, 109, 640, 645, 117, 654, 659, 125, 682, 687, 696, 701, 710, 715, 724, 729, 738, 743<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 15, 11, 74, 14, 590, 594, 674, 679, 764, 769, 599, 604, 92, 614, 619, 101, 629, 634, 109, 644, 649, 117, 659, 664, 125, 689, 694, 704, 709, 719, 724, 734, 739, 749, 754<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Object667,Lambda668,Lambda673,Object751,Lambda752,Lambda757 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 74, 14, 590, 593, 668, 673, 752, 757, 598, 603, 92, 612, 617, 101, 626, 631, 109, 640, 645, 117, 654, 659, 125, 682, 687, 696, 701, 710, 715, 724, 729, 738, 743<br /><br />ROOT PgInsertSingle{1}ᐸrelational_item_relations(child_id,parent_id)ᐳ[11]<br />1: <br />ᐳ: 75, 78, 129, 76, 77<br />2: PgSelect[79], PgSelect[130]<br />ᐳ: 83, 84, 132, 133"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 74, 14, 590, 594, 674, 679, 764, 769, 599, 604, 92, 614, 619, 101, 629, 634, 109, 644, 649, 117, 659, 664, 125, 689, 694, 704, 709, 719, 724, 734, 739, 749, 754<br /><br />ROOT PgInsertSingle{1}ᐸrelational_item_relations(child_id,parent_id)ᐳ[11]<br />1: <br />ᐳ: 75, 78, 129, 76, 77<br />2: PgSelect[79], PgSelect[130]<br />ᐳ: 83, 84, 132, 133"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression75,List76,Lambda77,PgClassExpression78,PgSelect79,First83,PgSelectSingle84,PgClassExpression129,PgSelect130,First132,PgSelectSingle133 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 84, 14, 590, 593, 598, 603, 92, 612, 617, 101, 626, 631, 109, 640, 645, 117, 654, 659, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 85, 96<br />2: 86, 97, 105, 113, 121<br />ᐳ: 90, 91, 93, 94, 95, 99, 100, 102, 103, 104, 107, 108, 110, 111, 112, 115, 116, 118, 119, 120, 123, 124, 126, 127, 128"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 84, 14, 590, 594, 599, 604, 92, 614, 619, 101, 629, 634, 109, 644, 649, 117, 659, 664, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 85, 96<br />2: 86, 97, 105, 113, 121<br />ᐳ: 90, 91, 93, 94, 95, 99, 100, 102, 103, 104, 107, 108, 110, 111, 112, 115, 116, 118, 119, 120, 123, 124, 126, 127, 128"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression85,PgSelect86,First90,PgSelectSingle91,PgClassExpression93,List94,Lambda95,PgClassExpression96,PgSelect97,First99,PgSelectSingle100,PgClassExpression102,List103,Lambda104,PgSelect105,First107,PgSelectSingle108,PgClassExpression110,List111,Lambda112,PgSelect113,First115,PgSelectSingle116,PgClassExpression118,List119,Lambda120,PgSelect121,First123,PgSelectSingle124,PgClassExpression126,List127,Lambda128 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 133, 14, 590, 593, 682, 687, 92, 696, 701, 101, 710, 715, 109, 724, 729, 117, 738, 743, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 134, 145<br />2: 135, 146, 154, 162, 170<br />ᐳ: 139, 140, 142, 143, 144, 148, 149, 151, 152, 153, 156, 157, 159, 160, 161, 164, 165, 167, 168, 169, 172, 173, 175, 176, 177"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 133, 14, 590, 594, 689, 694, 92, 704, 709, 101, 719, 724, 109, 734, 739, 117, 749, 754, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 134, 145<br />2: 135, 146, 154, 162, 170<br />ᐳ: 139, 140, 142, 143, 144, 148, 149, 151, 152, 153, 156, 157, 159, 160, 161, 164, 165, 167, 168, 169, 172, 173, 175, 176, 177"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression134,PgSelect135,First139,PgSelectSingle140,PgClassExpression142,List143,Lambda144,PgClassExpression145,PgSelect146,First148,PgSelectSingle149,PgClassExpression151,List152,Lambda153,PgSelect154,First156,PgSelectSingle157,PgClassExpression159,List160,Lambda161,PgSelect162,First164,PgSelectSingle165,PgClassExpression167,List168,Lambda169,PgSelect170,First172,PgSelectSingle173,PgClassExpression175,List176,Lambda177 bucket5
-    Bucket6("Bucket 6 (mutationField)<br />Deps: 2, 983, 985, 590, 832, 833, 666, 1013, 916, 917, 1019, 246, 593, 850, 855, 92, 864, 869, 101, 878, 883, 109, 892, 897, 117, 906, 911, 125, 766, 771, 780, 785, 794, 799, 808, 813, 822, 827<br /><br />1: Access[184]<br />2: Access[185]<br />3: Object[186]<br />4: Lambda[189]<br />5: Lambda[193]<br />6: Access[986]<br />7: List[194]<br />8: Object[195]<br />9: Lambda[197]<br />10: Object[199]<br />11: Lambda[201]<br />12: Object[203]<br />13: Lambda[205]<br />14: Object[207]<br />15: Lambda[209]<br />16: Object[211]<br />17: List[212]<br />18: Lambda[213]<br />19: Access[214]<br />20: __Flag[215]<br />21: Condition[188]<br />22: __Flag[216]<br />23: Lambda[218]<br />24: Lambda[222]<br />25: Access[987]<br />26: List[223]<br />27: Object[224]<br />28: Lambda[226]<br />29: Object[228]<br />30: Lambda[230]<br />31: Object[232]<br />32: Lambda[234]<br />33: Object[236]<br />34: Lambda[238]<br />35: Object[240]<br />36: List[241]<br />37: Lambda[242]<br />38: Access[243]<br />39: __Flag[244]<br />40: Condition[217]<br />41: __Flag[245]<br />42: PgInsertSingle[183]<br />43: <br />ᐳ: Object[187]"):::bucket
+    Bucket6("Bucket 6 (mutationField)<br />Deps: 2, 1011, 1013, 246, 590, 594, 944, 949, 854, 859, 869, 874, 92, 884, 889, 101, 899, 904, 109, 914, 919, 117, 929, 934, 125, 779, 784, 794, 799, 809, 814, 824, 829, 839, 844<br /><br />1: Access[184]<br />2: Access[185]<br />3: Object[186]<br />4: Lambda[189]<br />5: Lambda[193]<br />6: Access[1014]<br />7: List[194]<br />8: Object[195]<br />9: Lambda[197]<br />10: Object[199]<br />11: Lambda[201]<br />12: Object[203]<br />13: Lambda[205]<br />14: Object[207]<br />15: Lambda[209]<br />16: Object[211]<br />17: List[212]<br />18: Lambda[213]<br />19: Access[214]<br />20: __Flag[215]<br />21: Condition[188]<br />22: __Flag[216]<br />23: Lambda[218]<br />24: Lambda[222]<br />25: Access[1015]<br />26: List[223]<br />27: Object[224]<br />28: Lambda[226]<br />29: Object[228]<br />30: Lambda[230]<br />31: Object[232]<br />32: Lambda[234]<br />33: Object[236]<br />34: Lambda[238]<br />35: Object[240]<br />36: List[241]<br />37: Lambda[242]<br />38: Access[243]<br />39: __Flag[244]<br />40: Condition[217]<br />41: __Flag[245]<br />42: PgInsertSingle[183]<br />43: <br />ᐳ: Object[187]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgInsertSingle183,Access184,Access185,Object186,Object187,Condition188,Lambda189,Lambda193,List194,Object195,Lambda197,Object199,Lambda201,Object203,Lambda205,Object207,Lambda209,Object211,List212,Lambda213,Access214,__Flag215,__Flag216,Condition217,Lambda218,Lambda222,List223,Object224,Lambda226,Object228,Lambda230,Object232,Lambda234,Object236,Lambda238,Object240,List241,Lambda242,Access243,__Flag244,__Flag245,Access986,Access987 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 590, 832, 833, 666, 1013, 916, 917, 1019, 187, 183, 246, 186, 593, 850, 855, 92, 864, 869, 101, 878, 883, 109, 892, 897, 117, 906, 911, 125, 766, 771, 780, 785, 794, 799, 808, 813, 822, 827<br /><br />ROOT Object{6}ᐸ{result}ᐳ[187]"):::bucket
+    class Bucket6,PgInsertSingle183,Access184,Access185,Object186,Object187,Condition188,Lambda189,Lambda193,List194,Object195,Lambda197,Object199,Lambda201,Object203,Lambda205,Object207,Lambda209,Object211,List212,Lambda213,Access214,__Flag215,__Flag216,Condition217,Lambda218,Lambda222,List223,Object224,Lambda226,Object228,Lambda230,Object232,Lambda234,Object236,Lambda238,Object240,List241,Lambda242,Access243,__Flag244,__Flag245,Access1014,Access1015 bucket6
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 187, 183, 246, 186, 590, 594, 944, 949, 854, 859, 869, 874, 92, 884, 889, 101, 899, 904, 109, 914, 919, 117, 929, 934, 125, 779, 784, 794, 799, 809, 814, 824, 829, 839, 844<br /><br />ROOT Object{6}ᐸ{result}ᐳ[187]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Object835,Lambda836,Lambda841,Object919,Lambda920,Lambda925 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 183, 246, 186, 590, 593, 920, 925, 836, 841, 850, 855, 92, 864, 869, 101, 878, 883, 109, 892, 897, 117, 906, 911, 125, 766, 771, 780, 785, 794, 799, 808, 813, 822, 827<br /><br />ROOT PgInsertSingle{6}ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ[183]<br />1: <br />ᐳ: 247, 248, 249, 250<br />2: PgSelect[252], PgSelect[303]<br />ᐳ: 256, 257, 305, 306"):::bucket
+    class Bucket7 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 183, 246, 186, 590, 594, 944, 949, 854, 859, 869, 874, 92, 884, 889, 101, 899, 904, 109, 914, 919, 117, 929, 934, 125, 779, 784, 794, 799, 809, 814, 824, 829, 839, 844<br /><br />ROOT PgInsertSingle{6}ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ[183]<br />1: <br />ᐳ: 247, 248, 249, 250<br />2: PgSelect[252], PgSelect[303]<br />ᐳ: 256, 257, 305, 306"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression247,PgClassExpression248,List249,Lambda250,PgSelect252,First256,PgSelectSingle257,PgSelect303,First305,PgSelectSingle306 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 257, 186, 590, 593, 850, 855, 92, 864, 869, 101, 878, 883, 109, 892, 897, 117, 906, 911, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 258, 269<br />2: 259, 270, 278, 286, 294<br />ᐳ: 263, 264, 266, 267, 268, 272, 273, 275, 276, 277, 280, 281, 283, 284, 285, 288, 289, 291, 292, 293, 296, 297, 299, 300, 301"):::bucket
+    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 257, 186, 590, 594, 869, 874, 92, 884, 889, 101, 899, 904, 109, 914, 919, 117, 929, 934, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 258, 269<br />2: 259, 270, 278, 286, 294<br />ᐳ: 263, 264, 266, 267, 268, 272, 273, 275, 276, 277, 280, 281, 283, 284, 285, 288, 289, 291, 292, 293, 296, 297, 299, 300, 301"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression258,PgSelect259,First263,PgSelectSingle264,PgClassExpression266,List267,Lambda268,PgClassExpression269,PgSelect270,First272,PgSelectSingle273,PgClassExpression275,List276,Lambda277,PgSelect278,First280,PgSelectSingle281,PgClassExpression283,List284,Lambda285,PgSelect286,First288,PgSelectSingle289,PgClassExpression291,List292,Lambda293,PgSelect294,First296,PgSelectSingle297,PgClassExpression299,List300,Lambda301 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 306, 186, 590, 593, 766, 771, 92, 780, 785, 101, 794, 799, 109, 808, 813, 117, 822, 827, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 307, 318<br />2: 308, 319, 327, 335, 343<br />ᐳ: 312, 313, 315, 316, 317, 321, 322, 324, 325, 326, 329, 330, 332, 333, 334, 337, 338, 340, 341, 342, 345, 346, 348, 349, 350"):::bucket
+    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 306, 186, 590, 594, 779, 784, 92, 794, 799, 101, 809, 814, 109, 824, 829, 117, 839, 844, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 307, 318<br />2: 308, 319, 327, 335, 343<br />ᐳ: 312, 313, 315, 316, 317, 321, 322, 324, 325, 326, 329, 330, 332, 333, 334, 337, 338, 340, 341, 342, 345, 346, 348, 349, 350"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgClassExpression307,PgSelect308,First312,PgSelectSingle313,PgClassExpression315,List316,Lambda317,PgClassExpression318,PgSelect319,First321,PgSelectSingle322,PgClassExpression324,List325,Lambda326,PgSelect327,First329,PgSelectSingle330,PgClassExpression332,List333,Lambda334,PgSelect335,First337,PgSelectSingle338,PgClassExpression340,List341,Lambda342,PgSelect343,First345,PgSelectSingle346,PgClassExpression348,List349,Lambda350 bucket10
-    Bucket11("Bucket 11 (mutationField)<br />Deps: 2, 989, 991, 590, 930, 931, 932, 1020, 944, 945, 1021, 419, 593, 430, 435, 438, 441, 444<br /><br />1: Access[357]<br />2: Access[358]<br />3: Object[359]<br />4: Lambda[362]<br />5: Lambda[366]<br />6: Access[988]<br />7: List[367]<br />8: Object[368]<br />9: Lambda[370]<br />10: Object[372]<br />11: Lambda[374]<br />12: Object[376]<br />13: Lambda[378]<br />14: Object[380]<br />15: Lambda[382]<br />16: Object[384]<br />17: List[385]<br />18: Lambda[386]<br />19: Access[387]<br />20: __Flag[388]<br />21: Condition[361]<br />22: __Flag[389]<br />23: Lambda[391]<br />24: Lambda[395]<br />25: Access[990]<br />26: List[396]<br />27: Object[397]<br />28: Lambda[399]<br />29: Object[401]<br />30: Lambda[403]<br />31: Object[405]<br />32: Lambda[407]<br />33: Object[409]<br />34: Lambda[411]<br />35: Object[413]<br />36: List[414]<br />37: Lambda[415]<br />38: Access[416]<br />39: __Flag[417]<br />40: Condition[390]<br />41: __Flag[418]<br />42: PgInsertSingle[356]<br />43: <br />ᐳ: Object[360]"):::bucket
+    Bucket11("Bucket 11 (mutationField)<br />Deps: 2, 1017, 1019, 419, 590, 594, 959, 964, 974, 979, 430, 435, 438, 441, 444<br /><br />1: Access[357]<br />2: Access[358]<br />3: Object[359]<br />4: Lambda[362]<br />5: Lambda[366]<br />6: Access[1016]<br />7: List[367]<br />8: Object[368]<br />9: Lambda[370]<br />10: Object[372]<br />11: Lambda[374]<br />12: Object[376]<br />13: Lambda[378]<br />14: Object[380]<br />15: Lambda[382]<br />16: Object[384]<br />17: List[385]<br />18: Lambda[386]<br />19: Access[387]<br />20: __Flag[388]<br />21: Condition[361]<br />22: __Flag[389]<br />23: Lambda[391]<br />24: Lambda[395]<br />25: Access[1018]<br />26: List[396]<br />27: Object[397]<br />28: Lambda[399]<br />29: Object[401]<br />30: Lambda[403]<br />31: Object[405]<br />32: Lambda[407]<br />33: Object[409]<br />34: Lambda[411]<br />35: Object[413]<br />36: List[414]<br />37: Lambda[415]<br />38: Access[416]<br />39: __Flag[417]<br />40: Condition[390]<br />41: __Flag[418]<br />42: PgInsertSingle[356]<br />43: <br />ᐳ: Object[360]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgInsertSingle356,Access357,Access358,Object359,Object360,Condition361,Lambda362,Lambda366,List367,Object368,Lambda370,Object372,Lambda374,Object376,Lambda378,Object380,Lambda382,Object384,List385,Lambda386,Access387,__Flag388,__Flag389,Condition390,Lambda391,Lambda395,List396,Object397,Lambda399,Object401,Lambda403,Object405,Lambda407,Object409,Lambda411,Object413,List414,Lambda415,Access416,__Flag417,__Flag418,Access988,Access990 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 590, 930, 931, 932, 1020, 944, 945, 1021, 360, 356, 419, 359, 593, 430, 435, 438, 441, 444<br /><br />ROOT Object{11}ᐸ{result}ᐳ[360]"):::bucket
+    class Bucket11,PgInsertSingle356,Access357,Access358,Object359,Object360,Condition361,Lambda362,Lambda366,List367,Object368,Lambda370,Object372,Lambda374,Object376,Lambda378,Object380,Lambda382,Object384,List385,Lambda386,Access387,__Flag388,__Flag389,Condition390,Lambda391,Lambda395,List396,Object397,Lambda399,Object401,Lambda403,Object405,Lambda407,Object409,Lambda411,Object413,List414,Lambda415,Access416,__Flag417,__Flag418,Access1016,Access1018 bucket11
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 360, 356, 419, 359, 590, 594, 959, 964, 974, 979, 430, 435, 438, 441, 444<br /><br />ROOT Object{11}ᐸ{result}ᐳ[360]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,Object933,Lambda934,Lambda939,Object947,Lambda948,Lambda953 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 356, 419, 359, 590, 593, 934, 939, 948, 953, 430, 435, 438, 441, 444<br /><br />ROOT PgInsertSingle{11}ᐸsingle_table_item_relations(child_id,parent_id)ᐳ[356]<br />1: <br />ᐳ: 420, 423, 447, 421, 422<br />2: PgSelect[424], PgSelect[448]<br />ᐳ: 428, 429, 450, 451"):::bucket
+    class Bucket12 bucket12
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 356, 419, 359, 590, 594, 959, 964, 974, 979, 430, 435, 438, 441, 444<br /><br />ROOT PgInsertSingle{11}ᐸsingle_table_item_relations(child_id,parent_id)ᐳ[356]<br />1: <br />ᐳ: 420, 423, 447, 421, 422<br />2: PgSelect[424], PgSelect[448]<br />ᐳ: 428, 429, 450, 451"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression420,List421,Lambda422,PgClassExpression423,PgSelect424,First428,PgSelectSingle429,PgClassExpression447,PgSelect448,First450,PgSelectSingle451 bucket13
     Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 429, 430, 435, 438, 441, 444<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
@@ -1126,13 +1128,13 @@ graph TD
     Bucket15("Bucket 15 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 451, 430, 435, 438, 441, 444<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression453,List454,Lambda455,PgClassExpression456,List458,Lambda459,List461,Lambda462,List464,Lambda465,List467,Lambda468 bucket15
-    Bucket16("Bucket 16 (mutationField)<br />Deps: 2, 989, 991, 590, 958, 959, 932, 1022, 972, 973, 1023, 537, 593, 430, 435, 438, 441, 444<br /><br />1: Access[475]<br />2: Access[476]<br />3: Object[477]<br />4: Lambda[480]<br />5: Lambda[484]<br />6: Access[992]<br />7: List[485]<br />8: Object[486]<br />9: Lambda[488]<br />10: Object[490]<br />11: Lambda[492]<br />12: Object[494]<br />13: Lambda[496]<br />14: Object[498]<br />15: Lambda[500]<br />16: Object[502]<br />17: List[503]<br />18: Lambda[504]<br />19: Access[505]<br />20: __Flag[506]<br />21: Condition[479]<br />22: __Flag[507]<br />23: Lambda[509]<br />24: Lambda[513]<br />25: Access[993]<br />26: List[514]<br />27: Object[515]<br />28: Lambda[517]<br />29: Object[519]<br />30: Lambda[521]<br />31: Object[523]<br />32: Lambda[525]<br />33: Object[527]<br />34: Lambda[529]<br />35: Object[531]<br />36: List[532]<br />37: Lambda[533]<br />38: Access[534]<br />39: __Flag[535]<br />40: Condition[508]<br />41: __Flag[536]<br />42: PgInsertSingle[474]<br />43: <br />ᐳ: Object[478]"):::bucket
+    Bucket16("Bucket 16 (mutationField)<br />Deps: 2, 1017, 1019, 537, 590, 594, 1004, 1009, 989, 994, 430, 435, 438, 441, 444<br /><br />1: Access[475]<br />2: Access[476]<br />3: Object[477]<br />4: Lambda[480]<br />5: Lambda[484]<br />6: Access[1020]<br />7: List[485]<br />8: Object[486]<br />9: Lambda[488]<br />10: Object[490]<br />11: Lambda[492]<br />12: Object[494]<br />13: Lambda[496]<br />14: Object[498]<br />15: Lambda[500]<br />16: Object[502]<br />17: List[503]<br />18: Lambda[504]<br />19: Access[505]<br />20: __Flag[506]<br />21: Condition[479]<br />22: __Flag[507]<br />23: Lambda[509]<br />24: Lambda[513]<br />25: Access[1021]<br />26: List[514]<br />27: Object[515]<br />28: Lambda[517]<br />29: Object[519]<br />30: Lambda[521]<br />31: Object[523]<br />32: Lambda[525]<br />33: Object[527]<br />34: Lambda[529]<br />35: Object[531]<br />36: List[532]<br />37: Lambda[533]<br />38: Access[534]<br />39: __Flag[535]<br />40: Condition[508]<br />41: __Flag[536]<br />42: PgInsertSingle[474]<br />43: <br />ᐳ: Object[478]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgInsertSingle474,Access475,Access476,Object477,Object478,Condition479,Lambda480,Lambda484,List485,Object486,Lambda488,Object490,Lambda492,Object494,Lambda496,Object498,Lambda500,Object502,List503,Lambda504,Access505,__Flag506,__Flag507,Condition508,Lambda509,Lambda513,List514,Object515,Lambda517,Object519,Lambda521,Object523,Lambda525,Object527,Lambda529,Object531,List532,Lambda533,Access534,__Flag535,__Flag536,Access992,Access993 bucket16
-    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 590, 958, 959, 932, 1022, 972, 973, 1023, 478, 474, 537, 477, 593, 430, 435, 438, 441, 444<br /><br />ROOT Object{16}ᐸ{result}ᐳ[478]"):::bucket
+    class Bucket16,PgInsertSingle474,Access475,Access476,Object477,Object478,Condition479,Lambda480,Lambda484,List485,Object486,Lambda488,Object490,Lambda492,Object494,Lambda496,Object498,Lambda500,Object502,List503,Lambda504,Access505,__Flag506,__Flag507,Condition508,Lambda509,Lambda513,List514,Object515,Lambda517,Object519,Lambda521,Object523,Lambda525,Object527,Lambda529,Object531,List532,Lambda533,Access534,__Flag535,__Flag536,Access1020,Access1021 bucket16
+    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 478, 474, 537, 477, 590, 594, 1004, 1009, 989, 994, 430, 435, 438, 441, 444<br /><br />ROOT Object{16}ᐸ{result}ᐳ[478]"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,Object961,Lambda962,Lambda967,Object975,Lambda976,Lambda981 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 474, 537, 477, 590, 593, 976, 981, 962, 967, 430, 435, 438, 441, 444<br /><br />ROOT PgInsertSingle{16}ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ[474]<br />1: <br />ᐳ: 538, 539, 540, 541<br />2: PgSelect[543], PgSelect[567]<br />ᐳ: 547, 548, 569, 570"):::bucket
+    class Bucket17 bucket17
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 474, 537, 477, 590, 594, 1004, 1009, 989, 994, 430, 435, 438, 441, 444<br /><br />ROOT PgInsertSingle{16}ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ[474]<br />1: <br />ᐳ: 538, 539, 540, 541<br />2: PgSelect[543], PgSelect[567]<br />ᐳ: 547, 548, 569, 570"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,PgClassExpression538,PgClassExpression539,List540,Lambda541,PgSelect543,First547,PgSelectSingle548,PgSelect567,First569,PgSelectSingle570 bucket18
     Bucket19("Bucket 19 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 548, 430, 435, 438, 441, 444<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/procedure-mutation.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/procedure-mutation.mermaid
@@ -9,164 +9,185 @@ graph TD
 
 
     %% plan dependencies
-    Object647{{"Object[647∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object648{{"Object[648∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda640{{"Lambda[640∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant644{{"Constant[644∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant645{{"Constant[645∈0] ➊<br />ᐸsql.identifier(”json_identity_mutation”)ᐳ"}}:::plan
-    Constant646{{"Constant[646∈0] ➊<br />ᐸCodec(json)ᐳ"}}:::plan
-    Lambda640 & Constant644 & Constant645 & Constant646 --> Object647
-    Object661{{"Object[661∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant658{{"Constant[658∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant659{{"Constant[659∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation”)ᐳ"}}:::plan
-    Constant660{{"Constant[660∈0] ➊<br />ᐸCodec(jsonb)ᐳ"}}:::plan
-    Lambda640 & Constant658 & Constant659 & Constant660 --> Object661
-    Object675{{"Object[675∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant672{{"Constant[672∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant673{{"Constant[673∈0] ➊<br />ᐸsql.identifier(”json_identity_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant672 & Constant673 & Constant646 --> Object675
-    Object689{{"Object[689∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant686{{"Constant[686∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant687{{"Constant[687∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant686 & Constant687 & Constant660 --> Object689
-    Object703{{"Object[703∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant700{{"Constant[700∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant701{{"Constant[701∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation_plpgsql”)ᐳ"}}:::plan
-    Lambda640 & Constant700 & Constant701 & Constant660 --> Object703
-    Object717{{"Object[717∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant714{{"Constant[714∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant715{{"Constant[715∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation_plpgsql_with_defaultᐳ"}}:::plan
-    Lambda640 & Constant714 & Constant715 & Constant660 --> Object717
-    Object731{{"Object[731∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant728{{"Constant[728∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant729{{"Constant[729∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation_plpgsql_with_defaultᐳ"}}:::plan
-    Lambda640 & Constant728 & Constant729 & Constant660 --> Object731
-    Object745{{"Object[745∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant742{{"Constant[742∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant743{{"Constant[743∈0] ➊<br />ᐸsql.identifier(”add_1_mutation”)ᐳ"}}:::plan
-    Constant744{{"Constant[744∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda640 & Constant742 & Constant743 & Constant744 --> Object745
-    Object759{{"Object[759∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant756{{"Constant[756∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant757{{"Constant[757∈0] ➊<br />ᐸsql.identifier(”add_2_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant756 & Constant757 & Constant744 --> Object759
-    Object773{{"Object[773∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant770{{"Constant[770∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant771{{"Constant[771∈0] ➊<br />ᐸsql.identifier(”add_3_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant770 & Constant771 & Constant744 --> Object773
-    Object787{{"Object[787∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant784{{"Constant[784∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant785{{"Constant[785∈0] ➊<br />ᐸsql.identifier(”add_4_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant784 & Constant785 & Constant744 --> Object787
-    Object801{{"Object[801∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant798{{"Constant[798∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸsql.identifier(”add_4_mutation_error”)ᐳ"}}:::plan
-    Lambda640 & Constant798 & Constant799 & Constant744 --> Object801
-    Object815{{"Object[815∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant812{{"Constant[812∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant813{{"Constant[813∈0] ➊<br />ᐸsql.identifier(”mult_1”)ᐳ"}}:::plan
-    Lambda640 & Constant812 & Constant813 & Constant744 --> Object815
-    Object829{{"Object[829∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant826{{"Constant[826∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant827{{"Constant[827∈0] ➊<br />ᐸsql.identifier(”mult_2”)ᐳ"}}:::plan
-    Lambda640 & Constant826 & Constant827 & Constant744 --> Object829
+    Constant645{{"Constant[645∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant646{{"Constant[646∈0] ➊<br />ᐸsql.identifier(”json_identity_mutation”)ᐳ"}}:::plan
+    Constant647{{"Constant[647∈0] ➊<br />ᐸCodec(json)ᐳ"}}:::plan
+    Lambda640 & Constant645 & Constant646 & Constant647 --> Object648
+    Object663{{"Object[663∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant660{{"Constant[660∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant661{{"Constant[661∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation”)ᐳ"}}:::plan
+    Constant662{{"Constant[662∈0] ➊<br />ᐸCodec(jsonb)ᐳ"}}:::plan
+    Lambda640 & Constant660 & Constant661 & Constant662 --> Object663
+    Object678{{"Object[678∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant675{{"Constant[675∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant676{{"Constant[676∈0] ➊<br />ᐸsql.identifier(”json_identity_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant675 & Constant676 & Constant647 --> Object678
+    Object693{{"Object[693∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant690{{"Constant[690∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant691{{"Constant[691∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant690 & Constant691 & Constant662 --> Object693
+    Object708{{"Object[708∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant705{{"Constant[705∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant706{{"Constant[706∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation_plpgsql”)ᐳ"}}:::plan
+    Lambda640 & Constant705 & Constant706 & Constant662 --> Object708
+    Object723{{"Object[723∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant720{{"Constant[720∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant721{{"Constant[721∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation_plpgsql_with_defaultᐳ"}}:::plan
+    Lambda640 & Constant720 & Constant721 & Constant662 --> Object723
+    Object738{{"Object[738∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant735{{"Constant[735∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant736{{"Constant[736∈0] ➊<br />ᐸsql.identifier(”jsonb_identity_mutation_plpgsql_with_defaultᐳ"}}:::plan
+    Lambda640 & Constant735 & Constant736 & Constant662 --> Object738
+    Object753{{"Object[753∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant750{{"Constant[750∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant751{{"Constant[751∈0] ➊<br />ᐸsql.identifier(”add_1_mutation”)ᐳ"}}:::plan
+    Constant752{{"Constant[752∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda640 & Constant750 & Constant751 & Constant752 --> Object753
+    Object768{{"Object[768∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant765{{"Constant[765∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant766{{"Constant[766∈0] ➊<br />ᐸsql.identifier(”add_2_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant765 & Constant766 & Constant752 --> Object768
+    Object783{{"Object[783∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant780{{"Constant[780∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant781{{"Constant[781∈0] ➊<br />ᐸsql.identifier(”add_3_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant780 & Constant781 & Constant752 --> Object783
+    Object798{{"Object[798∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant795{{"Constant[795∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant796{{"Constant[796∈0] ➊<br />ᐸsql.identifier(”add_4_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant795 & Constant796 & Constant752 --> Object798
+    Object813{{"Object[813∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant810{{"Constant[810∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant811{{"Constant[811∈0] ➊<br />ᐸsql.identifier(”add_4_mutation_error”)ᐳ"}}:::plan
+    Lambda640 & Constant810 & Constant811 & Constant752 --> Object813
+    Object828{{"Object[828∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant825{{"Constant[825∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant826{{"Constant[826∈0] ➊<br />ᐸsql.identifier(”mult_1”)ᐳ"}}:::plan
+    Lambda640 & Constant825 & Constant826 & Constant752 --> Object828
     Object843{{"Object[843∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant840{{"Constant[840∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant841{{"Constant[841∈0] ➊<br />ᐸsql.identifier(”mult_3”)ᐳ"}}:::plan
-    Lambda640 & Constant840 & Constant841 & Constant744 --> Object843
-    Object857{{"Object[857∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant854{{"Constant[854∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant855{{"Constant[855∈0] ➊<br />ᐸsql.identifier(”mult_4”)ᐳ"}}:::plan
-    Lambda640 & Constant854 & Constant855 & Constant744 --> Object857
-    Object871{{"Object[871∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant868{{"Constant[868∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant869{{"Constant[869∈0] ➊<br />ᐸsql.identifier(”types_mutation”)ᐳ"}}:::plan
-    Constant870{{"Constant[870∈0] ➊<br />ᐸCodec(bool)ᐳ"}}:::plan
-    Lambda640 & Constant868 & Constant869 & Constant870 --> Object871
-    Object885{{"Object[885∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant882{{"Constant[882∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant883{{"Constant[883∈0] ➊<br />ᐸsql.identifier(”compound_type_mutation”)ᐳ"}}:::plan
-    Constant884{{"Constant[884∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda640 & Constant882 & Constant883 & Constant884 --> Object885
-    Object899{{"Object[899∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant896{{"Constant[896∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant897{{"Constant[897∈0] ➊<br />ᐸsql.identifier(”compound_type_set_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant896 & Constant897 & Constant884 --> Object899
-    Object913{{"Object[913∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant910{{"Constant[910∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant911{{"Constant[911∈0] ➊<br />ᐸsql.identifier(”compound_type_array_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant910 & Constant911 & Constant884 --> Object913
-    Object955{{"Object[955∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant952{{"Constant[952∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant953{{"Constant[953∈0] ➊<br />ᐸsql.identifier(”table_mutation”)ᐳ"}}:::plan
-    Constant940{{"Constant[940∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda640 & Constant952 & Constant953 & Constant940 --> Object955
-    Object997{{"Object[997∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant994{{"Constant[994∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant995{{"Constant[995∈0] ➊<br />ᐸsql.identifier(”table_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant994 & Constant995 & Constant940 --> Object997
-    Object1011{{"Object[1011∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1008{{"Constant[1008∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1009{{"Constant[1009∈0] ➊<br />ᐸsql.identifier(”table_set_mutation”)ᐳ"}}:::plan
-    Constant926{{"Constant[926∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda640 & Constant1008 & Constant1009 & Constant926 --> Object1011
-    Object1025{{"Object[1025∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1022{{"Constant[1022∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1023{{"Constant[1023∈0] ➊<br />ᐸsql.identifier(”int_set_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant1022 & Constant1023 & Constant744 --> Object1025
-    Object1039{{"Object[1039∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1036{{"Constant[1036∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1037{{"Constant[1037∈0] ➊<br />ᐸsql.identifier(”no_args_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant1036 & Constant1037 & Constant744 --> Object1039
+    Constant841{{"Constant[841∈0] ➊<br />ᐸsql.identifier(”mult_2”)ᐳ"}}:::plan
+    Lambda640 & Constant840 & Constant841 & Constant752 --> Object843
+    Object858{{"Object[858∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant855{{"Constant[855∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant856{{"Constant[856∈0] ➊<br />ᐸsql.identifier(”mult_3”)ᐳ"}}:::plan
+    Lambda640 & Constant855 & Constant856 & Constant752 --> Object858
+    Object873{{"Object[873∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant870{{"Constant[870∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant871{{"Constant[871∈0] ➊<br />ᐸsql.identifier(”mult_4”)ᐳ"}}:::plan
+    Lambda640 & Constant870 & Constant871 & Constant752 --> Object873
+    Object888{{"Object[888∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant885{{"Constant[885∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant886{{"Constant[886∈0] ➊<br />ᐸsql.identifier(”types_mutation”)ᐳ"}}:::plan
+    Constant887{{"Constant[887∈0] ➊<br />ᐸCodec(bool)ᐳ"}}:::plan
+    Lambda640 & Constant885 & Constant886 & Constant887 --> Object888
+    Object903{{"Object[903∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant900{{"Constant[900∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant901{{"Constant[901∈0] ➊<br />ᐸsql.identifier(”compound_type_mutation”)ᐳ"}}:::plan
+    Constant902{{"Constant[902∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda640 & Constant900 & Constant901 & Constant902 --> Object903
+    Object918{{"Object[918∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant915{{"Constant[915∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant916{{"Constant[916∈0] ➊<br />ᐸsql.identifier(”compound_type_set_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant915 & Constant916 & Constant902 --> Object918
+    Object933{{"Object[933∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant930{{"Constant[930∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant931{{"Constant[931∈0] ➊<br />ᐸsql.identifier(”compound_type_array_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant930 & Constant931 & Constant902 --> Object933
+    Object948{{"Object[948∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant945{{"Constant[945∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant946{{"Constant[946∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant947{{"Constant[947∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda640 & Constant945 & Constant946 & Constant947 --> Object948
+    Object963{{"Object[963∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant960{{"Constant[960∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant961{{"Constant[961∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant962{{"Constant[962∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda640 & Constant960 & Constant961 & Constant962 --> Object963
+    Object978{{"Object[978∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant975{{"Constant[975∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant976{{"Constant[976∈0] ➊<br />ᐸsql.identifier(”table_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant975 & Constant976 & Constant962 --> Object978
+    Object993{{"Object[993∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant990{{"Constant[990∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant991{{"Constant[991∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda640 & Constant990 & Constant991 & Constant947 --> Object993
+    Object1008{{"Object[1008∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1005{{"Constant[1005∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1006{{"Constant[1006∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda640 & Constant1005 & Constant1006 & Constant962 --> Object1008
+    Object1023{{"Object[1023∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1020{{"Constant[1020∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1021{{"Constant[1021∈0] ➊<br />ᐸsql.identifier(”table_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant1020 & Constant1021 & Constant962 --> Object1023
+    Object1038{{"Object[1038∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1035{{"Constant[1035∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1036{{"Constant[1036∈0] ➊<br />ᐸsql.identifier(”table_set_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant1035 & Constant1036 & Constant947 --> Object1038
     Object1053{{"Object[1053∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1050{{"Constant[1050∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1051{{"Constant[1051∈0] ➊<br />ᐸsql.identifier(”return_void_mutation”)ᐳ"}}:::plan
-    Constant1052{{"Constant[1052∈0] ➊<br />ᐸCodec(void)ᐳ"}}:::plan
-    Lambda640 & Constant1050 & Constant1051 & Constant1052 --> Object1053
-    Object1067{{"Object[1067∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1064{{"Constant[1064∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1065{{"Constant[1065∈0] ➊<br />ᐸsql.identifier(”guid_fn”)ᐳ"}}:::plan
-    Constant1066{{"Constant[1066∈0] ➊<br />ᐸDomainCodecᐸvarcharᐳ(guid)ᐳ"}}:::plan
-    Lambda640 & Constant1064 & Constant1065 & Constant1066 --> Object1067
-    Object1081{{"Object[1081∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1078{{"Constant[1078∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1079{{"Constant[1079∈0] ➊<br />ᐸsql.identifier(”guid_fn”)ᐳ"}}:::plan
-    Lambda640 & Constant1078 & Constant1079 & Constant1066 --> Object1081
-    Object1109{{"Object[1109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1106{{"Constant[1106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1107{{"Constant[1107∈0] ➊<br />ᐸsql.identifier(”post_many”)ᐳ"}}:::plan
-    Lambda640 & Constant1106 & Constant1107 & Constant940 --> Object1109
-    Object1123{{"Object[1123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1120{{"Constant[1120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1121{{"Constant[1121∈0] ➊<br />ᐸsql.identifier(”post_with_suffix”)ᐳ"}}:::plan
-    Lambda640 & Constant1120 & Constant1121 & Constant940 --> Object1123
-    Object1137{{"Object[1137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1134{{"Constant[1134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1135{{"Constant[1135∈0] ➊<br />ᐸsql.identifier(”issue756_mutation”)ᐳ"}}:::plan
-    Constant1136{{"Constant[1136∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
-    Lambda640 & Constant1134 & Constant1135 & Constant1136 --> Object1137
-    Object1151{{"Object[1151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1148{{"Constant[1148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1149{{"Constant[1149∈0] ➊<br />ᐸsql.identifier(”issue756_set_mutation”)ᐳ"}}:::plan
-    Lambda640 & Constant1148 & Constant1149 & Constant1136 --> Object1151
-    Object1165{{"Object[1165∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1162{{"Constant[1162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1163{{"Constant[1163∈0] ➊<br />ᐸsql.identifier(”mutation_compound_type_array”)ᐳ"}}:::plan
-    Lambda640 & Constant1162 & Constant1163 & Constant884 --> Object1165
-    Object1179{{"Object[1179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1176{{"Constant[1176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1177{{"Constant[1177∈0] ➊<br />ᐸsql.identifier(”mutation_text_array”)ᐳ"}}:::plan
-    Constant1178{{"Constant[1178∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(textArray)ᐳ"}}:::plan
-    Lambda640 & Constant1176 & Constant1177 & Constant1178 --> Object1179
-    Object1193{{"Object[1193∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1190{{"Constant[1190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1191{{"Constant[1191∈0] ➊<br />ᐸsql.identifier(”mutation_interval_array”)ᐳ"}}:::plan
-    Constant1192{{"Constant[1192∈0] ➊<br />ᐸListCodecᐸinterval[]ᐳ(intervalArray)ᐳ"}}:::plan
-    Lambda640 & Constant1190 & Constant1191 & Constant1192 --> Object1193
-    Object1207{{"Object[1207∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1204{{"Constant[1204∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1205{{"Constant[1205∈0] ➊<br />ᐸsql.identifier(”mutation_interval_set”)ᐳ"}}:::plan
-    Constant1206{{"Constant[1206∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
-    Lambda640 & Constant1204 & Constant1205 & Constant1206 --> Object1207
+    Constant1051{{"Constant[1051∈0] ➊<br />ᐸsql.identifier(”int_set_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant1050 & Constant1051 & Constant752 --> Object1053
+    Object1068{{"Object[1068∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1065{{"Constant[1065∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1066{{"Constant[1066∈0] ➊<br />ᐸsql.identifier(”no_args_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant1065 & Constant1066 & Constant752 --> Object1068
+    Object1083{{"Object[1083∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1080{{"Constant[1080∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1081{{"Constant[1081∈0] ➊<br />ᐸsql.identifier(”return_void_mutation”)ᐳ"}}:::plan
+    Constant1082{{"Constant[1082∈0] ➊<br />ᐸCodec(void)ᐳ"}}:::plan
+    Lambda640 & Constant1080 & Constant1081 & Constant1082 --> Object1083
+    Object1098{{"Object[1098∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1095{{"Constant[1095∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1096{{"Constant[1096∈0] ➊<br />ᐸsql.identifier(”guid_fn”)ᐳ"}}:::plan
+    Constant1097{{"Constant[1097∈0] ➊<br />ᐸDomainCodecᐸvarcharᐳ(guid)ᐳ"}}:::plan
+    Lambda640 & Constant1095 & Constant1096 & Constant1097 --> Object1098
+    Object1113{{"Object[1113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1110{{"Constant[1110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1111{{"Constant[1111∈0] ➊<br />ᐸsql.identifier(”guid_fn”)ᐳ"}}:::plan
+    Lambda640 & Constant1110 & Constant1111 & Constant1097 --> Object1113
+    Object1128{{"Object[1128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1125{{"Constant[1125∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1126{{"Constant[1126∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
+    Constant1127{{"Constant[1127∈0] ➊<br />ᐸRecordCodec(comptype)ᐳ"}}:::plan
+    Lambda640 & Constant1125 & Constant1126 & Constant1127 --> Object1128
+    Object1143{{"Object[1143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1140{{"Constant[1140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1141{{"Constant[1141∈0] ➊<br />ᐸsql.identifier(”post_many”)ᐳ"}}:::plan
+    Lambda640 & Constant1140 & Constant1141 & Constant962 --> Object1143
+    Object1158{{"Object[1158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1155{{"Constant[1155∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1156{{"Constant[1156∈0] ➊<br />ᐸsql.identifier(”post_with_suffix”)ᐳ"}}:::plan
+    Lambda640 & Constant1155 & Constant1156 & Constant962 --> Object1158
+    Object1173{{"Object[1173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1170{{"Constant[1170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1171{{"Constant[1171∈0] ➊<br />ᐸsql.identifier(”issue756_mutation”)ᐳ"}}:::plan
+    Constant1172{{"Constant[1172∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
+    Lambda640 & Constant1170 & Constant1171 & Constant1172 --> Object1173
+    Object1188{{"Object[1188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1185{{"Constant[1185∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1186{{"Constant[1186∈0] ➊<br />ᐸsql.identifier(”issue756_set_mutation”)ᐳ"}}:::plan
+    Lambda640 & Constant1185 & Constant1186 & Constant1172 --> Object1188
+    Object1203{{"Object[1203∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1200{{"Constant[1200∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1201{{"Constant[1201∈0] ➊<br />ᐸsql.identifier(”mutation_compound_type_array”)ᐳ"}}:::plan
+    Lambda640 & Constant1200 & Constant1201 & Constant902 --> Object1203
+    Object1218{{"Object[1218∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1215{{"Constant[1215∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1216{{"Constant[1216∈0] ➊<br />ᐸsql.identifier(”mutation_text_array”)ᐳ"}}:::plan
+    Constant1217{{"Constant[1217∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(textArray)ᐳ"}}:::plan
+    Lambda640 & Constant1215 & Constant1216 & Constant1217 --> Object1218
+    Object1233{{"Object[1233∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1230{{"Constant[1230∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1231{{"Constant[1231∈0] ➊<br />ᐸsql.identifier(”mutation_interval_array”)ᐳ"}}:::plan
+    Constant1232{{"Constant[1232∈0] ➊<br />ᐸListCodecᐸinterval[]ᐳ(intervalArray)ᐳ"}}:::plan
+    Lambda640 & Constant1230 & Constant1231 & Constant1232 --> Object1233
+    Object1248{{"Object[1248∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1245{{"Constant[1245∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1246{{"Constant[1246∈0] ➊<br />ᐸsql.identifier(”mutation_interval_set”)ᐳ"}}:::plan
+    Constant1247{{"Constant[1247∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
+    Lambda640 & Constant1245 & Constant1246 & Constant1247 --> Object1248
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -174,241 +195,252 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant1225{{"Constant[1225∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1225 --> Lambda640
+    Constant1266{{"Constant[1266∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1266 --> Lambda640
     Lambda643{{"Lambda[643∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1226{{"Constant[1226∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1226 --> Lambda643
-    Lambda648{{"Lambda[648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object647 --> Lambda648
-    Lambda653{{"Lambda[653∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1254{{"Constant[1254∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant1254 --> Lambda653
-    Lambda662{{"Lambda[662∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object661 --> Lambda662
-    Lambda667{{"Lambda[667∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1255{{"Constant[1255∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1255 --> Lambda667
-    Lambda676{{"Lambda[676∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object675 --> Lambda676
-    Lambda681{{"Lambda[681∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1256{{"Constant[1256∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant1256 --> Lambda681
-    Lambda690{{"Lambda[690∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object689 --> Lambda690
-    Lambda695{{"Lambda[695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1257{{"Constant[1257∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1257 --> Lambda695
-    Lambda704{{"Lambda[704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object703 --> Lambda704
+    Constant1267{{"Constant[1267∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1267 --> Lambda643
+    Access644{{"Access[644∈0] ➊<br />ᐸ643.0ᐳ"}}:::plan
+    Lambda643 --> Access644
+    Lambda649{{"Lambda[649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object648 --> Lambda649
+    Lambda654{{"Lambda[654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1295{{"Constant[1295∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant1295 --> Lambda654
+    Lambda664{{"Lambda[664∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object663 --> Lambda664
+    Lambda669{{"Lambda[669∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1296{{"Constant[1296∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1296 --> Lambda669
+    Lambda679{{"Lambda[679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object678 --> Lambda679
+    Lambda684{{"Lambda[684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1297{{"Constant[1297∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant1297 --> Lambda684
+    Lambda694{{"Lambda[694∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object693 --> Lambda694
+    Lambda699{{"Lambda[699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1298{{"Constant[1298∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1298 --> Lambda699
     Lambda709{{"Lambda[709∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1258{{"Constant[1258∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1258 --> Lambda709
-    Lambda718{{"Lambda[718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object717 --> Lambda718
-    Lambda723{{"Lambda[723∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1259{{"Constant[1259∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1259 --> Lambda723
-    Lambda732{{"Lambda[732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 --> Lambda732
-    Lambda737{{"Lambda[737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1260{{"Constant[1260∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1260 --> Lambda737
-    Lambda746{{"Lambda[746∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object745 --> Lambda746
-    Lambda751{{"Lambda[751∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1261{{"Constant[1261∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_1_ᐳ"}}:::plan
-    Constant1261 --> Lambda751
-    Lambda760{{"Lambda[760∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object759 --> Lambda760
-    Lambda765{{"Lambda[765∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1262{{"Constant[1262∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_2_ᐳ"}}:::plan
-    Constant1262 --> Lambda765
+    Object708 --> Lambda709
+    Lambda714{{"Lambda[714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1299{{"Constant[1299∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1299 --> Lambda714
+    Lambda724{{"Lambda[724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object723 --> Lambda724
+    Lambda729{{"Lambda[729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1300{{"Constant[1300∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1300 --> Lambda729
+    Lambda739{{"Lambda[739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object738 --> Lambda739
+    Lambda744{{"Lambda[744∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1301{{"Constant[1301∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1301 --> Lambda744
+    Lambda754{{"Lambda[754∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object753 --> Lambda754
+    Lambda759{{"Lambda[759∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1302{{"Constant[1302∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_1_ᐳ"}}:::plan
+    Constant1302 --> Lambda759
+    Lambda769{{"Lambda[769∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object768 --> Lambda769
     Lambda774{{"Lambda[774∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object773 --> Lambda774
-    Lambda779{{"Lambda[779∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1263{{"Constant[1263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_3_ᐳ"}}:::plan
-    Constant1263 --> Lambda779
-    Lambda788{{"Lambda[788∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object787 --> Lambda788
-    Lambda793{{"Lambda[793∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1264{{"Constant[1264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_4_ᐳ"}}:::plan
-    Constant1264 --> Lambda793
-    Lambda802{{"Lambda[802∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object801 --> Lambda802
-    Lambda807{{"Lambda[807∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1265{{"Constant[1265∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_4_ᐳ"}}:::plan
-    Constant1265 --> Lambda807
-    Lambda816{{"Lambda[816∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object815 --> Lambda816
-    Lambda821{{"Lambda[821∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1266{{"Constant[1266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_1ᐳ"}}:::plan
-    Constant1266 --> Lambda821
-    Lambda830{{"Lambda[830∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object829 --> Lambda830
-    Lambda835{{"Lambda[835∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1267{{"Constant[1267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_2ᐳ"}}:::plan
-    Constant1267 --> Lambda835
+    Constant1303{{"Constant[1303∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_2_ᐳ"}}:::plan
+    Constant1303 --> Lambda774
+    Lambda784{{"Lambda[784∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object783 --> Lambda784
+    Lambda789{{"Lambda[789∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1304{{"Constant[1304∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_3_ᐳ"}}:::plan
+    Constant1304 --> Lambda789
+    Lambda799{{"Lambda[799∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object798 --> Lambda799
+    Lambda804{{"Lambda[804∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1305{{"Constant[1305∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_4_ᐳ"}}:::plan
+    Constant1305 --> Lambda804
+    Lambda814{{"Lambda[814∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object813 --> Lambda814
+    Lambda819{{"Lambda[819∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1306{{"Constant[1306∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_4_ᐳ"}}:::plan
+    Constant1306 --> Lambda819
+    Lambda829{{"Lambda[829∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object828 --> Lambda829
+    Lambda834{{"Lambda[834∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1307{{"Constant[1307∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_1ᐳ"}}:::plan
+    Constant1307 --> Lambda834
     Lambda844{{"Lambda[844∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object843 --> Lambda844
     Lambda849{{"Lambda[849∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1268{{"Constant[1268∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_3ᐳ"}}:::plan
-    Constant1268 --> Lambda849
-    Lambda858{{"Lambda[858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object857 --> Lambda858
-    Lambda863{{"Lambda[863∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1269{{"Constant[1269∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_4ᐳ"}}:::plan
-    Constant1269 --> Lambda863
-    Lambda872{{"Lambda[872∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object871 --> Lambda872
-    Lambda877{{"Lambda[877∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1270{{"Constant[1270∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types_ᐳ"}}:::plan
-    Constant1270 --> Lambda877
-    Lambda886{{"Lambda[886∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object885 --> Lambda886
-    Lambda891{{"Lambda[891∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1271{{"Constant[1271∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant1271 --> Lambda891
-    Lambda900{{"Lambda[900∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object899 --> Lambda900
-    Lambda905{{"Lambda[905∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1272{{"Constant[1272∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant1272 --> Lambda905
-    Lambda914{{"Lambda[914∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object913 --> Lambda914
+    Constant1308{{"Constant[1308∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_2ᐳ"}}:::plan
+    Constant1308 --> Lambda849
+    Lambda859{{"Lambda[859∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object858 --> Lambda859
+    Lambda864{{"Lambda[864∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1309{{"Constant[1309∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_3ᐳ"}}:::plan
+    Constant1309 --> Lambda864
+    Lambda874{{"Lambda[874∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object873 --> Lambda874
+    Lambda879{{"Lambda[879∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1310{{"Constant[1310∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mult_4ᐳ"}}:::plan
+    Constant1310 --> Lambda879
+    Lambda889{{"Lambda[889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object888 --> Lambda889
+    Lambda894{{"Lambda[894∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1311{{"Constant[1311∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types_ᐳ"}}:::plan
+    Constant1311 --> Lambda894
+    Lambda904{{"Lambda[904∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object903 --> Lambda904
+    Lambda909{{"Lambda[909∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1312{{"Constant[1312∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant1312 --> Lambda909
     Lambda919{{"Lambda[919∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1273{{"Constant[1273∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant1273 --> Lambda919
-    Lambda956{{"Lambda[956∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object955 --> Lambda956
-    Lambda961{{"Lambda[961∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1276{{"Constant[1276∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1276 --> Lambda961
-    Lambda998{{"Lambda[998∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object997 --> Lambda998
-    Lambda1003{{"Lambda[1003∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1279{{"Constant[1279∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1279 --> Lambda1003
-    Lambda1012{{"Lambda[1012∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1011 --> Lambda1012
-    Lambda1017{{"Lambda[1017∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1280{{"Constant[1280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1280 --> Lambda1017
-    Lambda1026{{"Lambda[1026∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1025 --> Lambda1026
-    Lambda1031{{"Lambda[1031∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1281{{"Constant[1281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
-    Constant1281 --> Lambda1031
-    Lambda1040{{"Lambda[1040∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1039 --> Lambda1040
-    Lambda1045{{"Lambda[1045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1282{{"Constant[1282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”no_argᐳ"}}:::plan
-    Constant1282 --> Lambda1045
+    Object918 --> Lambda919
+    Lambda924{{"Lambda[924∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1313{{"Constant[1313∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant1313 --> Lambda924
+    Lambda934{{"Lambda[934∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object933 --> Lambda934
+    Lambda939{{"Lambda[939∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1314{{"Constant[1314∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant1314 --> Lambda939
+    Lambda949{{"Lambda[949∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object948 --> Lambda949
+    Lambda954{{"Lambda[954∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1315{{"Constant[1315∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1315 --> Lambda954
+    Lambda964{{"Lambda[964∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object963 --> Lambda964
+    Lambda969{{"Lambda[969∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1316{{"Constant[1316∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1316 --> Lambda969
+    Lambda979{{"Lambda[979∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object978 --> Lambda979
+    Lambda984{{"Lambda[984∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1317{{"Constant[1317∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1317 --> Lambda984
+    Lambda994{{"Lambda[994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object993 --> Lambda994
+    Lambda999{{"Lambda[999∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1318{{"Constant[1318∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1318 --> Lambda999
+    Lambda1009{{"Lambda[1009∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1008 --> Lambda1009
+    Lambda1014{{"Lambda[1014∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1319{{"Constant[1319∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1319 --> Lambda1014
+    Lambda1024{{"Lambda[1024∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1023 --> Lambda1024
+    Lambda1029{{"Lambda[1029∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1320{{"Constant[1320∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1320 --> Lambda1029
+    Lambda1039{{"Lambda[1039∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1038 --> Lambda1039
+    Lambda1044{{"Lambda[1044∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1321{{"Constant[1321∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1321 --> Lambda1044
     Lambda1054{{"Lambda[1054∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object1053 --> Lambda1054
     Lambda1059{{"Lambda[1059∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1283{{"Constant[1283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”returnᐳ"}}:::plan
-    Constant1283 --> Lambda1059
-    Lambda1068{{"Lambda[1068∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1067 --> Lambda1068
-    Lambda1073{{"Lambda[1073∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1284{{"Constant[1284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”guid_fᐳ"}}:::plan
-    Constant1284 --> Lambda1073
-    Lambda1082{{"Lambda[1082∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1081 --> Lambda1082
-    Lambda1087{{"Lambda[1087∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1285{{"Constant[1285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”guid_fᐳ"}}:::plan
-    Constant1285 --> Lambda1087
-    Lambda1110{{"Lambda[1110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1109 --> Lambda1110
-    Lambda1115{{"Lambda[1115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1287{{"Constant[1287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_mᐳ"}}:::plan
-    Constant1287 --> Lambda1115
-    Lambda1124{{"Lambda[1124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1123 --> Lambda1124
+    Constant1322{{"Constant[1322∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
+    Constant1322 --> Lambda1059
+    Lambda1069{{"Lambda[1069∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1068 --> Lambda1069
+    Lambda1074{{"Lambda[1074∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1323{{"Constant[1323∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”no_argᐳ"}}:::plan
+    Constant1323 --> Lambda1074
+    Lambda1084{{"Lambda[1084∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1083 --> Lambda1084
+    Lambda1089{{"Lambda[1089∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1324{{"Constant[1324∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”returnᐳ"}}:::plan
+    Constant1324 --> Lambda1089
+    Lambda1099{{"Lambda[1099∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1098 --> Lambda1099
+    Lambda1104{{"Lambda[1104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1325{{"Constant[1325∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”guid_fᐳ"}}:::plan
+    Constant1325 --> Lambda1104
+    Lambda1114{{"Lambda[1114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1113 --> Lambda1114
+    Lambda1119{{"Lambda[1119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1326{{"Constant[1326∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”guid_fᐳ"}}:::plan
+    Constant1326 --> Lambda1119
     Lambda1129{{"Lambda[1129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1288{{"Constant[1288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_wᐳ"}}:::plan
-    Constant1288 --> Lambda1129
-    Lambda1138{{"Lambda[1138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1137 --> Lambda1138
-    Lambda1143{{"Lambda[1143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1289{{"Constant[1289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant1289 --> Lambda1143
-    Lambda1152{{"Lambda[1152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1151 --> Lambda1152
-    Lambda1157{{"Lambda[1157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1290{{"Constant[1290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant1290 --> Lambda1157
-    Lambda1166{{"Lambda[1166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1165 --> Lambda1166
-    Lambda1171{{"Lambda[1171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1291{{"Constant[1291∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant1291 --> Lambda1171
-    Lambda1180{{"Lambda[1180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1179 --> Lambda1180
-    Lambda1185{{"Lambda[1185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1292{{"Constant[1292∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant1292 --> Lambda1185
+    Object1128 --> Lambda1129
+    Lambda1134{{"Lambda[1134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1327{{"Constant[1327∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1327 --> Lambda1134
+    Lambda1144{{"Lambda[1144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1143 --> Lambda1144
+    Lambda1149{{"Lambda[1149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1328{{"Constant[1328∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_mᐳ"}}:::plan
+    Constant1328 --> Lambda1149
+    Lambda1159{{"Lambda[1159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1158 --> Lambda1159
+    Lambda1164{{"Lambda[1164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1329{{"Constant[1329∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_wᐳ"}}:::plan
+    Constant1329 --> Lambda1164
+    Lambda1174{{"Lambda[1174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1173 --> Lambda1174
+    Lambda1179{{"Lambda[1179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1330{{"Constant[1330∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant1330 --> Lambda1179
+    Lambda1189{{"Lambda[1189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1188 --> Lambda1189
     Lambda1194{{"Lambda[1194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1193 --> Lambda1194
-    Lambda1199{{"Lambda[1199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1293{{"Constant[1293∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant1293 --> Lambda1199
-    Lambda1208{{"Lambda[1208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1207 --> Lambda1208
-    Lambda1213{{"Lambda[1213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1294{{"Constant[1294∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
-    Constant1294 --> Lambda1213
+    Constant1331{{"Constant[1331∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant1331 --> Lambda1194
+    Lambda1204{{"Lambda[1204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1203 --> Lambda1204
+    Lambda1209{{"Lambda[1209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1332{{"Constant[1332∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant1332 --> Lambda1209
+    Lambda1219{{"Lambda[1219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1218 --> Lambda1219
+    Lambda1224{{"Lambda[1224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1333{{"Constant[1333∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant1333 --> Lambda1224
+    Lambda1234{{"Lambda[1234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1233 --> Lambda1234
+    Lambda1239{{"Lambda[1239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1334{{"Constant[1334∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant1334 --> Lambda1239
+    Lambda1249{{"Lambda[1249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1248 --> Lambda1249
+    Lambda1254{{"Lambda[1254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1335{{"Constant[1335∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”mutatiᐳ"}}:::plan
+    Constant1335 --> Lambda1254
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant111{{"Constant[111∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant324{{"Constant[324∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
     Constant641{{"Constant[641∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant924{{"Constant[924∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant925{{"Constant[925∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant938{{"Constant[938∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant939{{"Constant[939∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant966{{"Constant[966∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant967{{"Constant[967∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant980{{"Constant[980∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant981{{"Constant[981∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1092{{"Constant[1092∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1093{{"Constant[1093∈0] ➊<br />ᐸsql.identifier(”frmcdc_comptype”)ᐳ"}}:::plan
-    Constant1094{{"Constant[1094∈0] ➊<br />ᐸRecordCodec(comptype)ᐳ"}}:::plan
-    Constant1214{{"Constant[1214∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Constant1215{{"Constant[1215∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Constant1216{{"Constant[1216∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
-    Constant1217{{"Constant[1217∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
-    Constant1218{{"Constant[1218∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
-    Constant1219{{"Constant[1219∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
-    Constant1220{{"Constant[1220∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant1221{{"Constant[1221∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant1222{{"Constant[1222∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
-    Constant1223{{"Constant[1223∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
-    Constant1224{{"Constant[1224∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant1227{{"Constant[1227∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant1228{{"Constant[1228∈0] ➊<br />ᐸ0ᐳ"}}:::plan
-    Constant1229{{"Constant[1229∈0] ➊<br />ᐸ'50'ᐳ"}}:::plan
-    Constant1230{{"Constant[1230∈0] ➊<br />ᐸ'xyz'ᐳ"}}:::plan
-    Constant1231{{"Constant[1231∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Constant1238{{"Constant[1238∈0] ➊<br />ᐸ-1ᐳ"}}:::plan
-    Constant1239{{"Constant[1239∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Constant1240{{"Constant[1240∈0] ➊<br />ᐸ'x'ᐳ"}}:::plan
-    Constant1241{{"Constant[1241∈0] ➊<br />ᐸ'0123456789abcde'ᐳ"}}:::plan
-    Constant1252{{"Constant[1252∈0] ➊<br />ᐸ'test'ᐳ"}}:::plan
-    Constant1274{{"Constant[1274∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1275{{"Constant[1275∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1277{{"Constant[1277∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1278{{"Constant[1278∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1286{{"Constant[1286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1300{{"Constant[1300∈0] ➊<br />ᐸ[ 1, 2, 3 ]ᐳ"}}:::plan
-    Constant1306{{"Constant[1306∈0] ➊<br />ᐸ§{ id: 15, headline: 'headline_', body: 'body' }ᐳ"}}:::plan
-    Constant1307{{"Constant[1307∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: false }, end: §{ value: 5,ᐳ"}}:::plan
-    Constant1308{{"Constant[1308∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'FOᐳ"}}:::plan
-    Constant1314{{"Constant[1314∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
-    Constant1318{{"Constant[1318∈0] ➊<br />ᐸ[ §{ id: 7, headline: 'headline', body: 'body', author_id: 9ᐳ"}}:::plan
+    Constant1255{{"Constant[1255∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Constant1256{{"Constant[1256∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Constant1257{{"Constant[1257∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
+    Constant1258{{"Constant[1258∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
+    Constant1259{{"Constant[1259∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
+    Constant1260{{"Constant[1260∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
+    Constant1261{{"Constant[1261∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant1262{{"Constant[1262∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant1263{{"Constant[1263∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
+    Constant1264{{"Constant[1264∈0] ➊<br />ᐸ'world'ᐳ"}}:::plan
+    Constant1265{{"Constant[1265∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant1268{{"Constant[1268∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant1269{{"Constant[1269∈0] ➊<br />ᐸ0ᐳ"}}:::plan
+    Constant1270{{"Constant[1270∈0] ➊<br />ᐸ'50'ᐳ"}}:::plan
+    Constant1271{{"Constant[1271∈0] ➊<br />ᐸ'xyz'ᐳ"}}:::plan
+    Constant1272{{"Constant[1272∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Constant1279{{"Constant[1279∈0] ➊<br />ᐸ-1ᐳ"}}:::plan
+    Constant1280{{"Constant[1280∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Constant1281{{"Constant[1281∈0] ➊<br />ᐸ'x'ᐳ"}}:::plan
+    Constant1282{{"Constant[1282∈0] ➊<br />ᐸ'0123456789abcde'ᐳ"}}:::plan
+    Constant1293{{"Constant[1293∈0] ➊<br />ᐸ'test'ᐳ"}}:::plan
+    Constant1341{{"Constant[1341∈0] ➊<br />ᐸ[ 1, 2, 3 ]ᐳ"}}:::plan
+    Constant1347{{"Constant[1347∈0] ➊<br />ᐸ§{ id: 15, headline: 'headline_', body: 'body' }ᐳ"}}:::plan
+    Constant1348{{"Constant[1348∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: false }, end: §{ value: 5,ᐳ"}}:::plan
+    Constant1349{{"Constant[1349∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'FOᐳ"}}:::plan
+    Constant1355{{"Constant[1355∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
+    Constant1359{{"Constant[1359∈0] ➊<br />ᐸ[ §{ id: 7, headline: 'headline', body: 'body', author_id: 9ᐳ"}}:::plan
     PgSelect9[["PgSelect[9∈1] ➊<br />ᐸjson_identity_mutation(mutation)ᐳ"]]:::sideeffectplan
-    Object12 & Constant1214 & Lambda640 & Lambda643 & Lambda648 & Lambda653 --> PgSelect9
+    Object12 & Constant1255 & Lambda640 & Access644 & Lambda649 & Lambda654 --> PgSelect9
     First13{{"First[13∈1] ➊"}}:::plan
     PgSelect9 --> First13
     PgSelectSingle14{{"PgSelectSingle[14∈1] ➊<br />ᐸjson_identity_mutationᐳ"}}:::plan
@@ -419,7 +451,7 @@ graph TD
     PgClassExpression15 --> Object16
     PgSelect20[["PgSelect[20∈3] ➊<br />ᐸjsonb_identity_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object23{{"Object[23∈3] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object23 & Constant1215 & Lambda640 & Lambda643 & Lambda662 & Lambda667 --> PgSelect20
+    Object23 & Constant1256 & Lambda640 & Access644 & Lambda664 & Lambda669 --> PgSelect20
     Access21{{"Access[21∈3] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access22{{"Access[22∈3] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access21 & Access22 --> Object23
@@ -435,7 +467,7 @@ graph TD
     PgClassExpression26 --> Object27
     PgSelect31[["PgSelect[31∈5] ➊<br />ᐸjson_identity_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object34{{"Object[34∈5] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object34 & Constant1216 & Lambda640 & Lambda643 & Lambda676 & Lambda681 --> PgSelect31
+    Object34 & Constant1257 & Lambda640 & Access644 & Lambda679 & Lambda684 --> PgSelect31
     Access32{{"Access[32∈5] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access33{{"Access[33∈5] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access32 & Access33 --> Object34
@@ -451,7 +483,7 @@ graph TD
     PgClassExpression37 --> Object38
     PgSelect42[["PgSelect[42∈7] ➊<br />ᐸjsonb_identity_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object45{{"Object[45∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object45 & Constant1217 & Lambda640 & Lambda643 & Lambda690 & Lambda695 --> PgSelect42
+    Object45 & Constant1258 & Lambda640 & Access644 & Lambda694 & Lambda699 --> PgSelect42
     Access43{{"Access[43∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access44{{"Access[44∈7] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access43 & Access44 --> Object45
@@ -467,7 +499,7 @@ graph TD
     PgClassExpression48 --> Object49
     PgSelect53[["PgSelect[53∈9] ➊<br />ᐸjsonb_identity_mutation_plpgsql(mutation)ᐳ"]]:::sideeffectplan
     Object56{{"Object[56∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object56 & Constant1218 & Lambda640 & Lambda643 & Lambda704 & Lambda709 --> PgSelect53
+    Object56 & Constant1259 & Lambda640 & Access644 & Lambda709 & Lambda714 --> PgSelect53
     Access54{{"Access[54∈9] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access55{{"Access[55∈9] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access54 & Access55 --> Object56
@@ -483,7 +515,7 @@ graph TD
     PgClassExpression59 --> Object60
     PgSelect63[["PgSelect[63∈11] ➊<br />ᐸjsonb_identity_mutation_plpgsql_with_default(mutation)ᐳ"]]:::sideeffectplan
     Object66{{"Object[66∈11] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object66 & Lambda640 & Lambda643 & Lambda718 & Lambda723 --> PgSelect63
+    Object66 & Lambda640 & Access644 & Lambda724 & Lambda729 --> PgSelect63
     Access64{{"Access[64∈11] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access65{{"Access[65∈11] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access64 & Access65 --> Object66
@@ -499,7 +531,7 @@ graph TD
     PgClassExpression69 --> Object70
     PgSelect74[["PgSelect[74∈13] ➊<br />ᐸjsonb_identity_mutation_plpgsql_with_default(mutation)ᐳ"]]:::sideeffectplan
     Object77{{"Object[77∈13] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object77 & Constant1219 & Lambda640 & Lambda643 & Lambda732 & Lambda737 --> PgSelect74
+    Object77 & Constant1260 & Lambda640 & Access644 & Lambda739 & Lambda744 --> PgSelect74
     Access75{{"Access[75∈13] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access76{{"Access[76∈13] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access75 & Access76 --> Object77
@@ -515,7 +547,7 @@ graph TD
     PgClassExpression80 --> Object81
     PgSelect86[["PgSelect[86∈15] ➊<br />ᐸadd_1_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object89{{"Object[89∈15] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object89 & Constant1220 & Constant1221 & Lambda640 & Lambda643 & Lambda746 & Lambda751 --> PgSelect86
+    Object89 & Constant1261 & Constant1262 & Lambda640 & Access644 & Lambda754 & Lambda759 --> PgSelect86
     Access87{{"Access[87∈15] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access88{{"Access[88∈15] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access87 & Access88 --> Object89
@@ -531,13 +563,13 @@ graph TD
     PgClassExpression92 --> Object93
     PgSelect99[["PgSelect[99∈17] ➊<br />ᐸadd_2_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object102{{"Object[102∈17] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object102 & Constant1221 & Constant1221 & Lambda640 & Lambda643 & Lambda760 & Lambda765 --> PgSelect99
+    Object102 & Constant1262 & Constant1262 & Lambda640 & Access644 & Lambda769 & Lambda774 --> PgSelect99
     Access100{{"Access[100∈17] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access101{{"Access[101∈17] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access100 & Access101 --> Object102
     Object106{{"Object[106∈17] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
     PgClassExpression105{{"PgClassExpression[105∈17] ➊<br />ᐸ__add_2_mutation__.vᐳ"}}:::plan
-    PgClassExpression105 & Constant1222 --> Object106
+    PgClassExpression105 & Constant1263 --> Object106
     __Value2 --> Access100
     __Value2 --> Access101
     First103{{"First[103∈17] ➊"}}:::plan
@@ -547,13 +579,13 @@ graph TD
     PgSelectSingle104 --> PgClassExpression105
     PgSelect112[["PgSelect[112∈19] ➊<br />ᐸadd_3_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object115{{"Object[115∈19] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object115 & Constant111 & Constant1224 & Lambda640 & Lambda643 & Lambda774 & Lambda779 --> PgSelect112
+    Object115 & Constant111 & Constant1265 & Lambda640 & Access644 & Lambda784 & Lambda789 --> PgSelect112
     Access113{{"Access[113∈19] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access114{{"Access[114∈19] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access113 & Access114 --> Object115
     Object119{{"Object[119∈19] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
     PgClassExpression118{{"PgClassExpression[118∈19] ➊<br />ᐸ__add_3_mutation__.vᐳ"}}:::plan
-    PgClassExpression118 & Constant1223 --> Object119
+    PgClassExpression118 & Constant1264 --> Object119
     __Value2 --> Access113
     __Value2 --> Access114
     First116{{"First[116∈19] ➊"}}:::plan
@@ -563,7 +595,7 @@ graph TD
     PgSelectSingle117 --> PgClassExpression118
     PgSelect124[["PgSelect[124∈21] ➊<br />ᐸadd_4_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object127{{"Object[127∈21] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object127 & Constant1220 & Constant1227 & Lambda640 & Lambda643 & Lambda788 & Lambda793 --> PgSelect124
+    Object127 & Constant1261 & Constant1268 & Lambda640 & Access644 & Lambda799 & Lambda804 --> PgSelect124
     Access125{{"Access[125∈21] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access126{{"Access[126∈21] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access125 & Access126 --> Object127
@@ -579,7 +611,7 @@ graph TD
     PgClassExpression130 --> Object131
     PgSelect136[["PgSelect[136∈23] ➊<br />ᐸadd_4_mutation_error(mutation)ᐳ"]]:::sideeffectplan
     Object139{{"Object[139∈23] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object139 & Constant1220 & Constant1227 & Lambda640 & Lambda643 & Lambda802 & Lambda807 --> PgSelect136
+    Object139 & Constant1261 & Constant1268 & Lambda640 & Access644 & Lambda814 & Lambda819 --> PgSelect136
     Access137{{"Access[137∈23] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access138{{"Access[138∈23] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access137 & Access138 --> Object139
@@ -595,7 +627,7 @@ graph TD
     PgClassExpression142 --> Object143
     PgSelect148[["PgSelect[148∈25] ➊<br />ᐸmult_1(mutation)ᐳ"]]:::sideeffectplan
     Object151{{"Object[151∈25] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object151 & Constant1228 & Constant1220 & Lambda640 & Lambda643 & Lambda816 & Lambda821 --> PgSelect148
+    Object151 & Constant1269 & Constant1261 & Lambda640 & Access644 & Lambda829 & Lambda834 --> PgSelect148
     Access149{{"Access[149∈25] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access150{{"Access[150∈25] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access149 & Access150 --> Object151
@@ -611,7 +643,7 @@ graph TD
     PgClassExpression154 --> Object155
     PgSelect160[["PgSelect[160∈27] ➊<br />ᐸmult_2(mutation)ᐳ"]]:::sideeffectplan
     Object163{{"Object[163∈27] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object163 & Constant1220 & Constant1220 & Lambda640 & Lambda643 & Lambda830 & Lambda835 --> PgSelect160
+    Object163 & Constant1261 & Constant1261 & Lambda640 & Access644 & Lambda844 & Lambda849 --> PgSelect160
     Access161{{"Access[161∈27] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access162{{"Access[162∈27] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access161 & Access162 --> Object163
@@ -627,7 +659,7 @@ graph TD
     PgClassExpression166 --> Object167
     PgSelect172[["PgSelect[172∈29] ➊<br />ᐸmult_3(mutation)ᐳ"]]:::sideeffectplan
     Object175{{"Object[175∈29] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object175 & Constant1220 & Constant1221 & Lambda640 & Lambda643 & Lambda844 & Lambda849 --> PgSelect172
+    Object175 & Constant1261 & Constant1262 & Lambda640 & Access644 & Lambda859 & Lambda864 --> PgSelect172
     Access173{{"Access[173∈29] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access174{{"Access[174∈29] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access173 & Access174 --> Object175
@@ -643,7 +675,7 @@ graph TD
     PgClassExpression178 --> Object179
     PgSelect184[["PgSelect[184∈31] ➊<br />ᐸmult_4(mutation)ᐳ"]]:::sideeffectplan
     Object187{{"Object[187∈31] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object187 & Constant1224 & Constant1221 & Lambda640 & Lambda643 & Lambda858 & Lambda863 --> PgSelect184
+    Object187 & Constant1265 & Constant1262 & Lambda640 & Access644 & Lambda874 & Lambda879 --> PgSelect184
     Access185{{"Access[185∈31] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access186{{"Access[186∈31] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access185 & Access186 --> Object187
@@ -659,7 +691,7 @@ graph TD
     PgClassExpression190 --> Object191
     PgSelect213[["PgSelect[213∈33] ➊<br />ᐸtypes_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object216{{"Object[216∈33] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object216 & Constant1229 & Constant641 & Constant1230 & Constant1300 & Constant1231 & Constant1307 & Lambda640 & Lambda643 & Lambda872 & Lambda877 --> PgSelect213
+    Object216 & Constant1270 & Constant641 & Constant1271 & Constant1341 & Constant1272 & Constant1348 & Lambda640 & Access644 & Lambda889 & Lambda894 --> PgSelect213
     Access214{{"Access[214∈33] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access215{{"Access[215∈33] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access214 & Access215 --> Object216
@@ -675,7 +707,7 @@ graph TD
     PgClassExpression219 --> Object220
     PgSelect234[["PgSelect[234∈35] ➊<br />ᐸcompound_type_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object237{{"Object[237∈35] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object237 & Constant1308 & Lambda640 & Lambda643 & Lambda886 & Lambda891 --> PgSelect234
+    Object237 & Constant1349 & Lambda640 & Access644 & Lambda904 & Lambda909 --> PgSelect234
     Access235{{"Access[235∈35] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access236{{"Access[236∈35] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access235 & Access236 --> Object237
@@ -705,7 +737,7 @@ graph TD
     PgSelectSingle239 --> PgClassExpression251
     PgSelect265[["PgSelect[265∈39] ➊<br />ᐸcompound_type_set_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object268{{"Object[268∈39] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object268 & Constant1308 & Lambda640 & Lambda643 & Lambda900 & Lambda905 --> PgSelect265
+    Object268 & Constant1349 & Lambda640 & Access644 & Lambda919 & Lambda924 --> PgSelect265
     Access266{{"Access[266∈39] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access267{{"Access[267∈39] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access266 & Access267 --> Object268
@@ -735,7 +767,7 @@ graph TD
     PgSelectSingle271 --> PgClassExpression282
     PgSelect296[["PgSelect[296∈44] ➊<br />ᐸcompound_type_array_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object299{{"Object[299∈44] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object299 & Constant1308 & Lambda640 & Lambda643 & Lambda914 & Lambda919 --> PgSelect296
+    Object299 & Constant1349 & Lambda640 & Access644 & Lambda934 & Lambda939 --> PgSelect296
     Access297{{"Access[297∈44] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access298{{"Access[298∈44] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access297 & Access298 --> Object299
@@ -765,7 +797,7 @@ graph TD
     PgSelectSingle302 --> PgClassExpression313
     PgSelect317[["PgSelect[317∈49] ➊<br />ᐸtable_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object320{{"Object[320∈49] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object320 & Constant1224 & Lambda640 & Lambda643 & Lambda956 & Lambda961 --> PgSelect317
+    Object320 & Constant1265 & Lambda640 & Access644 & Lambda979 & Lambda984 --> PgSelect317
     Access318{{"Access[318∈49] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access319{{"Access[319∈49] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access318 & Access319 --> Object320
@@ -779,23 +811,19 @@ graph TD
     PgSelectSingle322 --> Object323
     PgSelect331[["PgSelect[331∈50] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression330{{"PgClassExpression[330∈50] ➊<br />ᐸ__table_mu...author_id”ᐳ"}}:::plan
-    Lambda928{{"Lambda[928∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda933{{"Lambda[933∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object320 & PgClassExpression330 & Lambda640 & Lambda643 & Lambda928 & Lambda933 --> PgSelect331
+    Object320 & PgClassExpression330 & Lambda640 & Access644 & Lambda949 & Lambda954 --> PgSelect331
     PgSelect342[["PgSelect[342∈50] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression341{{"PgClassExpression[341∈50] ➊<br />ᐸ__table_mutation__.”id”ᐳ"}}:::plan
-    Lambda942{{"Lambda[942∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda947{{"Lambda[947∈50] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object320 & PgClassExpression341 & Lambda640 & Lambda643 & Lambda942 & Lambda947 --> PgSelect342
-    Object927{{"Object[927∈50] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant924 & Constant925 & Constant926 --> Object927
-    Object941{{"Object[941∈50] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant938 & Constant939 & Constant940 --> Object941
+    Object320 & PgClassExpression341 & Lambda640 & Access644 & Lambda964 & Lambda969 --> PgSelect342
     Edge347{{"Edge[347∈50] ➊"}}:::plan
     PgSelectSingle346{{"PgSelectSingle[346∈50] ➊<br />ᐸpostᐳ"}}:::plan
     PgCursor348{{"PgCursor[348∈50] ➊"}}:::plan
     Connection344{{"Connection[344∈50] ➊<br />ᐸ342ᐳ"}}:::plan
     PgSelectSingle346 & PgCursor348 & Connection344 --> Edge347
+    List326{{"List[326∈50] ➊<br />ᐸ324,341ᐳ"}}:::plan
+    Constant324 & PgClassExpression341 --> List326
+    Lambda327{{"Lambda[327∈50] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List326 --> Lambda327
     PgSelectSingle322 --> PgClassExpression330
     First335{{"First[335∈50] ➊"}}:::plan
     PgSelect331 --> First335
@@ -810,14 +838,6 @@ graph TD
     PgClassExpression349{{"PgClassExpression[349∈50] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle346 --> PgClassExpression349
     PgClassExpression349 --> List350
-    Object927 --> Lambda928
-    Constant1274 --> Lambda933
-    Object941 --> Lambda942
-    Constant1275 --> Lambda947
-    List326{{"List[326∈51] ➊<br />ᐸ324,341ᐳ"}}:::plan
-    Constant324 & PgClassExpression341 --> List326
-    Lambda327{{"Lambda[327∈51] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List326 --> Lambda327
     PgClassExpression328{{"PgClassExpression[328∈51] ➊<br />ᐸ__table_mu...”headline”ᐳ"}}:::plan
     PgSelectSingle322 --> PgClassExpression328
     PgClassExpression337{{"PgClassExpression[337∈52] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
@@ -828,7 +848,7 @@ graph TD
     PgSelectSingle346 --> PgClassExpression352
     PgSelect356[["PgSelect[356∈55] ➊<br />ᐸtable_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object359{{"Object[359∈55] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object359 & Constant1238 & Lambda640 & Lambda643 & Lambda998 & Lambda1003 --> PgSelect356
+    Object359 & Constant1279 & Lambda640 & Access644 & Lambda1024 & Lambda1029 --> PgSelect356
     Access357{{"Access[357∈55] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access358{{"Access[358∈55] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access357 & Access358 --> Object359
@@ -842,23 +862,19 @@ graph TD
     PgSelectSingle361 --> Object362
     PgSelect370[["PgSelect[370∈56] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression369{{"PgClassExpression[369∈56] ➊<br />ᐸ__table_mu...author_id”ᐳ"}}:::plan
-    Lambda970{{"Lambda[970∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda975{{"Lambda[975∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object359 & PgClassExpression369 & Lambda640 & Lambda643 & Lambda970 & Lambda975 --> PgSelect370
+    Object359 & PgClassExpression369 & Lambda640 & Access644 & Lambda994 & Lambda999 --> PgSelect370
     PgSelect381[["PgSelect[381∈56] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression380{{"PgClassExpression[380∈56] ➊<br />ᐸ__table_mutation__.”id”ᐳ"}}:::plan
-    Lambda984{{"Lambda[984∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda989{{"Lambda[989∈56] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object359 & PgClassExpression380 & Lambda640 & Lambda643 & Lambda984 & Lambda989 --> PgSelect381
-    Object969{{"Object[969∈56] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant966 & Constant967 & Constant926 --> Object969
-    Object983{{"Object[983∈56] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant980 & Constant981 & Constant940 --> Object983
+    Object359 & PgClassExpression380 & Lambda640 & Access644 & Lambda1009 & Lambda1014 --> PgSelect381
     Edge386{{"Edge[386∈56] ➊"}}:::plan
     PgSelectSingle385{{"PgSelectSingle[385∈56] ➊<br />ᐸpostᐳ"}}:::plan
     PgCursor387{{"PgCursor[387∈56] ➊"}}:::plan
     Connection383{{"Connection[383∈56] ➊<br />ᐸ381ᐳ"}}:::plan
     PgSelectSingle385 & PgCursor387 & Connection383 --> Edge386
+    List365{{"List[365∈56] ➊<br />ᐸ324,380ᐳ"}}:::plan
+    Constant324 & PgClassExpression380 --> List365
+    Lambda366{{"Lambda[366∈56] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List365 --> Lambda366
     PgSelectSingle361 --> PgClassExpression369
     First374{{"First[374∈56] ➊"}}:::plan
     PgSelect370 --> First374
@@ -873,14 +889,6 @@ graph TD
     PgClassExpression388{{"PgClassExpression[388∈56] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle385 --> PgClassExpression388
     PgClassExpression388 --> List389
-    Object969 --> Lambda970
-    Constant1277 --> Lambda975
-    Object983 --> Lambda984
-    Constant1278 --> Lambda989
-    List365{{"List[365∈57] ➊<br />ᐸ324,380ᐳ"}}:::plan
-    Constant324 & PgClassExpression380 --> List365
-    Lambda366{{"Lambda[366∈57] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List365 --> Lambda366
     PgClassExpression367{{"PgClassExpression[367∈57] ➊<br />ᐸ__table_mu...”headline”ᐳ"}}:::plan
     PgSelectSingle361 --> PgClassExpression367
     PgClassExpression376{{"PgClassExpression[376∈58] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
@@ -891,7 +899,7 @@ graph TD
     PgSelectSingle385 --> PgClassExpression391
     PgSelect394[["PgSelect[394∈61] ➊<br />ᐸtable_set_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object397{{"Object[397∈61] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object397 & Lambda640 & Lambda643 & Lambda1012 & Lambda1017 --> PgSelect394
+    Object397 & Lambda640 & Access644 & Lambda1039 & Lambda1044 --> PgSelect394
     Access395{{"Access[395∈61] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access396{{"Access[396∈61] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access395 & Access396 --> Object397
@@ -907,7 +915,7 @@ graph TD
     PgSelectSingle400 --> PgClassExpression401
     PgSelect407[["PgSelect[407∈65] ➊<br />ᐸint_set_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object410{{"Object[410∈65] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object410 & Constant1224 & Constant111 & Constant1239 & Lambda640 & Lambda643 & Lambda1026 & Lambda1031 --> PgSelect407
+    Object410 & Constant1265 & Constant111 & Constant1280 & Lambda640 & Access644 & Lambda1054 & Lambda1059 --> PgSelect407
     Access408{{"Access[408∈65] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access409{{"Access[409∈65] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access408 & Access409 --> Object410
@@ -923,13 +931,13 @@ graph TD
     PgSelectSingle413 --> PgClassExpression414
     PgSelect417[["PgSelect[417∈68] ➊<br />ᐸno_args_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object420{{"Object[420∈68] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object420 & Lambda640 & Lambda643 & Lambda1040 & Lambda1045 --> PgSelect417
+    Object420 & Lambda640 & Access644 & Lambda1069 & Lambda1074 --> PgSelect417
     Access418{{"Access[418∈68] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access419{{"Access[419∈68] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access418 & Access419 --> Object420
     Object424{{"Object[424∈68] ➊<br />ᐸ{result,clientMutationId}ᐳ"}}:::plan
     PgClassExpression423{{"PgClassExpression[423∈68] ➊<br />ᐸ__no_args_mutation__.vᐳ"}}:::plan
-    PgClassExpression423 & Constant1240 --> Object424
+    PgClassExpression423 & Constant1281 --> Object424
     __Value2 --> Access418
     __Value2 --> Access419
     First421{{"First[421∈68] ➊"}}:::plan
@@ -939,7 +947,7 @@ graph TD
     PgSelectSingle422 --> PgClassExpression423
     PgSelect427[["PgSelect[427∈70] ➊<br />ᐸreturn_void_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object430{{"Object[430∈70] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object430 & Lambda640 & Lambda643 & Lambda1054 & Lambda1059 --> PgSelect427
+    Object430 & Lambda640 & Access644 & Lambda1084 & Lambda1089 --> PgSelect427
     Access428{{"Access[428∈70] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access429{{"Access[429∈70] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access428 & Access429 --> Object430
@@ -955,7 +963,7 @@ graph TD
     PgClassExpression433 --> Object434
     PgSelect438[["PgSelect[438∈72] ➊<br />ᐸguid_fn(mutation)ᐳ"]]:::sideeffectplan
     Object441{{"Object[441∈72] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object441 & Constant111 & Lambda640 & Lambda643 & Lambda1068 & Lambda1073 --> PgSelect438
+    Object441 & Constant111 & Lambda640 & Access644 & Lambda1099 & Lambda1104 --> PgSelect438
     Access439{{"Access[439∈72] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access440{{"Access[440∈72] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access439 & Access440 --> Object441
@@ -971,7 +979,7 @@ graph TD
     PgClassExpression444 --> Object445
     PgSelect449[["PgSelect[449∈74] ➊<br />ᐸguid_fn(mutation)ᐳ"]]:::sideeffectplan
     Object452{{"Object[452∈74] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object452 & Constant1241 & Lambda640 & Lambda643 & Lambda1082 & Lambda1087 --> PgSelect449
+    Object452 & Constant1282 & Lambda640 & Access644 & Lambda1114 & Lambda1119 --> PgSelect449
     Access450{{"Access[450∈74] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access451{{"Access[451∈74] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access450 & Access451 --> Object452
@@ -987,7 +995,7 @@ graph TD
     PgClassExpression455 --> Object456
     PgSelect506[["PgSelect[506∈76] ➊<br />ᐸpost_many(mutation)ᐳ"]]:::sideeffectplan
     Object509{{"Object[509∈76] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object509 & Constant1318 & Lambda640 & Lambda643 & Lambda1110 & Lambda1115 --> PgSelect506
+    Object509 & Constant1359 & Lambda640 & Access644 & Lambda1144 & Lambda1149 --> PgSelect506
     Access507{{"Access[507∈76] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access508{{"Access[508∈76] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access507 & Access508 --> Object509
@@ -995,19 +1003,13 @@ graph TD
     __Value2 --> Access508
     Object510{{"Object[510∈76] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelect506 --> Object510
-    Object1095{{"Object[1095∈77] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1092 & Constant1093 & Constant1094 --> Object1095
-    Lambda1096{{"Lambda[1096∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1095 --> Lambda1096
-    Lambda1101{{"Lambda[1101∈77] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1286 --> Lambda1101
     __Item511[/"__Item[511∈78]<br />ᐸ506ᐳ"\]:::itemplan
     PgSelect506 ==> __Item511
     PgSelectSingle512{{"PgSelectSingle[512∈78]<br />ᐸpost_manyᐳ"}}:::plan
     __Item511 --> PgSelectSingle512
     PgSelect516[["PgSelect[516∈79]<br />ᐸfrmcdc_comptypeᐳ"]]:::plan
     PgClassExpression515{{"PgClassExpression[515∈79]<br />ᐸ__post_man...comptypes”ᐳ"}}:::plan
-    Object509 & PgClassExpression515 & Lambda640 & Lambda643 & Lambda1096 & Lambda1101 --> PgSelect516
+    Object509 & PgClassExpression515 & Lambda640 & Access644 & Lambda1129 & Lambda1134 --> PgSelect516
     PgClassExpression513{{"PgClassExpression[513∈79]<br />ᐸ__post_many__.”id”ᐳ"}}:::plan
     PgSelectSingle512 --> PgClassExpression513
     PgClassExpression514{{"PgClassExpression[514∈79]<br />ᐸ__post_man...”headline”ᐳ"}}:::plan
@@ -1023,7 +1025,7 @@ graph TD
     PgSelectSingle521 --> PgClassExpression523
     PgSelect532[["PgSelect[532∈82] ➊<br />ᐸpost_with_suffix(mutation)ᐳ"]]:::sideeffectplan
     Object535{{"Object[535∈82] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object535 & Constant1306 & Constant1252 & Lambda640 & Lambda643 & Lambda1124 & Lambda1129 --> PgSelect532
+    Object535 & Constant1347 & Constant1293 & Lambda640 & Access644 & Lambda1159 & Lambda1164 --> PgSelect532
     Access533{{"Access[533∈82] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access534{{"Access[534∈82] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access533 & Access534 --> Object535
@@ -1041,7 +1043,7 @@ graph TD
     PgSelectSingle537 --> PgClassExpression540
     PgSelect543[["PgSelect[543∈85] ➊<br />ᐸissue756_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object546{{"Object[546∈85] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object546 & Lambda640 & Lambda643 & Lambda1138 & Lambda1143 --> PgSelect543
+    Object546 & Lambda640 & Access644 & Lambda1174 & Lambda1179 --> PgSelect543
     Access544{{"Access[544∈85] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access545{{"Access[545∈85] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access544 & Access545 --> Object546
@@ -1059,7 +1061,7 @@ graph TD
     PgSelectSingle548 --> PgClassExpression551
     PgSelect554[["PgSelect[554∈88] ➊<br />ᐸissue756_set_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object557{{"Object[557∈88] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object557 & Lambda640 & Lambda643 & Lambda1152 & Lambda1157 --> PgSelect554
+    Object557 & Lambda640 & Access644 & Lambda1189 & Lambda1194 --> PgSelect554
     Access555{{"Access[555∈88] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access556{{"Access[556∈88] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access555 & Access556 --> Object557
@@ -1077,7 +1079,7 @@ graph TD
     PgSelectSingle560 --> PgClassExpression562
     PgSelect576[["PgSelect[576∈92] ➊<br />ᐸmutation_compound_type_array(mutation)ᐳ"]]:::sideeffectplan
     Object579{{"Object[579∈92] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object579 & Constant1314 & Lambda640 & Lambda643 & Lambda1166 & Lambda1171 --> PgSelect576
+    Object579 & Constant1355 & Lambda640 & Access644 & Lambda1204 & Lambda1209 --> PgSelect576
     Access577{{"Access[577∈92] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access578{{"Access[578∈92] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access577 & Access578 --> Object579
@@ -1107,7 +1109,7 @@ graph TD
     PgSelectSingle582 --> PgClassExpression593
     PgSelect596[["PgSelect[596∈97] ➊<br />ᐸmutation_text_array(mutation)ᐳ"]]:::sideeffectplan
     Object599{{"Object[599∈97] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object599 & Lambda640 & Lambda643 & Lambda1180 & Lambda1185 --> PgSelect596
+    Object599 & Lambda640 & Access644 & Lambda1219 & Lambda1224 --> PgSelect596
     Access597{{"Access[597∈97] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access598{{"Access[598∈97] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access597 & Access598 --> Object599
@@ -1125,7 +1127,7 @@ graph TD
     PgClassExpression602 ==> __Item604
     PgSelect607[["PgSelect[607∈100] ➊<br />ᐸmutation_interval_array(mutation)ᐳ"]]:::sideeffectplan
     Object610{{"Object[610∈100] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object610 & Lambda640 & Lambda643 & Lambda1194 & Lambda1199 --> PgSelect607
+    Object610 & Lambda640 & Access644 & Lambda1234 & Lambda1239 --> PgSelect607
     Access608{{"Access[608∈100] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access609{{"Access[609∈100] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access608 & Access609 --> Object610
@@ -1143,7 +1145,7 @@ graph TD
     PgClassExpression613 ==> __Item615
     PgSelect624[["PgSelect[624∈104] ➊<br />ᐸmutation_interval_set(mutation)ᐳ"]]:::sideeffectplan
     Object627{{"Object[627∈104] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object627 & Lambda640 & Lambda643 & Lambda1208 & Lambda1213 --> PgSelect624
+    Object627 & Lambda640 & Access644 & Lambda1249 & Lambda1254 --> PgSelect624
     Access625{{"Access[625∈104] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access626{{"Access[626∈104] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access625 & Access626 --> Object627
@@ -1163,110 +1165,110 @@ graph TD
     subgraph "Buckets for mutations/v4/procedure-mutation"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,Access10,Access11,Object12,Constant111,Constant324,Lambda640,Constant641,Lambda643,Constant644,Constant645,Constant646,Object647,Lambda648,Lambda653,Constant658,Constant659,Constant660,Object661,Lambda662,Lambda667,Constant672,Constant673,Object675,Lambda676,Lambda681,Constant686,Constant687,Object689,Lambda690,Lambda695,Constant700,Constant701,Object703,Lambda704,Lambda709,Constant714,Constant715,Object717,Lambda718,Lambda723,Constant728,Constant729,Object731,Lambda732,Lambda737,Constant742,Constant743,Constant744,Object745,Lambda746,Lambda751,Constant756,Constant757,Object759,Lambda760,Lambda765,Constant770,Constant771,Object773,Lambda774,Lambda779,Constant784,Constant785,Object787,Lambda788,Lambda793,Constant798,Constant799,Object801,Lambda802,Lambda807,Constant812,Constant813,Object815,Lambda816,Lambda821,Constant826,Constant827,Object829,Lambda830,Lambda835,Constant840,Constant841,Object843,Lambda844,Lambda849,Constant854,Constant855,Object857,Lambda858,Lambda863,Constant868,Constant869,Constant870,Object871,Lambda872,Lambda877,Constant882,Constant883,Constant884,Object885,Lambda886,Lambda891,Constant896,Constant897,Object899,Lambda900,Lambda905,Constant910,Constant911,Object913,Lambda914,Lambda919,Constant924,Constant925,Constant926,Constant938,Constant939,Constant940,Constant952,Constant953,Object955,Lambda956,Lambda961,Constant966,Constant967,Constant980,Constant981,Constant994,Constant995,Object997,Lambda998,Lambda1003,Constant1008,Constant1009,Object1011,Lambda1012,Lambda1017,Constant1022,Constant1023,Object1025,Lambda1026,Lambda1031,Constant1036,Constant1037,Object1039,Lambda1040,Lambda1045,Constant1050,Constant1051,Constant1052,Object1053,Lambda1054,Lambda1059,Constant1064,Constant1065,Constant1066,Object1067,Lambda1068,Lambda1073,Constant1078,Constant1079,Object1081,Lambda1082,Lambda1087,Constant1092,Constant1093,Constant1094,Constant1106,Constant1107,Object1109,Lambda1110,Lambda1115,Constant1120,Constant1121,Object1123,Lambda1124,Lambda1129,Constant1134,Constant1135,Constant1136,Object1137,Lambda1138,Lambda1143,Constant1148,Constant1149,Object1151,Lambda1152,Lambda1157,Constant1162,Constant1163,Object1165,Lambda1166,Lambda1171,Constant1176,Constant1177,Constant1178,Object1179,Lambda1180,Lambda1185,Constant1190,Constant1191,Constant1192,Object1193,Lambda1194,Lambda1199,Constant1204,Constant1205,Constant1206,Object1207,Lambda1208,Lambda1213,Constant1214,Constant1215,Constant1216,Constant1217,Constant1218,Constant1219,Constant1220,Constant1221,Constant1222,Constant1223,Constant1224,Constant1225,Constant1226,Constant1227,Constant1228,Constant1229,Constant1230,Constant1231,Constant1238,Constant1239,Constant1240,Constant1241,Constant1252,Constant1254,Constant1255,Constant1256,Constant1257,Constant1258,Constant1259,Constant1260,Constant1261,Constant1262,Constant1263,Constant1264,Constant1265,Constant1266,Constant1267,Constant1268,Constant1269,Constant1270,Constant1271,Constant1272,Constant1273,Constant1274,Constant1275,Constant1276,Constant1277,Constant1278,Constant1279,Constant1280,Constant1281,Constant1282,Constant1283,Constant1284,Constant1285,Constant1286,Constant1287,Constant1288,Constant1289,Constant1290,Constant1291,Constant1292,Constant1293,Constant1294,Constant1300,Constant1306,Constant1307,Constant1308,Constant1314,Constant1318 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 12, 1214, 640, 643, 648, 653<br /><br />1: PgSelect[9]<br />2: <br />ᐳ: 13, 14, 15, 16"):::bucket
+    class Bucket0,__Value2,__Value4,Constant7,Access10,Access11,Object12,Constant111,Constant324,Lambda640,Constant641,Lambda643,Access644,Constant645,Constant646,Constant647,Object648,Lambda649,Lambda654,Constant660,Constant661,Constant662,Object663,Lambda664,Lambda669,Constant675,Constant676,Object678,Lambda679,Lambda684,Constant690,Constant691,Object693,Lambda694,Lambda699,Constant705,Constant706,Object708,Lambda709,Lambda714,Constant720,Constant721,Object723,Lambda724,Lambda729,Constant735,Constant736,Object738,Lambda739,Lambda744,Constant750,Constant751,Constant752,Object753,Lambda754,Lambda759,Constant765,Constant766,Object768,Lambda769,Lambda774,Constant780,Constant781,Object783,Lambda784,Lambda789,Constant795,Constant796,Object798,Lambda799,Lambda804,Constant810,Constant811,Object813,Lambda814,Lambda819,Constant825,Constant826,Object828,Lambda829,Lambda834,Constant840,Constant841,Object843,Lambda844,Lambda849,Constant855,Constant856,Object858,Lambda859,Lambda864,Constant870,Constant871,Object873,Lambda874,Lambda879,Constant885,Constant886,Constant887,Object888,Lambda889,Lambda894,Constant900,Constant901,Constant902,Object903,Lambda904,Lambda909,Constant915,Constant916,Object918,Lambda919,Lambda924,Constant930,Constant931,Object933,Lambda934,Lambda939,Constant945,Constant946,Constant947,Object948,Lambda949,Lambda954,Constant960,Constant961,Constant962,Object963,Lambda964,Lambda969,Constant975,Constant976,Object978,Lambda979,Lambda984,Constant990,Constant991,Object993,Lambda994,Lambda999,Constant1005,Constant1006,Object1008,Lambda1009,Lambda1014,Constant1020,Constant1021,Object1023,Lambda1024,Lambda1029,Constant1035,Constant1036,Object1038,Lambda1039,Lambda1044,Constant1050,Constant1051,Object1053,Lambda1054,Lambda1059,Constant1065,Constant1066,Object1068,Lambda1069,Lambda1074,Constant1080,Constant1081,Constant1082,Object1083,Lambda1084,Lambda1089,Constant1095,Constant1096,Constant1097,Object1098,Lambda1099,Lambda1104,Constant1110,Constant1111,Object1113,Lambda1114,Lambda1119,Constant1125,Constant1126,Constant1127,Object1128,Lambda1129,Lambda1134,Constant1140,Constant1141,Object1143,Lambda1144,Lambda1149,Constant1155,Constant1156,Object1158,Lambda1159,Lambda1164,Constant1170,Constant1171,Constant1172,Object1173,Lambda1174,Lambda1179,Constant1185,Constant1186,Object1188,Lambda1189,Lambda1194,Constant1200,Constant1201,Object1203,Lambda1204,Lambda1209,Constant1215,Constant1216,Constant1217,Object1218,Lambda1219,Lambda1224,Constant1230,Constant1231,Constant1232,Object1233,Lambda1234,Lambda1239,Constant1245,Constant1246,Constant1247,Object1248,Lambda1249,Lambda1254,Constant1255,Constant1256,Constant1257,Constant1258,Constant1259,Constant1260,Constant1261,Constant1262,Constant1263,Constant1264,Constant1265,Constant1266,Constant1267,Constant1268,Constant1269,Constant1270,Constant1271,Constant1272,Constant1279,Constant1280,Constant1281,Constant1282,Constant1293,Constant1295,Constant1296,Constant1297,Constant1298,Constant1299,Constant1300,Constant1301,Constant1302,Constant1303,Constant1304,Constant1305,Constant1306,Constant1307,Constant1308,Constant1309,Constant1310,Constant1311,Constant1312,Constant1313,Constant1314,Constant1315,Constant1316,Constant1317,Constant1318,Constant1319,Constant1320,Constant1321,Constant1322,Constant1323,Constant1324,Constant1325,Constant1326,Constant1327,Constant1328,Constant1329,Constant1330,Constant1331,Constant1332,Constant1333,Constant1334,Constant1335,Constant1341,Constant1347,Constant1348,Constant1349,Constant1355,Constant1359 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 12, 1255, 640, 644, 649, 654<br /><br />1: PgSelect[9]<br />2: <br />ᐳ: 13, 14, 15, 16"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect9,First13,PgSelectSingle14,PgClassExpression15,Object16 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 15<br /><br />ROOT Object{1}ᐸ{result}ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (mutationField)<br />Deps: 1215, 640, 643, 662, 667, 2<br /><br />1: Access[21]<br />2: Access[22]<br />3: Object[23]<br />4: PgSelect[20]<br />5: <br />ᐳ: 24, 25, 26, 27"):::bucket
+    Bucket3("Bucket 3 (mutationField)<br />Deps: 1256, 640, 644, 664, 669, 2<br /><br />1: Access[21]<br />2: Access[22]<br />3: Object[23]<br />4: PgSelect[20]<br />5: <br />ᐳ: 24, 25, 26, 27"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgSelect20,Access21,Access22,Object23,First24,PgSelectSingle25,PgClassExpression26,Object27 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 27, 26<br /><br />ROOT Object{3}ᐸ{result}ᐳ[27]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4 bucket4
-    Bucket5("Bucket 5 (mutationField)<br />Deps: 1216, 640, 643, 676, 681, 2<br /><br />1: Access[32]<br />2: Access[33]<br />3: Object[34]<br />4: PgSelect[31]<br />5: <br />ᐳ: 35, 36, 37, 38"):::bucket
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 1257, 640, 644, 679, 684, 2<br /><br />1: Access[32]<br />2: Access[33]<br />3: Object[34]<br />4: PgSelect[31]<br />5: <br />ᐳ: 35, 36, 37, 38"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgSelect31,Access32,Access33,Object34,First35,PgSelectSingle36,PgClassExpression37,Object38 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 38, 37<br /><br />ROOT Object{5}ᐸ{result}ᐳ[38]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6 bucket6
-    Bucket7("Bucket 7 (mutationField)<br />Deps: 1217, 640, 643, 690, 695, 2<br /><br />1: Access[43]<br />2: Access[44]<br />3: Object[45]<br />4: PgSelect[42]<br />5: <br />ᐳ: 46, 47, 48, 49"):::bucket
+    Bucket7("Bucket 7 (mutationField)<br />Deps: 1258, 640, 644, 694, 699, 2<br /><br />1: Access[43]<br />2: Access[44]<br />3: Object[45]<br />4: PgSelect[42]<br />5: <br />ᐳ: 46, 47, 48, 49"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgSelect42,Access43,Access44,Object45,First46,PgSelectSingle47,PgClassExpression48,Object49 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49, 48<br /><br />ROOT Object{7}ᐸ{result}ᐳ[49]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8 bucket8
-    Bucket9("Bucket 9 (mutationField)<br />Deps: 1218, 640, 643, 704, 709, 2<br /><br />1: Access[54]<br />2: Access[55]<br />3: Object[56]<br />4: PgSelect[53]<br />5: <br />ᐳ: 57, 58, 59, 60"):::bucket
+    Bucket9("Bucket 9 (mutationField)<br />Deps: 1259, 640, 644, 709, 714, 2<br /><br />1: Access[54]<br />2: Access[55]<br />3: Object[56]<br />4: PgSelect[53]<br />5: <br />ᐳ: 57, 58, 59, 60"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgSelect53,Access54,Access55,Object56,First57,PgSelectSingle58,PgClassExpression59,Object60 bucket9
     Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 60, 59<br /><br />ROOT Object{9}ᐸ{result}ᐳ[60]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10 bucket10
-    Bucket11("Bucket 11 (mutationField)<br />Deps: 640, 643, 718, 723, 2<br /><br />1: Access[64]<br />2: Access[65]<br />3: Object[66]<br />4: PgSelect[63]<br />5: <br />ᐳ: 67, 68, 69, 70"):::bucket
+    Bucket11("Bucket 11 (mutationField)<br />Deps: 640, 644, 724, 729, 2<br /><br />1: Access[64]<br />2: Access[65]<br />3: Object[66]<br />4: PgSelect[63]<br />5: <br />ᐳ: 67, 68, 69, 70"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgSelect63,Access64,Access65,Object66,First67,PgSelectSingle68,PgClassExpression69,Object70 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 70, 69<br /><br />ROOT Object{11}ᐸ{result}ᐳ[70]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12 bucket12
-    Bucket13("Bucket 13 (mutationField)<br />Deps: 1219, 640, 643, 732, 737, 2<br /><br />1: Access[75]<br />2: Access[76]<br />3: Object[77]<br />4: PgSelect[74]<br />5: <br />ᐳ: 78, 79, 80, 81"):::bucket
+    Bucket13("Bucket 13 (mutationField)<br />Deps: 1260, 640, 644, 739, 744, 2<br /><br />1: Access[75]<br />2: Access[76]<br />3: Object[77]<br />4: PgSelect[74]<br />5: <br />ᐳ: 78, 79, 80, 81"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgSelect74,Access75,Access76,Object77,First78,PgSelectSingle79,PgClassExpression80,Object81 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 81, 80<br /><br />ROOT Object{13}ᐸ{result}ᐳ[81]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14 bucket14
-    Bucket15("Bucket 15 (mutationField)<br />Deps: 1220, 1221, 640, 643, 746, 751, 2, 7<br /><br />1: Access[87]<br />2: Access[88]<br />3: Object[89]<br />4: PgSelect[86]<br />5: <br />ᐳ: 90, 91, 92, 93"):::bucket
+    Bucket15("Bucket 15 (mutationField)<br />Deps: 1261, 1262, 640, 644, 754, 759, 2, 7<br /><br />1: Access[87]<br />2: Access[88]<br />3: Object[89]<br />4: PgSelect[86]<br />5: <br />ᐳ: 90, 91, 92, 93"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgSelect86,Access87,Access88,Object89,First90,PgSelectSingle91,PgClassExpression92,Object93 bucket15
     Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 93, 7, 92<br /><br />ROOT Object{15}ᐸ{result}ᐳ[93]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16 bucket16
-    Bucket17("Bucket 17 (mutationField)<br />Deps: 1221, 640, 643, 760, 765, 2, 1222<br /><br />1: Access[100]<br />2: Access[101]<br />3: Object[102]<br />4: PgSelect[99]<br />5: <br />ᐳ: 103, 104, 105, 106"):::bucket
+    Bucket17("Bucket 17 (mutationField)<br />Deps: 1262, 640, 644, 769, 774, 2, 1263<br /><br />1: Access[100]<br />2: Access[101]<br />3: Object[102]<br />4: PgSelect[99]<br />5: <br />ᐳ: 103, 104, 105, 106"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgSelect99,Access100,Access101,Object102,First103,PgSelectSingle104,PgClassExpression105,Object106 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 106, 1222, 105<br /><br />ROOT Object{17}ᐸ{result,clientMutationId}ᐳ[106]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 106, 1263, 105<br /><br />ROOT Object{17}ᐸ{result,clientMutationId}ᐳ[106]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18 bucket18
-    Bucket19("Bucket 19 (mutationField)<br />Deps: 111, 1224, 640, 643, 774, 779, 2, 1223<br /><br />1: Access[113]<br />2: Access[114]<br />3: Object[115]<br />4: PgSelect[112]<br />5: <br />ᐳ: 116, 117, 118, 119"):::bucket
+    Bucket19("Bucket 19 (mutationField)<br />Deps: 111, 1265, 640, 644, 784, 789, 2, 1264<br /><br />1: Access[113]<br />2: Access[114]<br />3: Object[115]<br />4: PgSelect[112]<br />5: <br />ᐳ: 116, 117, 118, 119"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgSelect112,Access113,Access114,Object115,First116,PgSelectSingle117,PgClassExpression118,Object119 bucket19
-    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 119, 1223, 118<br /><br />ROOT Object{19}ᐸ{result,clientMutationId}ᐳ[119]"):::bucket
+    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 119, 1264, 118<br /><br />ROOT Object{19}ᐸ{result,clientMutationId}ᐳ[119]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20 bucket20
-    Bucket21("Bucket 21 (mutationField)<br />Deps: 1220, 1227, 640, 643, 788, 793, 2<br /><br />1: Access[125]<br />2: Access[126]<br />3: Object[127]<br />4: PgSelect[124]<br />5: <br />ᐳ: 128, 129, 130, 131"):::bucket
+    Bucket21("Bucket 21 (mutationField)<br />Deps: 1261, 1268, 640, 644, 799, 804, 2<br /><br />1: Access[125]<br />2: Access[126]<br />3: Object[127]<br />4: PgSelect[124]<br />5: <br />ᐳ: 128, 129, 130, 131"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgSelect124,Access125,Access126,Object127,First128,PgSelectSingle129,PgClassExpression130,Object131 bucket21
     Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 131, 130<br /><br />ROOT Object{21}ᐸ{result}ᐳ[131]"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22 bucket22
-    Bucket23("Bucket 23 (mutationField)<br />Deps: 1220, 1227, 640, 643, 802, 807, 2<br /><br />1: Access[137]<br />2: Access[138]<br />3: Object[139]<br />4: PgSelect[136]<br />5: <br />ᐳ: 140, 141, 142, 143"):::bucket
+    Bucket23("Bucket 23 (mutationField)<br />Deps: 1261, 1268, 640, 644, 814, 819, 2<br /><br />1: Access[137]<br />2: Access[138]<br />3: Object[139]<br />4: PgSelect[136]<br />5: <br />ᐳ: 140, 141, 142, 143"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23,PgSelect136,Access137,Access138,Object139,First140,PgSelectSingle141,PgClassExpression142,Object143 bucket23
     Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 143, 142<br /><br />ROOT Object{23}ᐸ{result}ᐳ[143]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24 bucket24
-    Bucket25("Bucket 25 (mutationField)<br />Deps: 1228, 1220, 640, 643, 816, 821, 2<br /><br />1: Access[149]<br />2: Access[150]<br />3: Object[151]<br />4: PgSelect[148]<br />5: <br />ᐳ: 152, 153, 154, 155"):::bucket
+    Bucket25("Bucket 25 (mutationField)<br />Deps: 1269, 1261, 640, 644, 829, 834, 2<br /><br />1: Access[149]<br />2: Access[150]<br />3: Object[151]<br />4: PgSelect[148]<br />5: <br />ᐳ: 152, 153, 154, 155"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgSelect148,Access149,Access150,Object151,First152,PgSelectSingle153,PgClassExpression154,Object155 bucket25
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 155, 154<br /><br />ROOT Object{25}ᐸ{result}ᐳ[155]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26 bucket26
-    Bucket27("Bucket 27 (mutationField)<br />Deps: 1220, 640, 643, 830, 835, 2<br /><br />1: Access[161]<br />2: Access[162]<br />3: Object[163]<br />4: PgSelect[160]<br />5: <br />ᐳ: 164, 165, 166, 167"):::bucket
+    Bucket27("Bucket 27 (mutationField)<br />Deps: 1261, 640, 644, 844, 849, 2<br /><br />1: Access[161]<br />2: Access[162]<br />3: Object[163]<br />4: PgSelect[160]<br />5: <br />ᐳ: 164, 165, 166, 167"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgSelect160,Access161,Access162,Object163,First164,PgSelectSingle165,PgClassExpression166,Object167 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 167, 166<br /><br />ROOT Object{27}ᐸ{result}ᐳ[167]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28 bucket28
-    Bucket29("Bucket 29 (mutationField)<br />Deps: 1220, 1221, 640, 643, 844, 849, 2<br /><br />1: Access[173]<br />2: Access[174]<br />3: Object[175]<br />4: PgSelect[172]<br />5: <br />ᐳ: 176, 177, 178, 179"):::bucket
+    Bucket29("Bucket 29 (mutationField)<br />Deps: 1261, 1262, 640, 644, 859, 864, 2<br /><br />1: Access[173]<br />2: Access[174]<br />3: Object[175]<br />4: PgSelect[172]<br />5: <br />ᐳ: 176, 177, 178, 179"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,PgSelect172,Access173,Access174,Object175,First176,PgSelectSingle177,PgClassExpression178,Object179 bucket29
     Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 179, 178<br /><br />ROOT Object{29}ᐸ{result}ᐳ[179]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30 bucket30
-    Bucket31("Bucket 31 (mutationField)<br />Deps: 1224, 1221, 640, 643, 858, 863, 2<br /><br />1: Access[185]<br />2: Access[186]<br />3: Object[187]<br />4: PgSelect[184]<br />5: <br />ᐳ: 188, 189, 190, 191"):::bucket
+    Bucket31("Bucket 31 (mutationField)<br />Deps: 1265, 1262, 640, 644, 874, 879, 2<br /><br />1: Access[185]<br />2: Access[186]<br />3: Object[187]<br />4: PgSelect[184]<br />5: <br />ᐳ: 188, 189, 190, 191"):::bucket
     classDef bucket31 stroke:#a52a2a
     class Bucket31,PgSelect184,Access185,Access186,Object187,First188,PgSelectSingle189,PgClassExpression190,Object191 bucket31
     Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 191, 190<br /><br />ROOT Object{31}ᐸ{result}ᐳ[191]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32 bucket32
-    Bucket33("Bucket 33 (mutationField)<br />Deps: 1229, 641, 1230, 1300, 1231, 1307, 640, 643, 872, 877, 2<br /><br />1: Access[214]<br />2: Access[215]<br />3: Object[216]<br />4: PgSelect[213]<br />5: <br />ᐳ: 217, 218, 219, 220"):::bucket
+    Bucket33("Bucket 33 (mutationField)<br />Deps: 1270, 641, 1271, 1341, 1272, 1348, 640, 644, 889, 894, 2<br /><br />1: Access[214]<br />2: Access[215]<br />3: Object[216]<br />4: PgSelect[213]<br />5: <br />ᐳ: 217, 218, 219, 220"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgSelect213,Access214,Access215,Object216,First217,PgSelectSingle218,PgClassExpression219,Object220 bucket33
     Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 220, 219<br /><br />ROOT Object{33}ᐸ{result}ᐳ[220]"):::bucket
     classDef bucket34 stroke:#696969
     class Bucket34 bucket34
-    Bucket35("Bucket 35 (mutationField)<br />Deps: 1308, 640, 643, 886, 891, 2<br /><br />1: Access[235]<br />2: Access[236]<br />3: Object[237]<br />4: PgSelect[234]<br />5: <br />ᐳ: 238, 239, 240"):::bucket
+    Bucket35("Bucket 35 (mutationField)<br />Deps: 1349, 640, 644, 904, 909, 2<br /><br />1: Access[235]<br />2: Access[236]<br />3: Object[237]<br />4: PgSelect[234]<br />5: <br />ᐳ: 238, 239, 240"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgSelect234,Access235,Access236,Object237,First238,PgSelectSingle239,Object240 bucket35
     Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 240, 239<br /><br />ROOT Object{35}ᐸ{result}ᐳ[240]"):::bucket
@@ -1278,7 +1280,7 @@ graph TD
     Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 247<br /><br />ROOT PgClassExpression{37}ᐸ__compound...tion__.”g”ᐳ[247]"):::bucket
     classDef bucket38 stroke:#0000ff
     class Bucket38 bucket38
-    Bucket39("Bucket 39 (mutationField)<br />Deps: 1308, 640, 643, 900, 905, 2<br /><br />1: Access[266]<br />2: Access[267]<br />3: Object[268]<br />4: PgSelect[265]<br />5: <br />ᐳ: Object[269]"):::bucket
+    Bucket39("Bucket 39 (mutationField)<br />Deps: 1349, 640, 644, 919, 924, 2<br /><br />1: Access[266]<br />2: Access[267]<br />3: Object[268]<br />4: PgSelect[265]<br />5: <br />ᐳ: Object[269]"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,PgSelect265,Access266,Access267,Object268,Object269 bucket39
     Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 269, 265<br /><br />ROOT Object{39}ᐸ{result}ᐳ[269]"):::bucket
@@ -1293,7 +1295,7 @@ graph TD
     Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 278<br /><br />ROOT PgClassExpression{42}ᐸ__compound...tion__.”g”ᐳ[278]"):::bucket
     classDef bucket43 stroke:#ff0000
     class Bucket43 bucket43
-    Bucket44("Bucket 44 (mutationField)<br />Deps: 1308, 640, 643, 914, 919, 2<br /><br />1: Access[297]<br />2: Access[298]<br />3: Object[299]<br />4: PgSelect[296]<br />5: <br />ᐳ: Object[300]"):::bucket
+    Bucket44("Bucket 44 (mutationField)<br />Deps: 1349, 640, 644, 934, 939, 2<br /><br />1: Access[297]<br />2: Access[298]<br />3: Object[299]<br />4: PgSelect[296]<br />5: <br />ᐳ: Object[300]"):::bucket
     classDef bucket44 stroke:#ffff00
     class Bucket44,PgSelect296,Access297,Access298,Object299,Object300 bucket44
     Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 300, 296<br /><br />ROOT Object{44}ᐸ{result}ᐳ[300]"):::bucket
@@ -1308,15 +1310,15 @@ graph TD
     Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 309<br /><br />ROOT PgClassExpression{47}ᐸ__compound...tion__.”g”ᐳ[309]"):::bucket
     classDef bucket48 stroke:#a52a2a
     class Bucket48 bucket48
-    Bucket49("Bucket 49 (mutationField)<br />Deps: 1224, 640, 643, 956, 961, 2, 924, 925, 926, 1274, 938, 939, 940, 1275, 324<br /><br />1: Access[318]<br />2: Access[319]<br />3: Object[320]<br />4: PgSelect[317]<br />5: <br />ᐳ: 321, 322, 323"):::bucket
+    Bucket49("Bucket 49 (mutationField)<br />Deps: 1265, 640, 644, 979, 984, 2, 324, 949, 954, 964, 969<br /><br />1: Access[318]<br />2: Access[319]<br />3: Object[320]<br />4: PgSelect[317]<br />5: <br />ᐳ: 321, 322, 323"):::bucket
     classDef bucket49 stroke:#ff00ff
     class Bucket49,PgSelect317,Access318,Access319,Object320,First321,PgSelectSingle322,Object323 bucket49
-    Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 322, 320, 640, 643, 924, 925, 926, 1274, 938, 939, 940, 1275, 323, 324<br /><br />ROOT Object{49}ᐸ{result}ᐳ[323]<br />1: <br />ᐳ: 330, 341, 344, 927, 933, 941, 947, 928, 942<br />2: PgSelect[331], PgSelect[342]<br />ᐳ: 335, 336, 345, 346, 349, 350, 348, 347"):::bucket
+    Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 324, 322, 320, 640, 644, 949, 954, 964, 969, 323<br /><br />ROOT Object{49}ᐸ{result}ᐳ[323]<br />1: <br />ᐳ: 330, 341, 344, 326, 327<br />2: PgSelect[331], PgSelect[342]<br />ᐳ: 335, 336, 345, 346, 349, 350, 348, 347"):::bucket
     classDef bucket50 stroke:#f5deb3
-    class Bucket50,PgClassExpression330,PgSelect331,First335,PgSelectSingle336,PgClassExpression341,PgSelect342,Connection344,First345,PgSelectSingle346,Edge347,PgCursor348,PgClassExpression349,List350,Object927,Lambda928,Lambda933,Object941,Lambda942,Lambda947 bucket50
-    Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 324, 341, 322, 330<br /><br />ROOT PgSelectSingle{49}ᐸtable_mutationᐳ[322]"):::bucket
+    class Bucket50,List326,Lambda327,PgClassExpression330,PgSelect331,First335,PgSelectSingle336,PgClassExpression341,PgSelect342,Connection344,First345,PgSelectSingle346,Edge347,PgCursor348,PgClassExpression349,List350 bucket50
+    Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 322, 327, 341, 330<br /><br />ROOT PgSelectSingle{49}ᐸtable_mutationᐳ[322]"):::bucket
     classDef bucket51 stroke:#696969
-    class Bucket51,List326,Lambda327,PgClassExpression328 bucket51
+    class Bucket51,PgClassExpression328 bucket51
     Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 336<br /><br />ROOT PgSelectSingle{50}ᐸpersonᐳ[336]"):::bucket
     classDef bucket52 stroke:#00bfff
     class Bucket52,PgClassExpression337,PgClassExpression338 bucket52
@@ -1326,15 +1328,15 @@ graph TD
     Bucket54("Bucket 54 (nullableBoundary)<br />Deps: 346, 349<br /><br />ROOT PgSelectSingle{50}ᐸpostᐳ[346]"):::bucket
     classDef bucket54 stroke:#ffa500
     class Bucket54,PgClassExpression352 bucket54
-    Bucket55("Bucket 55 (mutationField)<br />Deps: 1238, 640, 643, 998, 1003, 2, 966, 967, 926, 1277, 980, 981, 940, 1278, 324<br /><br />1: Access[357]<br />2: Access[358]<br />3: Object[359]<br />4: PgSelect[356]<br />5: <br />ᐳ: 360, 361, 362"):::bucket
+    Bucket55("Bucket 55 (mutationField)<br />Deps: 1279, 640, 644, 1024, 1029, 2, 324, 994, 999, 1009, 1014<br /><br />1: Access[357]<br />2: Access[358]<br />3: Object[359]<br />4: PgSelect[356]<br />5: <br />ᐳ: 360, 361, 362"):::bucket
     classDef bucket55 stroke:#0000ff
     class Bucket55,PgSelect356,Access357,Access358,Object359,First360,PgSelectSingle361,Object362 bucket55
-    Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 361, 359, 640, 643, 966, 967, 926, 1277, 980, 981, 940, 1278, 362, 324<br /><br />ROOT Object{55}ᐸ{result}ᐳ[362]<br />1: <br />ᐳ: 369, 380, 383, 969, 975, 983, 989, 970, 984<br />2: PgSelect[370], PgSelect[381]<br />ᐳ: 374, 375, 384, 385, 388, 389, 387, 386"):::bucket
+    Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 324, 361, 359, 640, 644, 994, 999, 1009, 1014, 362<br /><br />ROOT Object{55}ᐸ{result}ᐳ[362]<br />1: <br />ᐳ: 369, 380, 383, 365, 366<br />2: PgSelect[370], PgSelect[381]<br />ᐳ: 374, 375, 384, 385, 388, 389, 387, 386"):::bucket
     classDef bucket56 stroke:#7fff00
-    class Bucket56,PgClassExpression369,PgSelect370,First374,PgSelectSingle375,PgClassExpression380,PgSelect381,Connection383,First384,PgSelectSingle385,Edge386,PgCursor387,PgClassExpression388,List389,Object969,Lambda970,Lambda975,Object983,Lambda984,Lambda989 bucket56
-    Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 324, 380, 361, 369<br /><br />ROOT PgSelectSingle{55}ᐸtable_mutationᐳ[361]"):::bucket
+    class Bucket56,List365,Lambda366,PgClassExpression369,PgSelect370,First374,PgSelectSingle375,PgClassExpression380,PgSelect381,Connection383,First384,PgSelectSingle385,Edge386,PgCursor387,PgClassExpression388,List389 bucket56
+    Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 361, 366, 380, 369<br /><br />ROOT PgSelectSingle{55}ᐸtable_mutationᐳ[361]"):::bucket
     classDef bucket57 stroke:#ff1493
-    class Bucket57,List365,Lambda366,PgClassExpression367 bucket57
+    class Bucket57,PgClassExpression367 bucket57
     Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 375<br /><br />ROOT PgSelectSingle{56}ᐸpersonᐳ[375]"):::bucket
     classDef bucket58 stroke:#808000
     class Bucket58,PgClassExpression376,PgClassExpression377 bucket58
@@ -1344,7 +1346,7 @@ graph TD
     Bucket60("Bucket 60 (nullableBoundary)<br />Deps: 385, 388<br /><br />ROOT PgSelectSingle{56}ᐸpostᐳ[385]"):::bucket
     classDef bucket60 stroke:#ff0000
     class Bucket60,PgClassExpression391 bucket60
-    Bucket61("Bucket 61 (mutationField)<br />Deps: 640, 643, 1012, 1017, 2<br /><br />1: Access[395]<br />2: Access[396]<br />3: Object[397]<br />4: PgSelect[394]<br />5: <br />ᐳ: Object[398]"):::bucket
+    Bucket61("Bucket 61 (mutationField)<br />Deps: 640, 644, 1039, 1044, 2<br /><br />1: Access[395]<br />2: Access[396]<br />3: Object[397]<br />4: PgSelect[394]<br />5: <br />ᐳ: Object[398]"):::bucket
     classDef bucket61 stroke:#ffff00
     class Bucket61,PgSelect394,Access395,Access396,Object397,Object398 bucket61
     Bucket62("Bucket 62 (nullableBoundary)<br />Deps: 398, 394<br /><br />ROOT Object{61}ᐸ{result}ᐳ[398]"):::bucket
@@ -1356,7 +1358,7 @@ graph TD
     Bucket64("Bucket 64 (nullableBoundary)<br />Deps: 400<br /><br />ROOT PgSelectSingle{63}ᐸtable_set_mutationᐳ[400]"):::bucket
     classDef bucket64 stroke:#3cb371
     class Bucket64,PgClassExpression401 bucket64
-    Bucket65("Bucket 65 (mutationField)<br />Deps: 1224, 111, 1239, 640, 643, 1026, 1031, 2<br /><br />1: Access[408]<br />2: Access[409]<br />3: Object[410]<br />4: PgSelect[407]<br />5: <br />ᐳ: Object[411]"):::bucket
+    Bucket65("Bucket 65 (mutationField)<br />Deps: 1265, 111, 1280, 640, 644, 1054, 1059, 2<br /><br />1: Access[408]<br />2: Access[409]<br />3: Object[410]<br />4: PgSelect[407]<br />5: <br />ᐳ: Object[411]"):::bucket
     classDef bucket65 stroke:#a52a2a
     class Bucket65,PgSelect407,Access408,Access409,Object410,Object411 bucket65
     Bucket66("Bucket 66 (nullableBoundary)<br />Deps: 411, 407<br /><br />ROOT Object{65}ᐸ{result}ᐳ[411]"):::bucket
@@ -1365,40 +1367,40 @@ graph TD
     Bucket67("Bucket 67 (listItem)<br /><br />ROOT __Item{67}ᐸ407ᐳ[412]"):::bucket
     classDef bucket67 stroke:#f5deb3
     class Bucket67,__Item412,PgSelectSingle413,PgClassExpression414 bucket67
-    Bucket68("Bucket 68 (mutationField)<br />Deps: 640, 643, 1040, 1045, 2, 1240<br /><br />1: Access[418]<br />2: Access[419]<br />3: Object[420]<br />4: PgSelect[417]<br />5: <br />ᐳ: 421, 422, 423, 424"):::bucket
+    Bucket68("Bucket 68 (mutationField)<br />Deps: 640, 644, 1069, 1074, 2, 1281<br /><br />1: Access[418]<br />2: Access[419]<br />3: Object[420]<br />4: PgSelect[417]<br />5: <br />ᐳ: 421, 422, 423, 424"):::bucket
     classDef bucket68 stroke:#696969
     class Bucket68,PgSelect417,Access418,Access419,Object420,First421,PgSelectSingle422,PgClassExpression423,Object424 bucket68
-    Bucket69("Bucket 69 (nullableBoundary)<br />Deps: 424, 1240, 423<br /><br />ROOT Object{68}ᐸ{result,clientMutationId}ᐳ[424]"):::bucket
+    Bucket69("Bucket 69 (nullableBoundary)<br />Deps: 424, 1281, 423<br /><br />ROOT Object{68}ᐸ{result,clientMutationId}ᐳ[424]"):::bucket
     classDef bucket69 stroke:#00bfff
     class Bucket69 bucket69
-    Bucket70("Bucket 70 (mutationField)<br />Deps: 640, 643, 1054, 1059, 2<br /><br />1: Access[428]<br />2: Access[429]<br />3: Object[430]<br />4: PgSelect[427]<br />5: <br />ᐳ: 431, 432, 433, 434"):::bucket
+    Bucket70("Bucket 70 (mutationField)<br />Deps: 640, 644, 1084, 1089, 2<br /><br />1: Access[428]<br />2: Access[429]<br />3: Object[430]<br />4: PgSelect[427]<br />5: <br />ᐳ: 431, 432, 433, 434"):::bucket
     classDef bucket70 stroke:#7f007f
     class Bucket70,PgSelect427,Access428,Access429,Object430,First431,PgSelectSingle432,PgClassExpression433,Object434 bucket70
     Bucket71("Bucket 71 (nullableBoundary)<br />Deps: 434<br /><br />ROOT Object{70}ᐸ{result}ᐳ[434]"):::bucket
     classDef bucket71 stroke:#ffa500
     class Bucket71 bucket71
-    Bucket72("Bucket 72 (mutationField)<br />Deps: 111, 640, 643, 1068, 1073, 2<br /><br />1: Access[439]<br />2: Access[440]<br />3: Object[441]<br />4: PgSelect[438]<br />5: <br />ᐳ: 442, 443, 444, 445"):::bucket
+    Bucket72("Bucket 72 (mutationField)<br />Deps: 111, 640, 644, 1099, 1104, 2<br /><br />1: Access[439]<br />2: Access[440]<br />3: Object[441]<br />4: PgSelect[438]<br />5: <br />ᐳ: 442, 443, 444, 445"):::bucket
     classDef bucket72 stroke:#0000ff
     class Bucket72,PgSelect438,Access439,Access440,Object441,First442,PgSelectSingle443,PgClassExpression444,Object445 bucket72
     Bucket73("Bucket 73 (nullableBoundary)<br />Deps: 445, 444<br /><br />ROOT Object{72}ᐸ{result}ᐳ[445]"):::bucket
     classDef bucket73 stroke:#7fff00
     class Bucket73 bucket73
-    Bucket74("Bucket 74 (mutationField)<br />Deps: 1241, 640, 643, 1082, 1087, 2<br /><br />1: Access[450]<br />2: Access[451]<br />3: Object[452]<br />4: PgSelect[449]<br />5: <br />ᐳ: 453, 454, 455, 456"):::bucket
+    Bucket74("Bucket 74 (mutationField)<br />Deps: 1282, 640, 644, 1114, 1119, 2<br /><br />1: Access[450]<br />2: Access[451]<br />3: Object[452]<br />4: PgSelect[449]<br />5: <br />ᐳ: 453, 454, 455, 456"):::bucket
     classDef bucket74 stroke:#ff1493
     class Bucket74,PgSelect449,Access450,Access451,Object452,First453,PgSelectSingle454,PgClassExpression455,Object456 bucket74
     Bucket75("Bucket 75 (nullableBoundary)<br />Deps: 456, 455<br /><br />ROOT Object{74}ᐸ{result}ᐳ[456]"):::bucket
     classDef bucket75 stroke:#808000
     class Bucket75 bucket75
-    Bucket76("Bucket 76 (mutationField)<br />Deps: 1318, 640, 643, 1110, 1115, 2, 1092, 1093, 1094, 1286<br /><br />1: Access[507]<br />2: Access[508]<br />3: Object[509]<br />4: PgSelect[506]<br />5: <br />ᐳ: Object[510]"):::bucket
+    Bucket76("Bucket 76 (mutationField)<br />Deps: 1359, 640, 644, 1144, 1149, 2, 1129, 1134<br /><br />1: Access[507]<br />2: Access[508]<br />3: Object[509]<br />4: PgSelect[506]<br />5: <br />ᐳ: Object[510]"):::bucket
     classDef bucket76 stroke:#dda0dd
     class Bucket76,PgSelect506,Access507,Access508,Object509,Object510 bucket76
-    Bucket77("Bucket 77 (nullableBoundary)<br />Deps: 640, 1092, 1093, 1094, 1286, 510, 506, 509, 643<br /><br />ROOT Object{76}ᐸ{result}ᐳ[510]"):::bucket
+    Bucket77("Bucket 77 (nullableBoundary)<br />Deps: 510, 506, 509, 640, 644, 1129, 1134<br /><br />ROOT Object{76}ᐸ{result}ᐳ[510]"):::bucket
     classDef bucket77 stroke:#ff0000
-    class Bucket77,Object1095,Lambda1096,Lambda1101 bucket77
-    Bucket78("Bucket 78 (listItem)<br />Deps: 509, 640, 643, 1096, 1101<br /><br />ROOT __Item{78}ᐸ506ᐳ[511]"):::bucket
+    class Bucket77 bucket77
+    Bucket78("Bucket 78 (listItem)<br />Deps: 509, 640, 644, 1129, 1134<br /><br />ROOT __Item{78}ᐸ506ᐳ[511]"):::bucket
     classDef bucket78 stroke:#ffff00
     class Bucket78,__Item511,PgSelectSingle512 bucket78
-    Bucket79("Bucket 79 (nullableBoundary)<br />Deps: 512, 509, 640, 643, 1096, 1101<br /><br />ROOT PgSelectSingle{78}ᐸpost_manyᐳ[512]<br />1: <br />ᐳ: 513, 514, 515<br />2: PgSelect[516]"):::bucket
+    Bucket79("Bucket 79 (nullableBoundary)<br />Deps: 512, 509, 640, 644, 1129, 1134<br /><br />ROOT PgSelectSingle{78}ᐸpost_manyᐳ[512]<br />1: <br />ᐳ: 513, 514, 515<br />2: PgSelect[516]"):::bucket
     classDef bucket79 stroke:#00ffff
     class Bucket79,PgClassExpression513,PgClassExpression514,PgClassExpression515,PgSelect516 bucket79
     Bucket80("Bucket 80 (listItem)<br /><br />ROOT __Item{80}ᐸ516ᐳ[520]"):::bucket
@@ -1407,7 +1409,7 @@ graph TD
     Bucket81("Bucket 81 (nullableBoundary)<br />Deps: 521<br /><br />ROOT PgSelectSingle{80}ᐸfrmcdc_comptypeᐳ[521]"):::bucket
     classDef bucket81 stroke:#3cb371
     class Bucket81,PgClassExpression522,PgClassExpression523 bucket81
-    Bucket82("Bucket 82 (mutationField)<br />Deps: 1306, 1252, 640, 643, 1124, 1129, 2<br /><br />1: Access[533]<br />2: Access[534]<br />3: Object[535]<br />4: PgSelect[532]<br />5: <br />ᐳ: 536, 537, 538"):::bucket
+    Bucket82("Bucket 82 (mutationField)<br />Deps: 1347, 1293, 640, 644, 1159, 1164, 2<br /><br />1: Access[533]<br />2: Access[534]<br />3: Object[535]<br />4: PgSelect[532]<br />5: <br />ᐳ: 536, 537, 538"):::bucket
     classDef bucket82 stroke:#a52a2a
     class Bucket82,PgSelect532,Access533,Access534,Object535,First536,PgSelectSingle537,Object538 bucket82
     Bucket83("Bucket 83 (nullableBoundary)<br />Deps: 538, 537<br /><br />ROOT Object{82}ᐸ{result}ᐳ[538]"):::bucket
@@ -1416,7 +1418,7 @@ graph TD
     Bucket84("Bucket 84 (nullableBoundary)<br />Deps: 537<br /><br />ROOT PgSelectSingle{82}ᐸpost_with_suffixᐳ[537]"):::bucket
     classDef bucket84 stroke:#f5deb3
     class Bucket84,PgClassExpression539,PgClassExpression540 bucket84
-    Bucket85("Bucket 85 (mutationField)<br />Deps: 640, 643, 1138, 1143, 2<br /><br />1: Access[544]<br />2: Access[545]<br />3: Object[546]<br />4: PgSelect[543]<br />5: <br />ᐳ: 547, 548, 549"):::bucket
+    Bucket85("Bucket 85 (mutationField)<br />Deps: 640, 644, 1174, 1179, 2<br /><br />1: Access[544]<br />2: Access[545]<br />3: Object[546]<br />4: PgSelect[543]<br />5: <br />ᐳ: 547, 548, 549"):::bucket
     classDef bucket85 stroke:#696969
     class Bucket85,PgSelect543,Access544,Access545,Object546,First547,PgSelectSingle548,Object549 bucket85
     Bucket86("Bucket 86 (nullableBoundary)<br />Deps: 549, 548<br /><br />ROOT Object{85}ᐸ{result}ᐳ[549]"):::bucket
@@ -1425,7 +1427,7 @@ graph TD
     Bucket87("Bucket 87 (nullableBoundary)<br />Deps: 548<br /><br />ROOT PgSelectSingle{85}ᐸissue756_mutationᐳ[548]"):::bucket
     classDef bucket87 stroke:#7f007f
     class Bucket87,PgClassExpression550,PgClassExpression551 bucket87
-    Bucket88("Bucket 88 (mutationField)<br />Deps: 640, 643, 1152, 1157, 2<br /><br />1: Access[555]<br />2: Access[556]<br />3: Object[557]<br />4: PgSelect[554]<br />5: <br />ᐳ: Object[558]"):::bucket
+    Bucket88("Bucket 88 (mutationField)<br />Deps: 640, 644, 1189, 1194, 2<br /><br />1: Access[555]<br />2: Access[556]<br />3: Object[557]<br />4: PgSelect[554]<br />5: <br />ᐳ: Object[558]"):::bucket
     classDef bucket88 stroke:#ffa500
     class Bucket88,PgSelect554,Access555,Access556,Object557,Object558 bucket88
     Bucket89("Bucket 89 (nullableBoundary)<br />Deps: 558, 554<br /><br />ROOT Object{88}ᐸ{result}ᐳ[558]"):::bucket
@@ -1437,7 +1439,7 @@ graph TD
     Bucket91("Bucket 91 (nullableBoundary)<br />Deps: 560<br /><br />ROOT PgSelectSingle{90}ᐸissue756_set_mutationᐳ[560]"):::bucket
     classDef bucket91 stroke:#ff1493
     class Bucket91,PgClassExpression561,PgClassExpression562 bucket91
-    Bucket92("Bucket 92 (mutationField)<br />Deps: 1314, 640, 643, 1166, 1171, 2<br /><br />1: Access[577]<br />2: Access[578]<br />3: Object[579]<br />4: PgSelect[576]<br />5: <br />ᐳ: Object[580]"):::bucket
+    Bucket92("Bucket 92 (mutationField)<br />Deps: 1355, 640, 644, 1204, 1209, 2<br /><br />1: Access[577]<br />2: Access[578]<br />3: Object[579]<br />4: PgSelect[576]<br />5: <br />ᐳ: Object[580]"):::bucket
     classDef bucket92 stroke:#808000
     class Bucket92,PgSelect576,Access577,Access578,Object579,Object580 bucket92
     Bucket93("Bucket 93 (nullableBoundary)<br />Deps: 580, 576<br /><br />ROOT Object{92}ᐸ{result}ᐳ[580]"):::bucket
@@ -1452,7 +1454,7 @@ graph TD
     Bucket96("Bucket 96 (nullableBoundary)<br />Deps: 589<br /><br />ROOT PgClassExpression{95}ᐸ__mutation...rray__.”g”ᐳ[589]"):::bucket
     classDef bucket96 stroke:#00ffff
     class Bucket96 bucket96
-    Bucket97("Bucket 97 (mutationField)<br />Deps: 640, 643, 1180, 1185, 2<br /><br />1: Access[597]<br />2: Access[598]<br />3: Object[599]<br />4: PgSelect[596]<br />5: <br />ᐳ: 600, 601, 602, 603"):::bucket
+    Bucket97("Bucket 97 (mutationField)<br />Deps: 640, 644, 1219, 1224, 2<br /><br />1: Access[597]<br />2: Access[598]<br />3: Object[599]<br />4: PgSelect[596]<br />5: <br />ᐳ: 600, 601, 602, 603"):::bucket
     classDef bucket97 stroke:#4169e1
     class Bucket97,PgSelect596,Access597,Access598,Object599,First600,PgSelectSingle601,PgClassExpression602,Object603 bucket97
     Bucket98("Bucket 98 (nullableBoundary)<br />Deps: 603, 602<br /><br />ROOT Object{97}ᐸ{result}ᐳ[603]"):::bucket
@@ -1461,7 +1463,7 @@ graph TD
     Bucket99("Bucket 99 (listItem)<br /><br />ROOT __Item{99}ᐸ602ᐳ[604]"):::bucket
     classDef bucket99 stroke:#a52a2a
     class Bucket99,__Item604 bucket99
-    Bucket100("Bucket 100 (mutationField)<br />Deps: 640, 643, 1194, 1199, 2<br /><br />1: Access[608]<br />2: Access[609]<br />3: Object[610]<br />4: PgSelect[607]<br />5: <br />ᐳ: 611, 612, 613, 614"):::bucket
+    Bucket100("Bucket 100 (mutationField)<br />Deps: 640, 644, 1234, 1239, 2<br /><br />1: Access[608]<br />2: Access[609]<br />3: Object[610]<br />4: PgSelect[607]<br />5: <br />ᐳ: 611, 612, 613, 614"):::bucket
     classDef bucket100 stroke:#ff00ff
     class Bucket100,PgSelect607,Access608,Access609,Object610,First611,PgSelectSingle612,PgClassExpression613,Object614 bucket100
     Bucket101("Bucket 101 (nullableBoundary)<br />Deps: 614, 613<br /><br />ROOT Object{100}ᐸ{result}ᐳ[614]"):::bucket
@@ -1473,7 +1475,7 @@ graph TD
     Bucket103("Bucket 103 (nullableBoundary)<br />Deps: 615<br /><br />ROOT __Item{102}ᐸ613ᐳ[615]"):::bucket
     classDef bucket103 stroke:#00bfff
     class Bucket103 bucket103
-    Bucket104("Bucket 104 (mutationField)<br />Deps: 640, 643, 1208, 1213, 2<br /><br />1: Access[625]<br />2: Access[626]<br />3: Object[627]<br />4: PgSelect[624]<br />5: <br />ᐳ: Object[628]"):::bucket
+    Bucket104("Bucket 104 (mutationField)<br />Deps: 640, 644, 1249, 1254, 2<br /><br />1: Access[625]<br />2: Access[626]<br />3: Object[627]<br />4: PgSelect[624]<br />5: <br />ᐳ: Object[628]"):::bucket
     classDef bucket104 stroke:#7f007f
     class Bucket104,PgSelect624,Access625,Access626,Object627,Object628 bucket104
     Bucket105("Bucket 105 (nullableBoundary)<br />Deps: 628, 624<br /><br />ROOT Object{104}ᐸ{result}ᐳ[628]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/rbac.createPerson.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/rbac.createPerson.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”frmcdc_wrapped_url”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(wrappedUrl)ᐳ"}}:::plan
+    Lambda40 & Constant45 & Constant46 & Constant47 --> Object48
     Object20{{"Object[20∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access18{{"Access[18∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access19{{"Access[19∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,35 +22,31 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access18
     __Value2 --> Access19
-    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant60 --> Lambda40
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”frmcdc_wrapped_url”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(wrappedUrl)ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ'Jane Doe'ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ'Unknown'ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ'jane.doe@example.com'ᐳ"}}:::plan
     Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[ 'Jay Doe', 'JD' ]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ url: 'http://example.com' }ᐳ"}}:::plan
+    Constant61 --> Lambda40
+    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant62 --> Lambda43
+    Access44{{"Access[44∈0] ➊<br />ᐸ43.0ᐳ"}}:::plan
+    Lambda43 --> Access44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object48 --> Lambda49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant63 --> Lambda54
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ'Jane Doe'ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ'Unknown'ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ'jane.doe@example.com'ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[ 'Jay Doe', 'JD' ]ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ url: 'http://example.com' }ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸperson(person_full_name,aliases,about,email,site)ᐳ"]]:::sideeffectplan
-    Object20 & Constant54 & Constant63 & Constant57 & Constant58 & Constant64 --> PgInsertSingle17
+    Object20 & Constant55 & Constant64 & Constant58 & Constant59 & Constant65 --> PgInsertSingle17
     Object21{{"Object[21∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle17 --> Object21
-    Object47{{"Object[47∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda40 & Constant44 & Constant45 & Constant46 --> Object47
-    Lambda43{{"Lambda[43∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant61 --> Lambda43
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object47 --> Lambda48
-    Lambda53{{"Lambda[53∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant62 --> Lambda53
     PgSelect31[["PgSelect[31∈3] ➊<br />ᐸfrmcdc_wrappedUrlᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__person__.”site”ᐳ"}}:::plan
-    Object20 & PgClassExpression30 & Lambda40 & Lambda43 & Lambda48 & Lambda53 --> PgSelect31
+    Object20 & PgClassExpression30 & Lambda40 & Access44 & Lambda49 & Lambda54 --> PgSelect31
     PgClassExpression24{{"PgClassExpression[24∈3] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgInsertSingle17 --> PgClassExpression24
     PgClassExpression25{{"PgClassExpression[25∈3] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
@@ -70,14 +72,14 @@ graph TD
     subgraph "Buckets for mutations/v4/rbac.createPerson"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access18,Access19,Object20,Lambda40,Constant44,Constant45,Constant46,Constant54,Constant57,Constant58,Constant60,Constant61,Constant62,Constant63,Constant64 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 54, 63, 57, 58, 64, 61, 40, 44, 45, 46, 62<br /><br />1: PgInsertSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
+    class Bucket0,__Value2,__Value4,Access18,Access19,Object20,Lambda40,Lambda43,Access44,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant55,Constant58,Constant59,Constant61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 55, 64, 58, 59, 65, 40, 44, 49, 54<br /><br />1: PgInsertSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle17,Object21 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 61, 40, 44, 45, 46, 62, 21, 17, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 17, 20, 40, 44, 49, 54<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda43,Object47,Lambda48,Lambda53 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20, 40, 43, 48, 53<br /><br />ROOT PgInsertSingle{1}ᐸperson(person_full_name,aliases,about,email,site)ᐳ[17]<br />1: <br />ᐳ: 24, 25, 26, 28, 29, 30<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20, 40, 44, 49, 54<br /><br />ROOT PgInsertSingle{1}ᐸperson(person_full_name,aliases,about,email,site)ᐳ[17]<br />1: <br />ᐳ: 24, 25, 26, 28, 29, 30<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgClassExpression28,PgClassExpression29,PgClassExpression30,PgSelect31,First35,PgSelectSingle36 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ26ᐳ[27]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/rbac.leftArmIdentity.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/rbac.leftArmIdentity.mermaid
@@ -9,12 +9,12 @@ graph TD
 
 
     %% plan dependencies
-    Object37{{"Object[37∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object38{{"Object[38∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸsql.identifier(”left_arm_identity”)ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda30 & Constant34 & Constant35 & Constant36 --> Object37
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸsql.identifier(”left_arm_identity”)ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda30 & Constant35 & Constant36 & Constant37 --> Object38
     Object17{{"Object[17∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,21 +22,23 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access15
     __Value2 --> Access16
-    Constant48{{"Constant[48∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant48 --> Lambda30
-    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
     Constant49{{"Constant[49∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant49 --> Lambda33
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object37 --> Lambda38
-    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant50 --> Lambda43
+    Constant49 --> Lambda30
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant50 --> Lambda33
+    Access34{{"Access[34∈0] ➊<br />ᐸ33.0ᐳ"}}:::plan
+    Lambda33 --> Access34
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object38 --> Lambda39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant51 --> Lambda44
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant21{{"Constant[21∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸ§{ id: 9001, person_id: 99, length_in_metres: 77, mood: 'jubᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ§{ id: 9001, person_id: 99, length_in_metres: 77, mood: 'jubᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸleft_arm_identity(mutation)ᐳ"]]:::sideeffectplan
-    Object17 & Constant51 & Lambda30 & Lambda33 & Lambda38 & Lambda43 --> PgSelect14
+    Object17 & Constant52 & Lambda30 & Access34 & Lambda39 & Lambda44 --> PgSelect14
     First18{{"First[18∈1] ➊"}}:::plan
     PgSelect14 --> First18
     PgSelectSingle19{{"PgSelectSingle[19∈1] ➊<br />ᐸleft_arm_identityᐳ"}}:::plan
@@ -61,8 +63,8 @@ graph TD
     subgraph "Buckets for mutations/v4/rbac.leftArmIdentity"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access15,Access16,Object17,Constant21,Lambda30,Lambda33,Constant34,Constant35,Constant36,Object37,Lambda38,Lambda43,Constant48,Constant49,Constant50,Constant51 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 51, 30, 33, 38, 43, 21<br /><br />1: PgSelect[14]<br />2: <br />ᐳ: 18, 19, 20"):::bucket
+    class Bucket0,__Value2,__Value4,Access15,Access16,Object17,Constant21,Lambda30,Lambda33,Access34,Constant35,Constant36,Constant37,Object38,Lambda39,Lambda44,Constant49,Constant50,Constant51,Constant52 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 52, 30, 34, 39, 44, 21<br /><br />1: PgSelect[14]<br />2: <br />ᐳ: 18, 19, 20"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect14,First18,PgSelectSingle19,Object20 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 20, 19, 21<br /><br />ROOT Object{1}ᐸ{result}ᐳ[20]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/rbac.updatePerson.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/rbac.updatePerson.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”frmcdc_wrapped_url”)ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(wrappedUrl)ᐳ"}}:::plan
+    Lambda41 & Constant46 & Constant47 & Constant48 --> Object49
     Object21{{"Object[21∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access19{{"Access[19∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access20{{"Access[20∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,36 +22,32 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access19
     __Value2 --> Access20
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant61 --> Lambda41
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant62 --> Lambda41
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant63 --> Lambda44
+    Access45{{"Access[45∈0] ➊<br />ᐸ44.0ᐳ"}}:::plan
+    Lambda44 --> Access45
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object49 --> Lambda50
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant64 --> Lambda55
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”frmcdc_wrapped_url”)ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(wrappedUrl)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ'Budd Daay'ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ'buddy@example.com'ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ[ 'BD', 'Buddy' ]ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ url: 'http://buddy.com' }ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ'Budd Daay'ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ'buddy@example.com'ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[ 'BD', 'Buddy' ]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ url: 'http://buddy.com' }ᐳ"}}:::plan
     PgUpdateSingle18[["PgUpdateSingle[18∈1] ➊<br />ᐸperson(id;person_full_name,aliases,about,email,site)ᐳ"]]:::sideeffectplan
-    Object21 & Constant55 & Constant56 & Constant64 & Constant39 & Constant59 & Constant65 --> PgUpdateSingle18
+    Object21 & Constant56 & Constant57 & Constant65 & Constant39 & Constant60 & Constant66 --> PgUpdateSingle18
     Object22{{"Object[22∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle18 --> Object22
-    Object48{{"Object[48∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda41 & Constant45 & Constant46 & Constant47 --> Object48
-    Lambda44{{"Lambda[44∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant62 --> Lambda44
-    Lambda49{{"Lambda[49∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object48 --> Lambda49
-    Lambda54{{"Lambda[54∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant63 --> Lambda54
     PgSelect32[["PgSelect[32∈3] ➊<br />ᐸfrmcdc_wrappedUrlᐳ"]]:::plan
     PgClassExpression31{{"PgClassExpression[31∈3] ➊<br />ᐸ__person__.”site”ᐳ"}}:::plan
-    Object21 & PgClassExpression31 & Lambda41 & Lambda44 & Lambda49 & Lambda54 --> PgSelect32
+    Object21 & PgClassExpression31 & Lambda41 & Access45 & Lambda50 & Lambda55 --> PgSelect32
     PgClassExpression25{{"PgClassExpression[25∈3] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgUpdateSingle18 --> PgClassExpression25
     PgClassExpression26{{"PgClassExpression[26∈3] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
@@ -71,14 +73,14 @@ graph TD
     subgraph "Buckets for mutations/v4/rbac.updatePerson"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access19,Access20,Object21,Constant39,Lambda41,Constant45,Constant46,Constant47,Constant55,Constant56,Constant59,Constant61,Constant62,Constant63,Constant64,Constant65 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 21, 55, 56, 64, 39, 59, 65, 62, 41, 45, 46, 47, 63<br /><br />1: PgUpdateSingle[18]<br />2: <br />ᐳ: Object[22]"):::bucket
+    class Bucket0,__Value2,__Value4,Access19,Access20,Object21,Constant39,Lambda41,Lambda44,Access45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant60,Constant62,Constant63,Constant64,Constant65,Constant66 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 21, 56, 57, 65, 39, 60, 66, 41, 45, 50, 55<br /><br />1: PgUpdateSingle[18]<br />2: <br />ᐳ: Object[22]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle18,Object22 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 62, 41, 45, 46, 47, 63, 22, 18, 21<br /><br />ROOT Object{1}ᐸ{result}ᐳ[22]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 22, 18, 21, 41, 45, 50, 55<br /><br />ROOT Object{1}ᐸ{result}ᐳ[22]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda44,Object48,Lambda49,Lambda54 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 21, 41, 44, 49, 54<br /><br />ROOT PgUpdateSingle{1}ᐸperson(id;person_full_name,aliases,about,email,site)ᐳ[18]<br />1: <br />ᐳ: 25, 26, 27, 29, 30, 31<br />2: PgSelect[32]<br />ᐳ: First[36], PgSelectSingle[37]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 21, 41, 45, 50, 55<br /><br />ROOT PgUpdateSingle{1}ᐸperson(id;person_full_name,aliases,about,email,site)ᐳ[18]<br />1: <br />ᐳ: 25, 26, 27, 29, 30, 31<br />2: PgSelect[32]<br />ᐳ: First[36], PgSelectSingle[37]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression25,PgClassExpression26,PgClassExpression27,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgSelect32,First36,PgSelectSingle37 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ27ᐳ[28]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.createLeftArm.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.createLeftArm.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object49{{"Object[49∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda41 & Constant46 & Constant47 & Constant48 --> Object49
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -20,42 +26,38 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDZd'ᐳ"}}:::plan
-    Constant56 --> Condition16
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDZd'ᐳ"}}:::plan
+    Constant57 --> Condition16
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant56 --> Lambda17
+    Constant57 --> Lambda17
     Access18{{"Access[18∈0] ➊<br />ᐸ17.1ᐳ"}}:::plan
     Lambda17 --> Access18
     __Flag19[["__Flag[19∈0] ➊<br />ᐸ18, rejectNull, onReject: INHIBITᐳ"]]:::plan
     Access18 --> __Flag19
     __Flag19 --> __Flag20
-    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant57 --> Lambda41
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant58 --> Lambda41
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant59 --> Lambda44
+    Access45{{"Access[45∈0] ➊<br />ᐸ44.0ᐳ"}}:::plan
+    Lambda44 --> Access45
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object49 --> Lambda50
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant60 --> Lambda55
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant22{{"Constant[22∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
     Constant33{{"Constant[33∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ0.69ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ0.69ᐳ"}}:::plan
     PgInsertSingle11[["PgInsertSingle[11∈1] ➊<br />ᐸleft_arm(length_in_metres,person_id)ᐳ"]]:::sideeffectplan
-    Object14 & Constant55 & __Flag21 --> PgInsertSingle11
+    Object14 & Constant56 & __Flag21 --> PgInsertSingle11
     Object15{{"Object[15∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle11 --> Object15
-    Object48{{"Object[48∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda41 & Constant45 & Constant46 & Constant47 --> Object48
-    Lambda44{{"Lambda[44∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant58 --> Lambda44
-    Lambda49{{"Lambda[49∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object48 --> Lambda49
-    Lambda54{{"Lambda[54∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant59 --> Lambda54
     PgSelect27[["PgSelect[27∈3] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈3] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object14 & PgClassExpression26 & Lambda41 & Lambda44 & Lambda49 & Lambda54 --> PgSelect27
+    Object14 & PgClassExpression26 & Lambda41 & Access45 & Lambda50 & Lambda55 --> PgSelect27
     List24{{"List[24∈3] ➊<br />ᐸ22,23ᐳ"}}:::plan
     PgClassExpression23{{"PgClassExpression[23∈3] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant22 & PgClassExpression23 --> List24
@@ -81,16 +83,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for mutations/v4/relay.createLeftArm"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 22, 33, 45, 46, 47, 55, 56, 57, 58, 59, 14, 16, 17, 18, 41<br />2: __Flag[19]<br />3: __Flag[20]<br />4: __Flag[21]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 22, 33, 46, 47, 48, 56, 57, 58, 59, 60, 14, 16, 17, 18, 41, 44, 45, 49, 50, 55<br />2: __Flag[19]<br />3: __Flag[20]<br />4: __Flag[21]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Condition16,Lambda17,Access18,__Flag19,__Flag20,__Flag21,Constant22,Constant33,Lambda41,Constant45,Constant46,Constant47,Constant55,Constant56,Constant57,Constant58,Constant59 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 55, 21, 58, 41, 45, 46, 47, 59, 22, 33<br /><br />1: PgInsertSingle[11]<br />2: <br />ᐳ: Object[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Condition16,Lambda17,Access18,__Flag19,__Flag20,__Flag21,Constant22,Constant33,Lambda41,Lambda44,Access45,Constant46,Constant47,Constant48,Object49,Lambda50,Lambda55,Constant56,Constant57,Constant58,Constant59,Constant60 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 56, 21, 22, 41, 45, 50, 55, 33<br /><br />1: PgInsertSingle[11]<br />2: <br />ᐳ: Object[15]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle11,Object15 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 58, 41, 45, 46, 47, 59, 15, 11, 22, 14, 33<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 15, 11, 22, 14, 41, 45, 50, 55, 33<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda44,Object48,Lambda49,Lambda54 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 22, 14, 41, 44, 49, 54, 33<br /><br />ROOT PgInsertSingle{1}ᐸleft_arm(length_in_metres,person_id)ᐳ[11]<br />1: <br />ᐳ: 23, 26, 37, 38, 24, 25<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 22, 14, 41, 45, 50, 55, 33<br /><br />ROOT PgInsertSingle{1}ᐸleft_arm(length_in_metres,person_id)ᐳ[11]<br />1: <br />ᐳ: 23, 26, 37, 38, 24, 25<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression23,List24,Lambda25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,PgClassExpression37,PgClassExpression38 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32, 33<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[32]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
     Object18{{"Object[18∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -18,50 +24,46 @@ graph TD
     Condition20{{"Condition[20∈0] ➊<br />ᐸexistsᐳ"}}:::plan
     __Flag24 & Condition20 --> __Flag25
     Lambda12{{"Lambda[12∈0] ➊<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
-    Constant59 --> Lambda12
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant60 --> Lambda12
     Access13{{"Access[13∈0] ➊<br />ᐸ12.1ᐳ"}}:::plan
     Lambda12 --> Access13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access16
     __Value2 --> Access17
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDNd'ᐳ"}}:::plan
-    Constant61 --> Condition20
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDNd'ᐳ"}}:::plan
+    Constant62 --> Condition20
     Lambda21{{"Lambda[21∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant61 --> Lambda21
+    Constant62 --> Lambda21
     Access22{{"Access[22∈0] ➊<br />ᐸ21.1ᐳ"}}:::plan
     Lambda21 --> Access22
     __Flag23[["__Flag[23∈0] ➊<br />ᐸ22, rejectNull, onReject: INHIBITᐳ"]]:::plan
     Access22 --> __Flag23
     __Flag23 --> __Flag24
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda45
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant63 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant65 --> Lambda59
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant26{{"Constant[26∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
     Constant37{{"Constant[37∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ0.74ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ0.74ᐳ"}}:::plan
     PgUpdateSingle15[["PgUpdateSingle[15∈1] ➊<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
     Object18 -->|rejectNull| PgUpdateSingle15
-    Access13 & Constant60 & __Flag25 --> PgUpdateSingle15
+    Access13 & Constant61 & __Flag25 --> PgUpdateSingle15
     Object19{{"Object[19∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle15 --> Object19
-    Object52{{"Object[52∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant63 --> Lambda48
-    Lambda53{{"Lambda[53∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant64 --> Lambda58
     PgSelect31[["PgSelect[31∈3] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression30 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect31
+    Object18 & PgClassExpression30 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect31
     List28{{"List[28∈3] ➊<br />ᐸ26,27ᐳ"}}:::plan
     PgClassExpression27{{"PgClassExpression[27∈3] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant26 & PgClassExpression27 --> List28
@@ -87,16 +89,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for mutations/v4/relay.updateLeftArm.differentPerson"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 26, 37, 49, 50, 51, 59, 60, 61, 62, 63, 64, 12, 13, 18, 20, 21, 22, 45<br />2: __Flag[23]<br />3: __Flag[24]<br />4: __Flag[25]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 26, 37, 50, 51, 52, 60, 61, 62, 63, 64, 65, 12, 13, 18, 20, 21, 22, 45, 48, 49, 53, 54, 59<br />2: __Flag[23]<br />3: __Flag[24]<br />4: __Flag[25]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Condition20,Lambda21,Access22,__Flag23,__Flag24,__Flag25,Constant26,Constant37,Lambda45,Constant49,Constant50,Constant51,Constant59,Constant60,Constant61,Constant62,Constant63,Constant64 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 60, 25, 63, 45, 49, 50, 51, 64, 26, 37<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Condition20,Lambda21,Access22,__Flag23,__Flag24,__Flag25,Constant26,Constant37,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant60,Constant61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 61, 25, 26, 45, 49, 54, 59, 37<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle15,Object19 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 63, 45, 49, 50, 51, 64, 19, 15, 26, 18, 37<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 15, 26, 18, 45, 49, 54, 59, 37<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda48,Object52,Lambda53,Lambda58 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 26, 18, 45, 48, 53, 58, 37<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[15]<br />1: <br />ᐳ: 27, 30, 41, 42, 28, 29<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 26, 18, 45, 49, 54, 59, 37<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[15]<br />1: <br />ᐳ: 27, 30, 41, 42, 28, 29<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression27,List28,Lambda29,PgClassExpression30,PgSelect31,First35,PgSelectSingle36,PgClassExpression41,PgClassExpression42 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 36, 37<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[36]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
     Object18{{"Object[18∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -18,50 +24,46 @@ graph TD
     Condition20{{"Condition[20∈0] ➊<br />ᐸexistsᐳ"}}:::plan
     __Flag24 & Condition20 --> __Flag25
     Lambda12{{"Lambda[12∈0] ➊<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
-    Constant59 --> Lambda12
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant60 --> Lambda12
     Access13{{"Access[13∈0] ➊<br />ᐸ12.1ᐳ"}}:::plan
     Lambda12 --> Access13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access16
     __Value2 --> Access17
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ'WyJteV90YWJsZXMiLDFd'ᐳ"}}:::plan
-    Constant61 --> Condition20
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ'WyJteV90YWJsZXMiLDFd'ᐳ"}}:::plan
+    Constant62 --> Condition20
     Lambda21{{"Lambda[21∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant61 --> Lambda21
+    Constant62 --> Lambda21
     Access22{{"Access[22∈0] ➊<br />ᐸ21.1ᐳ"}}:::plan
     Lambda21 --> Access22
     __Flag23[["__Flag[23∈0] ➊<br />ᐸ22, rejectNull, onReject: INHIBITᐳ"]]:::plan
     Access22 --> __Flag23
     __Flag23 --> __Flag24
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda45
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant63 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant65 --> Lambda59
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant26{{"Constant[26∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
     Constant37{{"Constant[37∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ0.75ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ0.75ᐳ"}}:::plan
     PgUpdateSingle15[["PgUpdateSingle[15∈1] ➊<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
     Object18 -->|rejectNull| PgUpdateSingle15
-    Access13 & Constant60 & __Flag25 --> PgUpdateSingle15
+    Access13 & Constant61 & __Flag25 --> PgUpdateSingle15
     Object19{{"Object[19∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle15 --> Object19
-    Object52{{"Object[52∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant63 --> Lambda48
-    Lambda53{{"Lambda[53∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant64 --> Lambda58
     PgSelect31[["PgSelect[31∈3] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression30 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect31
+    Object18 & PgClassExpression30 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect31
     List28{{"List[28∈3] ➊<br />ᐸ26,27ᐳ"}}:::plan
     PgClassExpression27{{"PgClassExpression[27∈3] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant26 & PgClassExpression27 --> List28
@@ -87,16 +89,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for mutations/v4/relay.updateLeftArm.invalidId"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 26, 37, 49, 50, 51, 59, 60, 61, 62, 63, 64, 12, 13, 18, 20, 21, 22, 45<br />2: __Flag[23]<br />3: __Flag[24]<br />4: __Flag[25]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 26, 37, 50, 51, 52, 60, 61, 62, 63, 64, 65, 12, 13, 18, 20, 21, 22, 45, 48, 49, 53, 54, 59<br />2: __Flag[23]<br />3: __Flag[24]<br />4: __Flag[25]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Condition20,Lambda21,Access22,__Flag23,__Flag24,__Flag25,Constant26,Constant37,Lambda45,Constant49,Constant50,Constant51,Constant59,Constant60,Constant61,Constant62,Constant63,Constant64 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 60, 25, 63, 45, 49, 50, 51, 64, 26, 37<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Condition20,Lambda21,Access22,__Flag23,__Flag24,__Flag25,Constant26,Constant37,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant60,Constant61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 61, 25, 26, 45, 49, 54, 59, 37<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle15,Object19 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 63, 45, 49, 50, 51, 64, 19, 15, 26, 18, 37<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 15, 26, 18, 45, 49, 54, 59, 37<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda48,Object52,Lambda53,Lambda58 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 26, 18, 45, 48, 53, 58, 37<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[15]<br />1: <br />ᐳ: 27, 30, 41, 42, 28, 29<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 26, 18, 45, 49, 54, 59, 37<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[15]<br />1: <br />ᐳ: 27, 30, 41, 42, 28, 29<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression27,List28,Lambda29,PgClassExpression30,PgSelect31,First35,PgSelectSingle36,PgClassExpression41,PgClassExpression42 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 36, 37<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[36]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
     Object18{{"Object[18∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -18,8 +24,8 @@ graph TD
     Condition20{{"Condition[20∈0] ➊<br />ᐸexistsᐳ"}}:::plan
     __Flag24 & Condition20 --> __Flag25
     Lambda12{{"Lambda[12∈0] ➊<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
-    Constant59 --> Lambda12
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant60 --> Lambda12
     Access13{{"Access[13∈0] ➊<br />ᐸ12.1ᐳ"}}:::plan
     Lambda12 --> Access13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
@@ -34,34 +40,30 @@ graph TD
     __Flag23[["__Flag[23∈0] ➊<br />ᐸ22, rejectNull, onReject: INHIBITᐳ"]]:::plan
     Access22 --> __Flag23
     __Flag23 --> __Flag24
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant61 --> Lambda45
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant62 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant63 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant64 --> Lambda59
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant26{{"Constant[26∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
     Constant37{{"Constant[37∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ0.71ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ0.71ᐳ"}}:::plan
     PgUpdateSingle15[["PgUpdateSingle[15∈1] ➊<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
     Object18 -->|rejectNull| PgUpdateSingle15
-    Access13 & Constant60 & __Flag25 --> PgUpdateSingle15
+    Access13 & Constant61 & __Flag25 --> PgUpdateSingle15
     Object19{{"Object[19∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle15 --> Object19
-    Object52{{"Object[52∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Lambda48{{"Lambda[48∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant62 --> Lambda48
-    Lambda53{{"Lambda[53∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant63 --> Lambda58
     PgSelect31[["PgSelect[31∈3] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression30 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect31
+    Object18 & PgClassExpression30 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect31
     List28{{"List[28∈3] ➊<br />ᐸ26,27ᐳ"}}:::plan
     PgClassExpression27{{"PgClassExpression[27∈3] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant26 & PgClassExpression27 --> List28
@@ -87,16 +89,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for mutations/v4/relay.updateLeftArm"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 26, 37, 43, 49, 50, 51, 59, 60, 61, 62, 63, 12, 13, 18, 20, 21, 22, 45<br />2: __Flag[23]<br />3: __Flag[24]<br />4: __Flag[25]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 26, 37, 43, 50, 51, 52, 60, 61, 62, 63, 64, 12, 13, 18, 20, 21, 22, 45, 48, 49, 53, 54, 59<br />2: __Flag[23]<br />3: __Flag[24]<br />4: __Flag[25]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Condition20,Lambda21,Access22,__Flag23,__Flag24,__Flag25,Constant26,Constant37,Constant43,Lambda45,Constant49,Constant50,Constant51,Constant59,Constant60,Constant61,Constant62,Constant63 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 60, 25, 62, 45, 49, 50, 51, 63, 26, 37<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda12,Access13,Access16,Access17,Object18,Condition20,Lambda21,Access22,__Flag23,__Flag24,__Flag25,Constant26,Constant37,Constant43,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant60,Constant61,Constant62,Constant63,Constant64 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 18, 13, 61, 25, 26, 45, 49, 54, 59, 37<br /><br />1: PgUpdateSingle[15]<br />2: <br />ᐳ: Object[19]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle15,Object19 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 62, 45, 49, 50, 51, 63, 19, 15, 26, 18, 37<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19, 15, 26, 18, 45, 49, 54, 59, 37<br /><br />ROOT Object{1}ᐸ{result}ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda48,Object52,Lambda53,Lambda58 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 26, 18, 45, 48, 53, 58, 37<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[15]<br />1: <br />ᐳ: 27, 30, 41, 42, 28, 29<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 26, 18, 45, 49, 54, 59, 37<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[15]<br />1: <br />ᐳ: 27, 30, 41, 42, 28, 29<br />2: PgSelect[31]<br />ᐳ: First[35], PgSelectSingle[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression27,List28,Lambda29,PgClassExpression30,PgSelect31,First35,PgSelectSingle36,PgClassExpression41,PgClassExpression42 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 36, 37<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[36]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.mermaid
@@ -9,46 +9,48 @@ graph TD
 
 
     %% plan dependencies
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
     Object17{{"Object[17∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access15 & Access16 --> Object17
     Lambda11{{"Lambda[11∈0] ➊<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
-    Constant52 --> Lambda11
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant53 --> Lambda11
     Access12{{"Access[12∈0] ➊<br />ᐸ11.1ᐳ"}}:::plan
     Lambda11 --> Access12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access15
     __Value2 --> Access16
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant54 --> Lambda38
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant55 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant56 --> Lambda41
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant57 --> Lambda52
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant19{{"Constant[19∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
     Constant30{{"Constant[30∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ0.71ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ0.71ᐳ"}}:::plan
     PgUpdateSingle14[["PgUpdateSingle[14∈1] ➊<br />ᐸleft_arm(id;length_in_metres)ᐳ"]]:::sideeffectplan
     Object17 -->|rejectNull| PgUpdateSingle14
-    Access12 & Constant53 --> PgUpdateSingle14
+    Access12 & Constant54 --> PgUpdateSingle14
     Object18{{"Object[18∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle14 --> Object18
-    Object45{{"Object[45∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Lambda41{{"Lambda[41∈2] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant55 --> Lambda41
-    Lambda46{{"Lambda[46∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object45 --> Lambda46
-    Lambda51{{"Lambda[51∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant56 --> Lambda51
     PgSelect24[["PgSelect[24∈3] ➊<br />ᐸpersonᐳ"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression23 & Lambda38 & Lambda41 & Lambda46 & Lambda51 --> PgSelect24
+    Object17 & PgClassExpression23 & Lambda38 & Access42 & Lambda47 & Lambda52 --> PgSelect24
     List21{{"List[21∈3] ➊<br />ᐸ19,20ᐳ"}}:::plan
     PgClassExpression20{{"PgClassExpression[20∈3] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant19 & PgClassExpression20 --> List21
@@ -76,14 +78,14 @@ graph TD
     subgraph "Buckets for mutations/v4/relay.updateLeftArm.withoutPersonId"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Lambda11,Access12,Access15,Access16,Object17,Constant19,Constant30,Lambda38,Constant42,Constant43,Constant44,Constant52,Constant53,Constant54,Constant55,Constant56 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 12, 53, 55, 38, 42, 43, 44, 56, 19, 30<br /><br />1: PgUpdateSingle[14]<br />2: <br />ᐳ: Object[18]"):::bucket
+    class Bucket0,__Value2,__Value4,Lambda11,Access12,Access15,Access16,Object17,Constant19,Constant30,Lambda38,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant53,Constant54,Constant55,Constant56,Constant57 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 12, 54, 19, 38, 42, 47, 52, 30<br /><br />1: PgUpdateSingle[14]<br />2: <br />ᐳ: Object[18]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle14,Object18 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 55, 38, 42, 43, 44, 56, 18, 14, 19, 17, 30<br /><br />ROOT Object{1}ᐸ{result}ᐳ[18]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 18, 14, 19, 17, 38, 42, 47, 52, 30<br /><br />ROOT Object{1}ᐸ{result}ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Lambda41,Object45,Lambda46,Lambda51 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 19, 17, 38, 41, 46, 51, 30<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres)ᐳ[14]<br />1: <br />ᐳ: 20, 23, 34, 35, 21, 22<br />2: PgSelect[24]<br />ᐳ: First[28], PgSelectSingle[29]"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 19, 17, 38, 42, 47, 52, 30<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres)ᐳ[14]<br />1: <br />ᐳ: 20, 23, 34, 35, 21, 22<br />2: PgSelect[24]<br />ᐳ: First[28], PgSelectSingle[29]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression20,List21,Lambda22,PgClassExpression23,PgSelect24,First28,PgSelectSingle29,PgClassExpression34,PgClassExpression35 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 29, 30<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[29]"):::bucket

--- a/postgraphile/postgraphile/__tests__/mutations/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/types.mermaid
@@ -9,20 +9,223 @@ graph TD
 
 
     %% plan dependencies
-    Object1370{{"Object[1370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object1223{{"Object[1223∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda1215{{"Lambda[1215∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1367{{"Constant[1367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1368{{"Constant[1368∈0] ➊<br />ᐸsql.identifier(”type_function_mutation”)ᐳ"}}:::plan
-    Constant1369{{"Constant[1369∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Lambda1215 & Constant1367 & Constant1368 & Constant1369 --> Object1370
-    Object1532{{"Object[1532∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1529{{"Constant[1529∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1530{{"Constant[1530∈0] ➊<br />ᐸsql.identifier(”type_function_list_mutation”)ᐳ"}}:::plan
-    Lambda1215 & Constant1529 & Constant1530 & Constant1369 --> Object1532
-    Object1694{{"Object[1694∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1691{{"Constant[1691∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1692{{"Constant[1692∈0] ➊<br />ᐸsql.identifier(”type_function_connection_mutation”)ᐳ"}}:::plan
-    Lambda1215 & Constant1691 & Constant1692 & Constant1369 --> Object1694
+    Constant1220{{"Constant[1220∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1221{{"Constant[1221∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant1222{{"Constant[1222∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda1215 & Constant1220 & Constant1221 & Constant1222 --> Object1223
+    Object1238{{"Object[1238∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1235{{"Constant[1235∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1236{{"Constant[1236∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1235 & Constant1236 & Constant1222 --> Object1238
+    Object1253{{"Object[1253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1250{{"Constant[1250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1251{{"Constant[1251∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant1252{{"Constant[1252∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda1215 & Constant1250 & Constant1251 & Constant1252 --> Object1253
+    Object1268{{"Object[1268∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1265{{"Constant[1265∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1266{{"Constant[1266∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1265 & Constant1266 & Constant1252 --> Object1268
+    Object1285{{"Object[1285∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1282{{"Constant[1282∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1283{{"Constant[1283∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1282 & Constant1283 & Constant1252 --> Object1285
+    Object1302{{"Object[1302∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1299{{"Constant[1299∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1300{{"Constant[1300∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Constant1301{{"Constant[1301∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
+    Lambda1215 & Constant1299 & Constant1300 & Constant1301 --> Object1302
+    Object1317{{"Object[1317∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1314{{"Constant[1314∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1315{{"Constant[1315∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1314 & Constant1315 & Constant1252 --> Object1317
+    Object1332{{"Object[1332∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1329{{"Constant[1329∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1330{{"Constant[1330∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1329 & Constant1330 & Constant1252 --> Object1332
+    Object1349{{"Object[1349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1346{{"Constant[1346∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1347{{"Constant[1347∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1346 & Constant1347 & Constant1252 --> Object1349
+    Object1366{{"Object[1366∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1363{{"Constant[1363∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1364{{"Constant[1364∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1363 & Constant1364 & Constant1301 --> Object1366
+    Object1381{{"Object[1381∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1378{{"Constant[1378∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1379{{"Constant[1379∈0] ➊<br />ᐸsql.identifier(”type_function_mutation”)ᐳ"}}:::plan
+    Constant1380{{"Constant[1380∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda1215 & Constant1378 & Constant1379 & Constant1380 --> Object1381
+    Object1396{{"Object[1396∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1393{{"Constant[1393∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1394{{"Constant[1394∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1393 & Constant1394 & Constant1222 --> Object1396
+    Object1411{{"Object[1411∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1408{{"Constant[1408∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1409{{"Constant[1409∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1408 & Constant1409 & Constant1222 --> Object1411
+    Object1426{{"Object[1426∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1423{{"Constant[1423∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1424{{"Constant[1424∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1423 & Constant1424 & Constant1252 --> Object1426
+    Object1441{{"Object[1441∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1438{{"Constant[1438∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1439{{"Constant[1439∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1438 & Constant1439 & Constant1252 --> Object1441
+    Object1458{{"Object[1458∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1455{{"Constant[1455∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1456{{"Constant[1456∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1455 & Constant1456 & Constant1252 --> Object1458
+    Object1475{{"Object[1475∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1472{{"Constant[1472∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1473{{"Constant[1473∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1472 & Constant1473 & Constant1301 --> Object1475
+    Object1490{{"Object[1490∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1487{{"Constant[1487∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1488{{"Constant[1488∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1487 & Constant1488 & Constant1252 --> Object1490
+    Object1505{{"Object[1505∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1502{{"Constant[1502∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1503{{"Constant[1503∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1502 & Constant1503 & Constant1252 --> Object1505
+    Object1522{{"Object[1522∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1519{{"Constant[1519∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1520{{"Constant[1520∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1519 & Constant1520 & Constant1252 --> Object1522
+    Object1539{{"Object[1539∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1536{{"Constant[1536∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1537{{"Constant[1537∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1536 & Constant1537 & Constant1301 --> Object1539
+    Object1554{{"Object[1554∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1551{{"Constant[1551∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1552{{"Constant[1552∈0] ➊<br />ᐸsql.identifier(”type_function_list_mutation”)ᐳ"}}:::plan
+    Lambda1215 & Constant1551 & Constant1552 & Constant1380 --> Object1554
+    Object1569{{"Object[1569∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1566{{"Constant[1566∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1567{{"Constant[1567∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1566 & Constant1567 & Constant1222 --> Object1569
+    Object1584{{"Object[1584∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1581{{"Constant[1581∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1582{{"Constant[1582∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1581 & Constant1582 & Constant1222 --> Object1584
+    Object1599{{"Object[1599∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1596{{"Constant[1596∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1597{{"Constant[1597∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1596 & Constant1597 & Constant1252 --> Object1599
+    Object1614{{"Object[1614∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1611{{"Constant[1611∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1612{{"Constant[1612∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1611 & Constant1612 & Constant1252 --> Object1614
+    Object1631{{"Object[1631∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1628{{"Constant[1628∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1629{{"Constant[1629∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1628 & Constant1629 & Constant1252 --> Object1631
+    Object1648{{"Object[1648∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1645{{"Constant[1645∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1646{{"Constant[1646∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1645 & Constant1646 & Constant1301 --> Object1648
+    Object1663{{"Object[1663∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1660{{"Constant[1660∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1661{{"Constant[1661∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1660 & Constant1661 & Constant1252 --> Object1663
+    Object1678{{"Object[1678∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1675{{"Constant[1675∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1676{{"Constant[1676∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1675 & Constant1676 & Constant1252 --> Object1678
+    Object1695{{"Object[1695∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1692{{"Constant[1692∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1693{{"Constant[1693∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1692 & Constant1693 & Constant1252 --> Object1695
+    Object1712{{"Object[1712∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1709{{"Constant[1709∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1710{{"Constant[1710∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1709 & Constant1710 & Constant1301 --> Object1712
+    Object1727{{"Object[1727∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1724{{"Constant[1724∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1725{{"Constant[1725∈0] ➊<br />ᐸsql.identifier(”type_function_connection_mutation”)ᐳ"}}:::plan
+    Lambda1215 & Constant1724 & Constant1725 & Constant1380 --> Object1727
+    Object1742{{"Object[1742∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1739{{"Constant[1739∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1740{{"Constant[1740∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1739 & Constant1740 & Constant1222 --> Object1742
+    Object1757{{"Object[1757∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1754{{"Constant[1754∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1755{{"Constant[1755∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1754 & Constant1755 & Constant1222 --> Object1757
+    Object1772{{"Object[1772∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1769{{"Constant[1769∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1770{{"Constant[1770∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1769 & Constant1770 & Constant1252 --> Object1772
+    Object1787{{"Object[1787∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1784{{"Constant[1784∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1785{{"Constant[1785∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1784 & Constant1785 & Constant1252 --> Object1787
+    Object1804{{"Object[1804∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1801{{"Constant[1801∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1802{{"Constant[1802∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1801 & Constant1802 & Constant1252 --> Object1804
+    Object1821{{"Object[1821∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1818{{"Constant[1818∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1819{{"Constant[1819∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1818 & Constant1819 & Constant1301 --> Object1821
+    Object1836{{"Object[1836∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1833{{"Constant[1833∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1834{{"Constant[1834∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1833 & Constant1834 & Constant1252 --> Object1836
+    Object1851{{"Object[1851∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1848{{"Constant[1848∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1849{{"Constant[1849∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1848 & Constant1849 & Constant1252 --> Object1851
+    Object1868{{"Object[1868∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1865{{"Constant[1865∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1866{{"Constant[1866∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1865 & Constant1866 & Constant1252 --> Object1868
+    Object1885{{"Object[1885∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1882{{"Constant[1882∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1883{{"Constant[1883∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1882 & Constant1883 & Constant1301 --> Object1885
+    Object1900{{"Object[1900∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1897{{"Constant[1897∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1898{{"Constant[1898∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1897 & Constant1898 & Constant1222 --> Object1900
+    Object1915{{"Object[1915∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1912{{"Constant[1912∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1913{{"Constant[1913∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1215 & Constant1912 & Constant1913 & Constant1222 --> Object1915
+    Object1930{{"Object[1930∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1927{{"Constant[1927∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1928{{"Constant[1928∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1927 & Constant1928 & Constant1252 --> Object1930
+    Object1945{{"Object[1945∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1942{{"Constant[1942∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1943{{"Constant[1943∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1942 & Constant1943 & Constant1252 --> Object1945
+    Object1962{{"Object[1962∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1959{{"Constant[1959∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1960{{"Constant[1960∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1959 & Constant1960 & Constant1252 --> Object1962
+    Object1979{{"Object[1979∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1976{{"Constant[1976∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1977{{"Constant[1977∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1976 & Constant1977 & Constant1301 --> Object1979
+    Object1994{{"Object[1994∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1991{{"Constant[1991∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1992{{"Constant[1992∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant1991 & Constant1992 & Constant1252 --> Object1994
+    Object2009{{"Object[2009∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2006{{"Constant[2006∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2007{{"Constant[2007∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant2006 & Constant2007 & Constant1252 --> Object2009
+    Object2026{{"Object[2026∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2023{{"Constant[2023∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2024{{"Constant[2024∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant2023 & Constant2024 & Constant1252 --> Object2026
+    Object2043{{"Object[2043∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2040{{"Constant[2040∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2041{{"Constant[2041∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda1215 & Constant2040 & Constant2041 & Constant1301 --> Object2043
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -30,308 +233,347 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant2045{{"Constant[2045∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant2045 --> Lambda1215
+    Constant2098{{"Constant[2098∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant2098 --> Lambda1215
     Lambda1218{{"Lambda[1218∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant2046{{"Constant[2046∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant2046 --> Lambda1218
-    Lambda1371{{"Lambda[1371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1370 --> Lambda1371
-    Lambda1376{{"Lambda[1376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2057{{"Constant[2057∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant2057 --> Lambda1376
-    Lambda1533{{"Lambda[1533∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1532 --> Lambda1533
-    Lambda1538{{"Lambda[1538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2068{{"Constant[2068∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant2068 --> Lambda1538
-    Lambda1695{{"Lambda[1695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1694 --> Lambda1695
-    Lambda1700{{"Lambda[1700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2079{{"Constant[2079∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant2079 --> Lambda1700
+    Constant2099{{"Constant[2099∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant2099 --> Lambda1218
+    Access1219{{"Access[1219∈0] ➊<br />ᐸ1218.0ᐳ"}}:::plan
+    Lambda1218 --> Access1219
+    Lambda1224{{"Lambda[1224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1223 --> Lambda1224
+    Lambda1229{{"Lambda[1229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2100{{"Constant[2100∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2100 --> Lambda1229
+    Lambda1239{{"Lambda[1239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1238 --> Lambda1239
+    Lambda1244{{"Lambda[1244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2101{{"Constant[2101∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2101 --> Lambda1244
+    Lambda1254{{"Lambda[1254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1253 --> Lambda1254
+    Lambda1259{{"Lambda[1259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2102{{"Constant[2102∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2102 --> Lambda1259
+    Lambda1269{{"Lambda[1269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1268 --> Lambda1269
+    Lambda1274{{"Lambda[1274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2103{{"Constant[2103∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2103 --> Lambda1274
+    Lambda1286{{"Lambda[1286∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1285 --> Lambda1286
+    Lambda1291{{"Lambda[1291∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2104{{"Constant[2104∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2104 --> Lambda1291
+    Lambda1303{{"Lambda[1303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1302 --> Lambda1303
+    Lambda1308{{"Lambda[1308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2105{{"Constant[2105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2105 --> Lambda1308
+    Lambda1318{{"Lambda[1318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1317 --> Lambda1318
+    Lambda1323{{"Lambda[1323∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2106{{"Constant[2106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2106 --> Lambda1323
+    Lambda1333{{"Lambda[1333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1332 --> Lambda1333
+    Lambda1338{{"Lambda[1338∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2107{{"Constant[2107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2107 --> Lambda1338
+    Lambda1350{{"Lambda[1350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1349 --> Lambda1350
+    Lambda1355{{"Lambda[1355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2108{{"Constant[2108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2108 --> Lambda1355
+    Lambda1367{{"Lambda[1367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1366 --> Lambda1367
+    Lambda1372{{"Lambda[1372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2109{{"Constant[2109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2109 --> Lambda1372
+    Lambda1382{{"Lambda[1382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1381 --> Lambda1382
+    Lambda1387{{"Lambda[1387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2110{{"Constant[2110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant2110 --> Lambda1387
+    Lambda1397{{"Lambda[1397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1396 --> Lambda1397
+    Lambda1402{{"Lambda[1402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2111{{"Constant[2111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2111 --> Lambda1402
+    Lambda1412{{"Lambda[1412∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1411 --> Lambda1412
+    Lambda1417{{"Lambda[1417∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2112{{"Constant[2112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2112 --> Lambda1417
+    Lambda1427{{"Lambda[1427∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1426 --> Lambda1427
+    Lambda1432{{"Lambda[1432∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2113{{"Constant[2113∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2113 --> Lambda1432
+    Lambda1442{{"Lambda[1442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1441 --> Lambda1442
+    Lambda1447{{"Lambda[1447∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2114{{"Constant[2114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2114 --> Lambda1447
+    Lambda1459{{"Lambda[1459∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1458 --> Lambda1459
+    Lambda1464{{"Lambda[1464∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2115{{"Constant[2115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2115 --> Lambda1464
+    Lambda1476{{"Lambda[1476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1475 --> Lambda1476
+    Lambda1481{{"Lambda[1481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2116{{"Constant[2116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2116 --> Lambda1481
+    Lambda1491{{"Lambda[1491∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1490 --> Lambda1491
+    Lambda1496{{"Lambda[1496∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2117{{"Constant[2117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2117 --> Lambda1496
+    Lambda1506{{"Lambda[1506∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1505 --> Lambda1506
+    Lambda1511{{"Lambda[1511∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2118{{"Constant[2118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2118 --> Lambda1511
+    Lambda1523{{"Lambda[1523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1522 --> Lambda1523
+    Lambda1528{{"Lambda[1528∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2119{{"Constant[2119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2119 --> Lambda1528
+    Lambda1540{{"Lambda[1540∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1539 --> Lambda1540
+    Lambda1545{{"Lambda[1545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2120{{"Constant[2120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2120 --> Lambda1545
+    Lambda1555{{"Lambda[1555∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1554 --> Lambda1555
+    Lambda1560{{"Lambda[1560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2121{{"Constant[2121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant2121 --> Lambda1560
+    Lambda1570{{"Lambda[1570∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1569 --> Lambda1570
+    Lambda1575{{"Lambda[1575∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2122{{"Constant[2122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2122 --> Lambda1575
+    Lambda1585{{"Lambda[1585∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1584 --> Lambda1585
+    Lambda1590{{"Lambda[1590∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2123{{"Constant[2123∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2123 --> Lambda1590
+    Lambda1600{{"Lambda[1600∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1599 --> Lambda1600
+    Lambda1605{{"Lambda[1605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2124{{"Constant[2124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2124 --> Lambda1605
+    Lambda1615{{"Lambda[1615∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1614 --> Lambda1615
+    Lambda1620{{"Lambda[1620∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2125{{"Constant[2125∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2125 --> Lambda1620
+    Lambda1632{{"Lambda[1632∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1631 --> Lambda1632
+    Lambda1637{{"Lambda[1637∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2126{{"Constant[2126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2126 --> Lambda1637
+    Lambda1649{{"Lambda[1649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1648 --> Lambda1649
+    Lambda1654{{"Lambda[1654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2127{{"Constant[2127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2127 --> Lambda1654
+    Lambda1664{{"Lambda[1664∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1663 --> Lambda1664
+    Lambda1669{{"Lambda[1669∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2128{{"Constant[2128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2128 --> Lambda1669
+    Lambda1679{{"Lambda[1679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1678 --> Lambda1679
+    Lambda1684{{"Lambda[1684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2129{{"Constant[2129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2129 --> Lambda1684
+    Lambda1696{{"Lambda[1696∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1695 --> Lambda1696
+    Lambda1701{{"Lambda[1701∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2130{{"Constant[2130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2130 --> Lambda1701
+    Lambda1713{{"Lambda[1713∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1712 --> Lambda1713
+    Lambda1718{{"Lambda[1718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2131{{"Constant[2131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2131 --> Lambda1718
+    Lambda1728{{"Lambda[1728∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1727 --> Lambda1728
+    Lambda1733{{"Lambda[1733∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2132{{"Constant[2132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant2132 --> Lambda1733
+    Lambda1743{{"Lambda[1743∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1742 --> Lambda1743
+    Lambda1748{{"Lambda[1748∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2133{{"Constant[2133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2133 --> Lambda1748
+    Lambda1758{{"Lambda[1758∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1757 --> Lambda1758
+    Lambda1763{{"Lambda[1763∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2134{{"Constant[2134∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2134 --> Lambda1763
+    Lambda1773{{"Lambda[1773∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1772 --> Lambda1773
+    Lambda1778{{"Lambda[1778∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2135{{"Constant[2135∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2135 --> Lambda1778
+    Lambda1788{{"Lambda[1788∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1787 --> Lambda1788
+    Lambda1793{{"Lambda[1793∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2136{{"Constant[2136∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2136 --> Lambda1793
+    Lambda1805{{"Lambda[1805∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1804 --> Lambda1805
+    Lambda1810{{"Lambda[1810∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2137{{"Constant[2137∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2137 --> Lambda1810
+    Lambda1822{{"Lambda[1822∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1821 --> Lambda1822
+    Lambda1827{{"Lambda[1827∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2138{{"Constant[2138∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2138 --> Lambda1827
+    Lambda1837{{"Lambda[1837∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1836 --> Lambda1837
+    Lambda1842{{"Lambda[1842∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2139{{"Constant[2139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2139 --> Lambda1842
+    Lambda1852{{"Lambda[1852∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1851 --> Lambda1852
+    Lambda1857{{"Lambda[1857∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2140{{"Constant[2140∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2140 --> Lambda1857
+    Lambda1869{{"Lambda[1869∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1868 --> Lambda1869
+    Lambda1874{{"Lambda[1874∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2141{{"Constant[2141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2141 --> Lambda1874
+    Lambda1886{{"Lambda[1886∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1885 --> Lambda1886
+    Lambda1891{{"Lambda[1891∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2142{{"Constant[2142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2142 --> Lambda1891
+    Lambda1901{{"Lambda[1901∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1900 --> Lambda1901
+    Lambda1906{{"Lambda[1906∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2143{{"Constant[2143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2143 --> Lambda1906
+    Lambda1916{{"Lambda[1916∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1915 --> Lambda1916
+    Lambda1921{{"Lambda[1921∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2144{{"Constant[2144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant2144 --> Lambda1921
+    Lambda1931{{"Lambda[1931∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1930 --> Lambda1931
+    Lambda1936{{"Lambda[1936∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2145{{"Constant[2145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2145 --> Lambda1936
+    Lambda1946{{"Lambda[1946∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1945 --> Lambda1946
+    Lambda1951{{"Lambda[1951∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2146{{"Constant[2146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2146 --> Lambda1951
+    Lambda1963{{"Lambda[1963∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1962 --> Lambda1963
+    Lambda1968{{"Lambda[1968∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2147{{"Constant[2147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2147 --> Lambda1968
+    Lambda1980{{"Lambda[1980∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1979 --> Lambda1980
+    Lambda1985{{"Lambda[1985∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2148{{"Constant[2148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2148 --> Lambda1985
+    Lambda1995{{"Lambda[1995∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1994 --> Lambda1995
+    Lambda2000{{"Lambda[2000∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2149{{"Constant[2149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2149 --> Lambda2000
+    Lambda2010{{"Lambda[2010∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2009 --> Lambda2010
+    Lambda2015{{"Lambda[2015∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2150{{"Constant[2150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2150 --> Lambda2015
+    Lambda2027{{"Lambda[2027∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2026 --> Lambda2027
+    Lambda2032{{"Lambda[2032∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2151{{"Constant[2151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2151 --> Lambda2032
+    Lambda2044{{"Lambda[2044∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2043 --> Lambda2044
+    Lambda2049{{"Lambda[2049∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant2152{{"Constant[2152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant2152 --> Lambda2049
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant1219{{"Constant[1219∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1220{{"Constant[1220∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1221{{"Constant[1221∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant1233{{"Constant[1233∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1234{{"Constant[1234∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1247{{"Constant[1247∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1248{{"Constant[1248∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1249{{"Constant[1249∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Constant1261{{"Constant[1261∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1262{{"Constant[1262∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1277{{"Constant[1277∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1278{{"Constant[1278∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1293{{"Constant[1293∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1294{{"Constant[1294∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1295{{"Constant[1295∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
-    Constant1307{{"Constant[1307∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1308{{"Constant[1308∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1321{{"Constant[1321∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1322{{"Constant[1322∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1337{{"Constant[1337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1338{{"Constant[1338∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1353{{"Constant[1353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1354{{"Constant[1354∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1381{{"Constant[1381∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1382{{"Constant[1382∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1395{{"Constant[1395∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1396{{"Constant[1396∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1409{{"Constant[1409∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1410{{"Constant[1410∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1423{{"Constant[1423∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1424{{"Constant[1424∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1439{{"Constant[1439∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1440{{"Constant[1440∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1455{{"Constant[1455∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1456{{"Constant[1456∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1469{{"Constant[1469∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1470{{"Constant[1470∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1483{{"Constant[1483∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1484{{"Constant[1484∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1499{{"Constant[1499∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1500{{"Constant[1500∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1515{{"Constant[1515∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1516{{"Constant[1516∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1543{{"Constant[1543∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1544{{"Constant[1544∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1557{{"Constant[1557∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1558{{"Constant[1558∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1571{{"Constant[1571∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1572{{"Constant[1572∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1585{{"Constant[1585∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1586{{"Constant[1586∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1601{{"Constant[1601∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1602{{"Constant[1602∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1617{{"Constant[1617∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1618{{"Constant[1618∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1631{{"Constant[1631∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1632{{"Constant[1632∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1645{{"Constant[1645∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1646{{"Constant[1646∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1661{{"Constant[1661∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1662{{"Constant[1662∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1677{{"Constant[1677∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1678{{"Constant[1678∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1705{{"Constant[1705∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1706{{"Constant[1706∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1719{{"Constant[1719∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1720{{"Constant[1720∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1733{{"Constant[1733∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1734{{"Constant[1734∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1747{{"Constant[1747∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1748{{"Constant[1748∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1763{{"Constant[1763∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1764{{"Constant[1764∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1779{{"Constant[1779∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1780{{"Constant[1780∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1793{{"Constant[1793∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1794{{"Constant[1794∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1807{{"Constant[1807∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1808{{"Constant[1808∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1823{{"Constant[1823∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1824{{"Constant[1824∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1839{{"Constant[1839∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1840{{"Constant[1840∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1853{{"Constant[1853∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1854{{"Constant[1854∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1867{{"Constant[1867∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1868{{"Constant[1868∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1881{{"Constant[1881∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1882{{"Constant[1882∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1895{{"Constant[1895∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1896{{"Constant[1896∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1911{{"Constant[1911∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1912{{"Constant[1912∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1927{{"Constant[1927∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1928{{"Constant[1928∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1941{{"Constant[1941∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1942{{"Constant[1942∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1955{{"Constant[1955∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1956{{"Constant[1956∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1971{{"Constant[1971∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1972{{"Constant[1972∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant1987{{"Constant[1987∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1988{{"Constant[1988∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant1997{{"Constant[1997∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant1998{{"Constant[1998∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant1999{{"Constant[1999∈0] ➊<br />ᐸ'1'ᐳ"}}:::plan
-    Constant2000{{"Constant[2000∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant2001{{"Constant[2001∈0] ➊<br />ᐸ'red'ᐳ"}}:::plan
-    Constant2005{{"Constant[2005∈0] ➊<br />ᐸ{ json: true }ᐳ"}}:::plan
-    Constant2006{{"Constant[2006∈0] ➊<br />ᐸ{ jsonb: true }ᐳ"}}:::plan
-    Constant2011{{"Constant[2011∈0] ➊<br />ᐸ'2012-01-11'ᐳ"}}:::plan
-    Constant2012{{"Constant[2012∈0] ➊<br />ᐸ'2012-01-01'ᐳ"}}:::plan
-    Constant2013{{"Constant[2013∈0] ➊<br />ᐸ'2010-01-01'ᐳ"}}:::plan
-    Constant2014{{"Constant[2014∈0] ➊<br />ᐸ'19:00:00'ᐳ"}}:::plan
-    Constant2015{{"Constant[2015∈0] ➊<br />ᐸ27ᐳ"}}:::plan
-    Constant2020{{"Constant[2020∈0] ➊<br />ᐸ'192.168.0.0'ᐳ"}}:::plan
-    Constant2021{{"Constant[2021∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
-    Constant2022{{"Constant[2022∈0] ➊<br />ᐸ'08:00:2b:01:02:03'ᐳ"}}:::plan
-    Constant2023{{"Constant[2023∈0] ➊<br />ᐸ'b.type_function'ᐳ"}}:::plan
-    Constant2024{{"Constant[2024∈0] ➊<br />ᐸ'b.type_function(int)'ᐳ"}}:::plan
-    Constant2025{{"Constant[2025∈0] ➊<br />ᐸ'*ᐸᐳ'ᐳ"}}:::plan
-    Constant2026{{"Constant[2026∈0] ➊<br />ᐸ'+(integer, integer)'ᐳ"}}:::plan
-    Constant2027{{"Constant[2027∈0] ➊<br />ᐸ'c.person'ᐳ"}}:::plan
-    Constant2028{{"Constant[2028∈0] ➊<br />ᐸ'numeric'ᐳ"}}:::plan
-    Constant2029{{"Constant[2029∈0] ➊<br />ᐸ'dutch'ᐳ"}}:::plan
-    Constant2030{{"Constant[2030∈0] ➊<br />ᐸ'dutch_stem'ᐳ"}}:::plan
-    Constant2037{{"Constant[2037∈0] ➊<br />ᐸᐸBuffer 5a 53 ea 5a 7f eaᐳᐳ"}}:::plan
-    Constant2040{{"Constant[2040∈0] ➊<br />ᐸ'Foo.Bar.Baz'ᐳ"}}:::plan
-    Constant2043{{"Constant[2043∈0] ➊<br />ᐸ{ json: true }ᐳ"}}:::plan
-    Constant2044{{"Constant[2044∈0] ➊<br />ᐸ{ jsonb: true }ᐳ"}}:::plan
-    Constant2047{{"Constant[2047∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2048{{"Constant[2048∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2049{{"Constant[2049∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2050{{"Constant[2050∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2051{{"Constant[2051∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2052{{"Constant[2052∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2053{{"Constant[2053∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2054{{"Constant[2054∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2055{{"Constant[2055∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2056{{"Constant[2056∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2058{{"Constant[2058∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2059{{"Constant[2059∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2060{{"Constant[2060∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2061{{"Constant[2061∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2062{{"Constant[2062∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2063{{"Constant[2063∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2064{{"Constant[2064∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2065{{"Constant[2065∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2066{{"Constant[2066∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2067{{"Constant[2067∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2069{{"Constant[2069∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2070{{"Constant[2070∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2071{{"Constant[2071∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2072{{"Constant[2072∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2073{{"Constant[2073∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2074{{"Constant[2074∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2075{{"Constant[2075∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2076{{"Constant[2076∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2077{{"Constant[2077∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2078{{"Constant[2078∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2080{{"Constant[2080∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2081{{"Constant[2081∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2082{{"Constant[2082∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2083{{"Constant[2083∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2084{{"Constant[2084∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2085{{"Constant[2085∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2086{{"Constant[2086∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2087{{"Constant[2087∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2088{{"Constant[2088∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2089{{"Constant[2089∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2090{{"Constant[2090∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2091{{"Constant[2091∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant2092{{"Constant[2092∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2093{{"Constant[2093∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2094{{"Constant[2094∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2095{{"Constant[2095∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2096{{"Constant[2096∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2097{{"Constant[2097∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2098{{"Constant[2098∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2099{{"Constant[2099∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant2100{{"Constant[2100∈0] ➊<br />ᐸ§{ seconds: undefined, minutes: 27, hours: undefined, days: ᐳ"}}:::plan
-    Constant2102{{"Constant[2102∈0] ➊<br />ᐸ[ 'red', 'green', 'blue' ]ᐳ"}}:::plan
-    Constant2103{{"Constant[2103∈0] ➊<br />ᐸ[ 'Hi' ]ᐳ"}}:::plan
-    Constant2110{{"Constant[2110∈0] ➊<br />ᐸ[ §{ seconds: undefined, minutes: 27, hours: undefined, daysᐳ"}}:::plan
-    Constant2111{{"Constant[2111∈0] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
-    Constant2112{{"Constant[2112∈0] ➊<br />ᐸ§{ a: §{ a: 1 } }ᐳ"}}:::plan
-    Constant2113{{"Constant[2113∈0] ➊<br />ᐸ§{ x: 99, y: 77 }ᐳ"}}:::plan
-    Constant2114{{"Constant[2114∈0] ➊<br />ᐸ§{ x: 0, y: 42 }ᐳ"}}:::plan
-    Constant2115{{"Constant[2115∈0] ➊<br />ᐸ[ 'T1', 'T2', 'T3' ]ᐳ"}}:::plan
-    Constant2116{{"Constant[2116∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
-    Constant2117{{"Constant[2117∈0] ➊<br />ᐸ[ ᐸBuffer 01 a0 5b 09 c0 ddᐳ, ᐸBuffer 01 a0 5bᐳ ]ᐳ"}}:::plan
-    Constant2118{{"Constant[2118∈0] ➊<br />ᐸ[ 'Bar.Baz.Qux', 'Bar.Foo.Fah' ]ᐳ"}}:::plan
-    Constant2132{{"Constant[2132∈0] ➊<br />ᐸ§{ start: §{ value: '1', inclusive: true }, end: §{ value: 'ᐳ"}}:::plan
-    Constant2133{{"Constant[2133∈0] ➊<br />ᐸ§{ start: §{ value: '1985-01-01', inclusive: true }, end: §{ᐳ"}}:::plan
-    Constant2134{{"Constant[2134∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: true }, end: §{ value: 2, ᐳ"}}:::plan
+    Constant2050{{"Constant[2050∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Constant2051{{"Constant[2051∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant2052{{"Constant[2052∈0] ➊<br />ᐸ'1'ᐳ"}}:::plan
+    Constant2053{{"Constant[2053∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant2054{{"Constant[2054∈0] ➊<br />ᐸ'red'ᐳ"}}:::plan
+    Constant2058{{"Constant[2058∈0] ➊<br />ᐸ{ json: true }ᐳ"}}:::plan
+    Constant2059{{"Constant[2059∈0] ➊<br />ᐸ{ jsonb: true }ᐳ"}}:::plan
+    Constant2064{{"Constant[2064∈0] ➊<br />ᐸ'2012-01-11'ᐳ"}}:::plan
+    Constant2065{{"Constant[2065∈0] ➊<br />ᐸ'2012-01-01'ᐳ"}}:::plan
+    Constant2066{{"Constant[2066∈0] ➊<br />ᐸ'2010-01-01'ᐳ"}}:::plan
+    Constant2067{{"Constant[2067∈0] ➊<br />ᐸ'19:00:00'ᐳ"}}:::plan
+    Constant2068{{"Constant[2068∈0] ➊<br />ᐸ27ᐳ"}}:::plan
+    Constant2073{{"Constant[2073∈0] ➊<br />ᐸ'192.168.0.0'ᐳ"}}:::plan
+    Constant2074{{"Constant[2074∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
+    Constant2075{{"Constant[2075∈0] ➊<br />ᐸ'08:00:2b:01:02:03'ᐳ"}}:::plan
+    Constant2076{{"Constant[2076∈0] ➊<br />ᐸ'b.type_function'ᐳ"}}:::plan
+    Constant2077{{"Constant[2077∈0] ➊<br />ᐸ'b.type_function(int)'ᐳ"}}:::plan
+    Constant2078{{"Constant[2078∈0] ➊<br />ᐸ'*ᐸᐳ'ᐳ"}}:::plan
+    Constant2079{{"Constant[2079∈0] ➊<br />ᐸ'+(integer, integer)'ᐳ"}}:::plan
+    Constant2080{{"Constant[2080∈0] ➊<br />ᐸ'c.person'ᐳ"}}:::plan
+    Constant2081{{"Constant[2081∈0] ➊<br />ᐸ'numeric'ᐳ"}}:::plan
+    Constant2082{{"Constant[2082∈0] ➊<br />ᐸ'dutch'ᐳ"}}:::plan
+    Constant2083{{"Constant[2083∈0] ➊<br />ᐸ'dutch_stem'ᐳ"}}:::plan
+    Constant2090{{"Constant[2090∈0] ➊<br />ᐸᐸBuffer 5a 53 ea 5a 7f eaᐳᐳ"}}:::plan
+    Constant2093{{"Constant[2093∈0] ➊<br />ᐸ'Foo.Bar.Baz'ᐳ"}}:::plan
+    Constant2096{{"Constant[2096∈0] ➊<br />ᐸ{ json: true }ᐳ"}}:::plan
+    Constant2097{{"Constant[2097∈0] ➊<br />ᐸ{ jsonb: true }ᐳ"}}:::plan
+    Constant2153{{"Constant[2153∈0] ➊<br />ᐸ§{ seconds: undefined, minutes: 27, hours: undefined, days: ᐳ"}}:::plan
+    Constant2155{{"Constant[2155∈0] ➊<br />ᐸ[ 'red', 'green', 'blue' ]ᐳ"}}:::plan
+    Constant2156{{"Constant[2156∈0] ➊<br />ᐸ[ 'Hi' ]ᐳ"}}:::plan
+    Constant2163{{"Constant[2163∈0] ➊<br />ᐸ[ §{ seconds: undefined, minutes: 27, hours: undefined, daysᐳ"}}:::plan
+    Constant2164{{"Constant[2164∈0] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
+    Constant2165{{"Constant[2165∈0] ➊<br />ᐸ§{ a: §{ a: 1 } }ᐳ"}}:::plan
+    Constant2166{{"Constant[2166∈0] ➊<br />ᐸ§{ x: 99, y: 77 }ᐳ"}}:::plan
+    Constant2167{{"Constant[2167∈0] ➊<br />ᐸ§{ x: 0, y: 42 }ᐳ"}}:::plan
+    Constant2168{{"Constant[2168∈0] ➊<br />ᐸ[ 'T1', 'T2', 'T3' ]ᐳ"}}:::plan
+    Constant2169{{"Constant[2169∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
+    Constant2170{{"Constant[2170∈0] ➊<br />ᐸ[ ᐸBuffer 01 a0 5b 09 c0 ddᐳ, ᐸBuffer 01 a0 5bᐳ ]ᐳ"}}:::plan
+    Constant2171{{"Constant[2171∈0] ➊<br />ᐸ[ 'Bar.Baz.Qux', 'Bar.Foo.Fah' ]ᐳ"}}:::plan
+    Constant2185{{"Constant[2185∈0] ➊<br />ᐸ§{ start: §{ value: '1', inclusive: true }, end: §{ value: 'ᐳ"}}:::plan
+    Constant2186{{"Constant[2186∈0] ➊<br />ᐸ§{ start: §{ value: '1985-01-01', inclusive: true }, end: §{ᐳ"}}:::plan
+    Constant2187{{"Constant[2187∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: true }, end: §{ value: 2, ᐳ"}}:::plan
     PgSelect9[["PgSelect[9∈1] ➊<br />ᐸtype_function_mutation(mutation)ᐳ"]]:::sideeffectplan
-    Object12 & Constant1997 & Lambda1215 & Lambda1218 & Lambda1371 & Lambda1376 --> PgSelect9
+    Object12 & Constant2050 & Lambda1215 & Access1219 & Lambda1382 & Lambda1387 --> PgSelect9
     First13{{"First[13∈1] ➊"}}:::plan
     PgSelect9 --> First13
     PgSelectSingle14{{"PgSelectSingle[14∈1] ➊<br />ᐸtype_function_mutationᐳ"}}:::plan
     First13 --> PgSelectSingle14
     Object15{{"Object[15∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelectSingle14 --> Object15
-    Object1222{{"Object[1222∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1219 & Constant1220 & Constant1221 --> Object1222
-    Object1236{{"Object[1236∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1233 & Constant1234 & Constant1221 --> Object1236
-    Object1250{{"Object[1250∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1247 & Constant1248 & Constant1249 --> Object1250
-    Object1264{{"Object[1264∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1261 & Constant1262 & Constant1249 --> Object1264
-    Object1280{{"Object[1280∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1277 & Constant1278 & Constant1249 --> Object1280
-    Object1296{{"Object[1296∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1293 & Constant1294 & Constant1295 --> Object1296
-    Object1310{{"Object[1310∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1307 & Constant1308 & Constant1249 --> Object1310
-    Object1324{{"Object[1324∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1321 & Constant1322 & Constant1249 --> Object1324
-    Object1340{{"Object[1340∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1337 & Constant1338 & Constant1249 --> Object1340
-    Object1356{{"Object[1356∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1353 & Constant1354 & Constant1295 --> Object1356
-    Lambda1223{{"Lambda[1223∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1222 --> Lambda1223
-    Lambda1228{{"Lambda[1228∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2047 --> Lambda1228
-    Lambda1237{{"Lambda[1237∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1236 --> Lambda1237
-    Lambda1242{{"Lambda[1242∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2048 --> Lambda1242
-    Lambda1251{{"Lambda[1251∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1250 --> Lambda1251
-    Lambda1256{{"Lambda[1256∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2049 --> Lambda1256
-    Lambda1265{{"Lambda[1265∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1264 --> Lambda1265
-    Lambda1270{{"Lambda[1270∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2050 --> Lambda1270
-    Lambda1281{{"Lambda[1281∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1280 --> Lambda1281
-    Lambda1286{{"Lambda[1286∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2051 --> Lambda1286
-    Lambda1297{{"Lambda[1297∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1296 --> Lambda1297
-    Lambda1302{{"Lambda[1302∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2052 --> Lambda1302
-    Lambda1311{{"Lambda[1311∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1310 --> Lambda1311
-    Lambda1316{{"Lambda[1316∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2053 --> Lambda1316
-    Lambda1325{{"Lambda[1325∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1324 --> Lambda1325
-    Lambda1330{{"Lambda[1330∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2054 --> Lambda1330
-    Lambda1341{{"Lambda[1341∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1340 --> Lambda1341
-    Lambda1346{{"Lambda[1346∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2055 --> Lambda1346
-    Lambda1357{{"Lambda[1357∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1356 --> Lambda1357
-    Lambda1362{{"Lambda[1362∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2056 --> Lambda1362
     PgSelect96[["PgSelect[96∈3] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression95{{"PgClassExpression[95∈3] ➊<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object12 & PgClassExpression95 & Lambda1218 & Lambda1265 & Lambda1270 & Lambda1218 & Lambda1281 & Lambda1286 & Lambda1215 & Lambda1218 & Lambda1297 & Lambda1302 --> PgSelect96
+    Object12 & PgClassExpression95 & Access1219 & Lambda1269 & Lambda1274 & Access1219 & Lambda1286 & Lambda1291 & Lambda1215 & Access1219 & Lambda1303 & Lambda1308 --> PgSelect96
     PgSelect138[["PgSelect[138∈3] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression137{{"PgClassExpression[137∈3] ➊<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object12 & PgClassExpression137 & Lambda1218 & Lambda1325 & Lambda1330 & Lambda1218 & Lambda1341 & Lambda1346 & Lambda1215 & Lambda1218 & Lambda1357 & Lambda1362 --> PgSelect138
+    Object12 & PgClassExpression137 & Access1219 & Lambda1333 & Lambda1338 & Access1219 & Lambda1350 & Lambda1355 & Lambda1215 & Access1219 & Lambda1367 & Lambda1372 --> PgSelect138
     PgSelect82[["PgSelect[82∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression81{{"PgClassExpression[81∈3] ➊<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object12 & PgClassExpression81 & Lambda1215 & Lambda1218 & Lambda1251 & Lambda1256 --> PgSelect82
+    Object12 & PgClassExpression81 & Lambda1215 & Access1219 & Lambda1254 & Lambda1259 --> PgSelect82
     PgSelect126[["PgSelect[126∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression125{{"PgClassExpression[125∈3] ➊<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object12 & PgClassExpression125 & Lambda1215 & Lambda1218 & Lambda1311 & Lambda1316 --> PgSelect126
+    Object12 & PgClassExpression125 & Lambda1215 & Access1219 & Lambda1318 & Lambda1323 --> PgSelect126
     PgSelect193[["PgSelect[193∈3] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈3] ➊<br />ᐸ__type_fun...”smallint”ᐳ"}}:::plan
-    Object12 & PgClassExpression17 & Lambda1215 & Lambda1218 & Lambda1237 & Lambda1242 --> PgSelect193
+    Object12 & PgClassExpression17 & Lambda1215 & Access1219 & Lambda1239 & Lambda1244 --> PgSelect193
     PgSelect199[["PgSelect[199∈3] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression16{{"PgClassExpression[16∈3] ➊<br />ᐸ__type_fun...ion__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression16 & Lambda1215 & Lambda1218 & Lambda1223 & Lambda1228 --> PgSelect199
+    Object12 & PgClassExpression16 & Lambda1215 & Access1219 & Lambda1224 & Lambda1229 --> PgSelect199
     PgSelectSingle14 --> PgClassExpression16
     PgSelectSingle14 --> PgClassExpression17
     PgClassExpression18{{"PgClassExpression[18∈3] ➊<br />ᐸ__type_fun..._.”bigint”ᐳ"}}:::plan
@@ -421,8 +663,8 @@ graph TD
     PgSelectSingle104{{"PgSelectSingle[104∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle99 --> PgSelectSingle104
     PgSelectSingle116{{"PgSelectSingle[116∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1287{{"RemapKeys[1287∈3] ➊<br />ᐸ99:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1287 --> PgSelectSingle116
+    RemapKeys1292{{"RemapKeys[1292∈3] ➊<br />ᐸ99:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1292 --> PgSelectSingle116
     PgClassExpression124{{"PgClassExpression[124∈3] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle99 --> PgClassExpression124
     PgSelectSingle14 --> PgClassExpression125
@@ -481,7 +723,7 @@ graph TD
     PgSelectSingle14 --> PgClassExpression205
     PgClassExpression206{{"PgClassExpression[206∈3] ➊<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression206
-    PgSelectSingle99 --> RemapKeys1287
+    PgSelectSingle99 --> RemapKeys1292
     __Item25[/"__Item[25∈4]<br />ᐸ24ᐳ"\]:::itemplan
     PgClassExpression24 ==> __Item25
     __Item29[/"__Item[29∈5]<br />ᐸ28ᐳ"\]:::itemplan
@@ -537,11 +779,11 @@ graph TD
     PgSelectSingle148{{"PgSelectSingle[148∈20] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle141 --> PgSelectSingle148
     PgSelectSingle160{{"PgSelectSingle[160∈20] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1347{{"RemapKeys[1347∈20] ➊<br />ᐸ141:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1347 --> PgSelectSingle160
+    RemapKeys1356{{"RemapKeys[1356∈20] ➊<br />ᐸ141:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1356 --> PgSelectSingle160
     PgClassExpression168{{"PgClassExpression[168∈20] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle141 --> PgClassExpression168
-    PgSelectSingle141 --> RemapKeys1347
+    PgSelectSingle141 --> RemapKeys1356
     PgClassExpression149{{"PgClassExpression[149∈21] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle148 --> PgClassExpression149
     PgClassExpression150{{"PgClassExpression[150∈21] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -588,7 +830,7 @@ graph TD
     PgClassExpression206 ==> __Item207
     PgSelect210[["PgSelect[210∈30] ➊<br />ᐸtype_function_list_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object213{{"Object[213∈30] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object213 & Lambda1215 & Lambda1218 & Lambda1533 & Lambda1538 --> PgSelect210
+    Object213 & Lambda1215 & Access1219 & Lambda1555 & Lambda1560 --> PgSelect210
     Access211{{"Access[211∈30] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access212{{"Access[212∈30] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access211 & Access212 --> Object213
@@ -596,88 +838,28 @@ graph TD
     __Value2 --> Access212
     Object214{{"Object[214∈30] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelect210 --> Object214
-    Object1384{{"Object[1384∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1381 & Constant1382 & Constant1221 --> Object1384
-    Object1398{{"Object[1398∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1395 & Constant1396 & Constant1221 --> Object1398
-    Object1412{{"Object[1412∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1409 & Constant1410 & Constant1249 --> Object1412
-    Object1426{{"Object[1426∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1423 & Constant1424 & Constant1249 --> Object1426
-    Object1442{{"Object[1442∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1439 & Constant1440 & Constant1249 --> Object1442
-    Object1458{{"Object[1458∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1455 & Constant1456 & Constant1295 --> Object1458
-    Object1472{{"Object[1472∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1469 & Constant1470 & Constant1249 --> Object1472
-    Object1486{{"Object[1486∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1483 & Constant1484 & Constant1249 --> Object1486
-    Object1502{{"Object[1502∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1499 & Constant1500 & Constant1249 --> Object1502
-    Object1518{{"Object[1518∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1515 & Constant1516 & Constant1295 --> Object1518
-    Lambda1385{{"Lambda[1385∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1384 --> Lambda1385
-    Lambda1390{{"Lambda[1390∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2058 --> Lambda1390
-    Lambda1399{{"Lambda[1399∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1398 --> Lambda1399
-    Lambda1404{{"Lambda[1404∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2059 --> Lambda1404
-    Lambda1413{{"Lambda[1413∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1412 --> Lambda1413
-    Lambda1418{{"Lambda[1418∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2060 --> Lambda1418
-    Lambda1427{{"Lambda[1427∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1426 --> Lambda1427
-    Lambda1432{{"Lambda[1432∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2061 --> Lambda1432
-    Lambda1443{{"Lambda[1443∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1442 --> Lambda1443
-    Lambda1448{{"Lambda[1448∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2062 --> Lambda1448
-    Lambda1459{{"Lambda[1459∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1458 --> Lambda1459
-    Lambda1464{{"Lambda[1464∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2063 --> Lambda1464
-    Lambda1473{{"Lambda[1473∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1472 --> Lambda1473
-    Lambda1478{{"Lambda[1478∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2064 --> Lambda1478
-    Lambda1487{{"Lambda[1487∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1486 --> Lambda1487
-    Lambda1492{{"Lambda[1492∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2065 --> Lambda1492
-    Lambda1503{{"Lambda[1503∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1502 --> Lambda1503
-    Lambda1508{{"Lambda[1508∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2066 --> Lambda1508
-    Lambda1519{{"Lambda[1519∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1518 --> Lambda1519
-    Lambda1524{{"Lambda[1524∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2067 --> Lambda1524
     __Item215[/"__Item[215∈32]<br />ᐸ210ᐳ"\]:::itemplan
     PgSelect210 ==> __Item215
     PgSelectSingle216{{"PgSelectSingle[216∈32]<br />ᐸtype_function_list_mutationᐳ"}}:::plan
     __Item215 --> PgSelectSingle216
     PgSelect297[["PgSelect[297∈33]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression296{{"PgClassExpression[296∈33]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object213 & PgClassExpression296 & Lambda1218 & Lambda1427 & Lambda1432 & Lambda1218 & Lambda1443 & Lambda1448 & Lambda1215 & Lambda1218 & Lambda1459 & Lambda1464 --> PgSelect297
+    Object213 & PgClassExpression296 & Access1219 & Lambda1442 & Lambda1447 & Access1219 & Lambda1459 & Lambda1464 & Lambda1215 & Access1219 & Lambda1476 & Lambda1481 --> PgSelect297
     PgSelect339[["PgSelect[339∈33]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression338{{"PgClassExpression[338∈33]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object213 & PgClassExpression338 & Lambda1218 & Lambda1487 & Lambda1492 & Lambda1218 & Lambda1503 & Lambda1508 & Lambda1215 & Lambda1218 & Lambda1519 & Lambda1524 --> PgSelect339
+    Object213 & PgClassExpression338 & Access1219 & Lambda1506 & Lambda1511 & Access1219 & Lambda1523 & Lambda1528 & Lambda1215 & Access1219 & Lambda1540 & Lambda1545 --> PgSelect339
     PgSelect283[["PgSelect[283∈33]<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression282{{"PgClassExpression[282∈33]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object213 & PgClassExpression282 & Lambda1215 & Lambda1218 & Lambda1413 & Lambda1418 --> PgSelect283
+    Object213 & PgClassExpression282 & Lambda1215 & Access1219 & Lambda1427 & Lambda1432 --> PgSelect283
     PgSelect327[["PgSelect[327∈33]<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression326{{"PgClassExpression[326∈33]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object213 & PgClassExpression326 & Lambda1215 & Lambda1218 & Lambda1473 & Lambda1478 --> PgSelect327
+    Object213 & PgClassExpression326 & Lambda1215 & Access1219 & Lambda1491 & Lambda1496 --> PgSelect327
     PgSelect394[["PgSelect[394∈33]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression218{{"PgClassExpression[218∈33]<br />ᐸ__type_fun...”smallint”ᐳ"}}:::plan
-    Object213 & PgClassExpression218 & Lambda1215 & Lambda1218 & Lambda1399 & Lambda1404 --> PgSelect394
+    Object213 & PgClassExpression218 & Lambda1215 & Access1219 & Lambda1412 & Lambda1417 --> PgSelect394
     PgSelect400[["PgSelect[400∈33]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression217{{"PgClassExpression[217∈33]<br />ᐸ__type_fun...ion__.”id”ᐳ"}}:::plan
-    Object213 & PgClassExpression217 & Lambda1215 & Lambda1218 & Lambda1385 & Lambda1390 --> PgSelect400
+    Object213 & PgClassExpression217 & Lambda1215 & Access1219 & Lambda1397 & Lambda1402 --> PgSelect400
     PgSelectSingle216 --> PgClassExpression217
     PgSelectSingle216 --> PgClassExpression218
     PgClassExpression219{{"PgClassExpression[219∈33]<br />ᐸ__type_fun..._.”bigint”ᐳ"}}:::plan
@@ -767,8 +949,8 @@ graph TD
     PgSelectSingle305{{"PgSelectSingle[305∈33]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle300 --> PgSelectSingle305
     PgSelectSingle317{{"PgSelectSingle[317∈33]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1449{{"RemapKeys[1449∈33]<br />ᐸ300:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1449 --> PgSelectSingle317
+    RemapKeys1465{{"RemapKeys[1465∈33]<br />ᐸ300:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1465 --> PgSelectSingle317
     PgClassExpression325{{"PgClassExpression[325∈33]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle300 --> PgClassExpression325
     PgSelectSingle216 --> PgClassExpression326
@@ -827,7 +1009,7 @@ graph TD
     PgSelectSingle216 --> PgClassExpression406
     PgClassExpression407{{"PgClassExpression[407∈33]<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle216 --> PgClassExpression407
-    PgSelectSingle300 --> RemapKeys1449
+    PgSelectSingle300 --> RemapKeys1465
     __Item226[/"__Item[226∈34]<br />ᐸ225ᐳ"\]:::itemplan
     PgClassExpression225 ==> __Item226
     __Item230[/"__Item[230∈35]<br />ᐸ229ᐳ"\]:::itemplan
@@ -883,11 +1065,11 @@ graph TD
     PgSelectSingle349{{"PgSelectSingle[349∈50]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle342 --> PgSelectSingle349
     PgSelectSingle361{{"PgSelectSingle[361∈50]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1509{{"RemapKeys[1509∈50]<br />ᐸ342:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1509 --> PgSelectSingle361
+    RemapKeys1529{{"RemapKeys[1529∈50]<br />ᐸ342:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1529 --> PgSelectSingle361
     PgClassExpression369{{"PgClassExpression[369∈50]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle342 --> PgClassExpression369
-    PgSelectSingle342 --> RemapKeys1509
+    PgSelectSingle342 --> RemapKeys1529
     PgClassExpression350{{"PgClassExpression[350∈51]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle349 --> PgClassExpression350
     PgClassExpression351{{"PgClassExpression[351∈51]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -934,7 +1116,7 @@ graph TD
     PgClassExpression407 ==> __Item408
     PgSelect411[["PgSelect[411∈60] ➊<br />ᐸtype_function_connection_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object414{{"Object[414∈60] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object414 & Lambda1215 & Lambda1218 & Lambda1695 & Lambda1700 --> PgSelect411
+    Object414 & Lambda1215 & Access1219 & Lambda1728 & Lambda1733 --> PgSelect411
     Access412{{"Access[412∈60] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access413{{"Access[413∈60] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access412 & Access413 --> Object414
@@ -942,88 +1124,28 @@ graph TD
     __Value2 --> Access413
     Object415{{"Object[415∈60] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgSelect411 --> Object415
-    Object1546{{"Object[1546∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1543 & Constant1544 & Constant1221 --> Object1546
-    Object1560{{"Object[1560∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1557 & Constant1558 & Constant1221 --> Object1560
-    Object1574{{"Object[1574∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1571 & Constant1572 & Constant1249 --> Object1574
-    Object1588{{"Object[1588∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1585 & Constant1586 & Constant1249 --> Object1588
-    Object1604{{"Object[1604∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1601 & Constant1602 & Constant1249 --> Object1604
-    Object1620{{"Object[1620∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1617 & Constant1618 & Constant1295 --> Object1620
-    Object1634{{"Object[1634∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1631 & Constant1632 & Constant1249 --> Object1634
-    Object1648{{"Object[1648∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1645 & Constant1646 & Constant1249 --> Object1648
-    Object1664{{"Object[1664∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1661 & Constant1662 & Constant1249 --> Object1664
-    Object1680{{"Object[1680∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1677 & Constant1678 & Constant1295 --> Object1680
-    Lambda1547{{"Lambda[1547∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1546 --> Lambda1547
-    Lambda1552{{"Lambda[1552∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2069 --> Lambda1552
-    Lambda1561{{"Lambda[1561∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1560 --> Lambda1561
-    Lambda1566{{"Lambda[1566∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2070 --> Lambda1566
-    Lambda1575{{"Lambda[1575∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1574 --> Lambda1575
-    Lambda1580{{"Lambda[1580∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2071 --> Lambda1580
-    Lambda1589{{"Lambda[1589∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1588 --> Lambda1589
-    Lambda1594{{"Lambda[1594∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2072 --> Lambda1594
-    Lambda1605{{"Lambda[1605∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1604 --> Lambda1605
-    Lambda1610{{"Lambda[1610∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2073 --> Lambda1610
-    Lambda1621{{"Lambda[1621∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1620 --> Lambda1621
-    Lambda1626{{"Lambda[1626∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2074 --> Lambda1626
-    Lambda1635{{"Lambda[1635∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1634 --> Lambda1635
-    Lambda1640{{"Lambda[1640∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2075 --> Lambda1640
-    Lambda1649{{"Lambda[1649∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1648 --> Lambda1649
-    Lambda1654{{"Lambda[1654∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2076 --> Lambda1654
-    Lambda1665{{"Lambda[1665∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1664 --> Lambda1665
-    Lambda1670{{"Lambda[1670∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2077 --> Lambda1670
-    Lambda1681{{"Lambda[1681∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1680 --> Lambda1681
-    Lambda1686{{"Lambda[1686∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2078 --> Lambda1686
     __Item416[/"__Item[416∈62]<br />ᐸ411ᐳ"\]:::itemplan
     PgSelect411 ==> __Item416
     PgSelectSingle417{{"PgSelectSingle[417∈62]<br />ᐸtype_function_connection_mutationᐳ"}}:::plan
     __Item416 --> PgSelectSingle417
     PgSelect498[["PgSelect[498∈63]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression497{{"PgClassExpression[497∈63]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object414 & PgClassExpression497 & Lambda1218 & Lambda1589 & Lambda1594 & Lambda1218 & Lambda1605 & Lambda1610 & Lambda1215 & Lambda1218 & Lambda1621 & Lambda1626 --> PgSelect498
+    Object414 & PgClassExpression497 & Access1219 & Lambda1615 & Lambda1620 & Access1219 & Lambda1632 & Lambda1637 & Lambda1215 & Access1219 & Lambda1649 & Lambda1654 --> PgSelect498
     PgSelect540[["PgSelect[540∈63]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression539{{"PgClassExpression[539∈63]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object414 & PgClassExpression539 & Lambda1218 & Lambda1649 & Lambda1654 & Lambda1218 & Lambda1665 & Lambda1670 & Lambda1215 & Lambda1218 & Lambda1681 & Lambda1686 --> PgSelect540
+    Object414 & PgClassExpression539 & Access1219 & Lambda1679 & Lambda1684 & Access1219 & Lambda1696 & Lambda1701 & Lambda1215 & Access1219 & Lambda1713 & Lambda1718 --> PgSelect540
     PgSelect484[["PgSelect[484∈63]<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression483{{"PgClassExpression[483∈63]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object414 & PgClassExpression483 & Lambda1215 & Lambda1218 & Lambda1575 & Lambda1580 --> PgSelect484
+    Object414 & PgClassExpression483 & Lambda1215 & Access1219 & Lambda1600 & Lambda1605 --> PgSelect484
     PgSelect528[["PgSelect[528∈63]<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression527{{"PgClassExpression[527∈63]<br />ᐸ__type_fun...ound_type”ᐳ"}}:::plan
-    Object414 & PgClassExpression527 & Lambda1215 & Lambda1218 & Lambda1635 & Lambda1640 --> PgSelect528
+    Object414 & PgClassExpression527 & Lambda1215 & Access1219 & Lambda1664 & Lambda1669 --> PgSelect528
     PgSelect595[["PgSelect[595∈63]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression419{{"PgClassExpression[419∈63]<br />ᐸ__type_fun...”smallint”ᐳ"}}:::plan
-    Object414 & PgClassExpression419 & Lambda1215 & Lambda1218 & Lambda1561 & Lambda1566 --> PgSelect595
+    Object414 & PgClassExpression419 & Lambda1215 & Access1219 & Lambda1585 & Lambda1590 --> PgSelect595
     PgSelect601[["PgSelect[601∈63]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression418{{"PgClassExpression[418∈63]<br />ᐸ__type_fun...ion__.”id”ᐳ"}}:::plan
-    Object414 & PgClassExpression418 & Lambda1215 & Lambda1218 & Lambda1547 & Lambda1552 --> PgSelect601
+    Object414 & PgClassExpression418 & Lambda1215 & Access1219 & Lambda1570 & Lambda1575 --> PgSelect601
     PgSelectSingle417 --> PgClassExpression418
     PgSelectSingle417 --> PgClassExpression419
     PgClassExpression420{{"PgClassExpression[420∈63]<br />ᐸ__type_fun..._.”bigint”ᐳ"}}:::plan
@@ -1113,8 +1235,8 @@ graph TD
     PgSelectSingle506{{"PgSelectSingle[506∈63]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle501 --> PgSelectSingle506
     PgSelectSingle518{{"PgSelectSingle[518∈63]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1611{{"RemapKeys[1611∈63]<br />ᐸ501:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1611 --> PgSelectSingle518
+    RemapKeys1638{{"RemapKeys[1638∈63]<br />ᐸ501:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1638 --> PgSelectSingle518
     PgClassExpression526{{"PgClassExpression[526∈63]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle501 --> PgClassExpression526
     PgSelectSingle417 --> PgClassExpression527
@@ -1173,7 +1295,7 @@ graph TD
     PgSelectSingle417 --> PgClassExpression607
     PgClassExpression608{{"PgClassExpression[608∈63]<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle417 --> PgClassExpression608
-    PgSelectSingle501 --> RemapKeys1611
+    PgSelectSingle501 --> RemapKeys1638
     __Item427[/"__Item[427∈64]<br />ᐸ426ᐳ"\]:::itemplan
     PgClassExpression426 ==> __Item427
     __Item431[/"__Item[431∈65]<br />ᐸ430ᐳ"\]:::itemplan
@@ -1229,11 +1351,11 @@ graph TD
     PgSelectSingle550{{"PgSelectSingle[550∈80]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle543 --> PgSelectSingle550
     PgSelectSingle562{{"PgSelectSingle[562∈80]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1671{{"RemapKeys[1671∈80]<br />ᐸ543:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1671 --> PgSelectSingle562
+    RemapKeys1702{{"RemapKeys[1702∈80]<br />ᐸ543:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1702 --> PgSelectSingle562
     PgClassExpression570{{"PgClassExpression[570∈80]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle543 --> PgClassExpression570
-    PgSelectSingle543 --> RemapKeys1671
+    PgSelectSingle543 --> RemapKeys1702
     PgClassExpression551{{"PgClassExpression[551∈81]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle550 --> PgClassExpression551
     PgClassExpression552{{"PgClassExpression[552∈81]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -1280,7 +1402,7 @@ graph TD
     PgClassExpression608 ==> __Item609
     PgUpdateSingle701[["PgUpdateSingle[701∈90] ➊<br />ᐸtypes(id;smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,nullablePoint,inet,cidr,macaddr,regproc,regprocedure,regoper,regoperator,regclass,regtype,regconfig,regdictionary,text_array_domain,int8_array_domain,bytea,bytea_array,ltree,ltree_array)ᐳ"]]:::sideeffectplan
     Object704{{"Object[704∈90] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object704 & Constant1997 & Constant1998 & Constant1999 & Constant1999 & Constant1999 & Constant2000 & Constant1999 & Constant2001 & Constant2102 & Constant1998 & Constant1998 & Constant2103 & Constant2005 & Constant2006 & Constant2132 & Constant2133 & Constant2134 & Constant2011 & Constant2012 & Constant2013 & Constant2014 & Constant2014 & Constant2100 & Constant2110 & Constant2015 & Constant2111 & Constant2112 & Constant2113 & Constant2114 & Constant2020 & Constant2021 & Constant2022 & Constant2023 & Constant2024 & Constant2025 & Constant2026 & Constant2027 & Constant2028 & Constant2029 & Constant2030 & Constant2115 & Constant2116 & Constant2037 & Constant2117 & Constant2040 & Constant2118 --> PgUpdateSingle701
+    Object704 & Constant2050 & Constant2051 & Constant2052 & Constant2052 & Constant2052 & Constant2053 & Constant2052 & Constant2054 & Constant2155 & Constant2051 & Constant2051 & Constant2156 & Constant2058 & Constant2059 & Constant2185 & Constant2186 & Constant2187 & Constant2064 & Constant2065 & Constant2066 & Constant2067 & Constant2067 & Constant2153 & Constant2163 & Constant2068 & Constant2164 & Constant2165 & Constant2166 & Constant2167 & Constant2073 & Constant2074 & Constant2075 & Constant2076 & Constant2077 & Constant2078 & Constant2079 & Constant2080 & Constant2081 & Constant2082 & Constant2083 & Constant2168 & Constant2169 & Constant2090 & Constant2170 & Constant2093 & Constant2171 --> PgUpdateSingle701
     Access702{{"Access[702∈90] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access703{{"Access[703∈90] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access702 & Access703 --> Object704
@@ -1288,84 +1410,24 @@ graph TD
     __Value2 --> Access703
     Object705{{"Object[705∈90] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle701 --> Object705
-    Object1708{{"Object[1708∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1705 & Constant1706 & Constant1221 --> Object1708
-    Object1722{{"Object[1722∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1719 & Constant1720 & Constant1221 --> Object1722
-    Object1736{{"Object[1736∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1733 & Constant1734 & Constant1249 --> Object1736
-    Object1750{{"Object[1750∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1747 & Constant1748 & Constant1249 --> Object1750
-    Object1766{{"Object[1766∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1763 & Constant1764 & Constant1249 --> Object1766
-    Object1782{{"Object[1782∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1779 & Constant1780 & Constant1295 --> Object1782
-    Object1796{{"Object[1796∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1793 & Constant1794 & Constant1249 --> Object1796
-    Object1810{{"Object[1810∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1807 & Constant1808 & Constant1249 --> Object1810
-    Object1826{{"Object[1826∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1823 & Constant1824 & Constant1249 --> Object1826
-    Object1842{{"Object[1842∈91] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1839 & Constant1840 & Constant1295 --> Object1842
-    Lambda1709{{"Lambda[1709∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1708 --> Lambda1709
-    Lambda1714{{"Lambda[1714∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2080 --> Lambda1714
-    Lambda1723{{"Lambda[1723∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1722 --> Lambda1723
-    Lambda1728{{"Lambda[1728∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2081 --> Lambda1728
-    Lambda1737{{"Lambda[1737∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1736 --> Lambda1737
-    Lambda1742{{"Lambda[1742∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2082 --> Lambda1742
-    Lambda1751{{"Lambda[1751∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1750 --> Lambda1751
-    Lambda1756{{"Lambda[1756∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2083 --> Lambda1756
-    Lambda1767{{"Lambda[1767∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1766 --> Lambda1767
-    Lambda1772{{"Lambda[1772∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2084 --> Lambda1772
-    Lambda1783{{"Lambda[1783∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1782 --> Lambda1783
-    Lambda1788{{"Lambda[1788∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2085 --> Lambda1788
-    Lambda1797{{"Lambda[1797∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1796 --> Lambda1797
-    Lambda1802{{"Lambda[1802∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2086 --> Lambda1802
-    Lambda1811{{"Lambda[1811∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1810 --> Lambda1811
-    Lambda1816{{"Lambda[1816∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2087 --> Lambda1816
-    Lambda1827{{"Lambda[1827∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1826 --> Lambda1827
-    Lambda1832{{"Lambda[1832∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2088 --> Lambda1832
-    Lambda1843{{"Lambda[1843∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1842 --> Lambda1843
-    Lambda1848{{"Lambda[1848∈91] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2089 --> Lambda1848
     PgSelect809[["PgSelect[809∈92] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression808{{"PgClassExpression[808∈92] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object704 & PgClassExpression808 & Lambda1218 & Lambda1751 & Lambda1756 & Lambda1218 & Lambda1767 & Lambda1772 & Lambda1215 & Lambda1218 & Lambda1783 & Lambda1788 --> PgSelect809
+    Object704 & PgClassExpression808 & Access1219 & Lambda1788 & Lambda1793 & Access1219 & Lambda1805 & Lambda1810 & Lambda1215 & Access1219 & Lambda1822 & Lambda1827 --> PgSelect809
     PgSelect851[["PgSelect[851∈92] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression850{{"PgClassExpression[850∈92] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object704 & PgClassExpression850 & Lambda1218 & Lambda1811 & Lambda1816 & Lambda1218 & Lambda1827 & Lambda1832 & Lambda1215 & Lambda1218 & Lambda1843 & Lambda1848 --> PgSelect851
+    Object704 & PgClassExpression850 & Access1219 & Lambda1852 & Lambda1857 & Access1219 & Lambda1869 & Lambda1874 & Lambda1215 & Access1219 & Lambda1886 & Lambda1891 --> PgSelect851
     PgSelect795[["PgSelect[795∈92] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression794{{"PgClassExpression[794∈92] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object704 & PgClassExpression794 & Lambda1215 & Lambda1218 & Lambda1737 & Lambda1742 --> PgSelect795
+    Object704 & PgClassExpression794 & Lambda1215 & Access1219 & Lambda1773 & Lambda1778 --> PgSelect795
     PgSelect839[["PgSelect[839∈92] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression838{{"PgClassExpression[838∈92] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object704 & PgClassExpression838 & Lambda1215 & Lambda1218 & Lambda1797 & Lambda1802 --> PgSelect839
+    Object704 & PgClassExpression838 & Lambda1215 & Access1219 & Lambda1837 & Lambda1842 --> PgSelect839
     PgSelect907[["PgSelect[907∈92] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression730{{"PgClassExpression[730∈92] ➊<br />ᐸ__types__.”smallint”ᐳ"}}:::plan
-    Object704 & PgClassExpression730 & Lambda1215 & Lambda1218 & Lambda1723 & Lambda1728 --> PgSelect907
+    Object704 & PgClassExpression730 & Lambda1215 & Access1219 & Lambda1758 & Lambda1763 --> PgSelect907
     PgSelect914[["PgSelect[914∈92] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression729{{"PgClassExpression[729∈92] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
-    Object704 & PgClassExpression729 & Lambda1215 & Lambda1218 & Lambda1709 & Lambda1714 --> PgSelect914
+    Object704 & PgClassExpression729 & Lambda1215 & Access1219 & Lambda1743 & Lambda1748 --> PgSelect914
     PgUpdateSingle701 --> PgClassExpression729
     PgUpdateSingle701 --> PgClassExpression730
     PgClassExpression731{{"PgClassExpression[731∈92] ➊<br />ᐸ__types__.”bigint”ᐳ"}}:::plan
@@ -1455,8 +1517,8 @@ graph TD
     PgSelectSingle817{{"PgSelectSingle[817∈92] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle812 --> PgSelectSingle817
     PgSelectSingle829{{"PgSelectSingle[829∈92] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1773{{"RemapKeys[1773∈92] ➊<br />ᐸ812:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1773 --> PgSelectSingle829
+    RemapKeys1811{{"RemapKeys[1811∈92] ➊<br />ᐸ812:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1811 --> PgSelectSingle829
     PgClassExpression837{{"PgClassExpression[837∈92] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle812 --> PgClassExpression837
     PgUpdateSingle701 --> PgClassExpression838
@@ -1515,7 +1577,7 @@ graph TD
     PgUpdateSingle701 --> PgClassExpression920
     PgClassExpression921{{"PgClassExpression[921∈92] ➊<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgUpdateSingle701 --> PgClassExpression921
-    PgSelectSingle812 --> RemapKeys1773
+    PgSelectSingle812 --> RemapKeys1811
     __Item738[/"__Item[738∈93]<br />ᐸ737ᐳ"\]:::itemplan
     PgClassExpression737 ==> __Item738
     __Item742[/"__Item[742∈94]<br />ᐸ741ᐳ"\]:::itemplan
@@ -1571,11 +1633,11 @@ graph TD
     PgSelectSingle861{{"PgSelectSingle[861∈109] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle854 --> PgSelectSingle861
     PgSelectSingle873{{"PgSelectSingle[873∈109] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1833{{"RemapKeys[1833∈109] ➊<br />ᐸ854:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1833 --> PgSelectSingle873
+    RemapKeys1875{{"RemapKeys[1875∈109] ➊<br />ᐸ854:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1875 --> PgSelectSingle873
     PgClassExpression881{{"PgClassExpression[881∈109] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle854 --> PgClassExpression881
-    PgSelectSingle854 --> RemapKeys1833
+    PgSelectSingle854 --> RemapKeys1875
     PgClassExpression862{{"PgClassExpression[862∈110] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle861 --> PgClassExpression862
     PgClassExpression863{{"PgClassExpression[863∈110] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -1622,7 +1684,7 @@ graph TD
     PgClassExpression921 ==> __Item922
     PgInsertSingle995[["PgInsertSingle[995∈119] ➊<br />ᐸtypes(smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,regproc,regprocedure,regoper,regoperator,regclass,regtype,regconfig,regdictionary,ltree,ltree_array)ᐳ"]]:::sideeffectplan
     Object998{{"Object[998∈119] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Object998 & Constant1998 & Constant1999 & Constant1999 & Constant1999 & Constant2000 & Constant1999 & Constant2001 & Constant2102 & Constant1998 & Constant1998 & Constant2103 & Constant2043 & Constant2044 & Constant2132 & Constant2133 & Constant2134 & Constant2011 & Constant2012 & Constant2013 & Constant2014 & Constant2014 & Constant2100 & Constant2110 & Constant2015 & Constant2111 & Constant2112 & Constant2113 & Constant2023 & Constant2024 & Constant2025 & Constant2026 & Constant2027 & Constant2028 & Constant2029 & Constant2030 & Constant2040 & Constant2118 --> PgInsertSingle995
+    Object998 & Constant2051 & Constant2052 & Constant2052 & Constant2052 & Constant2053 & Constant2052 & Constant2054 & Constant2155 & Constant2051 & Constant2051 & Constant2156 & Constant2096 & Constant2097 & Constant2185 & Constant2186 & Constant2187 & Constant2064 & Constant2065 & Constant2066 & Constant2067 & Constant2067 & Constant2153 & Constant2163 & Constant2068 & Constant2164 & Constant2165 & Constant2166 & Constant2076 & Constant2077 & Constant2078 & Constant2079 & Constant2080 & Constant2081 & Constant2082 & Constant2083 & Constant2093 & Constant2171 --> PgInsertSingle995
     Access996{{"Access[996∈119] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access997{{"Access[997∈119] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access996 & Access997 --> Object998
@@ -1630,84 +1692,24 @@ graph TD
     __Value2 --> Access997
     Object999{{"Object[999∈119] ➊<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle995 --> Object999
-    Object1856{{"Object[1856∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1853 & Constant1854 & Constant1221 --> Object1856
-    Object1870{{"Object[1870∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1867 & Constant1868 & Constant1221 --> Object1870
-    Object1884{{"Object[1884∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1881 & Constant1882 & Constant1249 --> Object1884
-    Object1898{{"Object[1898∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1895 & Constant1896 & Constant1249 --> Object1898
-    Object1914{{"Object[1914∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1911 & Constant1912 & Constant1249 --> Object1914
-    Object1930{{"Object[1930∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1927 & Constant1928 & Constant1295 --> Object1930
-    Object1944{{"Object[1944∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1941 & Constant1942 & Constant1249 --> Object1944
-    Object1958{{"Object[1958∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1955 & Constant1956 & Constant1249 --> Object1958
-    Object1974{{"Object[1974∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1971 & Constant1972 & Constant1249 --> Object1974
-    Object1990{{"Object[1990∈120] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1215 & Constant1987 & Constant1988 & Constant1295 --> Object1990
-    Lambda1857{{"Lambda[1857∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1856 --> Lambda1857
-    Lambda1862{{"Lambda[1862∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2090 --> Lambda1862
-    Lambda1871{{"Lambda[1871∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1870 --> Lambda1871
-    Lambda1876{{"Lambda[1876∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2091 --> Lambda1876
-    Lambda1885{{"Lambda[1885∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1884 --> Lambda1885
-    Lambda1890{{"Lambda[1890∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2092 --> Lambda1890
-    Lambda1899{{"Lambda[1899∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1898 --> Lambda1899
-    Lambda1904{{"Lambda[1904∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2093 --> Lambda1904
-    Lambda1915{{"Lambda[1915∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1914 --> Lambda1915
-    Lambda1920{{"Lambda[1920∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2094 --> Lambda1920
-    Lambda1931{{"Lambda[1931∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1930 --> Lambda1931
-    Lambda1936{{"Lambda[1936∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2095 --> Lambda1936
-    Lambda1945{{"Lambda[1945∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1944 --> Lambda1945
-    Lambda1950{{"Lambda[1950∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2096 --> Lambda1950
-    Lambda1959{{"Lambda[1959∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1958 --> Lambda1959
-    Lambda1964{{"Lambda[1964∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2097 --> Lambda1964
-    Lambda1975{{"Lambda[1975∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1974 --> Lambda1975
-    Lambda1980{{"Lambda[1980∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2098 --> Lambda1980
-    Lambda1991{{"Lambda[1991∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1990 --> Lambda1991
-    Lambda1996{{"Lambda[1996∈120] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant2099 --> Lambda1996
     PgSelect1099[["PgSelect[1099∈121] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression1098{{"PgClassExpression[1098∈121] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object998 & PgClassExpression1098 & Lambda1218 & Lambda1899 & Lambda1904 & Lambda1218 & Lambda1915 & Lambda1920 & Lambda1215 & Lambda1218 & Lambda1931 & Lambda1936 --> PgSelect1099
+    Object998 & PgClassExpression1098 & Access1219 & Lambda1946 & Lambda1951 & Access1219 & Lambda1963 & Lambda1968 & Lambda1215 & Access1219 & Lambda1980 & Lambda1985 --> PgSelect1099
     PgSelect1141[["PgSelect[1141∈121] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"]]:::plan
     PgClassExpression1140{{"PgClassExpression[1140∈121] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object998 & PgClassExpression1140 & Lambda1218 & Lambda1959 & Lambda1964 & Lambda1218 & Lambda1975 & Lambda1980 & Lambda1215 & Lambda1218 & Lambda1991 & Lambda1996 --> PgSelect1141
+    Object998 & PgClassExpression1140 & Access1219 & Lambda2010 & Lambda2015 & Access1219 & Lambda2027 & Lambda2032 & Lambda1215 & Access1219 & Lambda2044 & Lambda2049 --> PgSelect1141
     PgSelect1085[["PgSelect[1085∈121] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression1084{{"PgClassExpression[1084∈121] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object998 & PgClassExpression1084 & Lambda1215 & Lambda1218 & Lambda1885 & Lambda1890 --> PgSelect1085
+    Object998 & PgClassExpression1084 & Lambda1215 & Access1219 & Lambda1931 & Lambda1936 --> PgSelect1085
     PgSelect1129[["PgSelect[1129∈121] ➊<br />ᐸfrmcdc_compoundTypeᐳ"]]:::plan
     PgClassExpression1128{{"PgClassExpression[1128∈121] ➊<br />ᐸ__types__....ound_type”ᐳ"}}:::plan
-    Object998 & PgClassExpression1128 & Lambda1215 & Lambda1218 & Lambda1945 & Lambda1950 --> PgSelect1129
+    Object998 & PgClassExpression1128 & Lambda1215 & Access1219 & Lambda1995 & Lambda2000 --> PgSelect1129
     PgSelect1197[["PgSelect[1197∈121] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1020{{"PgClassExpression[1020∈121] ➊<br />ᐸ__types__.”smallint”ᐳ"}}:::plan
-    Object998 & PgClassExpression1020 & Lambda1215 & Lambda1218 & Lambda1871 & Lambda1876 --> PgSelect1197
+    Object998 & PgClassExpression1020 & Lambda1215 & Access1219 & Lambda1916 & Lambda1921 --> PgSelect1197
     PgSelect1204[["PgSelect[1204∈121] ➊<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1019{{"PgClassExpression[1019∈121] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
-    Object998 & PgClassExpression1019 & Lambda1215 & Lambda1218 & Lambda1857 & Lambda1862 --> PgSelect1204
+    Object998 & PgClassExpression1019 & Lambda1215 & Access1219 & Lambda1901 & Lambda1906 --> PgSelect1204
     PgInsertSingle995 --> PgClassExpression1019
     PgInsertSingle995 --> PgClassExpression1020
     PgClassExpression1021{{"PgClassExpression[1021∈121] ➊<br />ᐸ__types__.”bigint”ᐳ"}}:::plan
@@ -1797,8 +1799,8 @@ graph TD
     PgSelectSingle1107{{"PgSelectSingle[1107∈121] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1102 --> PgSelectSingle1107
     PgSelectSingle1119{{"PgSelectSingle[1119∈121] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1921{{"RemapKeys[1921∈121] ➊<br />ᐸ1102:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1921 --> PgSelectSingle1119
+    RemapKeys1969{{"RemapKeys[1969∈121] ➊<br />ᐸ1102:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys1969 --> PgSelectSingle1119
     PgClassExpression1127{{"PgClassExpression[1127∈121] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1102 --> PgClassExpression1127
     PgInsertSingle995 --> PgClassExpression1128
@@ -1857,7 +1859,7 @@ graph TD
     PgInsertSingle995 --> PgClassExpression1210
     PgClassExpression1211{{"PgClassExpression[1211∈121] ➊<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgInsertSingle995 --> PgClassExpression1211
-    PgSelectSingle1102 --> RemapKeys1921
+    PgSelectSingle1102 --> RemapKeys1969
     __Item1028[/"__Item[1028∈122]<br />ᐸ1027ᐳ"\]:::itemplan
     PgClassExpression1027 ==> __Item1028
     __Item1032[/"__Item[1032∈123]<br />ᐸ1031ᐳ"\]:::itemplan
@@ -1913,11 +1915,11 @@ graph TD
     PgSelectSingle1151{{"PgSelectSingle[1151∈138] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1144 --> PgSelectSingle1151
     PgSelectSingle1163{{"PgSelectSingle[1163∈138] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys1981{{"RemapKeys[1981∈138] ➊<br />ᐸ1144:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys1981 --> PgSelectSingle1163
+    RemapKeys2033{{"RemapKeys[2033∈138] ➊<br />ᐸ1144:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys2033 --> PgSelectSingle1163
     PgClassExpression1171{{"PgClassExpression[1171∈138] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1144 --> PgClassExpression1171
-    PgSelectSingle1144 --> RemapKeys1981
+    PgSelectSingle1144 --> RemapKeys2033
     PgClassExpression1152{{"PgClassExpression[1152∈139] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1151 --> PgClassExpression1152
     PgClassExpression1153{{"PgClassExpression[1153∈139] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -1968,16 +1970,16 @@ graph TD
     subgraph "Buckets for mutations/v4/types"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Lambda1215,Lambda1218,Constant1219,Constant1220,Constant1221,Constant1233,Constant1234,Constant1247,Constant1248,Constant1249,Constant1261,Constant1262,Constant1277,Constant1278,Constant1293,Constant1294,Constant1295,Constant1307,Constant1308,Constant1321,Constant1322,Constant1337,Constant1338,Constant1353,Constant1354,Constant1367,Constant1368,Constant1369,Object1370,Lambda1371,Lambda1376,Constant1381,Constant1382,Constant1395,Constant1396,Constant1409,Constant1410,Constant1423,Constant1424,Constant1439,Constant1440,Constant1455,Constant1456,Constant1469,Constant1470,Constant1483,Constant1484,Constant1499,Constant1500,Constant1515,Constant1516,Constant1529,Constant1530,Object1532,Lambda1533,Lambda1538,Constant1543,Constant1544,Constant1557,Constant1558,Constant1571,Constant1572,Constant1585,Constant1586,Constant1601,Constant1602,Constant1617,Constant1618,Constant1631,Constant1632,Constant1645,Constant1646,Constant1661,Constant1662,Constant1677,Constant1678,Constant1691,Constant1692,Object1694,Lambda1695,Lambda1700,Constant1705,Constant1706,Constant1719,Constant1720,Constant1733,Constant1734,Constant1747,Constant1748,Constant1763,Constant1764,Constant1779,Constant1780,Constant1793,Constant1794,Constant1807,Constant1808,Constant1823,Constant1824,Constant1839,Constant1840,Constant1853,Constant1854,Constant1867,Constant1868,Constant1881,Constant1882,Constant1895,Constant1896,Constant1911,Constant1912,Constant1927,Constant1928,Constant1941,Constant1942,Constant1955,Constant1956,Constant1971,Constant1972,Constant1987,Constant1988,Constant1997,Constant1998,Constant1999,Constant2000,Constant2001,Constant2005,Constant2006,Constant2011,Constant2012,Constant2013,Constant2014,Constant2015,Constant2020,Constant2021,Constant2022,Constant2023,Constant2024,Constant2025,Constant2026,Constant2027,Constant2028,Constant2029,Constant2030,Constant2037,Constant2040,Constant2043,Constant2044,Constant2045,Constant2046,Constant2047,Constant2048,Constant2049,Constant2050,Constant2051,Constant2052,Constant2053,Constant2054,Constant2055,Constant2056,Constant2057,Constant2058,Constant2059,Constant2060,Constant2061,Constant2062,Constant2063,Constant2064,Constant2065,Constant2066,Constant2067,Constant2068,Constant2069,Constant2070,Constant2071,Constant2072,Constant2073,Constant2074,Constant2075,Constant2076,Constant2077,Constant2078,Constant2079,Constant2080,Constant2081,Constant2082,Constant2083,Constant2084,Constant2085,Constant2086,Constant2087,Constant2088,Constant2089,Constant2090,Constant2091,Constant2092,Constant2093,Constant2094,Constant2095,Constant2096,Constant2097,Constant2098,Constant2099,Constant2100,Constant2102,Constant2103,Constant2110,Constant2111,Constant2112,Constant2113,Constant2114,Constant2115,Constant2116,Constant2117,Constant2118,Constant2132,Constant2133,Constant2134 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 12, 1997, 1215, 1218, 1371, 1376, 1219, 1220, 1221, 2047, 1233, 1234, 2048, 1247, 1248, 1249, 2049, 1261, 1262, 2050, 1277, 1278, 2051, 1293, 1294, 1295, 2052, 1307, 1308, 2053, 1321, 1322, 2054, 1337, 1338, 2055, 1353, 1354, 2056<br /><br />1: PgSelect[9]<br />2: <br />ᐳ: 13, 14, 15"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Lambda1215,Lambda1218,Access1219,Constant1220,Constant1221,Constant1222,Object1223,Lambda1224,Lambda1229,Constant1235,Constant1236,Object1238,Lambda1239,Lambda1244,Constant1250,Constant1251,Constant1252,Object1253,Lambda1254,Lambda1259,Constant1265,Constant1266,Object1268,Lambda1269,Lambda1274,Constant1282,Constant1283,Object1285,Lambda1286,Lambda1291,Constant1299,Constant1300,Constant1301,Object1302,Lambda1303,Lambda1308,Constant1314,Constant1315,Object1317,Lambda1318,Lambda1323,Constant1329,Constant1330,Object1332,Lambda1333,Lambda1338,Constant1346,Constant1347,Object1349,Lambda1350,Lambda1355,Constant1363,Constant1364,Object1366,Lambda1367,Lambda1372,Constant1378,Constant1379,Constant1380,Object1381,Lambda1382,Lambda1387,Constant1393,Constant1394,Object1396,Lambda1397,Lambda1402,Constant1408,Constant1409,Object1411,Lambda1412,Lambda1417,Constant1423,Constant1424,Object1426,Lambda1427,Lambda1432,Constant1438,Constant1439,Object1441,Lambda1442,Lambda1447,Constant1455,Constant1456,Object1458,Lambda1459,Lambda1464,Constant1472,Constant1473,Object1475,Lambda1476,Lambda1481,Constant1487,Constant1488,Object1490,Lambda1491,Lambda1496,Constant1502,Constant1503,Object1505,Lambda1506,Lambda1511,Constant1519,Constant1520,Object1522,Lambda1523,Lambda1528,Constant1536,Constant1537,Object1539,Lambda1540,Lambda1545,Constant1551,Constant1552,Object1554,Lambda1555,Lambda1560,Constant1566,Constant1567,Object1569,Lambda1570,Lambda1575,Constant1581,Constant1582,Object1584,Lambda1585,Lambda1590,Constant1596,Constant1597,Object1599,Lambda1600,Lambda1605,Constant1611,Constant1612,Object1614,Lambda1615,Lambda1620,Constant1628,Constant1629,Object1631,Lambda1632,Lambda1637,Constant1645,Constant1646,Object1648,Lambda1649,Lambda1654,Constant1660,Constant1661,Object1663,Lambda1664,Lambda1669,Constant1675,Constant1676,Object1678,Lambda1679,Lambda1684,Constant1692,Constant1693,Object1695,Lambda1696,Lambda1701,Constant1709,Constant1710,Object1712,Lambda1713,Lambda1718,Constant1724,Constant1725,Object1727,Lambda1728,Lambda1733,Constant1739,Constant1740,Object1742,Lambda1743,Lambda1748,Constant1754,Constant1755,Object1757,Lambda1758,Lambda1763,Constant1769,Constant1770,Object1772,Lambda1773,Lambda1778,Constant1784,Constant1785,Object1787,Lambda1788,Lambda1793,Constant1801,Constant1802,Object1804,Lambda1805,Lambda1810,Constant1818,Constant1819,Object1821,Lambda1822,Lambda1827,Constant1833,Constant1834,Object1836,Lambda1837,Lambda1842,Constant1848,Constant1849,Object1851,Lambda1852,Lambda1857,Constant1865,Constant1866,Object1868,Lambda1869,Lambda1874,Constant1882,Constant1883,Object1885,Lambda1886,Lambda1891,Constant1897,Constant1898,Object1900,Lambda1901,Lambda1906,Constant1912,Constant1913,Object1915,Lambda1916,Lambda1921,Constant1927,Constant1928,Object1930,Lambda1931,Lambda1936,Constant1942,Constant1943,Object1945,Lambda1946,Lambda1951,Constant1959,Constant1960,Object1962,Lambda1963,Lambda1968,Constant1976,Constant1977,Object1979,Lambda1980,Lambda1985,Constant1991,Constant1992,Object1994,Lambda1995,Lambda2000,Constant2006,Constant2007,Object2009,Lambda2010,Lambda2015,Constant2023,Constant2024,Object2026,Lambda2027,Lambda2032,Constant2040,Constant2041,Object2043,Lambda2044,Lambda2049,Constant2050,Constant2051,Constant2052,Constant2053,Constant2054,Constant2058,Constant2059,Constant2064,Constant2065,Constant2066,Constant2067,Constant2068,Constant2073,Constant2074,Constant2075,Constant2076,Constant2077,Constant2078,Constant2079,Constant2080,Constant2081,Constant2082,Constant2083,Constant2090,Constant2093,Constant2096,Constant2097,Constant2098,Constant2099,Constant2100,Constant2101,Constant2102,Constant2103,Constant2104,Constant2105,Constant2106,Constant2107,Constant2108,Constant2109,Constant2110,Constant2111,Constant2112,Constant2113,Constant2114,Constant2115,Constant2116,Constant2117,Constant2118,Constant2119,Constant2120,Constant2121,Constant2122,Constant2123,Constant2124,Constant2125,Constant2126,Constant2127,Constant2128,Constant2129,Constant2130,Constant2131,Constant2132,Constant2133,Constant2134,Constant2135,Constant2136,Constant2137,Constant2138,Constant2139,Constant2140,Constant2141,Constant2142,Constant2143,Constant2144,Constant2145,Constant2146,Constant2147,Constant2148,Constant2149,Constant2150,Constant2151,Constant2152,Constant2153,Constant2155,Constant2156,Constant2163,Constant2164,Constant2165,Constant2166,Constant2167,Constant2168,Constant2169,Constant2170,Constant2171,Constant2185,Constant2186,Constant2187 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 12, 2050, 1215, 1219, 1382, 1387, 1254, 1259, 1269, 1274, 1286, 1291, 1303, 1308, 1318, 1323, 1333, 1338, 1350, 1355, 1367, 1372, 1239, 1244, 1224, 1229<br /><br />1: PgSelect[9]<br />2: <br />ᐳ: 13, 14, 15"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect9,First13,PgSelectSingle14,Object15 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 1215, 1219, 1220, 1221, 2047, 1233, 1234, 2048, 1247, 1248, 1249, 2049, 1261, 1262, 2050, 1277, 1278, 2051, 1293, 1294, 1295, 2052, 1307, 1308, 2053, 1321, 1322, 2054, 1337, 1338, 2055, 1353, 1354, 2056, 15, 14, 12, 1218<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 15, 14, 12, 1215, 1219, 1254, 1259, 1269, 1274, 1286, 1291, 1303, 1308, 1318, 1323, 1333, 1338, 1350, 1355, 1367, 1372, 1239, 1244, 1224, 1229<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Object1222,Lambda1223,Lambda1228,Object1236,Lambda1237,Lambda1242,Object1250,Lambda1251,Lambda1256,Object1264,Lambda1265,Lambda1270,Object1280,Lambda1281,Lambda1286,Object1296,Lambda1297,Lambda1302,Object1310,Lambda1311,Lambda1316,Object1324,Lambda1325,Lambda1330,Object1340,Lambda1341,Lambda1346,Object1356,Lambda1357,Lambda1362 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 1215, 1218, 1251, 1256, 1265, 1270, 1281, 1286, 1297, 1302, 1311, 1316, 1325, 1330, 1341, 1346, 1357, 1362, 1237, 1242, 1223, 1228<br /><br />ROOT PgSelectSingle{1}ᐸtype_function_mutationᐳ[14]<br />1: <br />ᐳ: 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 30, 31, 32, 39, 46, 53, 60, 61, 62, 63, 64, 65, 72, 80, 81, 95, 125, 137, 169, 172, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 188, 190, 191, 205, 206, 40, 43, 47, 50, 54, 57<br />2: 82, 96, 126, 138, 193, 199<br />ᐳ: 86, 87, 88, 89, 90, 91, 92, 93, 94, 98, 99, 104, 124, 128, 129, 140, 141, 195, 196, 201, 202, 1287, 116"):::bucket
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 12, 1215, 1219, 1254, 1259, 1269, 1274, 1286, 1291, 1303, 1308, 1318, 1323, 1333, 1338, 1350, 1355, 1367, 1372, 1239, 1244, 1224, 1229<br /><br />ROOT PgSelectSingle{1}ᐸtype_function_mutationᐳ[14]<br />1: <br />ᐳ: 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 30, 31, 32, 39, 46, 53, 60, 61, 62, 63, 64, 65, 72, 80, 81, 95, 125, 137, 169, 172, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 188, 190, 191, 205, 206, 40, 43, 47, 50, 54, 57<br />2: 82, 96, 126, 138, 193, 199<br />ᐳ: 86, 87, 88, 89, 90, 91, 92, 93, 94, 98, 99, 104, 124, 128, 129, 140, 141, 195, 196, 201, 202, 1292, 116"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression39,Access40,Access43,PgClassExpression46,Access47,Access50,PgClassExpression53,Access54,Access57,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgClassExpression72,PgClassExpression80,PgClassExpression81,PgSelect82,First86,PgSelectSingle87,PgClassExpression88,PgClassExpression89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,PgClassExpression95,PgSelect96,First98,PgSelectSingle99,PgSelectSingle104,PgSelectSingle116,PgClassExpression124,PgClassExpression125,PgSelect126,First128,PgSelectSingle129,PgClassExpression137,PgSelect138,First140,PgSelectSingle141,PgClassExpression169,PgClassExpression172,PgClassExpression175,PgClassExpression176,PgClassExpression177,PgClassExpression178,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression186,PgClassExpression188,PgClassExpression190,PgClassExpression191,PgSelect193,First195,PgSelectSingle196,PgSelect199,First201,PgSelectSingle202,PgClassExpression205,PgClassExpression206,RemapKeys1287 bucket3
+    class Bucket3,PgClassExpression16,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression39,Access40,Access43,PgClassExpression46,Access47,Access50,PgClassExpression53,Access54,Access57,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgClassExpression72,PgClassExpression80,PgClassExpression81,PgSelect82,First86,PgSelectSingle87,PgClassExpression88,PgClassExpression89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,PgClassExpression95,PgSelect96,First98,PgSelectSingle99,PgSelectSingle104,PgSelectSingle116,PgClassExpression124,PgClassExpression125,PgSelect126,First128,PgSelectSingle129,PgClassExpression137,PgSelect138,First140,PgSelectSingle141,PgClassExpression169,PgClassExpression172,PgClassExpression175,PgClassExpression176,PgClassExpression177,PgClassExpression178,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression186,PgClassExpression188,PgClassExpression190,PgClassExpression191,PgSelect193,First195,PgSelectSingle196,PgSelect199,First201,PgSelectSingle202,PgClassExpression205,PgClassExpression206,RemapKeys1292 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25 bucket4
@@ -2028,7 +2030,7 @@ graph TD
     class Bucket19,PgClassExpression130,PgClassExpression131,PgClassExpression132,PgClassExpression133,PgClassExpression134,PgClassExpression135,PgClassExpression136 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 141<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_nestedCompoundTypeᐳ[141]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgSelectSingle148,PgSelectSingle160,PgClassExpression168,RemapKeys1347 bucket20
+    class Bucket20,PgSelectSingle148,PgSelectSingle160,PgClassExpression168,RemapKeys1356 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 148<br /><br />ROOT PgSelectSingle{20}ᐸfrmcdc_compoundTypeᐳ[148]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression149,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155 bucket21
@@ -2056,18 +2058,18 @@ graph TD
     Bucket29("Bucket 29 (listItem)<br /><br />ROOT __Item{29}ᐸ206ᐳ[207]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,__Item207 bucket29
-    Bucket30("Bucket 30 (mutationField)<br />Deps: 1215, 1218, 1533, 1538, 2, 1381, 1382, 1221, 2058, 1395, 1396, 2059, 1409, 1410, 1249, 2060, 1423, 1424, 2061, 1439, 1440, 2062, 1455, 1456, 1295, 2063, 1469, 1470, 2064, 1483, 1484, 2065, 1499, 1500, 2066, 1515, 1516, 2067<br /><br />1: Access[211]<br />2: Access[212]<br />3: Object[213]<br />4: PgSelect[210]<br />5: <br />ᐳ: Object[214]"):::bucket
+    Bucket30("Bucket 30 (mutationField)<br />Deps: 1215, 1219, 1555, 1560, 2, 1427, 1432, 1442, 1447, 1459, 1464, 1476, 1481, 1491, 1496, 1506, 1511, 1523, 1528, 1540, 1545, 1412, 1417, 1397, 1402<br /><br />1: Access[211]<br />2: Access[212]<br />3: Object[213]<br />4: PgSelect[210]<br />5: <br />ᐳ: Object[214]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,PgSelect210,Access211,Access212,Object213,Object214 bucket30
-    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 1215, 1381, 1382, 1221, 2058, 1395, 1396, 2059, 1409, 1410, 1249, 2060, 1423, 1424, 2061, 1439, 1440, 2062, 1455, 1456, 1295, 2063, 1469, 1470, 2064, 1483, 1484, 2065, 1499, 1500, 2066, 1515, 1516, 2067, 214, 210, 213, 1218<br /><br />ROOT Object{30}ᐸ{result}ᐳ[214]"):::bucket
+    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 214, 210, 213, 1215, 1219, 1427, 1432, 1442, 1447, 1459, 1464, 1476, 1481, 1491, 1496, 1506, 1511, 1523, 1528, 1540, 1545, 1412, 1417, 1397, 1402<br /><br />ROOT Object{30}ᐸ{result}ᐳ[214]"):::bucket
     classDef bucket31 stroke:#a52a2a
-    class Bucket31,Object1384,Lambda1385,Lambda1390,Object1398,Lambda1399,Lambda1404,Object1412,Lambda1413,Lambda1418,Object1426,Lambda1427,Lambda1432,Object1442,Lambda1443,Lambda1448,Object1458,Lambda1459,Lambda1464,Object1472,Lambda1473,Lambda1478,Object1486,Lambda1487,Lambda1492,Object1502,Lambda1503,Lambda1508,Object1518,Lambda1519,Lambda1524 bucket31
-    Bucket32("Bucket 32 (listItem)<br />Deps: 213, 1215, 1218, 1413, 1418, 1427, 1432, 1443, 1448, 1459, 1464, 1473, 1478, 1487, 1492, 1503, 1508, 1519, 1524, 1399, 1404, 1385, 1390<br /><br />ROOT __Item{32}ᐸ210ᐳ[215]"):::bucket
+    class Bucket31 bucket31
+    Bucket32("Bucket 32 (listItem)<br />Deps: 213, 1215, 1219, 1427, 1432, 1442, 1447, 1459, 1464, 1476, 1481, 1491, 1496, 1506, 1511, 1523, 1528, 1540, 1545, 1412, 1417, 1397, 1402<br /><br />ROOT __Item{32}ᐸ210ᐳ[215]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32,__Item215,PgSelectSingle216 bucket32
-    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 216, 213, 1215, 1218, 1413, 1418, 1427, 1432, 1443, 1448, 1459, 1464, 1473, 1478, 1487, 1492, 1503, 1508, 1519, 1524, 1399, 1404, 1385, 1390<br /><br />ROOT PgSelectSingle{32}ᐸtype_function_list_mutationᐳ[216]<br />1: <br />ᐳ: 217, 218, 219, 220, 221, 222, 223, 224, 225, 227, 228, 229, 231, 232, 233, 240, 247, 254, 261, 262, 263, 264, 265, 266, 273, 281, 282, 296, 326, 338, 370, 373, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 389, 391, 392, 406, 407, 241, 244, 248, 251, 255, 258<br />2: 283, 297, 327, 339, 394, 400<br />ᐳ: 287, 288, 289, 290, 291, 292, 293, 294, 295, 299, 300, 305, 325, 329, 330, 341, 342, 396, 397, 402, 403, 1449, 317"):::bucket
+    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 216, 213, 1215, 1219, 1427, 1432, 1442, 1447, 1459, 1464, 1476, 1481, 1491, 1496, 1506, 1511, 1523, 1528, 1540, 1545, 1412, 1417, 1397, 1402<br /><br />ROOT PgSelectSingle{32}ᐸtype_function_list_mutationᐳ[216]<br />1: <br />ᐳ: 217, 218, 219, 220, 221, 222, 223, 224, 225, 227, 228, 229, 231, 232, 233, 240, 247, 254, 261, 262, 263, 264, 265, 266, 273, 281, 282, 296, 326, 338, 370, 373, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 389, 391, 392, 406, 407, 241, 244, 248, 251, 255, 258<br />2: 283, 297, 327, 339, 394, 400<br />ᐳ: 287, 288, 289, 290, 291, 292, 293, 294, 295, 299, 300, 305, 325, 329, 330, 341, 342, 396, 397, 402, 403, 1465, 317"):::bucket
     classDef bucket33 stroke:#f5deb3
-    class Bucket33,PgClassExpression217,PgClassExpression218,PgClassExpression219,PgClassExpression220,PgClassExpression221,PgClassExpression222,PgClassExpression223,PgClassExpression224,PgClassExpression225,PgClassExpression227,PgClassExpression228,PgClassExpression229,PgClassExpression231,PgClassExpression232,PgClassExpression233,PgClassExpression240,Access241,Access244,PgClassExpression247,Access248,Access251,PgClassExpression254,Access255,Access258,PgClassExpression261,PgClassExpression262,PgClassExpression263,PgClassExpression264,PgClassExpression265,PgClassExpression266,PgClassExpression273,PgClassExpression281,PgClassExpression282,PgSelect283,First287,PgSelectSingle288,PgClassExpression289,PgClassExpression290,PgClassExpression291,PgClassExpression292,PgClassExpression293,PgClassExpression294,PgClassExpression295,PgClassExpression296,PgSelect297,First299,PgSelectSingle300,PgSelectSingle305,PgSelectSingle317,PgClassExpression325,PgClassExpression326,PgSelect327,First329,PgSelectSingle330,PgClassExpression338,PgSelect339,First341,PgSelectSingle342,PgClassExpression370,PgClassExpression373,PgClassExpression376,PgClassExpression377,PgClassExpression378,PgClassExpression379,PgClassExpression380,PgClassExpression381,PgClassExpression382,PgClassExpression383,PgClassExpression384,PgClassExpression385,PgClassExpression386,PgClassExpression387,PgClassExpression389,PgClassExpression391,PgClassExpression392,PgSelect394,First396,PgSelectSingle397,PgSelect400,First402,PgSelectSingle403,PgClassExpression406,PgClassExpression407,RemapKeys1449 bucket33
+    class Bucket33,PgClassExpression217,PgClassExpression218,PgClassExpression219,PgClassExpression220,PgClassExpression221,PgClassExpression222,PgClassExpression223,PgClassExpression224,PgClassExpression225,PgClassExpression227,PgClassExpression228,PgClassExpression229,PgClassExpression231,PgClassExpression232,PgClassExpression233,PgClassExpression240,Access241,Access244,PgClassExpression247,Access248,Access251,PgClassExpression254,Access255,Access258,PgClassExpression261,PgClassExpression262,PgClassExpression263,PgClassExpression264,PgClassExpression265,PgClassExpression266,PgClassExpression273,PgClassExpression281,PgClassExpression282,PgSelect283,First287,PgSelectSingle288,PgClassExpression289,PgClassExpression290,PgClassExpression291,PgClassExpression292,PgClassExpression293,PgClassExpression294,PgClassExpression295,PgClassExpression296,PgSelect297,First299,PgSelectSingle300,PgSelectSingle305,PgSelectSingle317,PgClassExpression325,PgClassExpression326,PgSelect327,First329,PgSelectSingle330,PgClassExpression338,PgSelect339,First341,PgSelectSingle342,PgClassExpression370,PgClassExpression373,PgClassExpression376,PgClassExpression377,PgClassExpression378,PgClassExpression379,PgClassExpression380,PgClassExpression381,PgClassExpression382,PgClassExpression383,PgClassExpression384,PgClassExpression385,PgClassExpression386,PgClassExpression387,PgClassExpression389,PgClassExpression391,PgClassExpression392,PgSelect394,First396,PgSelectSingle397,PgSelect400,First402,PgSelectSingle403,PgClassExpression406,PgClassExpression407,RemapKeys1465 bucket33
     Bucket34("Bucket 34 (listItem)<br /><br />ROOT __Item{34}ᐸ225ᐳ[226]"):::bucket
     classDef bucket34 stroke:#696969
     class Bucket34,__Item226 bucket34
@@ -2118,7 +2120,7 @@ graph TD
     class Bucket49,PgClassExpression331,PgClassExpression332,PgClassExpression333,PgClassExpression334,PgClassExpression335,PgClassExpression336,PgClassExpression337 bucket49
     Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 342<br /><br />ROOT PgSelectSingle{33}ᐸfrmcdc_nestedCompoundTypeᐳ[342]"):::bucket
     classDef bucket50 stroke:#f5deb3
-    class Bucket50,PgSelectSingle349,PgSelectSingle361,PgClassExpression369,RemapKeys1509 bucket50
+    class Bucket50,PgSelectSingle349,PgSelectSingle361,PgClassExpression369,RemapKeys1529 bucket50
     Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 349<br /><br />ROOT PgSelectSingle{50}ᐸfrmcdc_compoundTypeᐳ[349]"):::bucket
     classDef bucket51 stroke:#696969
     class Bucket51,PgClassExpression350,PgClassExpression351,PgClassExpression352,PgClassExpression353,PgClassExpression354,PgClassExpression355,PgClassExpression356 bucket51
@@ -2146,18 +2148,18 @@ graph TD
     Bucket59("Bucket 59 (listItem)<br /><br />ROOT __Item{59}ᐸ407ᐳ[408]"):::bucket
     classDef bucket59 stroke:#dda0dd
     class Bucket59,__Item408 bucket59
-    Bucket60("Bucket 60 (mutationField)<br />Deps: 1215, 1218, 1695, 1700, 2, 1543, 1544, 1221, 2069, 1557, 1558, 2070, 1571, 1572, 1249, 2071, 1585, 1586, 2072, 1601, 1602, 2073, 1617, 1618, 1295, 2074, 1631, 1632, 2075, 1645, 1646, 2076, 1661, 1662, 2077, 1677, 1678, 2078<br /><br />1: Access[412]<br />2: Access[413]<br />3: Object[414]<br />4: PgSelect[411]<br />5: <br />ᐳ: Object[415]"):::bucket
+    Bucket60("Bucket 60 (mutationField)<br />Deps: 1215, 1219, 1728, 1733, 2, 1600, 1605, 1615, 1620, 1632, 1637, 1649, 1654, 1664, 1669, 1679, 1684, 1696, 1701, 1713, 1718, 1585, 1590, 1570, 1575<br /><br />1: Access[412]<br />2: Access[413]<br />3: Object[414]<br />4: PgSelect[411]<br />5: <br />ᐳ: Object[415]"):::bucket
     classDef bucket60 stroke:#ff0000
     class Bucket60,PgSelect411,Access412,Access413,Object414,Object415 bucket60
-    Bucket61("Bucket 61 (nullableBoundary)<br />Deps: 1215, 1543, 1544, 1221, 2069, 1557, 1558, 2070, 1571, 1572, 1249, 2071, 1585, 1586, 2072, 1601, 1602, 2073, 1617, 1618, 1295, 2074, 1631, 1632, 2075, 1645, 1646, 2076, 1661, 1662, 2077, 1677, 1678, 2078, 415, 411, 414, 1218<br /><br />ROOT Object{60}ᐸ{result}ᐳ[415]"):::bucket
+    Bucket61("Bucket 61 (nullableBoundary)<br />Deps: 415, 411, 414, 1215, 1219, 1600, 1605, 1615, 1620, 1632, 1637, 1649, 1654, 1664, 1669, 1679, 1684, 1696, 1701, 1713, 1718, 1585, 1590, 1570, 1575<br /><br />ROOT Object{60}ᐸ{result}ᐳ[415]"):::bucket
     classDef bucket61 stroke:#ffff00
-    class Bucket61,Object1546,Lambda1547,Lambda1552,Object1560,Lambda1561,Lambda1566,Object1574,Lambda1575,Lambda1580,Object1588,Lambda1589,Lambda1594,Object1604,Lambda1605,Lambda1610,Object1620,Lambda1621,Lambda1626,Object1634,Lambda1635,Lambda1640,Object1648,Lambda1649,Lambda1654,Object1664,Lambda1665,Lambda1670,Object1680,Lambda1681,Lambda1686 bucket61
-    Bucket62("Bucket 62 (listItem)<br />Deps: 414, 1215, 1218, 1575, 1580, 1589, 1594, 1605, 1610, 1621, 1626, 1635, 1640, 1649, 1654, 1665, 1670, 1681, 1686, 1561, 1566, 1547, 1552<br /><br />ROOT __Item{62}ᐸ411ᐳ[416]"):::bucket
+    class Bucket61 bucket61
+    Bucket62("Bucket 62 (listItem)<br />Deps: 414, 1215, 1219, 1600, 1605, 1615, 1620, 1632, 1637, 1649, 1654, 1664, 1669, 1679, 1684, 1696, 1701, 1713, 1718, 1585, 1590, 1570, 1575<br /><br />ROOT __Item{62}ᐸ411ᐳ[416]"):::bucket
     classDef bucket62 stroke:#00ffff
     class Bucket62,__Item416,PgSelectSingle417 bucket62
-    Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 417, 414, 1215, 1218, 1575, 1580, 1589, 1594, 1605, 1610, 1621, 1626, 1635, 1640, 1649, 1654, 1665, 1670, 1681, 1686, 1561, 1566, 1547, 1552<br /><br />ROOT PgSelectSingle{62}ᐸtype_function_connection_mutationᐳ[417]<br />1: <br />ᐳ: 418, 419, 420, 421, 422, 423, 424, 425, 426, 428, 429, 430, 432, 433, 434, 441, 448, 455, 462, 463, 464, 465, 466, 467, 474, 482, 483, 497, 527, 539, 571, 574, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 590, 592, 593, 607, 608, 442, 445, 449, 452, 456, 459<br />2: 484, 498, 528, 540, 595, 601<br />ᐳ: 488, 489, 490, 491, 492, 493, 494, 495, 496, 500, 501, 506, 526, 530, 531, 542, 543, 597, 598, 603, 604, 1611, 518"):::bucket
+    Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 417, 414, 1215, 1219, 1600, 1605, 1615, 1620, 1632, 1637, 1649, 1654, 1664, 1669, 1679, 1684, 1696, 1701, 1713, 1718, 1585, 1590, 1570, 1575<br /><br />ROOT PgSelectSingle{62}ᐸtype_function_connection_mutationᐳ[417]<br />1: <br />ᐳ: 418, 419, 420, 421, 422, 423, 424, 425, 426, 428, 429, 430, 432, 433, 434, 441, 448, 455, 462, 463, 464, 465, 466, 467, 474, 482, 483, 497, 527, 539, 571, 574, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 590, 592, 593, 607, 608, 442, 445, 449, 452, 456, 459<br />2: 484, 498, 528, 540, 595, 601<br />ᐳ: 488, 489, 490, 491, 492, 493, 494, 495, 496, 500, 501, 506, 526, 530, 531, 542, 543, 597, 598, 603, 604, 1638, 518"):::bucket
     classDef bucket63 stroke:#4169e1
-    class Bucket63,PgClassExpression418,PgClassExpression419,PgClassExpression420,PgClassExpression421,PgClassExpression422,PgClassExpression423,PgClassExpression424,PgClassExpression425,PgClassExpression426,PgClassExpression428,PgClassExpression429,PgClassExpression430,PgClassExpression432,PgClassExpression433,PgClassExpression434,PgClassExpression441,Access442,Access445,PgClassExpression448,Access449,Access452,PgClassExpression455,Access456,Access459,PgClassExpression462,PgClassExpression463,PgClassExpression464,PgClassExpression465,PgClassExpression466,PgClassExpression467,PgClassExpression474,PgClassExpression482,PgClassExpression483,PgSelect484,First488,PgSelectSingle489,PgClassExpression490,PgClassExpression491,PgClassExpression492,PgClassExpression493,PgClassExpression494,PgClassExpression495,PgClassExpression496,PgClassExpression497,PgSelect498,First500,PgSelectSingle501,PgSelectSingle506,PgSelectSingle518,PgClassExpression526,PgClassExpression527,PgSelect528,First530,PgSelectSingle531,PgClassExpression539,PgSelect540,First542,PgSelectSingle543,PgClassExpression571,PgClassExpression574,PgClassExpression577,PgClassExpression578,PgClassExpression579,PgClassExpression580,PgClassExpression581,PgClassExpression582,PgClassExpression583,PgClassExpression584,PgClassExpression585,PgClassExpression586,PgClassExpression587,PgClassExpression588,PgClassExpression590,PgClassExpression592,PgClassExpression593,PgSelect595,First597,PgSelectSingle598,PgSelect601,First603,PgSelectSingle604,PgClassExpression607,PgClassExpression608,RemapKeys1611 bucket63
+    class Bucket63,PgClassExpression418,PgClassExpression419,PgClassExpression420,PgClassExpression421,PgClassExpression422,PgClassExpression423,PgClassExpression424,PgClassExpression425,PgClassExpression426,PgClassExpression428,PgClassExpression429,PgClassExpression430,PgClassExpression432,PgClassExpression433,PgClassExpression434,PgClassExpression441,Access442,Access445,PgClassExpression448,Access449,Access452,PgClassExpression455,Access456,Access459,PgClassExpression462,PgClassExpression463,PgClassExpression464,PgClassExpression465,PgClassExpression466,PgClassExpression467,PgClassExpression474,PgClassExpression482,PgClassExpression483,PgSelect484,First488,PgSelectSingle489,PgClassExpression490,PgClassExpression491,PgClassExpression492,PgClassExpression493,PgClassExpression494,PgClassExpression495,PgClassExpression496,PgClassExpression497,PgSelect498,First500,PgSelectSingle501,PgSelectSingle506,PgSelectSingle518,PgClassExpression526,PgClassExpression527,PgSelect528,First530,PgSelectSingle531,PgClassExpression539,PgSelect540,First542,PgSelectSingle543,PgClassExpression571,PgClassExpression574,PgClassExpression577,PgClassExpression578,PgClassExpression579,PgClassExpression580,PgClassExpression581,PgClassExpression582,PgClassExpression583,PgClassExpression584,PgClassExpression585,PgClassExpression586,PgClassExpression587,PgClassExpression588,PgClassExpression590,PgClassExpression592,PgClassExpression593,PgSelect595,First597,PgSelectSingle598,PgSelect601,First603,PgSelectSingle604,PgClassExpression607,PgClassExpression608,RemapKeys1638 bucket63
     Bucket64("Bucket 64 (listItem)<br /><br />ROOT __Item{64}ᐸ426ᐳ[427]"):::bucket
     classDef bucket64 stroke:#3cb371
     class Bucket64,__Item427 bucket64
@@ -2208,7 +2210,7 @@ graph TD
     class Bucket79,PgClassExpression532,PgClassExpression533,PgClassExpression534,PgClassExpression535,PgClassExpression536,PgClassExpression537,PgClassExpression538 bucket79
     Bucket80("Bucket 80 (nullableBoundary)<br />Deps: 543<br /><br />ROOT PgSelectSingle{63}ᐸfrmcdc_nestedCompoundTypeᐳ[543]"):::bucket
     classDef bucket80 stroke:#4169e1
-    class Bucket80,PgSelectSingle550,PgSelectSingle562,PgClassExpression570,RemapKeys1671 bucket80
+    class Bucket80,PgSelectSingle550,PgSelectSingle562,PgClassExpression570,RemapKeys1702 bucket80
     Bucket81("Bucket 81 (nullableBoundary)<br />Deps: 550<br /><br />ROOT PgSelectSingle{80}ᐸfrmcdc_compoundTypeᐳ[550]"):::bucket
     classDef bucket81 stroke:#3cb371
     class Bucket81,PgClassExpression551,PgClassExpression552,PgClassExpression553,PgClassExpression554,PgClassExpression555,PgClassExpression556,PgClassExpression557 bucket81
@@ -2236,15 +2238,15 @@ graph TD
     Bucket89("Bucket 89 (listItem)<br /><br />ROOT __Item{89}ᐸ608ᐳ[609]"):::bucket
     classDef bucket89 stroke:#0000ff
     class Bucket89,__Item609 bucket89
-    Bucket90("Bucket 90 (mutationField)<br />Deps: 1997, 1998, 1999, 2000, 2001, 2102, 2103, 2005, 2006, 2132, 2133, 2134, 2011, 2012, 2013, 2014, 2100, 2110, 2015, 2111, 2112, 2113, 2114, 2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2115, 2116, 2037, 2117, 2040, 2118, 2, 1215, 1705, 1706, 1221, 2080, 1719, 1720, 2081, 1733, 1734, 1249, 2082, 1747, 1748, 2083, 1763, 1764, 2084, 1779, 1780, 1295, 2085, 1793, 1794, 2086, 1807, 1808, 2087, 1823, 1824, 2088, 1839, 1840, 2089, 1218<br /><br />1: Access[702]<br />2: Access[703]<br />3: Object[704]<br />4: PgUpdateSingle[701]<br />5: <br />ᐳ: Object[705]"):::bucket
+    Bucket90("Bucket 90 (mutationField)<br />Deps: 2050, 2051, 2052, 2053, 2054, 2155, 2156, 2058, 2059, 2185, 2186, 2187, 2064, 2065, 2066, 2067, 2153, 2163, 2068, 2164, 2165, 2166, 2167, 2073, 2074, 2075, 2076, 2077, 2078, 2079, 2080, 2081, 2082, 2083, 2168, 2169, 2090, 2170, 2093, 2171, 2, 1215, 1219, 1773, 1778, 1788, 1793, 1805, 1810, 1822, 1827, 1837, 1842, 1852, 1857, 1869, 1874, 1886, 1891, 1758, 1763, 1743, 1748<br /><br />1: Access[702]<br />2: Access[703]<br />3: Object[704]<br />4: PgUpdateSingle[701]<br />5: <br />ᐳ: Object[705]"):::bucket
     classDef bucket90 stroke:#7fff00
     class Bucket90,PgUpdateSingle701,Access702,Access703,Object704,Object705 bucket90
-    Bucket91("Bucket 91 (nullableBoundary)<br />Deps: 1215, 1705, 1706, 1221, 2080, 1719, 1720, 2081, 1733, 1734, 1249, 2082, 1747, 1748, 2083, 1763, 1764, 2084, 1779, 1780, 1295, 2085, 1793, 1794, 2086, 1807, 1808, 2087, 1823, 1824, 2088, 1839, 1840, 2089, 705, 701, 704, 1218<br /><br />ROOT Object{90}ᐸ{result}ᐳ[705]"):::bucket
+    Bucket91("Bucket 91 (nullableBoundary)<br />Deps: 705, 701, 704, 1215, 1219, 1773, 1778, 1788, 1793, 1805, 1810, 1822, 1827, 1837, 1842, 1852, 1857, 1869, 1874, 1886, 1891, 1758, 1763, 1743, 1748<br /><br />ROOT Object{90}ᐸ{result}ᐳ[705]"):::bucket
     classDef bucket91 stroke:#ff1493
-    class Bucket91,Object1708,Lambda1709,Lambda1714,Object1722,Lambda1723,Lambda1728,Object1736,Lambda1737,Lambda1742,Object1750,Lambda1751,Lambda1756,Object1766,Lambda1767,Lambda1772,Object1782,Lambda1783,Lambda1788,Object1796,Lambda1797,Lambda1802,Object1810,Lambda1811,Lambda1816,Object1826,Lambda1827,Lambda1832,Object1842,Lambda1843,Lambda1848 bucket91
-    Bucket92("Bucket 92 (nullableBoundary)<br />Deps: 701, 704, 1215, 1218, 1737, 1742, 1751, 1756, 1767, 1772, 1783, 1788, 1797, 1802, 1811, 1816, 1827, 1832, 1843, 1848, 1723, 1728, 1709, 1714<br /><br />ROOT PgUpdateSingle{90}ᐸtypes(id;smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,nullablePoint,inet,cidr,macaddr,regproc,regprocedure,regoper,regoperator,regclass,regtype,regconfig,regdictionary,text_array_domain,int8_array_domain,bytea,bytea_array,ltree,ltree_array)ᐳ[701]<br />1: <br />ᐳ: 729, 730, 731, 732, 733, 734, 735, 736, 737, 739, 740, 741, 743, 744, 745, 752, 759, 766, 773, 774, 775, 776, 777, 778, 785, 793, 794, 808, 838, 850, 882, 885, 888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 899, 901, 903, 904, 920, 921, 753, 756, 760, 763, 767, 770<br />2: 795, 809, 839, 851, 907, 914<br />ᐳ: 799, 800, 801, 802, 803, 804, 805, 806, 807, 811, 812, 817, 837, 841, 842, 853, 854, 909, 910, 916, 917, 1773, 829"):::bucket
+    class Bucket91 bucket91
+    Bucket92("Bucket 92 (nullableBoundary)<br />Deps: 701, 704, 1215, 1219, 1773, 1778, 1788, 1793, 1805, 1810, 1822, 1827, 1837, 1842, 1852, 1857, 1869, 1874, 1886, 1891, 1758, 1763, 1743, 1748<br /><br />ROOT PgUpdateSingle{90}ᐸtypes(id;smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,nullablePoint,inet,cidr,macaddr,regproc,regprocedure,regoper,regoperator,regclass,regtype,regconfig,regdictionary,text_array_domain,int8_array_domain,bytea,bytea_array,ltree,ltree_array)ᐳ[701]<br />1: <br />ᐳ: 729, 730, 731, 732, 733, 734, 735, 736, 737, 739, 740, 741, 743, 744, 745, 752, 759, 766, 773, 774, 775, 776, 777, 778, 785, 793, 794, 808, 838, 850, 882, 885, 888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 899, 901, 903, 904, 920, 921, 753, 756, 760, 763, 767, 770<br />2: 795, 809, 839, 851, 907, 914<br />ᐳ: 799, 800, 801, 802, 803, 804, 805, 806, 807, 811, 812, 817, 837, 841, 842, 853, 854, 909, 910, 916, 917, 1811, 829"):::bucket
     classDef bucket92 stroke:#808000
-    class Bucket92,PgClassExpression729,PgClassExpression730,PgClassExpression731,PgClassExpression732,PgClassExpression733,PgClassExpression734,PgClassExpression735,PgClassExpression736,PgClassExpression737,PgClassExpression739,PgClassExpression740,PgClassExpression741,PgClassExpression743,PgClassExpression744,PgClassExpression745,PgClassExpression752,Access753,Access756,PgClassExpression759,Access760,Access763,PgClassExpression766,Access767,Access770,PgClassExpression773,PgClassExpression774,PgClassExpression775,PgClassExpression776,PgClassExpression777,PgClassExpression778,PgClassExpression785,PgClassExpression793,PgClassExpression794,PgSelect795,First799,PgSelectSingle800,PgClassExpression801,PgClassExpression802,PgClassExpression803,PgClassExpression804,PgClassExpression805,PgClassExpression806,PgClassExpression807,PgClassExpression808,PgSelect809,First811,PgSelectSingle812,PgSelectSingle817,PgSelectSingle829,PgClassExpression837,PgClassExpression838,PgSelect839,First841,PgSelectSingle842,PgClassExpression850,PgSelect851,First853,PgSelectSingle854,PgClassExpression882,PgClassExpression885,PgClassExpression888,PgClassExpression889,PgClassExpression890,PgClassExpression891,PgClassExpression892,PgClassExpression893,PgClassExpression894,PgClassExpression895,PgClassExpression896,PgClassExpression897,PgClassExpression898,PgClassExpression899,PgClassExpression901,PgClassExpression903,PgClassExpression904,PgSelect907,First909,PgSelectSingle910,PgSelect914,First916,PgSelectSingle917,PgClassExpression920,PgClassExpression921,RemapKeys1773 bucket92
+    class Bucket92,PgClassExpression729,PgClassExpression730,PgClassExpression731,PgClassExpression732,PgClassExpression733,PgClassExpression734,PgClassExpression735,PgClassExpression736,PgClassExpression737,PgClassExpression739,PgClassExpression740,PgClassExpression741,PgClassExpression743,PgClassExpression744,PgClassExpression745,PgClassExpression752,Access753,Access756,PgClassExpression759,Access760,Access763,PgClassExpression766,Access767,Access770,PgClassExpression773,PgClassExpression774,PgClassExpression775,PgClassExpression776,PgClassExpression777,PgClassExpression778,PgClassExpression785,PgClassExpression793,PgClassExpression794,PgSelect795,First799,PgSelectSingle800,PgClassExpression801,PgClassExpression802,PgClassExpression803,PgClassExpression804,PgClassExpression805,PgClassExpression806,PgClassExpression807,PgClassExpression808,PgSelect809,First811,PgSelectSingle812,PgSelectSingle817,PgSelectSingle829,PgClassExpression837,PgClassExpression838,PgSelect839,First841,PgSelectSingle842,PgClassExpression850,PgSelect851,First853,PgSelectSingle854,PgClassExpression882,PgClassExpression885,PgClassExpression888,PgClassExpression889,PgClassExpression890,PgClassExpression891,PgClassExpression892,PgClassExpression893,PgClassExpression894,PgClassExpression895,PgClassExpression896,PgClassExpression897,PgClassExpression898,PgClassExpression899,PgClassExpression901,PgClassExpression903,PgClassExpression904,PgSelect907,First909,PgSelectSingle910,PgSelect914,First916,PgSelectSingle917,PgClassExpression920,PgClassExpression921,RemapKeys1811 bucket92
     Bucket93("Bucket 93 (listItem)<br /><br />ROOT __Item{93}ᐸ737ᐳ[738]"):::bucket
     classDef bucket93 stroke:#dda0dd
     class Bucket93,__Item738 bucket93
@@ -2295,7 +2297,7 @@ graph TD
     class Bucket108,PgClassExpression843,PgClassExpression844,PgClassExpression845,PgClassExpression846,PgClassExpression847,PgClassExpression848,PgClassExpression849 bucket108
     Bucket109("Bucket 109 (nullableBoundary)<br />Deps: 854<br /><br />ROOT PgSelectSingle{92}ᐸfrmcdc_nestedCompoundTypeᐳ[854]"):::bucket
     classDef bucket109 stroke:#808000
-    class Bucket109,PgSelectSingle861,PgSelectSingle873,PgClassExpression881,RemapKeys1833 bucket109
+    class Bucket109,PgSelectSingle861,PgSelectSingle873,PgClassExpression881,RemapKeys1875 bucket109
     Bucket110("Bucket 110 (nullableBoundary)<br />Deps: 861<br /><br />ROOT PgSelectSingle{109}ᐸfrmcdc_compoundTypeᐳ[861]"):::bucket
     classDef bucket110 stroke:#dda0dd
     class Bucket110,PgClassExpression862,PgClassExpression863,PgClassExpression864,PgClassExpression865,PgClassExpression866,PgClassExpression867,PgClassExpression868 bucket110
@@ -2323,15 +2325,15 @@ graph TD
     Bucket118("Bucket 118 (listItem)<br /><br />ROOT __Item{118}ᐸ921ᐳ[922]"):::bucket
     classDef bucket118 stroke:#f5deb3
     class Bucket118,__Item922 bucket118
-    Bucket119("Bucket 119 (mutationField)<br />Deps: 1998, 1999, 2000, 2001, 2102, 2103, 2043, 2044, 2132, 2133, 2134, 2011, 2012, 2013, 2014, 2100, 2110, 2015, 2111, 2112, 2113, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2040, 2118, 2, 1215, 1853, 1854, 1221, 2090, 1867, 1868, 2091, 1881, 1882, 1249, 2092, 1895, 1896, 2093, 1911, 1912, 2094, 1927, 1928, 1295, 2095, 1941, 1942, 2096, 1955, 1956, 2097, 1971, 1972, 2098, 1987, 1988, 2099, 1218<br /><br />1: Access[996]<br />2: Access[997]<br />3: Object[998]<br />4: PgInsertSingle[995]<br />5: <br />ᐳ: Object[999]"):::bucket
+    Bucket119("Bucket 119 (mutationField)<br />Deps: 2051, 2052, 2053, 2054, 2155, 2156, 2096, 2097, 2185, 2186, 2187, 2064, 2065, 2066, 2067, 2153, 2163, 2068, 2164, 2165, 2166, 2076, 2077, 2078, 2079, 2080, 2081, 2082, 2083, 2093, 2171, 2, 1215, 1219, 1931, 1936, 1946, 1951, 1963, 1968, 1980, 1985, 1995, 2000, 2010, 2015, 2027, 2032, 2044, 2049, 1916, 1921, 1901, 1906<br /><br />1: Access[996]<br />2: Access[997]<br />3: Object[998]<br />4: PgInsertSingle[995]<br />5: <br />ᐳ: Object[999]"):::bucket
     classDef bucket119 stroke:#696969
     class Bucket119,PgInsertSingle995,Access996,Access997,Object998,Object999 bucket119
-    Bucket120("Bucket 120 (nullableBoundary)<br />Deps: 1215, 1853, 1854, 1221, 2090, 1867, 1868, 2091, 1881, 1882, 1249, 2092, 1895, 1896, 2093, 1911, 1912, 2094, 1927, 1928, 1295, 2095, 1941, 1942, 2096, 1955, 1956, 2097, 1971, 1972, 2098, 1987, 1988, 2099, 999, 995, 998, 1218<br /><br />ROOT Object{119}ᐸ{result}ᐳ[999]"):::bucket
+    Bucket120("Bucket 120 (nullableBoundary)<br />Deps: 999, 995, 998, 1215, 1219, 1931, 1936, 1946, 1951, 1963, 1968, 1980, 1985, 1995, 2000, 2010, 2015, 2027, 2032, 2044, 2049, 1916, 1921, 1901, 1906<br /><br />ROOT Object{119}ᐸ{result}ᐳ[999]"):::bucket
     classDef bucket120 stroke:#00bfff
-    class Bucket120,Object1856,Lambda1857,Lambda1862,Object1870,Lambda1871,Lambda1876,Object1884,Lambda1885,Lambda1890,Object1898,Lambda1899,Lambda1904,Object1914,Lambda1915,Lambda1920,Object1930,Lambda1931,Lambda1936,Object1944,Lambda1945,Lambda1950,Object1958,Lambda1959,Lambda1964,Object1974,Lambda1975,Lambda1980,Object1990,Lambda1991,Lambda1996 bucket120
-    Bucket121("Bucket 121 (nullableBoundary)<br />Deps: 995, 998, 1215, 1218, 1885, 1890, 1899, 1904, 1915, 1920, 1931, 1936, 1945, 1950, 1959, 1964, 1975, 1980, 1991, 1996, 1871, 1876, 1857, 1862<br /><br />ROOT PgInsertSingle{119}ᐸtypes(smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,regproc,regprocedure,regoper,regoperator,regclass,regtype,regconfig,regdictionary,ltree,ltree_array)ᐳ[995]<br />1: <br />ᐳ: 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1029, 1030, 1031, 1033, 1034, 1035, 1042, 1049, 1056, 1063, 1064, 1065, 1066, 1067, 1068, 1075, 1083, 1084, 1098, 1128, 1140, 1172, 1175, 1178, 1179, 1180, 1181, 1182, 1183, 1184, 1185, 1186, 1187, 1188, 1189, 1191, 1193, 1194, 1210, 1211, 1043, 1046, 1050, 1053, 1057, 1060<br />2: 1085, 1099, 1129, 1141, 1197, 1204<br />ᐳ: 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1101, 1102, 1107, 1127, 1131, 1132, 1143, 1144, 1199, 1200, 1206, 1207, 1921, 1119"):::bucket
+    class Bucket120 bucket120
+    Bucket121("Bucket 121 (nullableBoundary)<br />Deps: 995, 998, 1215, 1219, 1931, 1936, 1946, 1951, 1963, 1968, 1980, 1985, 1995, 2000, 2010, 2015, 2027, 2032, 2044, 2049, 1916, 1921, 1901, 1906<br /><br />ROOT PgInsertSingle{119}ᐸtypes(smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,regproc,regprocedure,regoper,regoperator,regclass,regtype,regconfig,regdictionary,ltree,ltree_array)ᐳ[995]<br />1: <br />ᐳ: 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1029, 1030, 1031, 1033, 1034, 1035, 1042, 1049, 1056, 1063, 1064, 1065, 1066, 1067, 1068, 1075, 1083, 1084, 1098, 1128, 1140, 1172, 1175, 1178, 1179, 1180, 1181, 1182, 1183, 1184, 1185, 1186, 1187, 1188, 1189, 1191, 1193, 1194, 1210, 1211, 1043, 1046, 1050, 1053, 1057, 1060<br />2: 1085, 1099, 1129, 1141, 1197, 1204<br />ᐳ: 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1101, 1102, 1107, 1127, 1131, 1132, 1143, 1144, 1199, 1200, 1206, 1207, 1969, 1119"):::bucket
     classDef bucket121 stroke:#7f007f
-    class Bucket121,PgClassExpression1019,PgClassExpression1020,PgClassExpression1021,PgClassExpression1022,PgClassExpression1023,PgClassExpression1024,PgClassExpression1025,PgClassExpression1026,PgClassExpression1027,PgClassExpression1029,PgClassExpression1030,PgClassExpression1031,PgClassExpression1033,PgClassExpression1034,PgClassExpression1035,PgClassExpression1042,Access1043,Access1046,PgClassExpression1049,Access1050,Access1053,PgClassExpression1056,Access1057,Access1060,PgClassExpression1063,PgClassExpression1064,PgClassExpression1065,PgClassExpression1066,PgClassExpression1067,PgClassExpression1068,PgClassExpression1075,PgClassExpression1083,PgClassExpression1084,PgSelect1085,First1089,PgSelectSingle1090,PgClassExpression1091,PgClassExpression1092,PgClassExpression1093,PgClassExpression1094,PgClassExpression1095,PgClassExpression1096,PgClassExpression1097,PgClassExpression1098,PgSelect1099,First1101,PgSelectSingle1102,PgSelectSingle1107,PgSelectSingle1119,PgClassExpression1127,PgClassExpression1128,PgSelect1129,First1131,PgSelectSingle1132,PgClassExpression1140,PgSelect1141,First1143,PgSelectSingle1144,PgClassExpression1172,PgClassExpression1175,PgClassExpression1178,PgClassExpression1179,PgClassExpression1180,PgClassExpression1181,PgClassExpression1182,PgClassExpression1183,PgClassExpression1184,PgClassExpression1185,PgClassExpression1186,PgClassExpression1187,PgClassExpression1188,PgClassExpression1189,PgClassExpression1191,PgClassExpression1193,PgClassExpression1194,PgSelect1197,First1199,PgSelectSingle1200,PgSelect1204,First1206,PgSelectSingle1207,PgClassExpression1210,PgClassExpression1211,RemapKeys1921 bucket121
+    class Bucket121,PgClassExpression1019,PgClassExpression1020,PgClassExpression1021,PgClassExpression1022,PgClassExpression1023,PgClassExpression1024,PgClassExpression1025,PgClassExpression1026,PgClassExpression1027,PgClassExpression1029,PgClassExpression1030,PgClassExpression1031,PgClassExpression1033,PgClassExpression1034,PgClassExpression1035,PgClassExpression1042,Access1043,Access1046,PgClassExpression1049,Access1050,Access1053,PgClassExpression1056,Access1057,Access1060,PgClassExpression1063,PgClassExpression1064,PgClassExpression1065,PgClassExpression1066,PgClassExpression1067,PgClassExpression1068,PgClassExpression1075,PgClassExpression1083,PgClassExpression1084,PgSelect1085,First1089,PgSelectSingle1090,PgClassExpression1091,PgClassExpression1092,PgClassExpression1093,PgClassExpression1094,PgClassExpression1095,PgClassExpression1096,PgClassExpression1097,PgClassExpression1098,PgSelect1099,First1101,PgSelectSingle1102,PgSelectSingle1107,PgSelectSingle1119,PgClassExpression1127,PgClassExpression1128,PgSelect1129,First1131,PgSelectSingle1132,PgClassExpression1140,PgSelect1141,First1143,PgSelectSingle1144,PgClassExpression1172,PgClassExpression1175,PgClassExpression1178,PgClassExpression1179,PgClassExpression1180,PgClassExpression1181,PgClassExpression1182,PgClassExpression1183,PgClassExpression1184,PgClassExpression1185,PgClassExpression1186,PgClassExpression1187,PgClassExpression1188,PgClassExpression1189,PgClassExpression1191,PgClassExpression1193,PgClassExpression1194,PgSelect1197,First1199,PgSelectSingle1200,PgSelect1204,First1206,PgSelectSingle1207,PgClassExpression1210,PgClassExpression1211,RemapKeys1969 bucket121
     Bucket122("Bucket 122 (listItem)<br /><br />ROOT __Item{122}ᐸ1027ᐳ[1028]"):::bucket
     classDef bucket122 stroke:#ffa500
     class Bucket122,__Item1028 bucket122
@@ -2382,7 +2384,7 @@ graph TD
     class Bucket137,PgClassExpression1133,PgClassExpression1134,PgClassExpression1135,PgClassExpression1136,PgClassExpression1137,PgClassExpression1138,PgClassExpression1139 bucket137
     Bucket138("Bucket 138 (nullableBoundary)<br />Deps: 1144<br /><br />ROOT PgSelectSingle{121}ᐸfrmcdc_nestedCompoundTypeᐳ[1144]"):::bucket
     classDef bucket138 stroke:#7f007f
-    class Bucket138,PgSelectSingle1151,PgSelectSingle1163,PgClassExpression1171,RemapKeys1981 bucket138
+    class Bucket138,PgSelectSingle1151,PgSelectSingle1163,PgClassExpression1171,RemapKeys2033 bucket138
     Bucket139("Bucket 139 (nullableBoundary)<br />Deps: 1151<br /><br />ROOT PgSelectSingle{138}ᐸfrmcdc_compoundTypeᐳ[1151]"):::bucket
     classDef bucket139 stroke:#ffa500
     class Bucket139,PgClassExpression1152,PgClassExpression1153,PgClassExpression1154,PgClassExpression1155,PgClassExpression1156,PgClassExpression1157,PgClassExpression1158 bucket139

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.mermaid
@@ -9,35 +9,35 @@ graph TD
 
 
     %% plan dependencies
-    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda97 & Constant101 & Constant102 & Constant103 --> Object104
-    Object118{{"Object[118∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant116{{"Constant[116∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda97 & Constant115 & Constant116 & Constant117 --> Object118
-    Object132{{"Object[132∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda97 & Constant129 & Constant130 & Constant131 --> Object132
-    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda97 & Constant143 & Constant144 & Constant103 --> Object146
-    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda97 & Constant157 & Constant158 & Constant117 --> Object160
-    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda97 & Constant171 & Constant172 & Constant173 --> Object174
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda97 & Constant102 & Constant103 & Constant104 --> Object105
+    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda97 & Constant117 & Constant118 & Constant119 --> Object120
+    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda97 & Constant138 & Constant139 & Constant140 --> Object141
+    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda97 & Constant153 & Constant154 & Constant104 --> Object156
+    Object171{{"Object[171∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda97 & Constant168 & Constant169 & Constant119 --> Object171
+    Object192{{"Object[192∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda97 & Constant189 & Constant190 & Constant191 --> Object192
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -45,63 +45,67 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant181 --> Lambda97
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant205 --> Lambda97
     Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant182 --> Lambda100
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object104 --> Lambda105
-    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant183 --> Lambda110
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object118 --> Lambda119
-    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant184 --> Lambda124
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object132 --> Lambda133
-    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant185 --> Lambda138
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant206 --> Lambda100
+    Access101{{"Access[101∈0] ➊<br />ᐸ100.0ᐳ"}}:::plan
+    Lambda100 --> Access101
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object105 --> Lambda106
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant207 --> Lambda111
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object120 --> Lambda121
+    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant208 --> Lambda126
+    Access132{{"Access[132∈0] ➊<br />ᐸ100.1ᐳ"}}:::plan
+    Lambda100 --> Access132
+    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object141 --> Lambda142
     Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object146 --> Lambda147
-    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant186 --> Lambda152
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object160 --> Lambda161
-    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant187 --> Lambda166
-    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object174 --> Lambda175
-    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant188 --> Lambda180
+    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant209 --> Lambda147
+    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object156 --> Lambda157
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant210 --> Lambda162
+    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object171 --> Lambda172
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant211 --> Lambda177
+    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object192 --> Lambda193
+    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant212 --> Lambda198
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
     PgUnionAll15[["PgUnionAll[15∈1] ➊"]]:::plan
-    Object13 & Connection14 --> PgUnionAll15
+    Object13 & Connection14 & Lambda97 & Access101 & Access132 --> PgUnionAll15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgUnionAll15 ==> __Item16
     PgUnionAllSingle17["PgUnionAllSingle[17∈2]"]:::plan
     __Item16 --> PgUnionAllSingle17
     PgSelect21[["PgSelect[21∈3]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access20{{"Access[20∈3]<br />ᐸ19.0ᐳ"}}:::plan
-    Object13 & Access20 & Lambda97 & Lambda100 & Lambda133 & Lambda138 --> PgSelect21
-    PgSelect60[["PgSelect[60∈3]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access59{{"Access[59∈3]<br />ᐸ58.0ᐳ"}}:::plan
-    Object13 & Access59 & Lambda97 & Lambda100 & Lambda175 & Lambda180 --> PgSelect60
+    Object13 & Access20 & Lambda97 & Access101 & Lambda142 & Lambda147 --> PgSelect21
     PgUnionAll34[["PgUnionAll[34∈3]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression30{{"PgClassExpression[30∈3]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection33{{"Connection[33∈3] ➊<br />ᐸ31ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object13 & PgClassExpression30 & Connection33 --> PgUnionAll34
+    Object13 & PgClassExpression30 & Connection33 & Lambda97 & Access101 & Access132 --> PgUnionAll34
+    PgSelect60[["PgSelect[60∈3]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access59{{"Access[59∈3]<br />ᐸ58.0ᐳ"}}:::plan
+    Object13 & Access59 & Lambda97 & Access101 & Lambda193 & Lambda198 --> PgSelect60
     PgUnionAll71[["PgUnionAll[71∈3]<br />ᐳGcpApplication"]]:::plan
     PgClassExpression67{{"PgClassExpression[67∈3]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Connection70{{"Connection[70∈3] ➊<br />ᐸ68ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object13 & PgClassExpression67 & Connection70 --> PgUnionAll71
+    Object13 & PgClassExpression67 & Connection70 & Lambda97 & Access101 & Access132 --> PgUnionAll71
     Access18{{"Access[18∈3]<br />ᐸ17.1ᐳ<br />ᐳAwsApplication"}}:::plan
     PgUnionAllSingle17 --> Access18
     JSONParse19[["JSONParse[19∈3]<br />ᐸ18ᐳ"]]:::plan
@@ -130,10 +134,10 @@ graph TD
     __Item35 --> PgUnionAllSingle36
     PgSelect40[["PgSelect[40∈5]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access39{{"Access[39∈5]<br />ᐸ38.0ᐳ"}}:::plan
-    Object13 & Access39 & Lambda97 & Lambda100 & Lambda105 & Lambda110 --> PgSelect40
+    Object13 & Access39 & Lambda97 & Access101 & Lambda106 & Lambda111 --> PgSelect40
     PgSelect51[["PgSelect[51∈5]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access50{{"Access[50∈5]<br />ᐸ49.0ᐳ"}}:::plan
-    Object13 & Access50 & Lambda97 & Lambda100 & Lambda119 & Lambda124 --> PgSelect51
+    Object13 & Access50 & Lambda97 & Access101 & Lambda121 & Lambda126 --> PgSelect51
     Access37{{"Access[37∈5]<br />ᐸ36.1ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle36 --> Access37
     JSONParse38[["JSONParse[38∈5]<br />ᐸ37ᐳ"]]:::plan
@@ -168,10 +172,10 @@ graph TD
     __Item72 --> PgUnionAllSingle73
     PgSelect77[["PgSelect[77∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access76{{"Access[76∈7]<br />ᐸ75.0ᐳ"}}:::plan
-    Object13 & Access76 & Lambda97 & Lambda100 & Lambda147 & Lambda152 --> PgSelect77
+    Object13 & Access76 & Lambda97 & Access101 & Lambda157 & Lambda162 --> PgSelect77
     PgSelect88[["PgSelect[88∈7]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access87{{"Access[87∈7]<br />ᐸ86.0ᐳ"}}:::plan
-    Object13 & Access87 & Lambda97 & Lambda100 & Lambda161 & Lambda166 --> PgSelect88
+    Object13 & Access87 & Lambda97 & Access101 & Lambda172 & Lambda177 --> PgSelect88
     Access74{{"Access[74∈7]<br />ᐸ73.1ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle73 --> Access74
     JSONParse75[["JSONParse[75∈7]<br />ᐸ74ᐳ"]]:::plan
@@ -206,26 +210,26 @@ graph TD
     subgraph "Buckets for queries/polymorphic/only"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda97,Lambda100,Constant101,Constant102,Constant103,Object104,Lambda105,Lambda110,Constant115,Constant116,Constant117,Object118,Lambda119,Lambda124,Constant129,Constant130,Constant131,Object132,Lambda133,Lambda138,Constant143,Constant144,Object146,Lambda147,Lambda152,Constant157,Constant158,Object160,Lambda161,Lambda166,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 97, 100, 133, 138, 175, 180, 105, 110, 119, 124, 147, 152, 161, 166<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda97,Lambda100,Access101,Constant102,Constant103,Constant104,Object105,Lambda106,Lambda111,Constant117,Constant118,Constant119,Object120,Lambda121,Lambda126,Access132,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant168,Constant169,Object171,Lambda172,Lambda177,Constant189,Constant190,Constant191,Object192,Lambda193,Lambda198,Constant205,Constant206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 97, 101, 132, 142, 147, 193, 198, 106, 111, 121, 126, 157, 162, 172, 177<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUnionAll15 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 97, 100, 133, 138, 175, 180, 105, 110, 119, 124, 147, 152, 161, 166<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 97, 101, 142, 147, 132, 193, 198, 106, 111, 121, 126, 157, 162, 172, 177<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgUnionAllSingle17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 17, 13, 97, 100, 133, 138, 175, 180, 105, 110, 119, 124, 147, 152, 161, 166<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 18, 33, 70<br />2: JSONParse[19], JSONParse[58]<br />ᐳ: Access[20], Access[59]<br />3: PgSelect[21], PgSelect[60]<br />ᐳ: 25, 26, 27, 30, 62, 63, 64, 67<br />4: PgUnionAll[34], PgUnionAll[71]"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 17, 13, 97, 101, 142, 147, 132, 193, 198, 106, 111, 121, 126, 157, 162, 172, 177<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 18, 33, 70<br />2: JSONParse[19], JSONParse[58]<br />ᐳ: Access[20], Access[59]<br />3: PgSelect[21], PgSelect[60]<br />ᐳ: 25, 26, 27, 30, 62, 63, 64, 67<br />4: PgUnionAll[34], PgUnionAll[71]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,Access18,JSONParse19,Access20,PgSelect21,First25,PgSelectSingle26,PgClassExpression27,PgClassExpression30,Connection33,PgUnionAll34,JSONParse58,Access59,PgSelect60,First62,PgSelectSingle63,PgClassExpression64,PgClassExpression67,Connection70,PgUnionAll71 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 97, 100, 105, 110, 119, 124<br /><br />ROOT __Item{4}ᐸ34ᐳ[35]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 97, 101, 106, 111, 121, 126<br /><br />ROOT __Item{4}ᐸ34ᐳ[35]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item35,PgUnionAllSingle36 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 36, 13, 97, 100, 105, 110, 119, 124<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[37]<br />2: JSONParse[38], JSONParse[49]<br />ᐳ: Access[39], Access[50]<br />3: PgSelect[40], PgSelect[51]<br />ᐳ: 44, 45, 46, 47, 48, 53, 54, 55, 56, 57"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 36, 13, 97, 101, 106, 111, 121, 126<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[37]<br />2: JSONParse[38], JSONParse[49]<br />ᐳ: Access[39], Access[50]<br />3: PgSelect[40], PgSelect[51]<br />ᐳ: 44, 45, 46, 47, 48, 53, 54, 55, 56, 57"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,Access37,JSONParse38,Access39,PgSelect40,First44,PgSelectSingle45,PgClassExpression46,PgClassExpression47,PgClassExpression48,JSONParse49,Access50,PgSelect51,First53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket5
-    Bucket6("Bucket 6 (listItem)<br />Deps: 13, 97, 100, 147, 152, 161, 166<br /><br />ROOT __Item{6}ᐸ71ᐳ[72]"):::bucket
+    Bucket6("Bucket 6 (listItem)<br />Deps: 13, 97, 101, 157, 162, 172, 177<br /><br />ROOT __Item{6}ᐸ71ᐳ[72]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item72,PgUnionAllSingle73 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 73, 13, 97, 100, 147, 152, 161, 166<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[74]<br />2: JSONParse[75], JSONParse[86]<br />ᐳ: Access[76], Access[87]<br />3: PgSelect[77], PgSelect[88]<br />ᐳ: 81, 82, 83, 84, 85, 90, 91, 92, 93, 94"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 73, 13, 97, 101, 157, 162, 172, 177<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[74]<br />2: JSONParse[75], JSONParse[86]<br />ᐳ: Access[76], Access[87]<br />3: PgSelect[77], PgSelect[88]<br />ᐳ: 81, 82, 83, 84, 85, 90, 91, 92, 93, 94"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,Access74,JSONParse75,Access76,PgSelect77,First81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,JSONParse86,Access87,PgSelect88,First90,PgSelectSingle91,PgClassExpression92,PgClassExpression93,PgClassExpression94 bucket7
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.mermaid
@@ -9,17 +9,28 @@ graph TD
 
 
     %% plan dependencies
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda62 & Constant66 & Constant67 & Constant68 --> Object69
-    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda62 & Constant80 & Constant81 & Constant82 --> Object83
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda62 & Constant67 & Constant68 & Constant69 --> Object70
+    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda62 & Constant82 & Constant83 & Constant84 --> Object85
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda99 & Constant103 & Constant104 & Constant105 --> Object106
+    Connection28{{"Connection[28∈0] ➊<br />ᐸ24ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
+    PgValidateParsedCursor34["PgValidateParsedCursor[34∈0] ➊"]:::plan
+    Constant114 & Lambda29 & PgValidateParsedCursor34 --> Connection28
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -28,64 +39,67 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant104 --> Connection14
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
-    Constant106 --> Lambda29
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant108 --> Lambda62
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109 --> Lambda65
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object69 --> Lambda70
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant110 --> Lambda75
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object83 --> Lambda84
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant111 --> Lambda89
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ'AWfulS'ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant104 & Lambda91 & Lambda93 & Lambda98 & Lambda103 --> PgSelect15
-    Object97{{"Object[97∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda91 & Constant94 & Constant95 & Constant96 --> Object97
-    Connection28{{"Connection[28∈1] ➊<br />ᐸ24ᐳ"}}:::plan
-    PgValidateParsedCursor34["PgValidateParsedCursor[34∈1] ➊"]:::plan
-    Constant105 & Lambda29 & PgValidateParsedCursor34 --> Connection28
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant113 --> Connection14
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
+    Constant115 --> Lambda29
     Lambda29 --> PgValidateParsedCursor34
-    Access35{{"Access[35∈1] ➊<br />ᐸ29.1ᐳ"}}:::plan
+    Access35{{"Access[35∈0] ➊<br />ᐸ29.1ᐳ"}}:::plan
     Lambda29 --> Access35
-    ToPg36{{"ToPg[36∈1] ➊"}}:::plan
+    ToPg36{{"ToPg[36∈0] ➊"}}:::plan
     Access35 --> ToPg36
-    Access37{{"Access[37∈1] ➊<br />ᐸ29.2ᐳ"}}:::plan
+    Access37{{"Access[37∈0] ➊<br />ᐸ29.2ᐳ"}}:::plan
     Lambda29 --> Access37
-    Constant113 --> Lambda91
-    Constant114 --> Lambda93
-    Object97 --> Lambda98
-    Constant112 --> Lambda103
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant118 --> Lambda65
+    Access66{{"Access[66∈0] ➊<br />ᐸ65.0ᐳ"}}:::plan
+    Lambda65 --> Access66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant119 --> Lambda76
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object85 --> Lambda86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant120 --> Lambda91
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant122 --> Lambda93
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant123 --> Lambda95
+    Access96{{"Access[96∈0] ➊<br />ᐸ95.0ᐳ"}}:::plan
+    Lambda95 --> Access96
+    Access97{{"Access[97∈0] ➊<br />ᐸ95.1ᐳ"}}:::plan
+    Lambda95 --> Access97
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant124 --> Lambda99
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant125 --> Lambda101
+    Access102{{"Access[102∈0] ➊<br />ᐸ101.0ᐳ"}}:::plan
+    Lambda101 --> Access102
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object106 --> Lambda107
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant121 --> Lambda112
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ'AWfulS'ᐳ"}}:::plan
+    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
+    Object13 & Connection14 & Constant113 & Lambda99 & Access102 & Lambda107 & Lambda112 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgUnionAll30[["PgUnionAll[30∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Constant107 & Connection28 & Lambda29 & ToPg36 & Access37 --> PgUnionAll30
+    Object13 & PgClassExpression18 & Constant116 & Connection28 & Lambda29 & Constant114 & ToPg36 & Access37 & Lambda93 & Access96 & Access97 --> PgUnionAll30
     PgSelectSingle17 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
@@ -103,10 +117,10 @@ graph TD
     PgUnionAllSingle32 --> Access39
     PgSelect44[["PgSelect[44∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access43{{"Access[43∈6]<br />ᐸ42.0ᐳ"}}:::plan
-    Object13 & Access43 & Lambda62 & Lambda65 & Lambda70 & Lambda75 --> PgSelect44
+    Object13 & Access43 & Lambda62 & Access66 & Lambda71 & Lambda76 --> PgSelect44
     PgSelect54[["PgSelect[54∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access53{{"Access[53∈6]<br />ᐸ52.0ᐳ"}}:::plan
-    Object13 & Access53 & Lambda62 & Lambda65 & Lambda84 & Lambda89 --> PgSelect54
+    Object13 & Access53 & Lambda62 & Access66 & Lambda86 & Lambda91 --> PgSelect54
     JSONParse42[["JSONParse[42∈6]<br />ᐸ39ᐳ<br />ᐳAwsApplication"]]:::plan
     Access39 --> JSONParse42
     JSONParse42 --> Access43
@@ -133,25 +147,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-condition"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 67, 68, 69, 82, 83, 84, 103, 104, 105, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 13, 14, 29, 35, 36, 37, 62, 65, 66, 70, 71, 76, 85, 86, 91, 93, 95, 96, 97, 99, 101, 102, 106, 107, 112<br />2: PgValidateParsedCursor[34]<br />ᐳ: Connection[28]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda29,Lambda62,Lambda65,Constant66,Constant67,Constant68,Object69,Lambda70,Lambda75,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant94,Constant95,Constant96,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 104, 105, 29, 113, 114, 94, 95, 96, 112, 107, 62, 65, 70, 75, 84, 89<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: PgValidateParsedCursor[34]<br />ᐳ: 35, 37, 91, 93, 103, 28, 36, 97, 98<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection28,Lambda29,PgValidateParsedCursor34,Access35,ToPg36,Access37,Lambda62,Lambda65,Access66,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant82,Constant83,Constant84,Object85,Lambda86,Lambda91,Lambda93,Lambda95,Access96,Access97,Lambda99,Lambda101,Access102,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 113, 99, 102, 107, 112, 116, 28, 29, 114, 36, 37, 93, 96, 97, 62, 66, 71, 76, 86, 91<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Connection28,PgValidateParsedCursor34,Access35,ToPg36,Access37,Lambda91,Lambda93,Object97,Lambda98,Lambda103 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 107, 28, 29, 36, 37, 62, 65, 70, 75, 84, 89<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 116, 28, 29, 114, 36, 37, 93, 96, 97, 62, 66, 71, 76, 86, 91<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 107, 28, 29, 36, 37, 62, 65, 70, 75, 84, 89<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[30]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 116, 28, 29, 114, 36, 37, 93, 96, 97, 62, 66, 71, 76, 86, 91<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[30]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgUnionAll30 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 62, 65, 70, 75, 84, 89<br /><br />ROOT __Item{4}ᐸ30ᐳ[31]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 62, 66, 71, 76, 86, 91<br /><br />ROOT __Item{4}ᐸ30ᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item31,PgUnionAllSingle32 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32, 13, 62, 65, 70, 75, 84, 89<br /><br />ROOT PgUnionAllSingle{4}[32]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32, 13, 62, 66, 71, 76, 86, 91<br /><br />ROOT PgUnionAllSingle{4}[32]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgCursor33,Access38,Access39,List40 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 39, 13, 62, 65, 70, 75, 84, 89, 32<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[42], JSONParse[52]<br />ᐳ: Access[43], Access[53]<br />2: PgSelect[44], PgSelect[54]<br />ᐳ: 48, 49, 50, 51, 56, 57, 58, 59"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 39, 13, 62, 66, 71, 76, 86, 91, 32<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[42], JSONParse[52]<br />ᐳ: Access[43], Access[53]<br />2: PgSelect[44], PgSelect[54]<br />ᐳ: 48, 49, 50, 51, 56, 57, 58, 59"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,JSONParse42,Access43,PgSelect44,First48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,JSONParse52,Access53,PgSelect54,First56,PgSelectSingle57,PgClassExpression58,PgClassExpression59 bucket6
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.mermaid
@@ -9,17 +9,23 @@ graph TD
 
 
     %% plan dependencies
-    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda60 & Constant64 & Constant65 & Constant66 --> Object67
-    Object81{{"Object[81∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda60 & Constant78 & Constant79 & Constant80 --> Object81
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda60 & Constant65 & Constant66 & Constant67 --> Object68
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda60 & Constant80 & Constant81 & Constant82 --> Object83
+    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda97 & Constant101 & Constant102 & Constant103 --> Object104
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -28,50 +34,50 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant102 --> Connection14
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant103 --> Lambda60
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant111 --> Connection14
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant112 --> Lambda60
     Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant104 --> Lambda63
-    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object67 --> Lambda68
-    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant105 --> Lambda73
-    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object81 --> Lambda82
-    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant106 --> Lambda87
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda63
+    Access64{{"Access[64∈0] ➊<br />ᐸ63.0ᐳ"}}:::plan
+    Lambda63 --> Access64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant114 --> Lambda74
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object83 --> Lambda84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant115 --> Lambda89
+    Access95{{"Access[95∈0] ➊<br />ᐸ63.1ᐳ"}}:::plan
+    Lambda63 --> Access95
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant117 --> Lambda97
+    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant118 --> Lambda99
+    Access100{{"Access[100∈0] ➊<br />ᐸ99.0ᐳ"}}:::plan
+    Lambda99 --> Access100
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object104 --> Lambda105
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant116 --> Lambda110
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Connection27{{"Connection[27∈0] ➊<br />ᐸ23ᐳ"}}:::plan
     PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda101{{"Lambda[101∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant102 & Lambda89 & Lambda91 & Lambda96 & Lambda101 --> PgSelect15
-    Object95{{"Object[95∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda89 & Constant92 & Constant93 & Constant94 --> Object95
-    Constant108 --> Lambda89
-    Constant109 --> Lambda91
-    Object95 --> Lambda96
-    Constant107 --> Lambda101
-    Connection27{{"Connection[27∈1] ➊<br />ᐸ23ᐳ"}}:::plan
+    Object13 & Connection14 & Constant111 & Lambda97 & Access100 & Lambda105 & Lambda110 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgUnionAll28[["PgUnionAll[28∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Connection27 --> PgUnionAll28
+    Object13 & PgClassExpression18 & Connection27 & Lambda60 & Access64 & Access95 --> PgUnionAll28
     PgSelectSingle17 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
@@ -93,10 +99,10 @@ graph TD
     PgUnionAllSingle30 --> Access35
     PgSelect40[["PgSelect[40∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access39{{"Access[39∈6]<br />ᐸ38.0ᐳ"}}:::plan
-    Object13 & Access39 & Lambda60 & Lambda63 & Lambda68 & Lambda73 --> PgSelect40
+    Object13 & Access39 & Lambda60 & Access64 & Lambda69 & Lambda74 --> PgSelect40
     PgSelect51[["PgSelect[51∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access50{{"Access[50∈6]<br />ᐸ49.0ᐳ"}}:::plan
-    Object13 & Access50 & Lambda60 & Lambda63 & Lambda82 & Lambda87 --> PgSelect51
+    Object13 & Access50 & Lambda60 & Access64 & Lambda84 & Lambda89 --> PgSelect51
     JSONParse38[["JSONParse[38∈6]<br />ᐸ35ᐳ<br />ᐳAwsApplication"]]:::plan
     Access35 --> JSONParse38
     JSONParse38 --> Access39
@@ -129,23 +135,23 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-order"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda60,Lambda63,Constant64,Constant65,Constant66,Object67,Lambda68,Lambda73,Constant78,Constant79,Constant80,Object81,Lambda82,Lambda87,Constant92,Constant93,Constant94,Constant102,Constant103,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 102, 108, 109, 92, 93, 94, 107, 60, 63, 68, 73, 82, 87<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 27, 89, 91, 101, 95, 96<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection27,Lambda60,Lambda63,Access64,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Access95,Lambda97,Lambda99,Access100,Constant101,Constant102,Constant103,Object104,Lambda105,Lambda110,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 111, 97, 100, 105, 110, 27, 60, 64, 95, 69, 74, 84, 89<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Connection27,Lambda89,Lambda91,Object95,Lambda96,Lambda101 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 27, 60, 63, 68, 73, 82, 87<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 27, 60, 64, 95, 69, 74, 84, 89<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 27, 60, 63, 68, 73, 82, 87<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 27, 60, 64, 95, 69, 74, 84, 89<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgUnionAll28 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 60, 63, 68, 73, 82, 87<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 60, 64, 69, 74, 84, 89<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item29,PgUnionAllSingle30 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 13, 60, 63, 68, 73, 82, 87<br /><br />ROOT PgUnionAllSingle{4}[30]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 13, 60, 64, 69, 74, 84, 89<br /><br />ROOT PgUnionAllSingle{4}[30]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgCursor31,Access32,Access33,Access34,Access35,List36 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 35, 13, 60, 63, 68, 73, 82, 87, 30<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[38], JSONParse[49]<br />ᐳ: Access[39], Access[50]<br />2: PgSelect[40], PgSelect[51]<br />ᐳ: 44, 45, 46, 47, 48, 53, 54, 55, 56, 57"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 35, 13, 60, 64, 69, 74, 84, 89, 30<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[38], JSONParse[49]<br />ᐳ: Access[39], Access[50]<br />2: PgSelect[40], PgSelect[51]<br />ᐳ: 44, 45, 46, 47, 48, 53, 54, 55, 56, 57"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,JSONParse38,Access39,PgSelect40,First44,PgSelectSingle45,PgClassExpression46,PgClassExpression47,PgClassExpression48,JSONParse49,Access50,PgSelect51,First53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket6
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.mermaid
@@ -9,35 +9,46 @@ graph TD
 
 
     %% plan dependencies
-    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda114 & Constant118 & Constant119 & Constant120 --> Object121
-    Object135{{"Object[135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda114 & Constant132 & Constant133 & Constant134 --> Object135
-    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda114 & Constant146 & Constant147 & Constant148 --> Object149
-    Object163{{"Object[163∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda114 & Constant160 & Constant161 & Constant120 --> Object163
-    Object177{{"Object[177∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda114 & Constant174 & Constant175 & Constant134 --> Object177
-    Object191{{"Object[191∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda114 & Constant188 & Constant189 & Constant190 --> Object191
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda114 & Constant119 & Constant120 & Constant121 --> Object122
+    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda114 & Constant134 & Constant135 & Constant136 --> Object137
+    Object158{{"Object[158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant155{{"Constant[155∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda114 & Constant155 & Constant156 & Constant157 --> Object158
+    Object173{{"Object[173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda114 & Constant170 & Constant171 & Constant121 --> Object173
+    Object188{{"Object[188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda114 & Constant185 & Constant186 & Constant136 --> Object188
+    Object209{{"Object[209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda114 & Constant206 & Constant207 & Constant208 --> Object209
+    Object230{{"Object[230∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda223{{"Lambda[223∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda223 & Constant227 & Constant228 & Constant229 --> Object230
+    Connection26{{"Connection[26∈0] ➊<br />ᐸ22ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
+    PgValidateParsedCursor32["PgValidateParsedCursor[32∈0] ➊"]:::plan
+    Constant238 & Lambda27 & PgValidateParsedCursor32 --> Connection26
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -46,83 +57,86 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant212 --> Connection14
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
-    Constant214 --> Lambda27
-    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant215 --> Lambda114
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant216 --> Lambda117
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object121 --> Lambda122
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant217 --> Lambda127
-    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object135 --> Lambda136
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant218 --> Lambda141
-    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object149 --> Lambda150
-    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant219 --> Lambda155
-    Lambda164{{"Lambda[164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object163 --> Lambda164
-    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant220 --> Lambda169
-    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object177 --> Lambda178
-    Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant221 --> Lambda183
-    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object191 --> Lambda192
-    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant222 --> Lambda197
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant202{{"Constant[202∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant203{{"Constant[203∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Lambda199{{"Lambda[199∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda201{{"Lambda[201∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda206{{"Lambda[206∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda211{{"Lambda[211∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant212 & Lambda199 & Lambda201 & Lambda206 & Lambda211 --> PgSelect15
-    Object205{{"Object[205∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda199 & Constant202 & Constant203 & Constant204 --> Object205
-    Connection26{{"Connection[26∈1] ➊<br />ᐸ22ᐳ"}}:::plan
-    PgValidateParsedCursor32["PgValidateParsedCursor[32∈1] ➊"]:::plan
-    Constant213 & Lambda27 & PgValidateParsedCursor32 --> Connection26
+    Constant237{{"Constant[237∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant237 --> Connection14
+    Constant239{{"Constant[239∈0] ➊<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
+    Constant239 --> Lambda27
     Lambda27 --> PgValidateParsedCursor32
-    Access33{{"Access[33∈1] ➊<br />ᐸ27.1ᐳ"}}:::plan
+    Access33{{"Access[33∈0] ➊<br />ᐸ27.1ᐳ"}}:::plan
     Lambda27 --> Access33
-    ToPg34{{"ToPg[34∈1] ➊"}}:::plan
+    ToPg34{{"ToPg[34∈0] ➊"}}:::plan
     Access33 --> ToPg34
-    Access35{{"Access[35∈1] ➊<br />ᐸ27.2ᐳ"}}:::plan
+    Access35{{"Access[35∈0] ➊<br />ᐸ27.2ᐳ"}}:::plan
     Lambda27 --> Access35
-    Constant224 --> Lambda199
-    Constant225 --> Lambda201
-    Object205 --> Lambda206
-    Constant223 --> Lambda211
+    Constant240{{"Constant[240∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant240 --> Lambda114
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant241{{"Constant[241∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant241 --> Lambda117
+    Access118{{"Access[118∈0] ➊<br />ᐸ117.0ᐳ"}}:::plan
+    Lambda117 --> Access118
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant242 --> Lambda128
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object137 --> Lambda138
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant243 --> Lambda143
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant249{{"Constant[249∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant249 --> Lambda145
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant250{{"Constant[250∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant250 --> Lambda147
+    Access148{{"Access[148∈0] ➊<br />ᐸ147.0ᐳ"}}:::plan
+    Lambda147 --> Access148
+    Access149{{"Access[149∈0] ➊<br />ᐸ147.1ᐳ"}}:::plan
+    Lambda147 --> Access149
+    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object158 --> Lambda159
+    Lambda164{{"Lambda[164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant244 --> Lambda164
+    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object173 --> Lambda174
+    Lambda179{{"Lambda[179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant245{{"Constant[245∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant245 --> Lambda179
+    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object188 --> Lambda189
+    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant246 --> Lambda194
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object209 --> Lambda210
+    Lambda215{{"Lambda[215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant247{{"Constant[247∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant247 --> Lambda215
+    Constant251{{"Constant[251∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant251 --> Lambda223
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant252{{"Constant[252∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant252 --> Lambda225
+    Access226{{"Access[226∈0] ➊<br />ᐸ225.0ᐳ"}}:::plan
+    Lambda225 --> Access226
+    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object230 --> Lambda231
+    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant248{{"Constant[248∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant248 --> Lambda236
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
+    Object13 & Connection14 & Constant237 & Lambda223 & Access226 & Lambda231 & Lambda236 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgUnionAll28[["PgUnionAll[28∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Connection26 & Lambda27 & ToPg34 & Access35 --> PgUnionAll28
+    Object13 & PgClassExpression18 & Connection26 & Lambda27 & Constant238 & ToPg34 & Access35 & Lambda145 & Access148 & Access149 --> PgUnionAll28
     PgSelectSingle17 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
@@ -138,20 +152,20 @@ graph TD
     List38 --> PgCursor31
     PgUnionAllSingle30 --> Access36
     PgUnionAllSingle30 --> Access37
-    PgSelect42[["PgSelect[42∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access41{{"Access[41∈6]<br />ᐸ40.0ᐳ"}}:::plan
-    Object13 & Access41 & Lambda114 & Lambda117 & Lambda150 & Lambda155 --> PgSelect42
-    PgSelect79[["PgSelect[79∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access78{{"Access[78∈6]<br />ᐸ77.0ᐳ"}}:::plan
-    Object13 & Access78 & Lambda114 & Lambda117 & Lambda192 & Lambda197 --> PgSelect79
     PgUnionAll53[["PgUnionAll[53∈6]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression48{{"PgClassExpression[48∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection52{{"Connection[52∈6] ➊<br />ᐸ50ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object13 & PgClassExpression48 & Connection52 --> PgUnionAll53
+    Object13 & PgClassExpression48 & Connection52 & Constant238 & Lambda145 & Access148 & Access149 --> PgUnionAll53
     PgUnionAll88[["PgUnionAll[88∈6]<br />ᐳGcpApplication"]]:::plan
     PgClassExpression83{{"PgClassExpression[83∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Connection87{{"Connection[87∈6] ➊<br />ᐸ85ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object13 & PgClassExpression83 & Connection87 --> PgUnionAll88
+    Object13 & PgClassExpression83 & Connection87 & Constant238 & Lambda145 & Access148 & Access149 --> PgUnionAll88
+    PgSelect42[["PgSelect[42∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access41{{"Access[41∈6]<br />ᐸ40.0ᐳ"}}:::plan
+    Object13 & Access41 & Lambda114 & Access118 & Lambda159 & Lambda164 --> PgSelect42
+    PgSelect79[["PgSelect[79∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access78{{"Access[78∈6]<br />ᐸ77.0ᐳ"}}:::plan
+    Object13 & Access78 & Lambda114 & Access118 & Lambda210 & Lambda215 --> PgSelect79
     JSONParse40[["JSONParse[40∈6]<br />ᐸ37ᐳ<br />ᐳAwsApplication"]]:::plan
     Access37 --> JSONParse40
     JSONParse40 --> Access41
@@ -160,7 +174,7 @@ graph TD
     PgSelectSingle47{{"PgSelectSingle[47∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
     First46 --> PgSelectSingle47
     PgSelectSingle47 --> PgClassExpression48
-    Constant213 --> Connection52
+    Constant238 --> Connection52
     JSONParse77[["JSONParse[77∈6]<br />ᐸ37ᐳ<br />ᐳGcpApplication"]]:::plan
     Access37 --> JSONParse77
     JSONParse77 --> Access78
@@ -169,7 +183,7 @@ graph TD
     PgSelectSingle82{{"PgSelectSingle[82∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
     First81 --> PgSelectSingle82
     PgSelectSingle82 --> PgClassExpression83
-    Constant213 --> Connection87
+    Constant238 --> Connection87
     __Item54[/"__Item[54∈7]<br />ᐸ53ᐳ"\]:::itemplan
     PgUnionAll53 ==> __Item54
     PgUnionAllSingle55["PgUnionAllSingle[55∈7]"]:::plan
@@ -184,10 +198,10 @@ graph TD
     PgUnionAllSingle55 --> Access58
     PgSelect63[["PgSelect[63∈9]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access62{{"Access[62∈9]<br />ᐸ61.0ᐳ"}}:::plan
-    Object13 & Access62 & Lambda114 & Lambda117 & Lambda122 & Lambda127 --> PgSelect63
+    Object13 & Access62 & Lambda114 & Access118 & Lambda123 & Lambda128 --> PgSelect63
     PgSelect72[["PgSelect[72∈9]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access71{{"Access[71∈9]<br />ᐸ70.0ᐳ"}}:::plan
-    Object13 & Access71 & Lambda114 & Lambda117 & Lambda136 & Lambda141 --> PgSelect72
+    Object13 & Access71 & Lambda114 & Access118 & Lambda138 & Lambda143 --> PgSelect72
     JSONParse61[["JSONParse[61∈9]<br />ᐸ58ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access58 --> JSONParse61
     JSONParse61 --> Access62
@@ -220,10 +234,10 @@ graph TD
     PgUnionAllSingle90 --> Access93
     PgSelect98[["PgSelect[98∈12]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access97{{"Access[97∈12]<br />ᐸ96.0ᐳ"}}:::plan
-    Object13 & Access97 & Lambda114 & Lambda117 & Lambda164 & Lambda169 --> PgSelect98
+    Object13 & Access97 & Lambda114 & Access118 & Lambda174 & Lambda179 --> PgSelect98
     PgSelect107[["PgSelect[107∈12]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access106{{"Access[106∈12]<br />ᐸ105.0ᐳ"}}:::plan
-    Object13 & Access106 & Lambda114 & Lambda117 & Lambda178 & Lambda183 --> PgSelect107
+    Object13 & Access106 & Lambda114 & Access118 & Lambda189 & Lambda194 --> PgSelect107
     JSONParse96[["JSONParse[96∈12]<br />ᐸ93ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access93 --> JSONParse96
     JSONParse96 --> Access97
@@ -246,43 +260,43 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-page-2"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 119, 120, 121, 134, 135, 136, 155, 156, 157, 170, 171, 185, 186, 206, 207, 208, 227, 228, 229, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 13, 14, 27, 33, 34, 35, 114, 117, 118, 122, 123, 128, 137, 138, 143, 145, 147, 148, 149, 158, 159, 164, 173, 174, 179, 188, 189, 194, 209, 210, 215, 223, 225, 226, 230, 231, 236<br />2: PgValidateParsedCursor[32]<br />ᐳ: Connection[26]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda27,Lambda114,Lambda117,Constant118,Constant119,Constant120,Object121,Lambda122,Lambda127,Constant132,Constant133,Constant134,Object135,Lambda136,Lambda141,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant160,Constant161,Object163,Lambda164,Lambda169,Constant174,Constant175,Object177,Lambda178,Lambda183,Constant188,Constant189,Constant190,Object191,Lambda192,Lambda197,Constant202,Constant203,Constant204,Constant212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222,Constant223,Constant224,Constant225 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 212, 213, 27, 224, 225, 202, 203, 204, 223, 114, 117, 150, 155, 192, 197, 122, 127, 136, 141, 164, 169, 178, 183<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: PgValidateParsedCursor[32]<br />ᐳ: 33, 35, 199, 201, 211, 26, 34, 205, 206<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection26,Lambda27,PgValidateParsedCursor32,Access33,ToPg34,Access35,Lambda114,Lambda117,Access118,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Lambda145,Lambda147,Access148,Access149,Constant155,Constant156,Constant157,Object158,Lambda159,Lambda164,Constant170,Constant171,Object173,Lambda174,Lambda179,Constant185,Constant186,Object188,Lambda189,Lambda194,Constant206,Constant207,Constant208,Object209,Lambda210,Lambda215,Lambda223,Lambda225,Access226,Constant227,Constant228,Constant229,Object230,Lambda231,Lambda236,Constant237,Constant238,Constant239,Constant240,Constant241,Constant242,Constant243,Constant244,Constant245,Constant246,Constant247,Constant248,Constant249,Constant250,Constant251,Constant252 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 237, 223, 226, 231, 236, 26, 27, 238, 34, 35, 145, 148, 149, 114, 118, 159, 164, 210, 215, 123, 128, 138, 143, 174, 179, 189, 194<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Connection26,PgValidateParsedCursor32,Access33,ToPg34,Access35,Lambda199,Lambda201,Object205,Lambda206,Lambda211 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 26, 27, 34, 35, 114, 117, 150, 155, 213, 192, 197, 122, 127, 136, 141, 164, 169, 178, 183<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 26, 27, 238, 34, 35, 145, 148, 149, 114, 118, 159, 164, 210, 215, 123, 128, 138, 143, 174, 179, 189, 194<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 26, 27, 34, 35, 114, 117, 150, 155, 213, 192, 197, 122, 127, 136, 141, 164, 169, 178, 183<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 26, 27, 238, 34, 35, 145, 148, 149, 114, 118, 159, 164, 210, 215, 123, 128, 138, 143, 174, 179, 189, 194<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgUnionAll28 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 114, 117, 150, 155, 213, 192, 197, 122, 127, 136, 141, 164, 169, 178, 183<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 114, 118, 159, 164, 238, 145, 148, 149, 210, 215, 123, 128, 138, 143, 174, 179, 189, 194<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item29,PgUnionAllSingle30 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 13, 114, 117, 150, 155, 213, 192, 197, 122, 127, 136, 141, 164, 169, 178, 183<br /><br />ROOT PgUnionAllSingle{4}[30]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30, 13, 114, 118, 159, 164, 238, 145, 148, 149, 210, 215, 123, 128, 138, 143, 174, 179, 189, 194<br /><br />ROOT PgUnionAllSingle{4}[30]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgCursor31,Access36,Access37,List38 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 37, 13, 114, 117, 150, 155, 213, 192, 197, 30, 122, 127, 136, 141, 164, 169, 178, 183<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[40], JSONParse[77]<br />ᐳ: 52, 87, 41, 78<br />2: PgSelect[42], PgSelect[79]<br />ᐳ: 46, 47, 48, 81, 82, 83<br />3: PgUnionAll[53], PgUnionAll[88]"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 37, 13, 114, 118, 159, 164, 238, 145, 148, 149, 210, 215, 30, 123, 128, 138, 143, 174, 179, 189, 194<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[40], JSONParse[77]<br />ᐳ: 52, 87, 41, 78<br />2: PgSelect[42], PgSelect[79]<br />ᐳ: 46, 47, 48, 81, 82, 83<br />3: PgUnionAll[53], PgUnionAll[88]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,JSONParse40,Access41,PgSelect42,First46,PgSelectSingle47,PgClassExpression48,Connection52,PgUnionAll53,JSONParse77,Access78,PgSelect79,First81,PgSelectSingle82,PgClassExpression83,Connection87,PgUnionAll88 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 13, 114, 117, 122, 127, 136, 141<br /><br />ROOT __Item{7}ᐸ53ᐳ[54]"):::bucket
+    Bucket7("Bucket 7 (listItem)<br />Deps: 13, 114, 118, 123, 128, 138, 143<br /><br />ROOT __Item{7}ᐸ53ᐳ[54]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item54,PgUnionAllSingle55 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 55, 13, 114, 117, 122, 127, 136, 141<br /><br />ROOT PgUnionAllSingle{7}[55]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 55, 13, 114, 118, 123, 128, 138, 143<br /><br />ROOT PgUnionAllSingle{7}[55]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgCursor56,Access57,Access58,List59 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 58, 13, 114, 117, 122, 127, 136, 141, 55<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[61], JSONParse[70]<br />ᐳ: Access[62], Access[71]<br />2: PgSelect[63], PgSelect[72]<br />ᐳ: 67, 68, 69, 74, 75, 76"):::bucket
+    Bucket9("Bucket 9 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 58, 13, 114, 118, 123, 128, 138, 143, 55<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[61], JSONParse[70]<br />ᐳ: Access[62], Access[71]<br />2: PgSelect[63], PgSelect[72]<br />ᐳ: 67, 68, 69, 74, 75, 76"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,JSONParse61,Access62,PgSelect63,First67,PgSelectSingle68,PgClassExpression69,JSONParse70,Access71,PgSelect72,First74,PgSelectSingle75,PgClassExpression76 bucket9
-    Bucket10("Bucket 10 (listItem)<br />Deps: 13, 114, 117, 164, 169, 178, 183<br /><br />ROOT __Item{10}ᐸ88ᐳ[89]"):::bucket
+    Bucket10("Bucket 10 (listItem)<br />Deps: 13, 114, 118, 174, 179, 189, 194<br /><br />ROOT __Item{10}ᐸ88ᐳ[89]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item89,PgUnionAllSingle90 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 90, 13, 114, 117, 164, 169, 178, 183<br /><br />ROOT PgUnionAllSingle{10}[90]"):::bucket
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 90, 13, 114, 118, 174, 179, 189, 194<br /><br />ROOT PgUnionAllSingle{10}[90]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgCursor91,Access92,Access93,List94 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 93, 13, 114, 117, 164, 169, 178, 183, 90<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[96], JSONParse[105]<br />ᐳ: Access[97], Access[106]<br />2: PgSelect[98], PgSelect[107]<br />ᐳ: 102, 103, 104, 109, 110, 111"):::bucket
+    Bucket12("Bucket 12 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 93, 13, 114, 118, 174, 179, 189, 194, 90<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[96], JSONParse[105]<br />ᐳ: Access[97], Access[106]<br />2: PgSelect[98], PgSelect[107]<br />ᐳ: 102, 103, 104, 109, 110, 111"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,JSONParse96,Access97,PgSelect98,First102,PgSelectSingle103,PgClassExpression104,JSONParse105,Access106,PgSelect107,First109,PgSelectSingle110,PgClassExpression111 bucket12
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-totalCount.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-totalCount.mermaid
@@ -9,6 +9,12 @@ graph TD
 
 
     %% plan dependencies
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -17,35 +23,41 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant45 --> Connection14
+    Constant52{{"Constant[52∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant52 --> Connection14
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant53 --> Lambda31
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant54 --> Lambda34
+    Access35{{"Access[35∈0] ➊<br />ᐸ34.0ᐳ"}}:::plan
+    Lambda34 --> Access35
+    Access36{{"Access[36∈0] ➊<br />ᐸ34.1ᐳ"}}:::plan
+    Lambda34 --> Access36
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant56 --> Lambda38
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant57 --> Lambda40
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant55 --> Lambda51
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Connection24{{"Connection[24∈0] ➊<br />ᐸ20ᐳ"}}:::plan
     PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Lambda31{{"Lambda[31∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda34{{"Lambda[34∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant45 & Lambda31 & Lambda34 & Lambda39 & Lambda44 --> PgSelect15
-    Object38{{"Object[38∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda31 & Constant35 & Constant36 & Constant37 --> Object38
-    Constant47 --> Lambda31
-    Constant48 --> Lambda34
-    Object38 --> Lambda39
-    Constant46 --> Lambda44
-    Connection24{{"Connection[24∈1] ➊<br />ᐸ20ᐳ"}}:::plan
+    Object13 & Connection14 & Constant52 & Lambda38 & Access41 & Lambda46 & Lambda51 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgUnionAll25[["PgUnionAll[25∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Connection24 --> PgUnionAll25
+    Object13 & PgClassExpression18 & Connection24 & Lambda31 & Access35 & Access36 --> PgUnionAll25
     PgSelectSingle17 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
@@ -61,14 +73,14 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-totalCount"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Constant35,Constant36,Constant37,Constant45,Constant46,Constant47,Constant48 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 45, 47, 48, 35, 36, 37, 46<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 24, 31, 34, 44, 38, 39<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection24,Lambda31,Lambda34,Access35,Access36,Lambda38,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Constant52,Constant53,Constant54,Constant55,Constant56,Constant57 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 52, 38, 41, 46, 51, 24, 31, 35, 36<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Connection24,Lambda31,Lambda34,Object38,Lambda39,Lambda44 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 24<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 24, 31, 35, 36<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 24<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[25]<br />ᐳ: First[26]<br />3: PgUnionAllSingle[27]<br />ᐳ: PgClassExpression[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 24, 31, 35, 36<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[25]<br />ᐳ: First[26]<br />3: PgUnionAllSingle[27]<br />ᐳ: PgClassExpression[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgUnionAll25,First26,PgUnionAllSingle27,PgClassExpression28 bucket3
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.mermaid
@@ -9,17 +9,23 @@ graph TD
 
 
     %% plan dependencies
-    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda61 & Constant65 & Constant66 & Constant67 --> Object68
-    Object82{{"Object[82∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda61 & Constant79 & Constant80 & Constant81 --> Object82
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda61 & Constant72 & Constant73 & Constant74 --> Object75
+    Object96{{"Object[96∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda61 & Constant93 & Constant94 & Constant95 --> Object96
+    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda110 & Constant114 & Constant115 & Constant116 --> Object117
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -28,50 +34,50 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant103 --> Connection14
-    Constant104{{"Constant[104∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant104 --> Lambda61
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant124 --> Connection14
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant125 --> Lambda61
     Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant105 --> Lambda64
-    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object68 --> Lambda69
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant106 --> Lambda74
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object82 --> Lambda83
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant107 --> Lambda88
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda92{{"Lambda[92∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda97{{"Lambda[97∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda102{{"Lambda[102∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant103 & Lambda90 & Lambda92 & Lambda97 & Lambda102 --> PgSelect15
-    Object96{{"Object[96∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda90 & Constant93 & Constant94 & Constant95 --> Object96
-    Constant109 --> Lambda90
-    Constant110 --> Lambda92
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant126 --> Lambda64
+    Access65{{"Access[65∈0] ➊<br />ᐸ64.0ᐳ"}}:::plan
+    Lambda64 --> Access65
+    Access66{{"Access[66∈0] ➊<br />ᐸ64.1ᐳ"}}:::plan
+    Lambda64 --> Access66
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object75 --> Lambda76
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant127 --> Lambda81
+    Lambda97{{"Lambda[97∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object96 --> Lambda97
-    Constant108 --> Lambda102
-    Connection24{{"Connection[24∈1] ➊<br />ᐸ20ᐳ"}}:::plan
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant128 --> Lambda102
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant130 --> Lambda110
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant131 --> Lambda112
+    Access113{{"Access[113∈0] ➊<br />ᐸ112.0ᐳ"}}:::plan
+    Lambda112 --> Access113
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object117 --> Lambda118
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant129 --> Lambda123
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection24{{"Connection[24∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
+    Object13 & Connection14 & Constant124 & Lambda110 & Access113 & Lambda118 & Lambda123 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgUnionAll25[["PgUnionAll[25∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Connection24 --> PgUnionAll25
+    Object13 & PgClassExpression18 & Connection24 & Lambda61 & Access65 & Access66 --> PgUnionAll25
     PgSelectSingle17 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
@@ -81,18 +87,18 @@ graph TD
     __Item26 --> PgUnionAllSingle27
     PgSelect31[["PgSelect[31∈5]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access30{{"Access[30∈5]<br />ᐸ29.0ᐳ"}}:::plan
-    Object13 & Access30 & Lambda61 & Lambda64 & Lambda69 & Lambda74 --> PgSelect31
-    PgSelect47[["PgSelect[47∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access46{{"Access[46∈5]<br />ᐸ45.0ᐳ"}}:::plan
-    Object13 & Access46 & Lambda61 & Lambda64 & Lambda83 & Lambda88 --> PgSelect47
+    Object13 & Access30 & Lambda61 & Access65 & Lambda76 & Lambda81 --> PgSelect31
     PgUnionAll41[["PgUnionAll[41∈5]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection40{{"Connection[40∈5] ➊<br />ᐸ38ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object13 & PgClassExpression37 & Connection40 --> PgUnionAll41
+    Object13 & PgClassExpression37 & Connection40 & Lambda61 & Access65 & Access66 --> PgUnionAll41
+    PgSelect47[["PgSelect[47∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access46{{"Access[46∈5]<br />ᐸ45.0ᐳ"}}:::plan
+    Object13 & Access46 & Lambda61 & Access65 & Lambda97 & Lambda102 --> PgSelect47
     PgUnionAll55[["PgUnionAll[55∈5]<br />ᐳGcpApplication"]]:::plan
     PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Connection54{{"Connection[54∈5] ➊<br />ᐸ52ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object13 & PgClassExpression51 & Connection54 --> PgUnionAll55
+    Object13 & PgClassExpression51 & Connection54 & Lambda61 & Access65 & Access66 --> PgUnionAll55
     Access28{{"Access[28∈5]<br />ᐸ27.1ᐳ<br />ᐳAwsApplication"}}:::plan
     PgUnionAllSingle27 --> Access28
     JSONParse29[["JSONParse[29∈5]<br />ᐸ28ᐳ"]]:::plan
@@ -129,20 +135,20 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-vuln-totalCount"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda61,Lambda64,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant79,Constant80,Constant81,Object82,Lambda83,Lambda88,Constant93,Constant94,Constant95,Constant103,Constant104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 103, 109, 110, 93, 94, 95, 108, 61, 64, 69, 74, 83, 88<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 24, 90, 92, 102, 96, 97<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection24,Lambda61,Lambda64,Access65,Access66,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant93,Constant94,Constant95,Object96,Lambda97,Lambda102,Lambda110,Lambda112,Access113,Constant114,Constant115,Constant116,Object117,Lambda118,Lambda123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 124, 110, 113, 118, 123, 24, 61, 65, 66, 76, 81, 97, 102<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Connection24,Lambda90,Lambda92,Object96,Lambda97,Lambda102 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 24, 61, 64, 69, 74, 83, 88<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 24, 61, 65, 66, 76, 81, 97, 102<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 24, 61, 64, 69, 74, 83, 88<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[25]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 24, 61, 65, 66, 76, 81, 97, 102<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: PgUnionAll[25]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgUnionAll25 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 61, 64, 69, 74, 83, 88<br /><br />ROOT __Item{4}ᐸ25ᐳ[26]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 61, 65, 76, 81, 66, 97, 102<br /><br />ROOT __Item{4}ᐸ25ᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item26,PgUnionAllSingle27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 27, 13, 61, 64, 69, 74, 83, 88<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 28, 40, 54<br />2: JSONParse[29], JSONParse[45]<br />ᐳ: Access[30], Access[46]<br />3: PgSelect[31], PgSelect[47]<br />ᐳ: 35, 36, 37, 49, 50, 51<br />4: PgUnionAll[41], PgUnionAll[55]<br />ᐳ: First[42], First[56]<br />5: 43, 57<br />ᐳ: 44, 58"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 27, 13, 61, 65, 76, 81, 66, 97, 102<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 28, 40, 54<br />2: JSONParse[29], JSONParse[45]<br />ᐳ: Access[30], Access[46]<br />3: PgSelect[31], PgSelect[47]<br />ᐳ: 35, 36, 37, 49, 50, 51<br />4: PgUnionAll[41], PgUnionAll[55]<br />ᐳ: First[42], First[56]<br />5: 43, 57<br />ᐳ: 44, 58"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,Access28,JSONParse29,Access30,PgSelect31,First35,PgSelectSingle36,PgClassExpression37,Connection40,PgUnionAll41,First42,PgUnionAllSingle43,PgClassExpression44,JSONParse45,Access46,PgSelect47,First49,PgSelectSingle50,PgClassExpression51,Connection54,PgUnionAll55,First56,PgUnionAllSingle57,PgClassExpression58 bucket5
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
@@ -9,77 +9,82 @@ graph TD
 
 
     %% plan dependencies
-    Object260{{"Object[260∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object267{{"Object[267∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda253{{"Lambda[253∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant257{{"Constant[257∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant258{{"Constant[258∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant259{{"Constant[259∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda253 & Constant257 & Constant258 & Constant259 --> Object260
-    Object274{{"Object[274∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda253 & Constant271 & Constant272 & Constant273 --> Object274
-    Object288{{"Object[288∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant285{{"Constant[285∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant286{{"Constant[286∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda253 & Constant285 & Constant286 & Constant287 --> Object288
-    Object302{{"Object[302∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant299{{"Constant[299∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant300{{"Constant[300∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant301{{"Constant[301∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda253 & Constant299 & Constant300 & Constant301 --> Object302
-    Object316{{"Object[316∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant313{{"Constant[313∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant314{{"Constant[314∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda253 & Constant313 & Constant314 & Constant287 --> Object316
-    Object330{{"Object[330∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant327{{"Constant[327∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant328{{"Constant[328∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda253 & Constant327 & Constant328 & Constant301 --> Object330
-    Object344{{"Object[344∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant341{{"Constant[341∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant342{{"Constant[342∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Constant343{{"Constant[343∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
-    Lambda253 & Constant341 & Constant342 & Constant343 --> Object344
-    Object358{{"Object[358∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant355{{"Constant[355∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant356{{"Constant[356∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant357{{"Constant[357∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda253 & Constant355 & Constant356 & Constant357 --> Object358
-    Object372{{"Object[372∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant369{{"Constant[369∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant370{{"Constant[370∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Lambda253 & Constant369 & Constant370 & Constant259 --> Object372
-    Object386{{"Object[386∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda253 & Constant383 & Constant384 & Constant287 --> Object386
-    Object400{{"Object[400∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant397{{"Constant[397∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant398{{"Constant[398∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda253 & Constant397 & Constant398 & Constant301 --> Object400
-    Object414{{"Object[414∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant412{{"Constant[412∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda253 & Constant411 & Constant412 & Constant287 --> Object414
-    Object428{{"Object[428∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda253 & Constant425 & Constant426 & Constant301 --> Object428
-    Object442{{"Object[442∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda253 & Constant439 & Constant440 & Constant343 --> Object442
-    Object456{{"Object[456∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant453{{"Constant[453∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant454{{"Constant[454∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda253 & Constant453 & Constant454 & Constant357 --> Object456
-    Object470{{"Object[470∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Lambda253 & Constant467 & Constant468 & Constant273 --> Object470
+    Constant264{{"Constant[264∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant265{{"Constant[265∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant266{{"Constant[266∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda253 & Constant264 & Constant265 & Constant266 --> Object267
+    Object282{{"Object[282∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant281{{"Constant[281∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda253 & Constant279 & Constant280 & Constant281 --> Object282
+    Object303{{"Object[303∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant300{{"Constant[300∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant301{{"Constant[301∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant302{{"Constant[302∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda253 & Constant300 & Constant301 & Constant302 --> Object303
+    Object318{{"Object[318∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant315{{"Constant[315∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant316{{"Constant[316∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant317{{"Constant[317∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda253 & Constant315 & Constant316 & Constant317 --> Object318
+    Object345{{"Object[345∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant342{{"Constant[342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant343{{"Constant[343∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda253 & Constant342 & Constant343 & Constant302 --> Object345
+    Object360{{"Object[360∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant358{{"Constant[358∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda253 & Constant357 & Constant358 & Constant317 --> Object360
+    Object381{{"Object[381∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant378{{"Constant[378∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant379{{"Constant[379∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Constant380{{"Constant[380∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
+    Lambda253 & Constant378 & Constant379 & Constant380 --> Object381
+    Object396{{"Object[396∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant393{{"Constant[393∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant394{{"Constant[394∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant395{{"Constant[395∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda253 & Constant393 & Constant394 & Constant395 --> Object396
+    Object417{{"Object[417∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant414{{"Constant[414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant415{{"Constant[415∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Lambda253 & Constant414 & Constant415 & Constant266 --> Object417
+    Object432{{"Object[432∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant430{{"Constant[430∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda253 & Constant429 & Constant430 & Constant302 --> Object432
+    Object447{{"Object[447∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant445{{"Constant[445∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda253 & Constant444 & Constant445 & Constant317 --> Object447
+    Object474{{"Object[474∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant471{{"Constant[471∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant472{{"Constant[472∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda253 & Constant471 & Constant472 & Constant302 --> Object474
+    Object489{{"Object[489∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant486{{"Constant[486∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant487{{"Constant[487∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda253 & Constant486 & Constant487 & Constant317 --> Object489
+    Object510{{"Object[510∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant507{{"Constant[507∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant508{{"Constant[508∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda253 & Constant507 & Constant508 & Constant380 --> Object510
+    Object525{{"Object[525∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant522{{"Constant[522∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant523{{"Constant[523∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda253 & Constant522 & Constant523 & Constant395 --> Object525
+    Object546{{"Object[546∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant543{{"Constant[543∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant544{{"Constant[544∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Lambda253 & Constant543 & Constant544 & Constant281 --> Object546
+    Object567{{"Object[567∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda560{{"Lambda[560∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant564{{"Constant[564∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant565{{"Constant[565∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda560 & Constant564 & Constant565 & Constant395 --> Object567
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -88,123 +93,124 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant491{{"Constant[491∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant491 --> Connection14
-    Constant492{{"Constant[492∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant492 --> Lambda253
+    Constant574{{"Constant[574∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant574 --> Connection14
+    Constant575{{"Constant[575∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant575 --> Lambda253
     Lambda256{{"Lambda[256∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant493{{"Constant[493∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant493 --> Lambda256
-    Lambda261{{"Lambda[261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object260 --> Lambda261
-    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant494{{"Constant[494∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant494 --> Lambda266
-    Lambda275{{"Lambda[275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object274 --> Lambda275
-    Lambda280{{"Lambda[280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant495{{"Constant[495∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant495 --> Lambda280
-    Lambda289{{"Lambda[289∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object288 --> Lambda289
-    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant496{{"Constant[496∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant496 --> Lambda294
-    Lambda303{{"Lambda[303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object302 --> Lambda303
-    Lambda308{{"Lambda[308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant497{{"Constant[497∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant497 --> Lambda308
-    Lambda317{{"Lambda[317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object316 --> Lambda317
-    Lambda322{{"Lambda[322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant498{{"Constant[498∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant498 --> Lambda322
-    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object330 --> Lambda331
-    Lambda336{{"Lambda[336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant499{{"Constant[499∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant499 --> Lambda336
-    Lambda345{{"Lambda[345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object344 --> Lambda345
-    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant500{{"Constant[500∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant500 --> Lambda350
-    Lambda359{{"Lambda[359∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object358 --> Lambda359
-    Lambda364{{"Lambda[364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant501{{"Constant[501∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant501 --> Lambda364
-    Lambda373{{"Lambda[373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object372 --> Lambda373
-    Lambda378{{"Lambda[378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant502{{"Constant[502∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant502 --> Lambda378
+    Constant576{{"Constant[576∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant576 --> Lambda256
+    Access257{{"Access[257∈0] ➊<br />ᐸ256.0ᐳ"}}:::plan
+    Lambda256 --> Access257
+    Access258{{"Access[258∈0] ➊<br />ᐸ256.1ᐳ"}}:::plan
+    Lambda256 --> Access258
+    Lambda268{{"Lambda[268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object267 --> Lambda268
+    Lambda273{{"Lambda[273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant577{{"Constant[577∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant577 --> Lambda273
+    Lambda283{{"Lambda[283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object282 --> Lambda283
+    Lambda288{{"Lambda[288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant578 --> Lambda288
+    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object303 --> Lambda304
+    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant579{{"Constant[579∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant579 --> Lambda309
+    Lambda319{{"Lambda[319∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object318 --> Lambda319
+    Lambda324{{"Lambda[324∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant580{{"Constant[580∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant580 --> Lambda324
+    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object345 --> Lambda346
+    Lambda351{{"Lambda[351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant581{{"Constant[581∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant581 --> Lambda351
+    Lambda361{{"Lambda[361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object360 --> Lambda361
+    Lambda366{{"Lambda[366∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant582{{"Constant[582∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant582 --> Lambda366
+    Lambda382{{"Lambda[382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object381 --> Lambda382
     Lambda387{{"Lambda[387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object386 --> Lambda387
-    Lambda392{{"Lambda[392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant503{{"Constant[503∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant503 --> Lambda392
-    Lambda401{{"Lambda[401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object400 --> Lambda401
-    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant504{{"Constant[504∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant504 --> Lambda406
-    Lambda415{{"Lambda[415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object414 --> Lambda415
-    Lambda420{{"Lambda[420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant505{{"Constant[505∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant505 --> Lambda420
-    Lambda429{{"Lambda[429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object428 --> Lambda429
-    Lambda434{{"Lambda[434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant506{{"Constant[506∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant506 --> Lambda434
-    Lambda443{{"Lambda[443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object442 --> Lambda443
+    Constant583{{"Constant[583∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant583 --> Lambda387
+    Lambda397{{"Lambda[397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object396 --> Lambda397
+    Lambda402{{"Lambda[402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant584{{"Constant[584∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant584 --> Lambda402
+    Lambda418{{"Lambda[418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object417 --> Lambda418
+    Lambda423{{"Lambda[423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant585{{"Constant[585∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant585 --> Lambda423
+    Lambda433{{"Lambda[433∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object432 --> Lambda433
+    Lambda438{{"Lambda[438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant586{{"Constant[586∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant586 --> Lambda438
     Lambda448{{"Lambda[448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant507{{"Constant[507∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant507 --> Lambda448
-    Lambda457{{"Lambda[457∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object456 --> Lambda457
-    Lambda462{{"Lambda[462∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant508{{"Constant[508∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant508 --> Lambda462
-    Lambda471{{"Lambda[471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object470 --> Lambda471
-    Lambda476{{"Lambda[476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant509{{"Constant[509∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant509 --> Lambda476
+    Object447 --> Lambda448
+    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant587{{"Constant[587∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant587 --> Lambda453
+    Lambda475{{"Lambda[475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object474 --> Lambda475
+    Lambda480{{"Lambda[480∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant588{{"Constant[588∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant588 --> Lambda480
+    Lambda490{{"Lambda[490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object489 --> Lambda490
+    Lambda495{{"Lambda[495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant589{{"Constant[589∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant589 --> Lambda495
+    Lambda511{{"Lambda[511∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object510 --> Lambda511
+    Lambda516{{"Lambda[516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant590{{"Constant[590∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant590 --> Lambda516
+    Lambda526{{"Lambda[526∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object525 --> Lambda526
+    Lambda531{{"Lambda[531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant591{{"Constant[591∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant591 --> Lambda531
+    Lambda547{{"Lambda[547∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object546 --> Lambda547
+    Lambda552{{"Lambda[552∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant592{{"Constant[592∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant592 --> Lambda552
+    Constant594{{"Constant[594∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant594 --> Lambda560
+    Lambda562{{"Lambda[562∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant595{{"Constant[595∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant595 --> Lambda562
+    Access563{{"Access[563∈0] ➊<br />ᐸ562.0ᐳ"}}:::plan
+    Lambda562 --> Access563
+    Lambda568{{"Lambda[568∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object567 --> Lambda568
+    Lambda573{{"Lambda[573∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant593{{"Constant[593∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant593 --> Lambda573
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant482{{"Constant[482∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant510{{"Constant[510∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant511{{"Constant[511∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant512{{"Constant[512∈0] ➊<br />ᐸ§{ first: 4, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Connection24{{"Connection[24∈0] ➊<br />ᐸ20ᐳ"}}:::plan
     PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Lambda478{{"Lambda[478∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda480{{"Lambda[480∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda485{{"Lambda[485∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda490{{"Lambda[490∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant491 & Lambda478 & Lambda480 & Lambda485 & Lambda490 --> PgSelect15
-    Object484{{"Object[484∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda478 & Constant481 & Constant482 & Constant357 --> Object484
-    Constant511 --> Lambda478
-    Constant512 --> Lambda480
-    Object484 --> Lambda485
-    Constant510 --> Lambda490
-    Connection24{{"Connection[24∈1] ➊<br />ᐸ20ᐳ"}}:::plan
+    Object13 & Connection14 & Constant574 & Lambda560 & Access563 & Lambda568 & Lambda573 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgUnionAll25[["PgUnionAll[25∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Connection24 --> PgUnionAll25
+    Object13 & PgClassExpression18 & Connection24 & Lambda253 & Access257 & Access258 --> PgUnionAll25
     PgUnionAll29[["PgUnionAll[29∈3]"]]:::plan
-    Object13 & PgClassExpression18 & Connection24 --> PgUnionAll29
+    Object13 & PgClassExpression18 & Connection24 & Lambda253 & Access257 & Access258 --> PgUnionAll29
     PgUnionAll53[["PgUnionAll[53∈3]"]]:::plan
-    Object13 & PgClassExpression18 & Connection24 --> PgUnionAll53
+    Object13 & PgClassExpression18 & Connection24 & Lambda253 & Access257 & Access258 --> PgUnionAll53
     PgSelectSingle17 --> PgClassExpression18
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
@@ -228,10 +234,10 @@ graph TD
     PgUnionAllSingle31 --> Access34
     PgSelect39[["PgSelect[39∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access38{{"Access[38∈6]<br />ᐸ37.0ᐳ"}}:::plan
-    Object13 & Access38 & Lambda253 & Lambda256 & Lambda261 & Lambda266 --> PgSelect39
+    Object13 & Access38 & Lambda253 & Access257 & Lambda268 & Lambda273 --> PgSelect39
     PgSelect48[["PgSelect[48∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access47{{"Access[47∈6]<br />ᐸ46.0ᐳ"}}:::plan
-    Object13 & Access47 & Lambda253 & Lambda256 & Lambda275 & Lambda280 --> PgSelect48
+    Object13 & Access47 & Lambda253 & Access257 & Lambda283 & Lambda288 --> PgSelect48
     JSONParse37[["JSONParse[37∈6]<br />ᐸ34ᐳ<br />ᐳAwsApplication"]]:::plan
     Access34 --> JSONParse37
     JSONParse37 --> Access38
@@ -256,34 +262,34 @@ graph TD
     __Item54 --> PgUnionAllSingle55
     PgSelect59[["PgSelect[59∈8]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access58{{"Access[58∈8]<br />ᐸ57.0ᐳ"}}:::plan
-    Object13 & Access58 & Lambda253 & Lambda256 & Lambda373 & Lambda378 --> PgSelect59
-    PgSelect157[["PgSelect[157∈8]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access156{{"Access[156∈8]<br />ᐸ155.0ᐳ"}}:::plan
-    Object13 & Access156 & Lambda253 & Lambda256 & Lambda471 & Lambda476 --> PgSelect157
+    Object13 & Access58 & Lambda253 & Access257 & Lambda418 & Lambda423 --> PgSelect59
     PgUnionAll70[["PgUnionAll[70∈8]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression68{{"PgClassExpression[68∈8]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression69{{"PgClassExpression[69∈8]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression68 & PgClassExpression69 --> PgUnionAll70
+    Object13 & PgClassExpression68 & PgClassExpression69 & Lambda253 & Access257 & Access258 --> PgUnionAll70
     PgUnionAll123[["PgUnionAll[123∈8]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression66{{"PgClassExpression[66∈8]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection122{{"Connection[122∈8] ➊<br />ᐸ120ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object13 & PgClassExpression66 & Connection122 --> PgUnionAll123
+    Object13 & PgClassExpression66 & Connection122 & Lambda253 & Access257 & Access258 --> PgUnionAll123
     PgUnionAll127[["PgUnionAll[127∈8]<br />ᐳAwsApplication"]]:::plan
-    Object13 & PgClassExpression66 & Connection122 --> PgUnionAll127
+    Object13 & PgClassExpression66 & Connection122 & Lambda253 & Access257 & Access258 --> PgUnionAll127
+    PgSelect157[["PgSelect[157∈8]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access156{{"Access[156∈8]<br />ᐸ155.0ᐳ"}}:::plan
+    Object13 & Access156 & Lambda253 & Access257 & Lambda547 & Lambda552 --> PgSelect157
     PgUnionAll166[["PgUnionAll[166∈8]<br />ᐳGcpApplication"]]:::plan
     PgClassExpression164{{"PgClassExpression[164∈8]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
     PgClassExpression165{{"PgClassExpression[165∈8]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object13 & PgClassExpression164 & PgClassExpression165 --> PgUnionAll166
+    Object13 & PgClassExpression164 & PgClassExpression165 & Lambda253 & Access257 & Access258 --> PgUnionAll166
     PgUnionAll219[["PgUnionAll[219∈8]<br />ᐳGcpApplication"]]:::plan
     PgClassExpression162{{"PgClassExpression[162∈8]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Connection218{{"Connection[218∈8] ➊<br />ᐸ216ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object13 & PgClassExpression162 & Connection218 --> PgUnionAll219
+    Object13 & PgClassExpression162 & Connection218 & Lambda253 & Access257 & Access258 --> PgUnionAll219
     PgUnionAll223[["PgUnionAll[223∈8]<br />ᐳGcpApplication"]]:::plan
-    Object13 & PgClassExpression162 & Connection218 --> PgUnionAll223
+    Object13 & PgClassExpression162 & Connection218 & Lambda253 & Access257 & Access258 --> PgUnionAll223
     PgUnionAll93[["PgUnionAll[93∈8]<br />ᐳAwsApplication"]]:::plan
-    Object13 & PgClassExpression66 --> PgUnionAll93
+    Object13 & PgClassExpression66 & Lambda253 & Access257 & Access258 --> PgUnionAll93
     PgUnionAll189[["PgUnionAll[189∈8]<br />ᐳGcpApplication"]]:::plan
-    Object13 & PgClassExpression162 --> PgUnionAll189
+    Object13 & PgClassExpression162 & Lambda253 & Access257 & Access258 --> PgUnionAll189
     Access56{{"Access[56∈8]<br />ᐸ55.1ᐳ<br />ᐳAwsApplication"}}:::plan
     PgUnionAllSingle55 --> Access56
     JSONParse57[["JSONParse[57∈8]<br />ᐸ56ᐳ"]]:::plan
@@ -336,10 +342,10 @@ graph TD
     PgUnionAllSingle221 --> PgClassExpression222
     PgSelect77[["PgSelect[77∈9]<br />ᐸorganizationsᐳ<br />ᐳAwsApplicationᐳOrganization"]]:::plan
     Access76{{"Access[76∈9]<br />ᐸ75.0ᐳ"}}:::plan
-    Object13 & Access76 & Lambda253 & Lambda256 & Lambda345 & Lambda350 --> PgSelect77
+    Object13 & Access76 & Lambda253 & Access257 & Lambda382 & Lambda387 --> PgSelect77
     PgSelect87[["PgSelect[87∈9]<br />ᐸpeopleᐳ<br />ᐳAwsApplicationᐳPerson"]]:::plan
     Access86{{"Access[86∈9]<br />ᐸ85.0ᐳ"}}:::plan
-    Object13 & Access86 & Lambda253 & Lambda256 & Lambda359 & Lambda364 --> PgSelect87
+    Object13 & Access86 & Lambda253 & Access257 & Lambda397 & Lambda402 --> PgSelect87
     Access74{{"Access[74∈9]<br />ᐸ73.1ᐳ<br />ᐳAwsApplicationᐳOrganization"}}:::plan
     PgUnionAllSingle73 --> Access74
     JSONParse75[["JSONParse[75∈9]<br />ᐸ74ᐳ"]]:::plan
@@ -370,10 +376,10 @@ graph TD
     __Item95 --> PgUnionAllSingle96
     PgSelect100[["PgSelect[100∈11]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access99{{"Access[99∈11]<br />ᐸ98.0ᐳ"}}:::plan
-    Object13 & Access99 & Lambda253 & Lambda256 & Lambda289 & Lambda294 --> PgSelect100
+    Object13 & Access99 & Lambda253 & Access257 & Lambda304 & Lambda309 --> PgSelect100
     PgSelect112[["PgSelect[112∈11]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access111{{"Access[111∈11]<br />ᐸ110.0ᐳ"}}:::plan
-    Object13 & Access111 & Lambda253 & Lambda256 & Lambda303 & Lambda308 --> PgSelect112
+    Object13 & Access111 & Lambda253 & Access257 & Lambda319 & Lambda324 --> PgSelect112
     Access97{{"Access[97∈11]<br />ᐸ96.1ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle96 --> Access97
     JSONParse98[["JSONParse[98∈11]<br />ᐸ97ᐳ"]]:::plan
@@ -420,10 +426,10 @@ graph TD
     PgUnionAllSingle129 --> Access132
     PgSelect137[["PgSelect[137∈14]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access136{{"Access[136∈14]<br />ᐸ135.0ᐳ"}}:::plan
-    Object13 & Access136 & Lambda253 & Lambda256 & Lambda317 & Lambda322 --> PgSelect137
+    Object13 & Access136 & Lambda253 & Access257 & Lambda346 & Lambda351 --> PgSelect137
     PgSelect148[["PgSelect[148∈14]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access147{{"Access[147∈14]<br />ᐸ146.0ᐳ"}}:::plan
-    Object13 & Access147 & Lambda253 & Lambda256 & Lambda331 & Lambda336 --> PgSelect148
+    Object13 & Access147 & Lambda253 & Access257 & Lambda361 & Lambda366 --> PgSelect148
     JSONParse135[["JSONParse[135∈14]<br />ᐸ132ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access132 --> JSONParse135
     JSONParse135 --> Access136
@@ -452,10 +458,10 @@ graph TD
     PgSelectSingle151 --> PgClassExpression154
     PgSelect173[["PgSelect[173∈15]<br />ᐸorganizationsᐳ<br />ᐳGcpApplicationᐳOrganization"]]:::plan
     Access172{{"Access[172∈15]<br />ᐸ171.0ᐳ"}}:::plan
-    Object13 & Access172 & Lambda253 & Lambda256 & Lambda443 & Lambda448 --> PgSelect173
+    Object13 & Access172 & Lambda253 & Access257 & Lambda511 & Lambda516 --> PgSelect173
     PgSelect183[["PgSelect[183∈15]<br />ᐸpeopleᐳ<br />ᐳGcpApplicationᐳPerson"]]:::plan
     Access182{{"Access[182∈15]<br />ᐸ181.0ᐳ"}}:::plan
-    Object13 & Access182 & Lambda253 & Lambda256 & Lambda457 & Lambda462 --> PgSelect183
+    Object13 & Access182 & Lambda253 & Access257 & Lambda526 & Lambda531 --> PgSelect183
     Access170{{"Access[170∈15]<br />ᐸ169.1ᐳ<br />ᐳGcpApplicationᐳOrganization"}}:::plan
     PgUnionAllSingle169 --> Access170
     JSONParse171[["JSONParse[171∈15]<br />ᐸ170ᐳ"]]:::plan
@@ -486,10 +492,10 @@ graph TD
     __Item191 --> PgUnionAllSingle192
     PgSelect196[["PgSelect[196∈17]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access195{{"Access[195∈17]<br />ᐸ194.0ᐳ"}}:::plan
-    Object13 & Access195 & Lambda253 & Lambda256 & Lambda387 & Lambda392 --> PgSelect196
+    Object13 & Access195 & Lambda253 & Access257 & Lambda433 & Lambda438 --> PgSelect196
     PgSelect208[["PgSelect[208∈17]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access207{{"Access[207∈17]<br />ᐸ206.0ᐳ"}}:::plan
-    Object13 & Access207 & Lambda253 & Lambda256 & Lambda401 & Lambda406 --> PgSelect208
+    Object13 & Access207 & Lambda253 & Access257 & Lambda448 & Lambda453 --> PgSelect208
     Access193{{"Access[193∈17]<br />ᐸ192.1ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle192 --> Access193
     JSONParse194[["JSONParse[194∈17]<br />ᐸ193ᐳ"]]:::plan
@@ -536,10 +542,10 @@ graph TD
     PgUnionAllSingle225 --> Access228
     PgSelect233[["PgSelect[233∈20]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access232{{"Access[232∈20]<br />ᐸ231.0ᐳ"}}:::plan
-    Object13 & Access232 & Lambda253 & Lambda256 & Lambda415 & Lambda420 --> PgSelect233
+    Object13 & Access232 & Lambda253 & Access257 & Lambda475 & Lambda480 --> PgSelect233
     PgSelect244[["PgSelect[244∈20]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access243{{"Access[243∈20]<br />ᐸ242.0ᐳ"}}:::plan
-    Object13 & Access243 & Lambda253 & Lambda256 & Lambda429 & Lambda434 --> PgSelect244
+    Object13 & Access243 & Lambda253 & Access257 & Lambda490 & Lambda495 --> PgSelect244
     JSONParse231[["JSONParse[231∈20]<br />ᐸ228ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access228 --> JSONParse231
     JSONParse231 --> Access232
@@ -572,65 +578,65 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-app-vulns"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda253,Lambda256,Constant257,Constant258,Constant259,Object260,Lambda261,Lambda266,Constant271,Constant272,Constant273,Object274,Lambda275,Lambda280,Constant285,Constant286,Constant287,Object288,Lambda289,Lambda294,Constant299,Constant300,Constant301,Object302,Lambda303,Lambda308,Constant313,Constant314,Object316,Lambda317,Lambda322,Constant327,Constant328,Object330,Lambda331,Lambda336,Constant341,Constant342,Constant343,Object344,Lambda345,Lambda350,Constant355,Constant356,Constant357,Object358,Lambda359,Lambda364,Constant369,Constant370,Object372,Lambda373,Lambda378,Constant383,Constant384,Object386,Lambda387,Lambda392,Constant397,Constant398,Object400,Lambda401,Lambda406,Constant411,Constant412,Object414,Lambda415,Lambda420,Constant425,Constant426,Object428,Lambda429,Lambda434,Constant439,Constant440,Object442,Lambda443,Lambda448,Constant453,Constant454,Object456,Lambda457,Lambda462,Constant467,Constant468,Object470,Lambda471,Lambda476,Constant481,Constant482,Constant491,Constant492,Constant493,Constant494,Constant495,Constant496,Constant497,Constant498,Constant499,Constant500,Constant501,Constant502,Constant503,Constant504,Constant505,Constant506,Constant507,Constant508,Constant509,Constant510,Constant511,Constant512 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 491, 511, 512, 481, 482, 357, 510, 253, 256, 261, 266, 275, 280, 373, 378, 471, 476, 345, 350, 359, 364, 289, 294, 303, 308, 317, 322, 331, 336, 443, 448, 457, 462, 387, 392, 401, 406, 415, 420, 429, 434<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 24, 478, 480, 490, 484, 485<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection24,Lambda253,Lambda256,Access257,Access258,Constant264,Constant265,Constant266,Object267,Lambda268,Lambda273,Constant279,Constant280,Constant281,Object282,Lambda283,Lambda288,Constant300,Constant301,Constant302,Object303,Lambda304,Lambda309,Constant315,Constant316,Constant317,Object318,Lambda319,Lambda324,Constant342,Constant343,Object345,Lambda346,Lambda351,Constant357,Constant358,Object360,Lambda361,Lambda366,Constant378,Constant379,Constant380,Object381,Lambda382,Lambda387,Constant393,Constant394,Constant395,Object396,Lambda397,Lambda402,Constant414,Constant415,Object417,Lambda418,Lambda423,Constant429,Constant430,Object432,Lambda433,Lambda438,Constant444,Constant445,Object447,Lambda448,Lambda453,Constant471,Constant472,Object474,Lambda475,Lambda480,Constant486,Constant487,Object489,Lambda490,Lambda495,Constant507,Constant508,Object510,Lambda511,Lambda516,Constant522,Constant523,Object525,Lambda526,Lambda531,Constant543,Constant544,Object546,Lambda547,Lambda552,Lambda560,Lambda562,Access563,Constant564,Constant565,Object567,Lambda568,Lambda573,Constant574,Constant575,Constant576,Constant577,Constant578,Constant579,Constant580,Constant581,Constant582,Constant583,Constant584,Constant585,Constant586,Constant587,Constant588,Constant589,Constant590,Constant591,Constant592,Constant593,Constant594,Constant595 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 574, 560, 563, 568, 573, 24, 253, 257, 258, 268, 273, 283, 288, 418, 423, 547, 552, 382, 387, 397, 402, 304, 309, 319, 324, 346, 351, 361, 366, 511, 516, 526, 531, 433, 438, 448, 453, 475, 480, 490, 495<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Connection24,Lambda478,Lambda480,Object484,Lambda485,Lambda490 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 24, 253, 256, 261, 266, 275, 280, 373, 378, 471, 476, 345, 350, 359, 364, 289, 294, 303, 308, 317, 322, 331, 336, 443, 448, 457, 462, 387, 392, 401, 406, 415, 420, 429, 434<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 24, 253, 257, 258, 268, 273, 283, 288, 418, 423, 547, 552, 382, 387, 397, 402, 304, 309, 319, 324, 346, 351, 361, 366, 511, 516, 526, 531, 433, 438, 448, 453, 475, 480, 490, 495<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 24, 253, 256, 261, 266, 275, 280, 373, 378, 471, 476, 345, 350, 359, 364, 289, 294, 303, 308, 317, 322, 331, 336, 443, 448, 457, 462, 387, 392, 401, 406, 415, 420, 429, 434<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: 25, 29, 53<br />ᐳ: First[26]<br />3: PgUnionAllSingle[27]<br />ᐳ: PgClassExpression[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 24, 253, 257, 258, 268, 273, 283, 288, 418, 423, 547, 552, 382, 387, 397, 402, 304, 309, 319, 324, 346, 351, 361, 366, 511, 516, 526, 531, 433, 438, 448, 453, 475, 480, 490, 495<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]<br />1: <br />ᐳ: 18, 19<br />2: 25, 29, 53<br />ᐳ: First[26]<br />3: PgUnionAllSingle[27]<br />ᐳ: PgClassExpression[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgClassExpression19,PgUnionAll25,First26,PgUnionAllSingle27,PgClassExpression28,PgUnionAll29,PgUnionAll53 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 253, 256, 261, 266, 275, 280<br /><br />ROOT __Item{4}ᐸ29ᐳ[30]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 13, 253, 257, 268, 273, 283, 288<br /><br />ROOT __Item{4}ᐸ29ᐳ[30]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item30,PgUnionAllSingle31 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 31, 13, 253, 256, 261, 266, 275, 280<br /><br />ROOT PgUnionAllSingle{4}[31]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 31, 13, 253, 257, 268, 273, 283, 288<br /><br />ROOT PgUnionAllSingle{4}[31]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgCursor32,Access33,Access34,List35 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 34, 13, 253, 256, 261, 266, 275, 280, 31<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[37], JSONParse[46]<br />ᐳ: Access[38], Access[47]<br />2: PgSelect[39], PgSelect[48]<br />ᐳ: 43, 44, 45, 50, 51, 52"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 34, 13, 253, 257, 268, 273, 283, 288, 31<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[37], JSONParse[46]<br />ᐳ: Access[38], Access[47]<br />2: PgSelect[39], PgSelect[48]<br />ᐳ: 43, 44, 45, 50, 51, 52"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,JSONParse37,Access38,PgSelect39,First43,PgSelectSingle44,PgClassExpression45,JSONParse46,Access47,PgSelect48,First50,PgSelectSingle51,PgClassExpression52 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 13, 253, 256, 373, 378, 471, 476, 345, 350, 359, 364, 289, 294, 303, 308, 317, 322, 331, 336, 443, 448, 457, 462, 387, 392, 401, 406, 415, 420, 429, 434<br /><br />ROOT __Item{7}ᐸ53ᐳ[54]"):::bucket
+    Bucket7("Bucket 7 (listItem)<br />Deps: 13, 253, 257, 418, 423, 258, 547, 552, 382, 387, 397, 402, 304, 309, 319, 324, 346, 351, 361, 366, 511, 516, 526, 531, 433, 438, 448, 453, 475, 480, 490, 495<br /><br />ROOT __Item{7}ᐸ53ᐳ[54]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item54,PgUnionAllSingle55 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 55, 13, 253, 256, 373, 378, 471, 476, 345, 350, 359, 364, 289, 294, 303, 308, 317, 322, 331, 336, 443, 448, 457, 462, 387, 392, 401, 406, 415, 420, 429, 434<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 56, 122, 218<br />2: JSONParse[57], JSONParse[155]<br />ᐳ: Access[58], Access[156]<br />3: PgSelect[59], PgSelect[157]<br />ᐳ: 63, 64, 65, 66, 67, 68, 69, 159, 160, 161, 162, 163, 164, 165<br />4: 70, 93, 123, 127, 166, 189, 219, 223<br />ᐳ: 72, 124, 168, 220<br />5: 73, 125, 169, 221<br />ᐳ: 126, 222"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 55, 13, 253, 257, 418, 423, 258, 547, 552, 382, 387, 397, 402, 304, 309, 319, 324, 346, 351, 361, 366, 511, 516, 526, 531, 433, 438, 448, 453, 475, 480, 490, 495<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 56, 122, 218<br />2: JSONParse[57], JSONParse[155]<br />ᐳ: Access[58], Access[156]<br />3: PgSelect[59], PgSelect[157]<br />ᐳ: 63, 64, 65, 66, 67, 68, 69, 159, 160, 161, 162, 163, 164, 165<br />4: 70, 93, 123, 127, 166, 189, 219, 223<br />ᐳ: 72, 124, 168, 220<br />5: 73, 125, 169, 221<br />ᐳ: 126, 222"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,Access56,JSONParse57,Access58,PgSelect59,First63,PgSelectSingle64,PgClassExpression65,PgClassExpression66,PgClassExpression67,PgClassExpression68,PgClassExpression69,PgUnionAll70,First72,PgUnionAllSingle73,PgUnionAll93,Connection122,PgUnionAll123,First124,PgUnionAllSingle125,PgClassExpression126,PgUnionAll127,JSONParse155,Access156,PgSelect157,First159,PgSelectSingle160,PgClassExpression161,PgClassExpression162,PgClassExpression163,PgClassExpression164,PgClassExpression165,PgUnionAll166,First168,PgUnionAllSingle169,PgUnionAll189,Connection218,PgUnionAll219,First220,PgUnionAllSingle221,PgClassExpression222,PgUnionAll223 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />Organization,Person<br />Deps: 73, 13, 253, 256, 345, 350, 359, 364<br />ᐳAwsApplicationᐳOrganization<br />ᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[74]<br />2: JSONParse[75], JSONParse[85]<br />ᐳ: Access[76], Access[86]<br />3: PgSelect[77], PgSelect[87]<br />ᐳ: 81, 82, 83, 84, 89, 90, 91, 92"):::bucket
+    Bucket9("Bucket 9 (polymorphic)<br />Organization,Person<br />Deps: 73, 13, 253, 257, 382, 387, 397, 402<br />ᐳAwsApplicationᐳOrganization<br />ᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[74]<br />2: JSONParse[75], JSONParse[85]<br />ᐳ: Access[76], Access[86]<br />3: PgSelect[77], PgSelect[87]<br />ᐳ: 81, 82, 83, 84, 89, 90, 91, 92"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,Access74,JSONParse75,Access76,PgSelect77,First81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,JSONParse85,Access86,PgSelect87,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92 bucket9
-    Bucket10("Bucket 10 (listItem)<br />Deps: 13, 253, 256, 289, 294, 303, 308<br /><br />ROOT __Item{10}ᐸ93ᐳ[95]"):::bucket
+    Bucket10("Bucket 10 (listItem)<br />Deps: 13, 253, 257, 304, 309, 319, 324<br /><br />ROOT __Item{10}ᐸ93ᐳ[95]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item95,PgUnionAllSingle96 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 96, 13, 253, 256, 289, 294, 303, 308<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[97]<br />2: JSONParse[98], JSONParse[110]<br />ᐳ: Access[99], Access[111]<br />3: PgSelect[100], PgSelect[112]<br />ᐳ: 104, 105, 106, 107, 108, 109, 114, 115, 116, 117, 118, 119"):::bucket
+    Bucket11("Bucket 11 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 96, 13, 253, 257, 304, 309, 319, 324<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[97]<br />2: JSONParse[98], JSONParse[110]<br />ᐳ: Access[99], Access[111]<br />3: PgSelect[100], PgSelect[112]<br />ᐳ: 104, 105, 106, 107, 108, 109, 114, 115, 116, 117, 118, 119"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,Access97,JSONParse98,Access99,PgSelect100,First104,PgSelectSingle105,PgClassExpression106,PgClassExpression107,PgClassExpression108,PgClassExpression109,JSONParse110,Access111,PgSelect112,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 13, 253, 256, 317, 322, 331, 336<br /><br />ROOT __Item{12}ᐸ127ᐳ[128]"):::bucket
+    Bucket12("Bucket 12 (listItem)<br />Deps: 13, 253, 257, 346, 351, 361, 366<br /><br />ROOT __Item{12}ᐸ127ᐳ[128]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,__Item128,PgUnionAllSingle129 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 129, 13, 253, 256, 317, 322, 331, 336<br /><br />ROOT PgUnionAllSingle{12}[129]"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 129, 13, 253, 257, 346, 351, 361, 366<br /><br />ROOT PgUnionAllSingle{12}[129]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgCursor130,Access131,Access132,List133 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 132, 13, 253, 256, 317, 322, 331, 336, 129<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[135], JSONParse[146]<br />ᐳ: Access[136], Access[147]<br />2: PgSelect[137], PgSelect[148]<br />ᐳ: 141, 142, 143, 144, 145, 150, 151, 152, 153, 154"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 132, 13, 253, 257, 346, 351, 361, 366, 129<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[135], JSONParse[146]<br />ᐳ: Access[136], Access[147]<br />2: PgSelect[137], PgSelect[148]<br />ᐳ: 141, 142, 143, 144, 145, 150, 151, 152, 153, 154"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,JSONParse135,Access136,PgSelect137,First141,PgSelectSingle142,PgClassExpression143,PgClassExpression144,PgClassExpression145,JSONParse146,Access147,PgSelect148,First150,PgSelectSingle151,PgClassExpression152,PgClassExpression153,PgClassExpression154 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 169, 13, 253, 256, 443, 448, 457, 462<br />ᐳGcpApplicationᐳOrganization<br />ᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[170]<br />2: JSONParse[171], JSONParse[181]<br />ᐳ: Access[172], Access[182]<br />3: PgSelect[173], PgSelect[183]<br />ᐳ: 177, 178, 179, 180, 185, 186, 187, 188"):::bucket
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 169, 13, 253, 257, 511, 516, 526, 531<br />ᐳGcpApplicationᐳOrganization<br />ᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[170]<br />2: JSONParse[171], JSONParse[181]<br />ᐳ: Access[172], Access[182]<br />3: PgSelect[173], PgSelect[183]<br />ᐳ: 177, 178, 179, 180, 185, 186, 187, 188"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,Access170,JSONParse171,Access172,PgSelect173,First177,PgSelectSingle178,PgClassExpression179,PgClassExpression180,JSONParse181,Access182,PgSelect183,First185,PgSelectSingle186,PgClassExpression187,PgClassExpression188 bucket15
-    Bucket16("Bucket 16 (listItem)<br />Deps: 13, 253, 256, 387, 392, 401, 406<br /><br />ROOT __Item{16}ᐸ189ᐳ[191]"):::bucket
+    Bucket16("Bucket 16 (listItem)<br />Deps: 13, 253, 257, 433, 438, 448, 453<br /><br />ROOT __Item{16}ᐸ189ᐳ[191]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,__Item191,PgUnionAllSingle192 bucket16
-    Bucket17("Bucket 17 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 192, 13, 253, 256, 387, 392, 401, 406<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[193]<br />2: JSONParse[194], JSONParse[206]<br />ᐳ: Access[195], Access[207]<br />3: PgSelect[196], PgSelect[208]<br />ᐳ: 200, 201, 202, 203, 204, 205, 210, 211, 212, 213, 214, 215"):::bucket
+    Bucket17("Bucket 17 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 192, 13, 253, 257, 433, 438, 448, 453<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[193]<br />2: JSONParse[194], JSONParse[206]<br />ᐳ: Access[195], Access[207]<br />3: PgSelect[196], PgSelect[208]<br />ᐳ: 200, 201, 202, 203, 204, 205, 210, 211, 212, 213, 214, 215"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,Access193,JSONParse194,Access195,PgSelect196,First200,PgSelectSingle201,PgClassExpression202,PgClassExpression203,PgClassExpression204,PgClassExpression205,JSONParse206,Access207,PgSelect208,First210,PgSelectSingle211,PgClassExpression212,PgClassExpression213,PgClassExpression214,PgClassExpression215 bucket17
-    Bucket18("Bucket 18 (listItem)<br />Deps: 13, 253, 256, 415, 420, 429, 434<br /><br />ROOT __Item{18}ᐸ223ᐳ[224]"):::bucket
+    Bucket18("Bucket 18 (listItem)<br />Deps: 13, 253, 257, 475, 480, 490, 495<br /><br />ROOT __Item{18}ᐸ223ᐳ[224]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,__Item224,PgUnionAllSingle225 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 225, 13, 253, 256, 415, 420, 429, 434<br /><br />ROOT PgUnionAllSingle{18}[225]"):::bucket
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 225, 13, 253, 257, 475, 480, 490, 495<br /><br />ROOT PgUnionAllSingle{18}[225]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgCursor226,Access227,Access228,List229 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 228, 13, 253, 256, 415, 420, 429, 434, 225<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[231], JSONParse[242]<br />ᐳ: Access[232], Access[243]<br />2: PgSelect[233], PgSelect[244]<br />ᐳ: 237, 238, 239, 240, 241, 246, 247, 248, 249, 250"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 228, 13, 253, 257, 475, 480, 490, 495, 225<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[231], JSONParse[242]<br />ᐳ: Access[232], Access[243]<br />2: PgSelect[233], PgSelect[244]<br />ᐳ: 237, 238, 239, 240, 241, 246, 247, 248, 249, 250"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20,JSONParse231,Access232,PgSelect233,First237,PgSelectSingle238,PgClassExpression239,PgClassExpression240,PgClassExpression241,JSONParse242,Access243,PgSelect244,First246,PgSelectSingle247,PgClassExpression248,PgClassExpression249,PgClassExpression250 bucket20
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.after-caroline.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.after-caroline.mermaid
@@ -9,68 +9,72 @@ graph TD
 
 
     %% plan dependencies
+    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
+    Lambda38 & Constant43 & Constant44 & Constant45 --> Object46
+    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda59 & Constant63 & Constant64 & Constant65 --> Object66
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor18["PgValidateParsedCursor[18∈0] ➊"]:::plan
-    Constant71 & Lambda16 & PgValidateParsedCursor18 --> Connection15
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ'WyI5NjdkZTdmYTdlIiwzXQ=='ᐳ"}}:::plan
-    Constant72 --> Lambda16
-    Lambda16 --> PgValidateParsedCursor18
-    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant76 --> Lambda38
+    Constant73 & Lambda16 & PgValidateParsedCursor18 --> Connection15
+    Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access12 & Access13 --> Object14
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access12
+    __Value2 --> Access13
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ'WyI5NjdkZTdmYTdlIiwzXQ=='ᐳ"}}:::plan
+    Constant74 --> Lambda16
+    Lambda16 --> PgValidateParsedCursor18
+    Access19{{"Access[19∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access19
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant78 --> Lambda38
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant79 --> Lambda41
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.0ᐳ"}}:::plan
+    Lambda41 --> Access42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object46 --> Lambda47
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant76 --> Lambda52
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant80 --> Lambda59
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant81 --> Lambda61
+    Access62{{"Access[62∈0] ➊<br />ᐸ61.0ᐳ"}}:::plan
+    Lambda61 --> Access62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object66 --> Lambda67
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant77 --> Lambda72
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant36{{"Constant[36∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Object14{{"Object[14∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access19{{"Access[19∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & Constant71 & Access19 & Lambda41 & Lambda46 & Lambda51 & Lambda58 & Lambda60 & Lambda65 & Lambda70 --> PgSelect17
-    Object45{{"Object[45∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda38 & Constant42 & Constant43 & Constant44 --> Object45
-    Object64{{"Object[64∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda58 & Constant61 & Constant62 & Constant63 --> Object64
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access13{{"Access[13∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access12 & Access13 --> Object14
-    __Value2 --> Access12
-    __Value2 --> Access13
-    Lambda16 --> Access19
-    Constant77 --> Lambda41
-    Object45 --> Lambda46
-    Constant74 --> Lambda51
-    Constant78 --> Lambda58
-    Constant79 --> Lambda60
-    Object64 --> Lambda65
-    Constant75 --> Lambda70
+    Object14 & Connection15 & Lambda16 & Constant73 & Access19 & Access42 & Lambda47 & Lambda52 & Lambda59 & Access62 & Lambda67 & Lambda72 --> PgSelect17
     __Item20[/"__Item[20∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgSelect17 ==> __Item20
     PgSelectSingle21{{"PgSelectSingle[21∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item20 --> PgSelectSingle21
-    Object55{{"Object[55∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access53{{"Access[53∈3]<br />ᐸ20.0ᐳ"}}:::plan
-    Access53 & Constant73 & Constant36 & Lambda38 & Constant39 --> Object55
+    Object56{{"Object[56∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access54{{"Access[54∈3]<br />ᐸ20.0ᐳ"}}:::plan
+    Access54 & Constant75 & Constant36 & Lambda38 & Constant39 --> Object56
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression23
     PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -79,11 +83,11 @@ graph TD
     List35{{"List[35∈3]<br />ᐸ23ᐳ"}}:::plan
     List35 --> PgCursor33
     PgClassExpression23 --> List35
-    __Item20 --> Access53
-    Lambda56{{"Lambda[56∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object55 --> Lambda56
-    __Item28[/"__Item[28∈4]<br />ᐸ56ᐳ"\]:::itemplan
-    Lambda56 ==> __Item28
+    __Item20 --> Access54
+    Lambda57{{"Lambda[57∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object56 --> Lambda57
+    __Item28[/"__Item[28∈4]<br />ᐸ57ᐳ"\]:::itemplan
+    Lambda57 ==> __Item28
     PgSelectSingle29{{"PgSelectSingle[29∈4]<br />ᐸlog_entriesᐳ"}}:::plan
     __Item28 --> PgSelectSingle29
     PgClassExpression30{{"PgClassExpression[30∈4]<br />ᐸ__log_entries__.”text”ᐳ"}}:::plan
@@ -94,19 +98,19 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-log-entries.after-caroline"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 36, 39, 42, 43, 44, 61, 62, 63, 71, 72, 73, 74, 75, 76, 77, 78, 79, 16, 38<br />2: PgValidateParsedCursor[18]<br />ᐳ: Connection[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 12, 13, 36, 39, 43, 44, 45, 63, 64, 65, 73, 74, 75, 76, 77, 78, 79, 80, 81, 14, 16, 19, 38, 41, 42, 46, 47, 52, 59, 61, 62, 66, 67, 72<br />2: PgValidateParsedCursor[18]<br />ᐳ: Connection[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection15,Lambda16,PgValidateParsedCursor18,Constant36,Lambda38,Constant39,Constant42,Constant43,Constant44,Constant61,Constant62,Constant63,Constant71,Constant72,Constant73,Constant74,Constant75,Constant76,Constant77,Constant78,Constant79 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 15, 16, 71, 77, 38, 42, 43, 44, 74, 78, 79, 61, 62, 63, 75, 73, 36, 39<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 12, 13, 19, 41, 45, 51, 58, 60, 70, 14, 46, 64, 65<br />2: PgSelect[17]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor18,Access19,Constant36,Lambda38,Constant39,Lambda41,Access42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Lambda59,Lambda61,Access62,Constant63,Constant64,Constant65,Object66,Lambda67,Lambda72,Constant73,Constant74,Constant75,Constant76,Constant77,Constant78,Constant79,Constant80,Constant81 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 73, 19, 42, 47, 52, 59, 62, 67, 72, 75, 36, 38, 39<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access12,Access13,Object14,PgSelect17,Access19,Lambda41,Object45,Lambda46,Lambda51,Lambda58,Lambda60,Object64,Lambda65,Lambda70 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 73, 36, 38, 39<br /><br />ROOT __Item{2}ᐸ17ᐳ[20]"):::bucket
+    class Bucket1,PgSelect17 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 75, 36, 38, 39<br /><br />ROOT __Item{2}ᐸ17ᐳ[20]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item20,PgSelectSingle21 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 20, 73, 36, 38, 39<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[21]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 20, 75, 36, 38, 39<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression32,PgCursor33,List35,Access53,Object55,Lambda56 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ56ᐳ[28]"):::bucket
+    class Bucket3,PgClassExpression23,PgClassExpression32,PgCursor33,List35,Access54,Object56,Lambda57 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ57ᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item28,PgSelectSingle29,PgClassExpression30,PgClassExpression31 bucket4
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.condition.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.condition.mermaid
@@ -9,62 +9,64 @@ graph TD
 
 
     %% plan dependencies
+    Object41{{"Object[41∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant67 --> Lambda33
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ[ { attribute: 'text', direction: 'DESC' }, { fragment: { n:ᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
+    Lambda33 & Constant38 & Constant39 & Constant40 --> Object41
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda33 & Constant58 & Constant59 & Constant60 --> Object61
+    Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access12 & Access13 --> Object14
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access12
+    __Value2 --> Access13
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant69 --> Lambda33
+    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant70 --> Lambda36
+    Access37{{"Access[37∈0] ➊<br />ᐸ36.0ᐳ"}}:::plan
+    Lambda36 --> Access37
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object41 --> Lambda42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'text', direction:ᐳ"}}:::plan
+    Constant71 --> Lambda47
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant72 --> Lambda67
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
     Constant31{{"Constant[31∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant34{{"Constant[34∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ[ { attribute: 'text', direction: 'DESC' }, { fragment: { n:ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'text', direction:ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Object14{{"Object[14∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant66 & Connection15 & Lambda36 & Lambda41 & Lambda46 & Lambda33 & Lambda36 & Lambda60 & Lambda65 --> PgSelect16
-    Object40{{"Object[40∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda33 & Constant37 & Constant38 & Constant39 --> Object40
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda33 & Constant56 & Constant57 & Constant58 --> Object59
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access13{{"Access[13∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access12 & Access13 --> Object14
-    __Value2 --> Access12
-    __Value2 --> Access13
-    Constant68 --> Lambda36
-    Object40 --> Lambda41
-    Constant69 --> Lambda46
-    Object59 --> Lambda60
-    Constant70 --> Lambda65
+    Object14 & Constant68 & Connection15 & Access37 & Lambda42 & Lambda47 & Lambda33 & Access37 & Lambda62 & Lambda67 --> PgSelect16
     __Item17[/"__Item[17∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item17 --> PgSelectSingle18
-    Object50{{"Object[50∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access48{{"Access[48∈3]<br />ᐸ17.0ᐳ"}}:::plan
-    Access48 & Constant31 & Constant31 & Lambda33 & Constant34 --> Object50
+    Object51{{"Object[51∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access49{{"Access[49∈3]<br />ᐸ17.0ᐳ"}}:::plan
+    Access49 & Constant31 & Constant31 & Lambda33 & Constant34 --> Object51
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression21
     PgClassExpression30{{"PgClassExpression[30∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression30
-    __Item17 --> Access48
-    Lambda51{{"Lambda[51∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object50 --> Lambda51
-    __Item26[/"__Item[26∈4]<br />ᐸ51ᐳ"\]:::itemplan
-    Lambda51 ==> __Item26
+    __Item17 --> Access49
+    Lambda52{{"Lambda[52∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object51 --> Lambda52
+    __Item26[/"__Item[26∈4]<br />ᐸ52ᐳ"\]:::itemplan
+    Lambda52 ==> __Item26
     PgSelectSingle27{{"PgSelectSingle[27∈4]<br />ᐸlog_entriesᐳ"}}:::plan
     __Item26 --> PgSelectSingle27
     PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__log_entries__.”text”ᐳ"}}:::plan
@@ -77,17 +79,17 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-log-entries.condition"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection15,Constant31,Lambda33,Constant34,Constant37,Constant38,Constant39,Constant56,Constant57,Constant58,Constant66,Constant67,Constant68,Constant69,Constant70 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 66, 15, 33, 68, 37, 38, 39, 69, 56, 57, 58, 70, 31, 34<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 12, 13, 36, 40, 46, 59, 65, 14, 41, 60<br />2: PgSelect[16]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Constant31,Lambda33,Constant34,Lambda36,Access37,Constant38,Constant39,Constant40,Object41,Lambda42,Lambda47,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71,Constant72 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 68, 15, 37, 42, 47, 33, 62, 67, 31, 34<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access12,Access13,Object14,PgSelect16,Lambda36,Object40,Lambda41,Lambda46,Object59,Lambda60,Lambda65 bucket1
+    class Bucket1,PgSelect16 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 31, 33, 34<br /><br />ROOT __Item{2}ᐸ16ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item17,PgSelectSingle18 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 17, 31, 33, 34<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[18]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression21,PgClassExpression30,Access48,Object50,Lambda51 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ51ᐳ[26]"):::bucket
+    class Bucket3,PgClassExpression21,PgClassExpression30,Access49,Object51,Lambda52 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ52ᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item26,PgSelectSingle27,PgClassExpression28,PgClassExpression29 bucket4
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.last-ordered.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.last-ordered.mermaid
@@ -9,70 +9,74 @@ graph TD
 
 
     %% plan dependencies
-    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant66 --> Connection14
+    Object41{{"Object[41∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant70 --> Lambda33
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ[ { attribute: 'text', direction: 'DESC' }, { fragment: { n:ᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
+    Lambda33 & Constant38 & Constant39 & Constant40 --> Object41
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { attribute: 'person_id', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda54 & Constant58 & Constant59 & Constant60 --> Object61
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access11 & Access12 --> Object13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access11
+    __Value2 --> Access12
+    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant68 --> Connection14
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant72 --> Lambda33
+    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant73 --> Lambda36
+    Access37{{"Access[37∈0] ➊<br />ᐸ36.0ᐳ"}}:::plan
+    Lambda36 --> Access37
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object41 --> Lambda42
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'text', direction:ᐳ"}}:::plan
+    Constant70 --> Lambda47
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: 5, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant74 --> Lambda54
+    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: 5, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant75 --> Lambda56
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_id', direcᐳ"}}:::plan
+    Constant71 --> Lambda67
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant31{{"Constant[31∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant34{{"Constant[34∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ[ { attribute: 'text', direction: 'DESC' }, { fragment: { n:ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { attribute: 'person_id', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'text', direction:ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_id', direcᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: 5, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: 5, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant66 & Lambda36 & Lambda41 & Lambda46 & Lambda53 & Lambda55 & Lambda60 & Lambda65 --> PgSelect15
-    Object40{{"Object[40∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda33 & Constant37 & Constant38 & Constant39 --> Object40
-    Object59{{"Object[59∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant56 & Constant57 & Constant58 --> Object59
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access11 & Access12 --> Object13
-    __Value2 --> Access11
-    __Value2 --> Access12
-    Constant71 --> Lambda36
-    Object40 --> Lambda41
-    Constant68 --> Lambda46
-    Constant72 --> Lambda53
-    Constant73 --> Lambda55
-    Object59 --> Lambda60
-    Constant69 --> Lambda65
+    Object13 & Connection14 & Constant68 & Access37 & Lambda42 & Lambda47 & Lambda54 & Access57 & Lambda62 & Lambda67 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
-    Object50{{"Object[50∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access48{{"Access[48∈3]<br />ᐸ16.0ᐳ"}}:::plan
-    Access48 & Constant67 & Constant31 & Lambda33 & Constant34 --> Object50
+    Object51{{"Object[51∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access49{{"Access[49∈3]<br />ᐸ16.0ᐳ"}}:::plan
+    Access49 & Constant69 & Constant31 & Lambda33 & Constant34 --> Object51
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression21
     PgClassExpression30{{"PgClassExpression[30∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression30
-    __Item16 --> Access48
-    Lambda51{{"Lambda[51∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object50 --> Lambda51
-    __Item26[/"__Item[26∈4]<br />ᐸ51ᐳ"\]:::itemplan
-    Lambda51 ==> __Item26
+    __Item16 --> Access49
+    Lambda52{{"Lambda[52∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object51 --> Lambda52
+    __Item26[/"__Item[26∈4]<br />ᐸ52ᐳ"\]:::itemplan
+    Lambda52 ==> __Item26
     PgSelectSingle27{{"PgSelectSingle[27∈4]<br />ᐸlog_entriesᐳ"}}:::plan
     __Item26 --> PgSelectSingle27
     PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__log_entries__.”text”ᐳ"}}:::plan
@@ -85,17 +89,17 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-log-entries.last-ordered"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection14,Constant31,Lambda33,Constant34,Constant37,Constant38,Constant39,Constant56,Constant57,Constant58,Constant66,Constant67,Constant68,Constant69,Constant70,Constant71,Constant72,Constant73 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 66, 71, 33, 37, 38, 39, 68, 72, 73, 56, 57, 58, 69, 67, 31, 34<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 36, 40, 46, 53, 55, 65, 13, 41, 59, 60<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Constant31,Lambda33,Constant34,Lambda36,Access37,Constant38,Constant39,Constant40,Object41,Lambda42,Lambda47,Lambda54,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant68,Constant69,Constant70,Constant71,Constant72,Constant73,Constant74,Constant75 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 68, 37, 42, 47, 54, 57, 62, 67, 69, 31, 33, 34<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect15,Lambda36,Object40,Lambda41,Lambda46,Lambda53,Lambda55,Object59,Lambda60,Lambda65 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 67, 31, 33, 34<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 69, 31, 33, 34<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 16, 67, 31, 33, 34<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 16, 69, 31, 33, 34<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[17]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression21,PgClassExpression30,Access48,Object50,Lambda51 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ51ᐳ[26]"):::bucket
+    class Bucket3,PgClassExpression21,PgClassExpression30,Access49,Object51,Lambda52 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ52ᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item26,PgSelectSingle27,PgClassExpression28,PgClassExpression29 bucket4
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-log-entries.mermaid
@@ -9,52 +9,54 @@ graph TD
 
 
     %% plan dependencies
+    Object40{{"Object[40∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant65 --> Lambda32
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
+    Lambda32 & Constant37 & Constant38 & Constant39 --> Object40
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda32 & Constant57 & Constant58 & Constant59 --> Object60
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access10
+    __Value2 --> Access11
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant67 --> Lambda32
+    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant68 --> Lambda35
+    Access36{{"Access[36∈0] ➊<br />ᐸ35.0ᐳ"}}:::plan
+    Lambda35 --> Access36
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object40 --> Lambda41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant69 --> Lambda46
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object60 --> Lambda61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant70 --> Lambda66
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant30{{"Constant[30∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant33{{"Constant[33∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpeopleᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda59{{"Lambda[59∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda35 & Lambda40 & Lambda45 & Lambda32 & Lambda35 & Lambda59 & Lambda64 --> PgSelect14
-    Object39{{"Object[39∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda32 & Constant36 & Constant37 & Constant38 --> Object39
-    Object58{{"Object[58∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda32 & Constant55 & Constant56 & Constant57 --> Object58
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access10 & Access11 --> Object12
-    __Value2 --> Access10
-    __Value2 --> Access11
-    Constant66 --> Lambda35
-    Object39 --> Lambda40
-    Constant67 --> Lambda45
-    Object58 --> Lambda59
-    Constant68 --> Lambda64
+    Object12 & Connection13 & Access36 & Lambda41 & Lambda46 & Lambda32 & Access36 & Lambda61 & Lambda66 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
-    Object49{{"Object[49∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access47{{"Access[47∈3]<br />ᐸ15.0ᐳ"}}:::plan
-    Access47 & Constant30 & Constant30 & Lambda32 & Constant33 --> Object49
+    Object50{{"Object[50∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access48{{"Access[48∈3]<br />ᐸ15.0ᐳ"}}:::plan
+    Access48 & Constant30 & Constant30 & Lambda32 & Constant33 --> Object50
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
@@ -63,11 +65,11 @@ graph TD
     List29{{"List[29∈3]<br />ᐸ17ᐳ"}}:::plan
     List29 --> PgCursor27
     PgClassExpression17 --> List29
-    __Item15 --> Access47
-    Lambda50{{"Lambda[50∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object49 --> Lambda50
-    __Item22[/"__Item[22∈4]<br />ᐸ50ᐳ"\]:::itemplan
-    Lambda50 ==> __Item22
+    __Item15 --> Access48
+    Lambda51{{"Lambda[51∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object50 --> Lambda51
+    __Item22[/"__Item[22∈4]<br />ᐸ51ᐳ"\]:::itemplan
+    Lambda51 ==> __Item22
     PgSelectSingle23{{"PgSelectSingle[23∈4]<br />ᐸlog_entriesᐳ"}}:::plan
     __Item22 --> PgSelectSingle23
     PgClassExpression24{{"PgClassExpression[24∈4]<br />ᐸ__log_entries__.”text”ᐳ"}}:::plan
@@ -80,17 +82,17 @@ graph TD
     subgraph "Buckets for queries/polymorphic/person-log-entries"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant30,Lambda32,Constant33,Constant36,Constant37,Constant38,Constant55,Constant56,Constant57,Constant65,Constant66,Constant67,Constant68 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 32, 66, 36, 37, 38, 67, 55, 56, 57, 68, 30, 33<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 35, 39, 45, 58, 64, 12, 40, 59<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant30,Lambda32,Constant33,Lambda35,Access36,Constant37,Constant38,Constant39,Object40,Lambda41,Lambda46,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant67,Constant68,Constant69,Constant70 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 36, 41, 46, 32, 61, 66, 30, 33<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda35,Object39,Lambda40,Lambda45,Object58,Lambda59,Lambda64 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 30, 32, 33<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 15, 30, 32, 33<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression26,PgCursor27,List29,Access47,Object49,Lambda50 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ50ᐳ[22]"):::bucket
+    class Bucket3,PgClassExpression17,PgClassExpression26,PgCursor27,List29,Access48,Object50,Lambda51 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ51ᐳ[22]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item22,PgSelectSingle23,PgClassExpression24,PgClassExpression25 bucket4
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.mermaid
@@ -9,440 +9,594 @@ graph TD
 
 
     %% plan dependencies
-    Object647{{"Object[647∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    List437{{"List[437∈0] ➊<br />ᐸ420,424,428,432,436ᐳ"}}:::plan
+    Object420{{"Object[420∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object424{{"Object[424∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object428{{"Object[428∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object432{{"Object[432∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object436{{"Object[436∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object420 & Object424 & Object428 & Object432 & Object436 --> List437
+    List526{{"List[526∈0] ➊<br />ᐸ509,513,517,521,525ᐳ"}}:::plan
+    Object509{{"Object[509∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object513{{"Object[513∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object517{{"Object[517∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object521{{"Object[521∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object525{{"Object[525∈0] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object509 & Object513 & Object517 & Object521 & Object525 --> List526
+    Object648{{"Object[648∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda640{{"Lambda[640∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant644{{"Constant[644∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant645{{"Constant[645∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant646{{"Constant[646∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
-    Lambda640 & Constant644 & Constant645 & Constant646 --> Object647
-    Object675{{"Object[675∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant672{{"Constant[672∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant673{{"Constant[673∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant674{{"Constant[674∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
-    Lambda640 & Constant672 & Constant673 & Constant674 --> Object675
-    Object689{{"Object[689∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant686{{"Constant[686∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant687{{"Constant[687∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant688{{"Constant[688∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
-    Lambda640 & Constant686 & Constant687 & Constant688 --> Object689
-    Object703{{"Object[703∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant700{{"Constant[700∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant701{{"Constant[701∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant702{{"Constant[702∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
-    Lambda640 & Constant700 & Constant701 & Constant702 --> Object703
-    Object717{{"Object[717∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant714{{"Constant[714∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant715{{"Constant[715∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant716{{"Constant[716∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
-    Lambda640 & Constant714 & Constant715 & Constant716 --> Object717
-    Object731{{"Object[731∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant728{{"Constant[728∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant729{{"Constant[729∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant730{{"Constant[730∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
-    Lambda640 & Constant728 & Constant729 & Constant730 --> Object731
-    Object745{{"Object[745∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant742{{"Constant[742∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant743{{"Constant[743∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant744{{"Constant[744∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
-    Lambda640 & Constant742 & Constant743 & Constant744 --> Object745
-    Object759{{"Object[759∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant756{{"Constant[756∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant757{{"Constant[757∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant756 & Constant757 & Constant674 --> Object759
-    Object773{{"Object[773∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant770{{"Constant[770∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant771{{"Constant[771∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant770 & Constant771 & Constant674 --> Object773
-    Object787{{"Object[787∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant784{{"Constant[784∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant785{{"Constant[785∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant784 & Constant785 & Constant688 --> Object787
-    Object801{{"Object[801∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant798{{"Constant[798∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant798 & Constant799 & Constant702 --> Object801
-    Object815{{"Object[815∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant812{{"Constant[812∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant813{{"Constant[813∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant812 & Constant813 & Constant716 --> Object815
-    Object829{{"Object[829∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant826{{"Constant[826∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant827{{"Constant[827∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant826 & Constant827 & Constant730 --> Object829
+    Constant645{{"Constant[645∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant646{{"Constant[646∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant647{{"Constant[647∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
+    Lambda640 & Constant645 & Constant646 & Constant647 --> Object648
+    Object663{{"Object[663∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant660{{"Constant[660∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant661{{"Constant[661∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda640 & Constant660 & Constant661 & Constant647 --> Object663
+    Object678{{"Object[678∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant675{{"Constant[675∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant676{{"Constant[676∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant677{{"Constant[677∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
+    Lambda640 & Constant675 & Constant676 & Constant677 --> Object678
+    Object693{{"Object[693∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant690{{"Constant[690∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant691{{"Constant[691∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant692{{"Constant[692∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
+    Lambda640 & Constant690 & Constant691 & Constant692 --> Object693
+    Object708{{"Object[708∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant705{{"Constant[705∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant706{{"Constant[706∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant707{{"Constant[707∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
+    Lambda640 & Constant705 & Constant706 & Constant707 --> Object708
+    Object723{{"Object[723∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant720{{"Constant[720∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant721{{"Constant[721∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant722{{"Constant[722∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
+    Lambda640 & Constant720 & Constant721 & Constant722 --> Object723
+    Object738{{"Object[738∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant735{{"Constant[735∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant736{{"Constant[736∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant737{{"Constant[737∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
+    Lambda640 & Constant735 & Constant736 & Constant737 --> Object738
+    Object753{{"Object[753∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant750{{"Constant[750∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant751{{"Constant[751∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant752{{"Constant[752∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
+    Lambda640 & Constant750 & Constant751 & Constant752 --> Object753
+    Object768{{"Object[768∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant765{{"Constant[765∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant766{{"Constant[766∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant765 & Constant766 & Constant677 --> Object768
+    Object783{{"Object[783∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant780{{"Constant[780∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant781{{"Constant[781∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant780 & Constant781 & Constant677 --> Object783
+    Object798{{"Object[798∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant795{{"Constant[795∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant796{{"Constant[796∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant795 & Constant796 & Constant692 --> Object798
+    Object813{{"Object[813∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant810{{"Constant[810∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant811{{"Constant[811∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant810 & Constant811 & Constant707 --> Object813
+    Object828{{"Object[828∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant825{{"Constant[825∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant826{{"Constant[826∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant825 & Constant826 & Constant722 --> Object828
     Object843{{"Object[843∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant840{{"Constant[840∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant841{{"Constant[841∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda640 & Constant840 & Constant841 & Constant744 --> Object843
-    Object857{{"Object[857∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant854{{"Constant[854∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant855{{"Constant[855∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant854 & Constant855 & Constant688 --> Object857
-    Object871{{"Object[871∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant868{{"Constant[868∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant869{{"Constant[869∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant868 & Constant869 & Constant674 --> Object871
-    Object885{{"Object[885∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant882{{"Constant[882∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant883{{"Constant[883∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant882 & Constant883 & Constant688 --> Object885
-    Object899{{"Object[899∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant896{{"Constant[896∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant897{{"Constant[897∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant896 & Constant897 & Constant702 --> Object899
-    Object913{{"Object[913∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant910{{"Constant[910∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant911{{"Constant[911∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant910 & Constant911 & Constant716 --> Object913
-    Object927{{"Object[927∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant924{{"Constant[924∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant925{{"Constant[925∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant924 & Constant925 & Constant730 --> Object927
-    Object941{{"Object[941∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant938{{"Constant[938∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant939{{"Constant[939∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda640 & Constant938 & Constant939 & Constant744 --> Object941
-    Object955{{"Object[955∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant952{{"Constant[952∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant953{{"Constant[953∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant952 & Constant953 & Constant702 --> Object955
-    Object969{{"Object[969∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant966{{"Constant[966∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant967{{"Constant[967∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant966 & Constant967 & Constant674 --> Object969
-    Object983{{"Object[983∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant980{{"Constant[980∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant981{{"Constant[981∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant980 & Constant981 & Constant688 --> Object983
-    Object997{{"Object[997∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant994{{"Constant[994∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant995{{"Constant[995∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant994 & Constant995 & Constant702 --> Object997
-    Object1011{{"Object[1011∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1008{{"Constant[1008∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1009{{"Constant[1009∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant1008 & Constant1009 & Constant716 --> Object1011
-    Object1025{{"Object[1025∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1022{{"Constant[1022∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1023{{"Constant[1023∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1022 & Constant1023 & Constant730 --> Object1025
-    Object1039{{"Object[1039∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1036{{"Constant[1036∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1037{{"Constant[1037∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1036 & Constant1037 & Constant744 --> Object1039
+    Constant841{{"Constant[841∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant840 & Constant841 & Constant737 --> Object843
+    Object858{{"Object[858∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant855{{"Constant[855∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant856{{"Constant[856∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant855 & Constant856 & Constant752 --> Object858
+    Object873{{"Object[873∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant870{{"Constant[870∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant871{{"Constant[871∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant870 & Constant871 & Constant692 --> Object873
+    Object888{{"Object[888∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant885{{"Constant[885∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant886{{"Constant[886∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant885 & Constant886 & Constant677 --> Object888
+    Object903{{"Object[903∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant900{{"Constant[900∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant901{{"Constant[901∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant900 & Constant901 & Constant692 --> Object903
+    Object918{{"Object[918∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant915{{"Constant[915∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant916{{"Constant[916∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant915 & Constant916 & Constant707 --> Object918
+    Object933{{"Object[933∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant930{{"Constant[930∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant931{{"Constant[931∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant930 & Constant931 & Constant722 --> Object933
+    Object948{{"Object[948∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant945{{"Constant[945∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant946{{"Constant[946∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant945 & Constant946 & Constant737 --> Object948
+    Object963{{"Object[963∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant960{{"Constant[960∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant961{{"Constant[961∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant960 & Constant961 & Constant752 --> Object963
+    Object978{{"Object[978∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant975{{"Constant[975∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant976{{"Constant[976∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant975 & Constant976 & Constant707 --> Object978
+    Object993{{"Object[993∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant990{{"Constant[990∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant991{{"Constant[991∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant990 & Constant991 & Constant677 --> Object993
+    Object1008{{"Object[1008∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1005{{"Constant[1005∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1006{{"Constant[1006∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant1005 & Constant1006 & Constant692 --> Object1008
+    Object1023{{"Object[1023∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1020{{"Constant[1020∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1021{{"Constant[1021∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant1020 & Constant1021 & Constant707 --> Object1023
+    Object1038{{"Object[1038∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1035{{"Constant[1035∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1036{{"Constant[1036∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant1035 & Constant1036 & Constant722 --> Object1038
     Object1053{{"Object[1053∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1050{{"Constant[1050∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1051{{"Constant[1051∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant1050 & Constant1051 & Constant716 --> Object1053
-    Object1067{{"Object[1067∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1064{{"Constant[1064∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1065{{"Constant[1065∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant1064 & Constant1065 & Constant674 --> Object1067
-    Object1081{{"Object[1081∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1078{{"Constant[1078∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1079{{"Constant[1079∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant1078 & Constant1079 & Constant688 --> Object1081
-    Object1095{{"Object[1095∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1092{{"Constant[1092∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1093{{"Constant[1093∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant1092 & Constant1093 & Constant702 --> Object1095
-    Object1109{{"Object[1109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1106{{"Constant[1106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1107{{"Constant[1107∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant1106 & Constant1107 & Constant716 --> Object1109
-    Object1123{{"Object[1123∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1120{{"Constant[1120∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1121{{"Constant[1121∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1120 & Constant1121 & Constant730 --> Object1123
-    Object1137{{"Object[1137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1134{{"Constant[1134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1135{{"Constant[1135∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1134 & Constant1135 & Constant744 --> Object1137
-    Object1151{{"Object[1151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1148{{"Constant[1148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1149{{"Constant[1149∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1148 & Constant1149 & Constant730 --> Object1151
-    Object1225{{"Object[1225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1222{{"Constant[1222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1223{{"Constant[1223∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant1222 & Constant1223 & Constant674 --> Object1225
-    Object1239{{"Object[1239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1236{{"Constant[1236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1237{{"Constant[1237∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant1236 & Constant1237 & Constant688 --> Object1239
-    Object1253{{"Object[1253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1250{{"Constant[1250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1251{{"Constant[1251∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant1250 & Constant1251 & Constant702 --> Object1253
+    Constant1051{{"Constant[1051∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1050 & Constant1051 & Constant737 --> Object1053
+    Object1068{{"Object[1068∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1065{{"Constant[1065∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1066{{"Constant[1066∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1065 & Constant1066 & Constant752 --> Object1068
+    Object1083{{"Object[1083∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1080{{"Constant[1080∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1081{{"Constant[1081∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant1080 & Constant1081 & Constant722 --> Object1083
+    Object1098{{"Object[1098∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1095{{"Constant[1095∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1096{{"Constant[1096∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant1095 & Constant1096 & Constant677 --> Object1098
+    Object1113{{"Object[1113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1110{{"Constant[1110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1111{{"Constant[1111∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant1110 & Constant1111 & Constant692 --> Object1113
+    Object1128{{"Object[1128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1125{{"Constant[1125∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1126{{"Constant[1126∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant1125 & Constant1126 & Constant707 --> Object1128
+    Object1143{{"Object[1143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1140{{"Constant[1140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1141{{"Constant[1141∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant1140 & Constant1141 & Constant722 --> Object1143
+    Object1158{{"Object[1158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1155{{"Constant[1155∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1156{{"Constant[1156∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1155 & Constant1156 & Constant737 --> Object1158
+    Object1173{{"Object[1173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1170{{"Constant[1170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1171{{"Constant[1171∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1170 & Constant1171 & Constant752 --> Object1173
+    Object1188{{"Object[1188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1185{{"Constant[1185∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1186{{"Constant[1186∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1185 & Constant1186 & Constant737 --> Object1188
+    Object1203{{"Object[1203∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1200{{"Constant[1200∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1201{{"Constant[1201∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1200 & Constant1201 & Constant752 --> Object1203
+    Object1218{{"Object[1218∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1215{{"Constant[1215∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1216{{"Constant[1216∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1215 & Constant1216 & Constant647 --> Object1218
+    Object1235{{"Object[1235∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1232{{"Constant[1232∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1233{{"Constant[1233∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1232 & Constant1233 & Constant647 --> Object1235
+    Object1252{{"Object[1252∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1249{{"Constant[1249∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1250{{"Constant[1250∈0] ➊<br />ᐸsql.identifier(”single_table_item_relations”)ᐳ"}}:::plan
+    Constant1251{{"Constant[1251∈0] ➊<br />ᐸRecordCodec(singleTableItemRelations)ᐳ"}}:::plan
+    Lambda640 & Constant1249 & Constant1250 & Constant1251 --> Object1252
     Object1267{{"Object[1267∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1264{{"Constant[1264∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1265{{"Constant[1265∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant1264 & Constant1265 & Constant716 --> Object1267
-    Object1281{{"Object[1281∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1278{{"Constant[1278∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1279{{"Constant[1279∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1278 & Constant1279 & Constant730 --> Object1281
-    Object1311{{"Object[1311∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1308{{"Constant[1308∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1309{{"Constant[1309∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Lambda640 & Constant1308 & Constant1309 & Constant674 --> Object1311
-    Object1325{{"Object[1325∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1322{{"Constant[1322∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1323{{"Constant[1323∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Lambda640 & Constant1322 & Constant1323 & Constant688 --> Object1325
-    Object1339{{"Object[1339∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1336{{"Constant[1336∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1337{{"Constant[1337∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Lambda640 & Constant1336 & Constant1337 & Constant702 --> Object1339
-    Object1353{{"Object[1353∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1350{{"Constant[1350∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1351{{"Constant[1351∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Lambda640 & Constant1350 & Constant1351 & Constant716 --> Object1353
-    Object1367{{"Object[1367∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1364{{"Constant[1364∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1365{{"Constant[1365∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Lambda640 & Constant1364 & Constant1365 & Constant730 --> Object1367
+    Constant1265{{"Constant[1265∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant1264 & Constant1265 & Constant677 --> Object1267
+    Object1282{{"Object[1282∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1279{{"Constant[1279∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1280{{"Constant[1280∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant1279 & Constant1280 & Constant692 --> Object1282
+    Object1297{{"Object[1297∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1294{{"Constant[1294∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1295{{"Constant[1295∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant1294 & Constant1295 & Constant707 --> Object1297
+    Object1312{{"Object[1312∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1309{{"Constant[1309∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1310{{"Constant[1310∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant1309 & Constant1310 & Constant722 --> Object1312
+    Object1327{{"Object[1327∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1324{{"Constant[1324∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1325{{"Constant[1325∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1324 & Constant1325 & Constant737 --> Object1327
+    Object1342{{"Object[1342∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1339{{"Constant[1339∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1340{{"Constant[1340∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1339 & Constant1340 & Constant752 --> Object1342
+    Object1359{{"Object[1359∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1356{{"Constant[1356∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1357{{"Constant[1357∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Lambda640 & Constant1356 & Constant1357 & Constant677 --> Object1359
+    Object1374{{"Object[1374∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1371{{"Constant[1371∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1372{{"Constant[1372∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Lambda640 & Constant1371 & Constant1372 & Constant692 --> Object1374
+    Object1389{{"Object[1389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1386{{"Constant[1386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1387{{"Constant[1387∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Lambda640 & Constant1386 & Constant1387 & Constant707 --> Object1389
+    Object1404{{"Object[1404∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1401{{"Constant[1401∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1402{{"Constant[1402∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Lambda640 & Constant1401 & Constant1402 & Constant722 --> Object1404
+    Object1419{{"Object[1419∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1416{{"Constant[1416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1417{{"Constant[1417∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1416 & Constant1417 & Constant737 --> Object1419
+    Object1434{{"Object[1434∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1431{{"Constant[1431∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1432{{"Constant[1432∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Lambda640 & Constant1431 & Constant1432 & Constant752 --> Object1434
+    Object1451{{"Object[1451∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1448{{"Constant[1448∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1449{{"Constant[1449∈0] ➊<br />ᐸsql.identifier(”relational_item_relations”)ᐳ"}}:::plan
+    Constant1450{{"Constant[1450∈0] ➊<br />ᐸRecordCodec(relationalItemRelations)ᐳ"}}:::plan
+    Lambda640 & Constant1448 & Constant1449 & Constant1450 --> Object1451
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    Lambda418[["Lambda[418∈0] ➊"]]:::unbatchedplan
+    List419{{"List[419∈0] ➊<br />ᐸ1458ᐳ"}}:::plan
+    Lambda418 & List419 --> Object420
+    Lambda422[["Lambda[422∈0] ➊"]]:::unbatchedplan
+    Lambda422 & List419 --> Object424
+    Lambda426[["Lambda[426∈0] ➊"]]:::unbatchedplan
+    Lambda426 & List419 --> Object428
+    Lambda430[["Lambda[430∈0] ➊"]]:::unbatchedplan
+    Lambda430 & List419 --> Object432
+    Lambda434[["Lambda[434∈0] ➊"]]:::unbatchedplan
+    Lambda434 & List419 --> Object436
+    __Flag441[["__Flag[441∈0] ➊<br />ᐸ440, if(413), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag440[["__Flag[440∈0] ➊<br />ᐸ439, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition413{{"Condition[413∈0] ➊<br />ᐸexistsᐳ"}}:::plan
+    __Flag440 & Condition413 --> __Flag441
+    Lambda507[["Lambda[507∈0] ➊"]]:::unbatchedplan
+    List508{{"List[508∈0] ➊<br />ᐸ1460ᐳ"}}:::plan
+    Lambda507 & List508 --> Object509
+    Lambda511[["Lambda[511∈0] ➊"]]:::unbatchedplan
+    Lambda511 & List508 --> Object513
+    Lambda515[["Lambda[515∈0] ➊"]]:::unbatchedplan
+    Lambda515 & List508 --> Object517
+    Lambda519[["Lambda[519∈0] ➊"]]:::unbatchedplan
+    Lambda519 & List508 --> Object521
+    Lambda523[["Lambda[523∈0] ➊"]]:::unbatchedplan
+    Lambda523 & List508 --> Object525
+    __Flag530[["__Flag[530∈0] ➊<br />ᐸ529, if(502), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag529[["__Flag[529∈0] ➊<br />ᐸ528, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition502{{"Condition[502∈0] ➊<br />ᐸexistsᐳ"}}:::plan
+    __Flag529 & Condition502 --> __Flag530
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant1408{{"Constant[1408∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1408 --> Lambda640
+    Constant1459{{"Constant[1459∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
+    Constant1459 --> Condition413
+    Lambda414{{"Lambda[414∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant1459 --> Lambda414
+    Lambda414 --> Lambda418
+    Access1458{{"Access[1458∈0] ➊<br />ᐸ414.base64JSON.1ᐳ"}}:::plan
+    Access1458 --> List419
+    Lambda414 --> Lambda422
+    Lambda414 --> Lambda426
+    Lambda414 --> Lambda430
+    Lambda414 --> Lambda434
+    Lambda438{{"Lambda[438∈0] ➊"}}:::plan
+    List437 --> Lambda438
+    Access439{{"Access[439∈0] ➊<br />ᐸ438.0ᐳ"}}:::plan
+    Lambda438 --> Access439
+    Access439 --> __Flag440
+    Constant1461{{"Constant[1461∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX2NoZWNrbGlzdF9pdGVtcyIsMjFd'ᐳ"}}:::plan
+    Constant1461 --> Condition502
+    Lambda503{{"Lambda[503∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant1461 --> Lambda503
+    Lambda503 --> Lambda507
+    Access1460{{"Access[1460∈0] ➊<br />ᐸ503.base64JSON.1ᐳ"}}:::plan
+    Access1460 --> List508
+    Lambda503 --> Lambda511
+    Lambda503 --> Lambda515
+    Lambda503 --> Lambda519
+    Lambda503 --> Lambda523
+    Lambda527{{"Lambda[527∈0] ➊"}}:::plan
+    List526 --> Lambda527
+    Access528{{"Access[528∈0] ➊<br />ᐸ527.0ᐳ"}}:::plan
+    Lambda527 --> Access528
+    Access528 --> __Flag529
+    Constant1462{{"Constant[1462∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1462 --> Lambda640
     Lambda643{{"Lambda[643∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1409{{"Constant[1409∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1409 --> Lambda643
-    Lambda648{{"Lambda[648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object647 --> Lambda648
-    Lambda653{{"Lambda[653∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1410{{"Constant[1410∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant1410 --> Lambda653
-    Lambda676{{"Lambda[676∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object675 --> Lambda676
-    Lambda681{{"Lambda[681∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1412{{"Constant[1412∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1412 --> Lambda681
-    Lambda690{{"Lambda[690∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object689 --> Lambda690
-    Lambda695{{"Lambda[695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1413{{"Constant[1413∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1413 --> Lambda695
-    Lambda704{{"Lambda[704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object703 --> Lambda704
+    Constant1463{{"Constant[1463∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1463 --> Lambda643
+    Access644{{"Access[644∈0] ➊<br />ᐸ643.0ᐳ"}}:::plan
+    Lambda643 --> Access644
+    Lambda649{{"Lambda[649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object648 --> Lambda649
+    Lambda654{{"Lambda[654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1464{{"Constant[1464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1464 --> Lambda654
+    Lambda664{{"Lambda[664∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object663 --> Lambda664
+    Lambda669{{"Lambda[669∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1465{{"Constant[1465∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1465 --> Lambda669
+    Lambda679{{"Lambda[679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object678 --> Lambda679
+    Lambda684{{"Lambda[684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1466{{"Constant[1466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1466 --> Lambda684
+    Lambda694{{"Lambda[694∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object693 --> Lambda694
+    Lambda699{{"Lambda[699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1467{{"Constant[1467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1467 --> Lambda699
     Lambda709{{"Lambda[709∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1414{{"Constant[1414∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1414 --> Lambda709
-    Lambda718{{"Lambda[718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object717 --> Lambda718
-    Lambda723{{"Lambda[723∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1415{{"Constant[1415∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1415 --> Lambda723
-    Lambda732{{"Lambda[732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object731 --> Lambda732
-    Lambda737{{"Lambda[737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1416{{"Constant[1416∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1416 --> Lambda737
-    Lambda746{{"Lambda[746∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object745 --> Lambda746
-    Lambda751{{"Lambda[751∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1417{{"Constant[1417∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1417 --> Lambda751
-    Lambda760{{"Lambda[760∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object759 --> Lambda760
-    Lambda765{{"Lambda[765∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1418{{"Constant[1418∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1418 --> Lambda765
+    Object708 --> Lambda709
+    Lambda714{{"Lambda[714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1468{{"Constant[1468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1468 --> Lambda714
+    Lambda724{{"Lambda[724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object723 --> Lambda724
+    Lambda729{{"Lambda[729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1469{{"Constant[1469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1469 --> Lambda729
+    Lambda739{{"Lambda[739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object738 --> Lambda739
+    Lambda744{{"Lambda[744∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1470{{"Constant[1470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1470 --> Lambda744
+    Lambda754{{"Lambda[754∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object753 --> Lambda754
+    Lambda759{{"Lambda[759∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1471{{"Constant[1471∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1471 --> Lambda759
+    Lambda769{{"Lambda[769∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object768 --> Lambda769
     Lambda774{{"Lambda[774∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object773 --> Lambda774
-    Lambda779{{"Lambda[779∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1419{{"Constant[1419∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1419 --> Lambda779
-    Lambda788{{"Lambda[788∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object787 --> Lambda788
-    Lambda793{{"Lambda[793∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1420{{"Constant[1420∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1420 --> Lambda793
-    Lambda802{{"Lambda[802∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object801 --> Lambda802
-    Lambda807{{"Lambda[807∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1421{{"Constant[1421∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1421 --> Lambda807
-    Lambda816{{"Lambda[816∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object815 --> Lambda816
-    Lambda821{{"Lambda[821∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1422{{"Constant[1422∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1422 --> Lambda821
-    Lambda830{{"Lambda[830∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object829 --> Lambda830
-    Lambda835{{"Lambda[835∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1423{{"Constant[1423∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1423 --> Lambda835
+    Constant1472{{"Constant[1472∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1472 --> Lambda774
+    Lambda784{{"Lambda[784∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object783 --> Lambda784
+    Lambda789{{"Lambda[789∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1473{{"Constant[1473∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1473 --> Lambda789
+    Lambda799{{"Lambda[799∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object798 --> Lambda799
+    Lambda804{{"Lambda[804∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1474{{"Constant[1474∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1474 --> Lambda804
+    Lambda814{{"Lambda[814∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object813 --> Lambda814
+    Lambda819{{"Lambda[819∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1475{{"Constant[1475∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1475 --> Lambda819
+    Lambda829{{"Lambda[829∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object828 --> Lambda829
+    Lambda834{{"Lambda[834∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1476{{"Constant[1476∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1476 --> Lambda834
     Lambda844{{"Lambda[844∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object843 --> Lambda844
     Lambda849{{"Lambda[849∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1424{{"Constant[1424∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1424 --> Lambda849
-    Lambda858{{"Lambda[858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object857 --> Lambda858
-    Lambda863{{"Lambda[863∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1425{{"Constant[1425∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1425 --> Lambda863
-    Lambda872{{"Lambda[872∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object871 --> Lambda872
-    Lambda877{{"Lambda[877∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1426{{"Constant[1426∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1426 --> Lambda877
-    Lambda886{{"Lambda[886∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object885 --> Lambda886
-    Lambda891{{"Lambda[891∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1427{{"Constant[1427∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1427 --> Lambda891
-    Lambda900{{"Lambda[900∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object899 --> Lambda900
-    Lambda905{{"Lambda[905∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1428{{"Constant[1428∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1428 --> Lambda905
-    Lambda914{{"Lambda[914∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object913 --> Lambda914
+    Constant1477{{"Constant[1477∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1477 --> Lambda849
+    Lambda859{{"Lambda[859∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object858 --> Lambda859
+    Lambda864{{"Lambda[864∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1478{{"Constant[1478∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1478 --> Lambda864
+    Lambda874{{"Lambda[874∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object873 --> Lambda874
+    Lambda879{{"Lambda[879∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1479{{"Constant[1479∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1479 --> Lambda879
+    Lambda889{{"Lambda[889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object888 --> Lambda889
+    Lambda894{{"Lambda[894∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1480{{"Constant[1480∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1480 --> Lambda894
+    Lambda904{{"Lambda[904∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object903 --> Lambda904
+    Lambda909{{"Lambda[909∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1481{{"Constant[1481∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1481 --> Lambda909
     Lambda919{{"Lambda[919∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1429{{"Constant[1429∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1429 --> Lambda919
-    Lambda928{{"Lambda[928∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object927 --> Lambda928
-    Lambda933{{"Lambda[933∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1430{{"Constant[1430∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1430 --> Lambda933
-    Lambda942{{"Lambda[942∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object941 --> Lambda942
-    Lambda947{{"Lambda[947∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1431{{"Constant[1431∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1431 --> Lambda947
-    Lambda956{{"Lambda[956∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object955 --> Lambda956
-    Lambda961{{"Lambda[961∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1432{{"Constant[1432∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1432 --> Lambda961
-    Lambda970{{"Lambda[970∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object969 --> Lambda970
-    Lambda975{{"Lambda[975∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1433{{"Constant[1433∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1433 --> Lambda975
+    Object918 --> Lambda919
+    Lambda924{{"Lambda[924∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1482{{"Constant[1482∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1482 --> Lambda924
+    Lambda934{{"Lambda[934∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object933 --> Lambda934
+    Lambda939{{"Lambda[939∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1483{{"Constant[1483∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1483 --> Lambda939
+    Lambda949{{"Lambda[949∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object948 --> Lambda949
+    Lambda954{{"Lambda[954∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1484{{"Constant[1484∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1484 --> Lambda954
+    Lambda964{{"Lambda[964∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object963 --> Lambda964
+    Lambda969{{"Lambda[969∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1485{{"Constant[1485∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1485 --> Lambda969
+    Lambda979{{"Lambda[979∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object978 --> Lambda979
     Lambda984{{"Lambda[984∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object983 --> Lambda984
-    Lambda989{{"Lambda[989∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1434{{"Constant[1434∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1434 --> Lambda989
-    Lambda998{{"Lambda[998∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object997 --> Lambda998
-    Lambda1003{{"Lambda[1003∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1435{{"Constant[1435∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1435 --> Lambda1003
-    Lambda1012{{"Lambda[1012∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1011 --> Lambda1012
-    Lambda1017{{"Lambda[1017∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1436{{"Constant[1436∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1436 --> Lambda1017
-    Lambda1026{{"Lambda[1026∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1025 --> Lambda1026
-    Lambda1031{{"Lambda[1031∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1437{{"Constant[1437∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1437 --> Lambda1031
-    Lambda1040{{"Lambda[1040∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1039 --> Lambda1040
-    Lambda1045{{"Lambda[1045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1438{{"Constant[1438∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1438 --> Lambda1045
+    Constant1486{{"Constant[1486∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1486 --> Lambda984
+    Lambda994{{"Lambda[994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object993 --> Lambda994
+    Lambda999{{"Lambda[999∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1487{{"Constant[1487∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1487 --> Lambda999
+    Lambda1009{{"Lambda[1009∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1008 --> Lambda1009
+    Lambda1014{{"Lambda[1014∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1488{{"Constant[1488∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1488 --> Lambda1014
+    Lambda1024{{"Lambda[1024∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1023 --> Lambda1024
+    Lambda1029{{"Lambda[1029∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1489{{"Constant[1489∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1489 --> Lambda1029
+    Lambda1039{{"Lambda[1039∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1038 --> Lambda1039
+    Lambda1044{{"Lambda[1044∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1490{{"Constant[1490∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1490 --> Lambda1044
     Lambda1054{{"Lambda[1054∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object1053 --> Lambda1054
     Lambda1059{{"Lambda[1059∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1439{{"Constant[1439∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1439 --> Lambda1059
-    Lambda1068{{"Lambda[1068∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1067 --> Lambda1068
-    Lambda1073{{"Lambda[1073∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1440{{"Constant[1440∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1440 --> Lambda1073
-    Lambda1082{{"Lambda[1082∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1081 --> Lambda1082
-    Lambda1087{{"Lambda[1087∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1441{{"Constant[1441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1441 --> Lambda1087
-    Lambda1096{{"Lambda[1096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1095 --> Lambda1096
-    Lambda1101{{"Lambda[1101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1442{{"Constant[1442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1442 --> Lambda1101
-    Lambda1110{{"Lambda[1110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1109 --> Lambda1110
-    Lambda1115{{"Lambda[1115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1443{{"Constant[1443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1443 --> Lambda1115
-    Lambda1124{{"Lambda[1124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1123 --> Lambda1124
+    Constant1491{{"Constant[1491∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1491 --> Lambda1059
+    Lambda1069{{"Lambda[1069∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1068 --> Lambda1069
+    Lambda1074{{"Lambda[1074∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1492{{"Constant[1492∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1492 --> Lambda1074
+    Lambda1084{{"Lambda[1084∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1083 --> Lambda1084
+    Lambda1089{{"Lambda[1089∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1493{{"Constant[1493∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1493 --> Lambda1089
+    Lambda1099{{"Lambda[1099∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1098 --> Lambda1099
+    Lambda1104{{"Lambda[1104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1494{{"Constant[1494∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1494 --> Lambda1104
+    Lambda1114{{"Lambda[1114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1113 --> Lambda1114
+    Lambda1119{{"Lambda[1119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1495{{"Constant[1495∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1495 --> Lambda1119
     Lambda1129{{"Lambda[1129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1444{{"Constant[1444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1444 --> Lambda1129
-    Lambda1138{{"Lambda[1138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1137 --> Lambda1138
-    Lambda1143{{"Lambda[1143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1445{{"Constant[1445∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1445 --> Lambda1143
-    Lambda1152{{"Lambda[1152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1151 --> Lambda1152
-    Lambda1157{{"Lambda[1157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1446{{"Constant[1446∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1446 --> Lambda1157
-    Lambda1226{{"Lambda[1226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1225 --> Lambda1226
-    Lambda1231{{"Lambda[1231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1451{{"Constant[1451∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1451 --> Lambda1231
-    Lambda1240{{"Lambda[1240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1239 --> Lambda1240
-    Lambda1245{{"Lambda[1245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1452{{"Constant[1452∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1452 --> Lambda1245
-    Lambda1254{{"Lambda[1254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1253 --> Lambda1254
-    Lambda1259{{"Lambda[1259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1453{{"Constant[1453∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1453 --> Lambda1259
+    Object1128 --> Lambda1129
+    Lambda1134{{"Lambda[1134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1496{{"Constant[1496∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1496 --> Lambda1134
+    Lambda1144{{"Lambda[1144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1143 --> Lambda1144
+    Lambda1149{{"Lambda[1149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1497{{"Constant[1497∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1497 --> Lambda1149
+    Lambda1159{{"Lambda[1159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1158 --> Lambda1159
+    Lambda1164{{"Lambda[1164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1498{{"Constant[1498∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1498 --> Lambda1164
+    Lambda1174{{"Lambda[1174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1173 --> Lambda1174
+    Lambda1179{{"Lambda[1179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1499{{"Constant[1499∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1499 --> Lambda1179
+    Lambda1189{{"Lambda[1189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1188 --> Lambda1189
+    Lambda1194{{"Lambda[1194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1500{{"Constant[1500∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1500 --> Lambda1194
+    Lambda1204{{"Lambda[1204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1203 --> Lambda1204
+    Lambda1209{{"Lambda[1209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1501{{"Constant[1501∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1501 --> Lambda1209
+    Lambda1219{{"Lambda[1219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1218 --> Lambda1219
+    Lambda1224{{"Lambda[1224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1502{{"Constant[1502∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1502 --> Lambda1224
+    Lambda1236{{"Lambda[1236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1235 --> Lambda1236
+    Lambda1241{{"Lambda[1241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1503{{"Constant[1503∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant1503 --> Lambda1241
+    Lambda1253{{"Lambda[1253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1252 --> Lambda1253
+    Lambda1258{{"Lambda[1258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1504{{"Constant[1504∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1504 --> Lambda1258
     Lambda1268{{"Lambda[1268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object1267 --> Lambda1268
     Lambda1273{{"Lambda[1273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1454{{"Constant[1454∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1454 --> Lambda1273
-    Lambda1282{{"Lambda[1282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1281 --> Lambda1282
-    Lambda1287{{"Lambda[1287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1455{{"Constant[1455∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1455 --> Lambda1287
-    Lambda1312{{"Lambda[1312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1311 --> Lambda1312
-    Lambda1317{{"Lambda[1317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1457{{"Constant[1457∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1457 --> Lambda1317
-    Lambda1326{{"Lambda[1326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1325 --> Lambda1326
-    Lambda1331{{"Lambda[1331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1458{{"Constant[1458∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1458 --> Lambda1331
-    Lambda1340{{"Lambda[1340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1339 --> Lambda1340
-    Lambda1345{{"Lambda[1345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1459{{"Constant[1459∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1459 --> Lambda1345
-    Lambda1354{{"Lambda[1354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1353 --> Lambda1354
-    Lambda1359{{"Lambda[1359∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1460{{"Constant[1460∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1460 --> Lambda1359
-    Lambda1368{{"Lambda[1368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1367 --> Lambda1368
-    Lambda1373{{"Lambda[1373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1461{{"Constant[1461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1461 --> Lambda1373
+    Constant1505{{"Constant[1505∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1505 --> Lambda1273
+    Lambda1283{{"Lambda[1283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1282 --> Lambda1283
+    Lambda1288{{"Lambda[1288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1506{{"Constant[1506∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1506 --> Lambda1288
+    Lambda1298{{"Lambda[1298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1297 --> Lambda1298
+    Lambda1303{{"Lambda[1303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1507{{"Constant[1507∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1507 --> Lambda1303
+    Lambda1313{{"Lambda[1313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1312 --> Lambda1313
+    Lambda1318{{"Lambda[1318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1508{{"Constant[1508∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1508 --> Lambda1318
+    Lambda1328{{"Lambda[1328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1327 --> Lambda1328
+    Lambda1333{{"Lambda[1333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1509{{"Constant[1509∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1509 --> Lambda1333
+    Lambda1343{{"Lambda[1343∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1342 --> Lambda1343
+    Lambda1348{{"Lambda[1348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1510{{"Constant[1510∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1510 --> Lambda1348
+    Lambda1360{{"Lambda[1360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1359 --> Lambda1360
+    Lambda1365{{"Lambda[1365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1511{{"Constant[1511∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1511 --> Lambda1365
+    Lambda1375{{"Lambda[1375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1374 --> Lambda1375
+    Lambda1380{{"Lambda[1380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1512{{"Constant[1512∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1512 --> Lambda1380
+    Lambda1390{{"Lambda[1390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1389 --> Lambda1390
+    Lambda1395{{"Lambda[1395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1513{{"Constant[1513∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1513 --> Lambda1395
+    Lambda1405{{"Lambda[1405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1404 --> Lambda1405
+    Lambda1410{{"Lambda[1410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1514{{"Constant[1514∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1514 --> Lambda1410
+    Lambda1420{{"Lambda[1420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1419 --> Lambda1420
+    Lambda1425{{"Lambda[1425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1515{{"Constant[1515∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1515 --> Lambda1425
+    Lambda1435{{"Lambda[1435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1434 --> Lambda1435
+    Lambda1440{{"Lambda[1440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1516{{"Constant[1516∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant1516 --> Lambda1440
+    Lambda1452{{"Lambda[1452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1451 --> Lambda1452
+    Lambda1457{{"Lambda[1457∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1517{{"Constant[1517∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1517 --> Lambda1457
+    Lambda414 --> Access1458
+    Lambda503 --> Access1460
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant17{{"Constant[17∈0] ➊<br />ᐸ'SingleTableTopic'ᐳ"}}:::plan
@@ -460,49 +614,15 @@ graph TD
     Constant445{{"Constant[445∈0] ➊<br />ᐸ'single_table_item_relations'ᐳ"}}:::plan
     Connection501{{"Connection[501∈0] ➊<br />ᐸ499ᐳ"}}:::plan
     Constant534{{"Constant[534∈0] ➊<br />ᐸ'relational_item_relations'ᐳ"}}:::plan
-    Constant658{{"Constant[658∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant659{{"Constant[659∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant1162{{"Constant[1162∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1163{{"Constant[1163∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant1176{{"Constant[1176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1177{{"Constant[1177∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant1192{{"Constant[1192∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1193{{"Constant[1193∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant1208{{"Constant[1208∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1209{{"Constant[1209∈0] ➊<br />ᐸsql.identifier(”single_table_item_relations”)ᐳ"}}:::plan
-    Constant1210{{"Constant[1210∈0] ➊<br />ᐸRecordCodec(singleTableItemRelations)ᐳ"}}:::plan
-    Constant1292{{"Constant[1292∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1293{{"Constant[1293∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant1378{{"Constant[1378∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1379{{"Constant[1379∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant1394{{"Constant[1394∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1395{{"Constant[1395∈0] ➊<br />ᐸsql.identifier(”relational_item_relations”)ᐳ"}}:::plan
-    Constant1396{{"Constant[1396∈0] ➊<br />ᐸRecordCodec(relationalItemRelations)ᐳ"}}:::plan
-    Constant1405{{"Constant[1405∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
-    Constant1407{{"Constant[1407∈0] ➊<br />ᐸ'WyJyZWxhdGlvbmFsX2NoZWNrbGlzdF9pdGVtcyIsMjFd'ᐳ"}}:::plan
-    Constant1411{{"Constant[1411∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1447{{"Constant[1447∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1448{{"Constant[1448∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant1449{{"Constant[1449∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant1450{{"Constant[1450∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1456{{"Constant[1456∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1462{{"Constant[1462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant1463{{"Constant[1463∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    Lambda662{{"Lambda[662∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda667{{"Lambda[667∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda640 & Lambda643 & Lambda662 & Lambda667 --> PgSelect14
-    Object661{{"Object[661∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant658 & Constant659 & Constant646 --> Object661
-    Object661 --> Lambda662
-    Constant1411 --> Lambda667
+    Object12 & Connection13 & Lambda640 & Access644 & Lambda664 & Lambda669 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
     PgSelect23[["PgSelect[23∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object12 & PgClassExpression22 & Lambda640 & Lambda643 & Lambda648 & Lambda653 --> PgSelect23
+    Object12 & PgClassExpression22 & Lambda640 & Access644 & Lambda649 & Lambda654 --> PgSelect23
     List19{{"List[19∈3]<br />ᐸ17,18ᐳ<br />ᐳSingleTableTopic"}}:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant17 & PgClassExpression18 --> List19
@@ -557,43 +677,37 @@ graph TD
     Lambda45{{"Lambda[45∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List44 --> Lambda45
     PgSelect119[["PgSelect[119∈5] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda1166{{"Lambda[1166∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1171{{"Lambda[1171∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection118 & Lambda640 & Lambda643 & Lambda1166 & Lambda1171 --> PgSelect119
-    Object1165{{"Object[1165∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1162 & Constant1163 & Constant744 --> Object1165
-    Object1165 --> Lambda1166
-    Constant1447 --> Lambda1171
+    Object12 & Connection118 & Lambda640 & Access644 & Lambda1204 & Lambda1209 --> PgSelect119
     __Item120[/"__Item[120∈6]<br />ᐸ119ᐳ"\]:::itemplan
     PgSelect119 ==> __Item120
     PgSelectSingle121{{"PgSelectSingle[121∈6]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item120 --> PgSelectSingle121
     PgSelect123[["PgSelect[123∈7]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression122{{"PgClassExpression[122∈7]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression122 & Lambda640 & Lambda643 & Lambda760 & Lambda765 --> PgSelect123
+    Object12 & PgClassExpression122 & Lambda640 & Access644 & Lambda769 & Lambda774 --> PgSelect123
     PgSelect134[["PgSelect[134∈7]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression130{{"PgClassExpression[130∈7]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression130 & Lambda640 & Lambda643 & Lambda746 & Lambda751 --> PgSelect134
+    Object12 & PgClassExpression130 & Lambda640 & Access644 & Lambda754 & Lambda759 --> PgSelect134
     PgSelect182[["PgSelect[182∈7]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression122 & Lambda640 & Lambda643 & Lambda858 & Lambda863 --> PgSelect182
+    Object12 & PgClassExpression122 & Lambda640 & Access644 & Lambda874 & Lambda879 --> PgSelect182
     PgSelect190[["PgSelect[190∈7]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression187{{"PgClassExpression[187∈7]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression187 & Lambda640 & Lambda643 & Lambda844 & Lambda849 --> PgSelect190
+    Object12 & PgClassExpression187 & Lambda640 & Access644 & Lambda859 & Lambda864 --> PgSelect190
     PgSelect238[["PgSelect[238∈7]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression122 & Lambda640 & Lambda643 & Lambda956 & Lambda961 --> PgSelect238
+    Object12 & PgClassExpression122 & Lambda640 & Access644 & Lambda979 & Lambda984 --> PgSelect238
     PgSelect246[["PgSelect[246∈7]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalDivider"]]:::plan
     PgClassExpression243{{"PgClassExpression[243∈7]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression243 & Lambda640 & Lambda643 & Lambda942 & Lambda947 --> PgSelect246
+    Object12 & PgClassExpression243 & Lambda640 & Access644 & Lambda964 & Lambda969 --> PgSelect246
     PgSelect294[["PgSelect[294∈7]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression122 & Lambda640 & Lambda643 & Lambda1054 & Lambda1059 --> PgSelect294
+    Object12 & PgClassExpression122 & Lambda640 & Access644 & Lambda1084 & Lambda1089 --> PgSelect294
     PgSelect302[["PgSelect[302∈7]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklist"]]:::plan
     PgClassExpression299{{"PgClassExpression[299∈7]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression299 & Lambda640 & Lambda643 & Lambda1040 & Lambda1045 --> PgSelect302
+    Object12 & PgClassExpression299 & Lambda640 & Access644 & Lambda1069 & Lambda1074 --> PgSelect302
     PgSelect350[["PgSelect[350∈7]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression122 & Lambda640 & Lambda643 & Lambda1152 & Lambda1157 --> PgSelect350
+    Object12 & PgClassExpression122 & Lambda640 & Access644 & Lambda1189 & Lambda1194 --> PgSelect350
     PgSelect358[["PgSelect[358∈7]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression355{{"PgClassExpression[355∈7]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression355 & Lambda640 & Lambda643 & Lambda1138 & Lambda1143 --> PgSelect358
+    Object12 & PgClassExpression355 & Lambda640 & Access644 & Lambda1174 & Lambda1179 --> PgSelect358
     List131{{"List[131∈7]<br />ᐸ129,130ᐳ<br />ᐳRelationalTopic"}}:::plan
     Constant129 & PgClassExpression130 --> List131
     List188{{"List[188∈7]<br />ᐸ154,187ᐳ<br />ᐳRelationalPost"}}:::plan
@@ -664,15 +778,15 @@ graph TD
     First360 --> PgSelectSingle361
     PgSelect139[["PgSelect[139∈8]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgClassExpression138{{"PgClassExpression[138∈8]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression138 & Lambda640 & Lambda643 & Lambda676 & Lambda681 --> PgSelect139
+    Object12 & PgClassExpression138 & Lambda640 & Access644 & Lambda679 & Lambda684 --> PgSelect139
     PgSelect150[["PgSelect[150∈8]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression138 & Lambda640 & Lambda643 & Lambda690 & Lambda695 --> PgSelect150
+    Object12 & PgClassExpression138 & Lambda640 & Access644 & Lambda694 & Lambda699 --> PgSelect150
     PgSelect158[["PgSelect[158∈8]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalTopicᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression138 & Lambda640 & Lambda643 & Lambda704 & Lambda709 --> PgSelect158
+    Object12 & PgClassExpression138 & Lambda640 & Access644 & Lambda709 & Lambda714 --> PgSelect158
     PgSelect166[["PgSelect[166∈8]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalTopicᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression138 & Lambda640 & Lambda643 & Lambda718 & Lambda723 --> PgSelect166
+    Object12 & PgClassExpression138 & Lambda640 & Access644 & Lambda724 & Lambda729 --> PgSelect166
     PgSelect174[["PgSelect[174∈8]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression138 & Lambda640 & Lambda643 & Lambda732 & Lambda737 --> PgSelect174
+    Object12 & PgClassExpression138 & Lambda640 & Access644 & Lambda739 & Lambda744 --> PgSelect174
     List147{{"List[147∈8]<br />ᐸ129,146ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     PgClassExpression146{{"PgClassExpression[146∈8]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression146 --> List147
@@ -728,15 +842,15 @@ graph TD
     List180 --> Lambda181
     PgSelect195[["PgSelect[195∈9]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgClassExpression194{{"PgClassExpression[194∈9]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression194 & Lambda640 & Lambda643 & Lambda774 & Lambda779 --> PgSelect195
+    Object12 & PgClassExpression194 & Lambda640 & Access644 & Lambda784 & Lambda789 --> PgSelect195
     PgSelect206[["PgSelect[206∈9]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression194 & Lambda640 & Lambda643 & Lambda788 & Lambda793 --> PgSelect206
+    Object12 & PgClassExpression194 & Lambda640 & Access644 & Lambda799 & Lambda804 --> PgSelect206
     PgSelect214[["PgSelect[214∈9]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalPostᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression194 & Lambda640 & Lambda643 & Lambda802 & Lambda807 --> PgSelect214
+    Object12 & PgClassExpression194 & Lambda640 & Access644 & Lambda814 & Lambda819 --> PgSelect214
     PgSelect222[["PgSelect[222∈9]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalPostᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression194 & Lambda640 & Lambda643 & Lambda816 & Lambda821 --> PgSelect222
+    Object12 & PgClassExpression194 & Lambda640 & Access644 & Lambda829 & Lambda834 --> PgSelect222
     PgSelect230[["PgSelect[230∈9]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression194 & Lambda640 & Lambda643 & Lambda830 & Lambda835 --> PgSelect230
+    Object12 & PgClassExpression194 & Lambda640 & Access644 & Lambda844 & Lambda849 --> PgSelect230
     List203{{"List[203∈9]<br />ᐸ129,202ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     PgClassExpression202{{"PgClassExpression[202∈9]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression202 --> List203
@@ -792,15 +906,15 @@ graph TD
     List236 --> Lambda237
     PgSelect251[["PgSelect[251∈10]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgClassExpression250{{"PgClassExpression[250∈10]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression250 & Lambda640 & Lambda643 & Lambda872 & Lambda877 --> PgSelect251
+    Object12 & PgClassExpression250 & Lambda640 & Access644 & Lambda889 & Lambda894 --> PgSelect251
     PgSelect262[["PgSelect[262∈10]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression250 & Lambda640 & Lambda643 & Lambda886 & Lambda891 --> PgSelect262
+    Object12 & PgClassExpression250 & Lambda640 & Access644 & Lambda904 & Lambda909 --> PgSelect262
     PgSelect270[["PgSelect[270∈10]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDividerᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression250 & Lambda640 & Lambda643 & Lambda900 & Lambda905 --> PgSelect270
+    Object12 & PgClassExpression250 & Lambda640 & Access644 & Lambda919 & Lambda924 --> PgSelect270
     PgSelect278[["PgSelect[278∈10]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalDividerᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression250 & Lambda640 & Lambda643 & Lambda914 & Lambda919 --> PgSelect278
+    Object12 & PgClassExpression250 & Lambda640 & Access644 & Lambda934 & Lambda939 --> PgSelect278
     PgSelect286[["PgSelect[286∈10]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression250 & Lambda640 & Lambda643 & Lambda928 & Lambda933 --> PgSelect286
+    Object12 & PgClassExpression250 & Lambda640 & Access644 & Lambda949 & Lambda954 --> PgSelect286
     List259{{"List[259∈10]<br />ᐸ129,258ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     PgClassExpression258{{"PgClassExpression[258∈10]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression258 --> List259
@@ -856,15 +970,15 @@ graph TD
     List292 --> Lambda293
     PgSelect307[["PgSelect[307∈11]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgClassExpression306{{"PgClassExpression[306∈11]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression306 & Lambda640 & Lambda643 & Lambda970 & Lambda975 --> PgSelect307
+    Object12 & PgClassExpression306 & Lambda640 & Access644 & Lambda994 & Lambda999 --> PgSelect307
     PgSelect318[["PgSelect[318∈11]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression306 & Lambda640 & Lambda643 & Lambda984 & Lambda989 --> PgSelect318
+    Object12 & PgClassExpression306 & Lambda640 & Access644 & Lambda1009 & Lambda1014 --> PgSelect318
     PgSelect326[["PgSelect[326∈11]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalChecklistᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression306 & Lambda640 & Lambda643 & Lambda998 & Lambda1003 --> PgSelect326
+    Object12 & PgClassExpression306 & Lambda640 & Access644 & Lambda1024 & Lambda1029 --> PgSelect326
     PgSelect334[["PgSelect[334∈11]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression306 & Lambda640 & Lambda643 & Lambda1012 & Lambda1017 --> PgSelect334
+    Object12 & PgClassExpression306 & Lambda640 & Access644 & Lambda1039 & Lambda1044 --> PgSelect334
     PgSelect342[["PgSelect[342∈11]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression306 & Lambda640 & Lambda643 & Lambda1026 & Lambda1031 --> PgSelect342
+    Object12 & PgClassExpression306 & Lambda640 & Access644 & Lambda1054 & Lambda1059 --> PgSelect342
     List315{{"List[315∈11]<br />ᐸ129,314ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     PgClassExpression314{{"PgClassExpression[314∈11]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression314 --> List315
@@ -920,15 +1034,15 @@ graph TD
     List348 --> Lambda349
     PgSelect363[["PgSelect[363∈12]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgClassExpression362{{"PgClassExpression[362∈12]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression362 & Lambda640 & Lambda643 & Lambda1068 & Lambda1073 --> PgSelect363
+    Object12 & PgClassExpression362 & Lambda640 & Access644 & Lambda1099 & Lambda1104 --> PgSelect363
     PgSelect374[["PgSelect[374∈12]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression362 & Lambda640 & Lambda643 & Lambda1082 & Lambda1087 --> PgSelect374
+    Object12 & PgClassExpression362 & Lambda640 & Access644 & Lambda1114 & Lambda1119 --> PgSelect374
     PgSelect382[["PgSelect[382∈12]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalChecklistItemᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression362 & Lambda640 & Lambda643 & Lambda1096 & Lambda1101 --> PgSelect382
+    Object12 & PgClassExpression362 & Lambda640 & Access644 & Lambda1129 & Lambda1134 --> PgSelect382
     PgSelect390[["PgSelect[390∈12]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression362 & Lambda640 & Lambda643 & Lambda1110 & Lambda1115 --> PgSelect390
+    Object12 & PgClassExpression362 & Lambda640 & Access644 & Lambda1144 & Lambda1149 --> PgSelect390
     PgSelect398[["PgSelect[398∈12]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression362 & Lambda640 & Lambda643 & Lambda1124 & Lambda1129 --> PgSelect398
+    Object12 & PgClassExpression362 & Lambda640 & Access644 & Lambda1159 & Lambda1164 --> PgSelect398
     List371{{"List[371∈12]<br />ᐸ129,370ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     PgClassExpression370{{"PgClassExpression[370∈12]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression370 --> List371
@@ -983,63 +1097,7 @@ graph TD
     Lambda405{{"Lambda[405∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List404 --> Lambda405
     PgSelect442[["PgSelect[442∈13] ➊<br />ᐸsingle_table_item_relationsᐳ"]]:::plan
-    __Flag441[["__Flag[441∈13] ➊<br />ᐸ440, if(413), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
-    Lambda1180{{"Lambda[1180∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1185{{"Lambda[1185∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1196{{"Lambda[1196∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1201{{"Lambda[1201∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1212{{"Lambda[1212∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1217{{"Lambda[1217∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & __Flag441 & Connection412 & Lambda643 & Lambda1180 & Lambda1185 & Lambda643 & Lambda1196 & Lambda1201 & Lambda640 & Lambda643 & Lambda1212 & Lambda1217 --> PgSelect442
-    List437{{"List[437∈13] ➊<br />ᐸ420,424,428,432,436ᐳ"}}:::plan
-    Object420{{"Object[420∈13] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object424{{"Object[424∈13] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object428{{"Object[428∈13] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object432{{"Object[432∈13] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object436{{"Object[436∈13] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object420 & Object424 & Object428 & Object432 & Object436 --> List437
-    Object1179{{"Object[1179∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1176 & Constant1177 & Constant646 --> Object1179
-    Object1195{{"Object[1195∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1192 & Constant1193 & Constant646 --> Object1195
-    Object1211{{"Object[1211∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1208 & Constant1209 & Constant1210 --> Object1211
-    Lambda418[["Lambda[418∈13] ➊"]]:::unbatchedplan
-    List419{{"List[419∈13] ➊<br />ᐸ1404ᐳ"}}:::plan
-    Lambda418 & List419 --> Object420
-    Lambda422[["Lambda[422∈13] ➊"]]:::unbatchedplan
-    Lambda422 & List419 --> Object424
-    Lambda426[["Lambda[426∈13] ➊"]]:::unbatchedplan
-    Lambda426 & List419 --> Object428
-    Lambda430[["Lambda[430∈13] ➊"]]:::unbatchedplan
-    Lambda430 & List419 --> Object432
-    Lambda434[["Lambda[434∈13] ➊"]]:::unbatchedplan
-    Lambda434 & List419 --> Object436
-    __Flag440[["__Flag[440∈13] ➊<br />ᐸ439, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition413{{"Condition[413∈13] ➊<br />ᐸexistsᐳ"}}:::plan
-    __Flag440 & Condition413 --> __Flag441
-    Constant1405 --> Condition413
-    Lambda414{{"Lambda[414∈13] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant1405 --> Lambda414
-    Lambda414 --> Lambda418
-    Access1404{{"Access[1404∈13] ➊<br />ᐸ414.base64JSON.1ᐳ"}}:::plan
-    Access1404 --> List419
-    Lambda414 --> Lambda422
-    Lambda414 --> Lambda426
-    Lambda414 --> Lambda430
-    Lambda414 --> Lambda434
-    Lambda438{{"Lambda[438∈13] ➊"}}:::plan
-    List437 --> Lambda438
-    Access439{{"Access[439∈13] ➊<br />ᐸ438.0ᐳ"}}:::plan
-    Lambda438 --> Access439
-    Access439 --> __Flag440
-    Object1179 --> Lambda1180
-    Constant1448 --> Lambda1185
-    Object1195 --> Lambda1196
-    Constant1449 --> Lambda1201
-    Object1211 --> Lambda1212
-    Constant1450 --> Lambda1217
-    Lambda414 --> Access1404
+    Object12 & __Flag441 & Connection412 & Access644 & Lambda1219 & Lambda1224 & Access644 & Lambda1236 & Lambda1241 & Lambda640 & Access644 & Lambda1253 & Lambda1258 --> PgSelect442
     __Item443[/"__Item[443∈14]<br />ᐸ442ᐳ"\]:::itemplan
     PgSelect442 ==> __Item443
     PgSelectSingle444{{"PgSelectSingle[444∈14]<br />ᐸsingle_table_item_relationsᐳ"}}:::plan
@@ -1051,13 +1109,13 @@ graph TD
     Lambda448{{"Lambda[448∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List447 --> Lambda448
     PgSelectSingle455{{"PgSelectSingle[455∈15]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    RemapKeys1186{{"RemapKeys[1186∈15]<br />ᐸ444:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1186 --> PgSelectSingle455
+    RemapKeys1225{{"RemapKeys[1225∈15]<br />ᐸ444:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1225 --> PgSelectSingle455
     PgSelectSingle477{{"PgSelectSingle[477∈15]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    RemapKeys1202{{"RemapKeys[1202∈15]<br />ᐸ444:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys1202 --> PgSelectSingle477
-    PgSelectSingle444 --> RemapKeys1186
-    PgSelectSingle444 --> RemapKeys1202
+    RemapKeys1242{{"RemapKeys[1242∈15]<br />ᐸ444:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys1242 --> PgSelectSingle477
+    PgSelectSingle444 --> RemapKeys1225
+    PgSelectSingle444 --> RemapKeys1242
     List458{{"List[458∈16]<br />ᐸ17,457ᐳ<br />ᐳSingleTableTopic"}}:::plan
     PgClassExpression457{{"PgClassExpression[457∈16]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant17 & PgClassExpression457 --> List458
@@ -1107,63 +1165,7 @@ graph TD
     Lambda494{{"Lambda[494∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List493 --> Lambda494
     PgSelect531[["PgSelect[531∈18] ➊<br />ᐸrelational_item_relationsᐳ"]]:::plan
-    __Flag530[["__Flag[530∈18] ➊<br />ᐸ529, if(502), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
-    Lambda1296{{"Lambda[1296∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1301{{"Lambda[1301∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1382{{"Lambda[1382∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1387{{"Lambda[1387∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1398{{"Lambda[1398∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1403{{"Lambda[1403∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & __Flag530 & Connection501 & Lambda643 & Lambda1296 & Lambda1301 & Lambda643 & Lambda1382 & Lambda1387 & Lambda640 & Lambda643 & Lambda1398 & Lambda1403 --> PgSelect531
-    List526{{"List[526∈18] ➊<br />ᐸ509,513,517,521,525ᐳ"}}:::plan
-    Object509{{"Object[509∈18] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object513{{"Object[513∈18] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object517{{"Object[517∈18] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object521{{"Object[521∈18] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object525{{"Object[525∈18] ➊<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object509 & Object513 & Object517 & Object521 & Object525 --> List526
-    Object1295{{"Object[1295∈18] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1292 & Constant1293 & Constant744 --> Object1295
-    Object1381{{"Object[1381∈18] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1378 & Constant1379 & Constant744 --> Object1381
-    Object1397{{"Object[1397∈18] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda640 & Constant1394 & Constant1395 & Constant1396 --> Object1397
-    Lambda507[["Lambda[507∈18] ➊"]]:::unbatchedplan
-    List508{{"List[508∈18] ➊<br />ᐸ1406ᐳ"}}:::plan
-    Lambda507 & List508 --> Object509
-    Lambda511[["Lambda[511∈18] ➊"]]:::unbatchedplan
-    Lambda511 & List508 --> Object513
-    Lambda515[["Lambda[515∈18] ➊"]]:::unbatchedplan
-    Lambda515 & List508 --> Object517
-    Lambda519[["Lambda[519∈18] ➊"]]:::unbatchedplan
-    Lambda519 & List508 --> Object521
-    Lambda523[["Lambda[523∈18] ➊"]]:::unbatchedplan
-    Lambda523 & List508 --> Object525
-    __Flag529[["__Flag[529∈18] ➊<br />ᐸ528, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition502{{"Condition[502∈18] ➊<br />ᐸexistsᐳ"}}:::plan
-    __Flag529 & Condition502 --> __Flag530
-    Constant1407 --> Condition502
-    Lambda503{{"Lambda[503∈18] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant1407 --> Lambda503
-    Lambda503 --> Lambda507
-    Access1406{{"Access[1406∈18] ➊<br />ᐸ503.base64JSON.1ᐳ"}}:::plan
-    Access1406 --> List508
-    Lambda503 --> Lambda511
-    Lambda503 --> Lambda515
-    Lambda503 --> Lambda519
-    Lambda503 --> Lambda523
-    Lambda527{{"Lambda[527∈18] ➊"}}:::plan
-    List526 --> Lambda527
-    Access528{{"Access[528∈18] ➊<br />ᐸ527.0ᐳ"}}:::plan
-    Lambda527 --> Access528
-    Access528 --> __Flag529
-    Object1295 --> Lambda1296
-    Constant1456 --> Lambda1301
-    Object1381 --> Lambda1382
-    Constant1462 --> Lambda1387
-    Object1397 --> Lambda1398
-    Constant1463 --> Lambda1403
-    Lambda503 --> Access1406
+    Object12 & __Flag530 & Connection501 & Access644 & Lambda1343 & Lambda1348 & Access644 & Lambda1435 & Lambda1440 & Lambda640 & Access644 & Lambda1452 & Lambda1457 --> PgSelect531
     __Item532[/"__Item[532∈19]<br />ᐸ531ᐳ"\]:::itemplan
     PgSelect531 ==> __Item532
     PgSelectSingle533{{"PgSelectSingle[533∈19]<br />ᐸrelational_item_relationsᐳ"}}:::plan
@@ -1175,24 +1177,24 @@ graph TD
     Lambda537{{"Lambda[537∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List536 --> Lambda537
     PgSelectSingle544{{"PgSelectSingle[544∈20]<br />ᐸrelational_itemsᐳ"}}:::plan
-    RemapKeys1302{{"RemapKeys[1302∈20]<br />ᐸ533:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1302 --> PgSelectSingle544
+    RemapKeys1349{{"RemapKeys[1349∈20]<br />ᐸ533:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1349 --> PgSelectSingle544
     PgSelectSingle593{{"PgSelectSingle[593∈20]<br />ᐸrelational_itemsᐳ"}}:::plan
-    RemapKeys1388{{"RemapKeys[1388∈20]<br />ᐸ533:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys1388 --> PgSelectSingle593
-    PgSelectSingle533 --> RemapKeys1302
-    PgSelectSingle533 --> RemapKeys1388
+    RemapKeys1441{{"RemapKeys[1441∈20]<br />ᐸ533:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys1441 --> PgSelectSingle593
+    PgSelectSingle533 --> RemapKeys1349
+    PgSelectSingle533 --> RemapKeys1441
     PgSelect546[["PgSelect[546∈21]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression545{{"PgClassExpression[545∈21]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression545 & Lambda640 & Lambda643 & Lambda1226 & Lambda1231 --> PgSelect546
+    Object12 & PgClassExpression545 & Lambda640 & Access644 & Lambda1268 & Lambda1273 --> PgSelect546
     PgSelect557[["PgSelect[557∈21]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression545 & Lambda640 & Lambda643 & Lambda1240 & Lambda1245 --> PgSelect557
+    Object12 & PgClassExpression545 & Lambda640 & Access644 & Lambda1283 & Lambda1288 --> PgSelect557
     PgSelect565[["PgSelect[565∈21]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression545 & Lambda640 & Lambda643 & Lambda1254 & Lambda1259 --> PgSelect565
+    Object12 & PgClassExpression545 & Lambda640 & Access644 & Lambda1298 & Lambda1303 --> PgSelect565
     PgSelect573[["PgSelect[573∈21]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression545 & Lambda640 & Lambda643 & Lambda1268 & Lambda1273 --> PgSelect573
+    Object12 & PgClassExpression545 & Lambda640 & Access644 & Lambda1313 & Lambda1318 --> PgSelect573
     PgSelect581[["PgSelect[581∈21]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression545 & Lambda640 & Lambda643 & Lambda1282 & Lambda1287 --> PgSelect581
+    Object12 & PgClassExpression545 & Lambda640 & Access644 & Lambda1328 & Lambda1333 --> PgSelect581
     List554{{"List[554∈21]<br />ᐸ129,553ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression553{{"PgClassExpression[553∈21]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression553 --> List554
@@ -1248,15 +1250,15 @@ graph TD
     List587 --> Lambda588
     PgSelect595[["PgSelect[595∈22]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression594{{"PgClassExpression[594∈22]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object12 & PgClassExpression594 & Lambda640 & Lambda643 & Lambda1312 & Lambda1317 --> PgSelect595
+    Object12 & PgClassExpression594 & Lambda640 & Access644 & Lambda1360 & Lambda1365 --> PgSelect595
     PgSelect606[["PgSelect[606∈22]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object12 & PgClassExpression594 & Lambda640 & Lambda643 & Lambda1326 & Lambda1331 --> PgSelect606
+    Object12 & PgClassExpression594 & Lambda640 & Access644 & Lambda1375 & Lambda1380 --> PgSelect606
     PgSelect614[["PgSelect[614∈22]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object12 & PgClassExpression594 & Lambda640 & Lambda643 & Lambda1340 & Lambda1345 --> PgSelect614
+    Object12 & PgClassExpression594 & Lambda640 & Access644 & Lambda1390 & Lambda1395 --> PgSelect614
     PgSelect622[["PgSelect[622∈22]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object12 & PgClassExpression594 & Lambda640 & Lambda643 & Lambda1354 & Lambda1359 --> PgSelect622
+    Object12 & PgClassExpression594 & Lambda640 & Access644 & Lambda1405 & Lambda1410 --> PgSelect622
     PgSelect630[["PgSelect[630∈22]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object12 & PgClassExpression594 & Lambda640 & Lambda643 & Lambda1368 & Lambda1373 --> PgSelect630
+    Object12 & PgClassExpression594 & Lambda640 & Access644 & Lambda1420 & Lambda1425 --> PgSelect630
     List603{{"List[603∈22]<br />ᐸ129,602ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression602{{"PgClassExpression[602∈22]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant129 & PgClassExpression602 --> List603
@@ -1314,73 +1316,73 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/relay.polyroot_with_related_poly"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 34, 37, 40, 43, 118, 129, 154, 162, 170, 178, 412, 445, 501, 534, 645, 646, 647, 660, 661, 675, 676, 677, 690, 691, 692, 705, 706, 707, 720, 721, 722, 735, 736, 737, 750, 751, 752, 765, 766, 780, 781, 795, 796, 810, 811, 825, 826, 840, 841, 855, 856, 870, 871, 885, 886, 900, 901, 915, 916, 930, 931, 945, 946, 960, 961, 975, 976, 990, 991, 1005, 1006, 1020, 1021, 1035, 1036, 1050, 1051, 1065, 1066, 1080, 1081, 1095, 1096, 1110, 1111, 1125, 1126, 1140, 1141, 1155, 1156, 1170, 1171, 1185, 1186, 1200, 1201, 1215, 1216, 1232, 1233, 1249, 1250, 1251, 1264, 1265, 1279, 1280, 1294, 1295, 1309, 1310, 1324, 1325, 1339, 1340, 1356, 1357, 1371, 1372, 1386, 1387, 1401, 1402, 1416, 1417, 1431, 1432, 1448, 1449, 1450, 1459, 1461, 1462, 1463, 1464, 1465, 1466, 1467, 1468, 1469, 1470, 1471, 1472, 1473, 1474, 1475, 1476, 1477, 1478, 1479, 1480, 1481, 1482, 1483, 1484, 1485, 1486, 1487, 1488, 1489, 1490, 1491, 1492, 1493, 1494, 1495, 1496, 1497, 1498, 1499, 1500, 1501, 1502, 1503, 1504, 1505, 1506, 1507, 1508, 1509, 1510, 1511, 1512, 1513, 1514, 1515, 1516, 1517, 12, 413, 414, 502, 503, 640, 643, 644, 648, 649, 654, 663, 664, 669, 678, 679, 684, 693, 694, 699, 708, 709, 714, 723, 724, 729, 738, 739, 744, 753, 754, 759, 768, 769, 774, 783, 784, 789, 798, 799, 804, 813, 814, 819, 828, 829, 834, 843, 844, 849, 858, 859, 864, 873, 874, 879, 888, 889, 894, 903, 904, 909, 918, 919, 924, 933, 934, 939, 948, 949, 954, 963, 964, 969, 978, 979, 984, 993, 994, 999, 1008, 1009, 1014, 1023, 1024, 1029, 1038, 1039, 1044, 1053, 1054, 1059, 1068, 1069, 1074, 1083, 1084, 1089, 1098, 1099, 1104, 1113, 1114, 1119, 1128, 1129, 1134, 1143, 1144, 1149, 1158, 1159, 1164, 1173, 1174, 1179, 1188, 1189, 1194, 1203, 1204, 1209, 1218, 1219, 1224, 1235, 1236, 1241, 1252, 1253, 1258, 1267, 1268, 1273, 1282, 1283, 1288, 1297, 1298, 1303, 1312, 1313, 1318, 1327, 1328, 1333, 1342, 1343, 1348, 1359, 1360, 1365, 1374, 1375, 1380, 1389, 1390, 1395, 1404, 1405, 1410, 1419, 1420, 1425, 1434, 1435, 1440, 1451, 1452, 1457, 1458, 1460, 419, 508<br />2: 418, 422, 426, 430, 434, 507, 511, 515, 519, 523<br />ᐳ: 420, 424, 428, 432, 436, 437, 438, 439, 509, 513, 517, 521, 525, 526, 527, 528<br />3: __Flag[440], __Flag[529]<br />4: __Flag[441], __Flag[530]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Constant34,Constant37,Constant40,Constant43,Connection118,Constant129,Constant154,Constant162,Constant170,Constant178,Connection412,Constant445,Connection501,Constant534,Lambda640,Lambda643,Constant644,Constant645,Constant646,Object647,Lambda648,Lambda653,Constant658,Constant659,Constant672,Constant673,Constant674,Object675,Lambda676,Lambda681,Constant686,Constant687,Constant688,Object689,Lambda690,Lambda695,Constant700,Constant701,Constant702,Object703,Lambda704,Lambda709,Constant714,Constant715,Constant716,Object717,Lambda718,Lambda723,Constant728,Constant729,Constant730,Object731,Lambda732,Lambda737,Constant742,Constant743,Constant744,Object745,Lambda746,Lambda751,Constant756,Constant757,Object759,Lambda760,Lambda765,Constant770,Constant771,Object773,Lambda774,Lambda779,Constant784,Constant785,Object787,Lambda788,Lambda793,Constant798,Constant799,Object801,Lambda802,Lambda807,Constant812,Constant813,Object815,Lambda816,Lambda821,Constant826,Constant827,Object829,Lambda830,Lambda835,Constant840,Constant841,Object843,Lambda844,Lambda849,Constant854,Constant855,Object857,Lambda858,Lambda863,Constant868,Constant869,Object871,Lambda872,Lambda877,Constant882,Constant883,Object885,Lambda886,Lambda891,Constant896,Constant897,Object899,Lambda900,Lambda905,Constant910,Constant911,Object913,Lambda914,Lambda919,Constant924,Constant925,Object927,Lambda928,Lambda933,Constant938,Constant939,Object941,Lambda942,Lambda947,Constant952,Constant953,Object955,Lambda956,Lambda961,Constant966,Constant967,Object969,Lambda970,Lambda975,Constant980,Constant981,Object983,Lambda984,Lambda989,Constant994,Constant995,Object997,Lambda998,Lambda1003,Constant1008,Constant1009,Object1011,Lambda1012,Lambda1017,Constant1022,Constant1023,Object1025,Lambda1026,Lambda1031,Constant1036,Constant1037,Object1039,Lambda1040,Lambda1045,Constant1050,Constant1051,Object1053,Lambda1054,Lambda1059,Constant1064,Constant1065,Object1067,Lambda1068,Lambda1073,Constant1078,Constant1079,Object1081,Lambda1082,Lambda1087,Constant1092,Constant1093,Object1095,Lambda1096,Lambda1101,Constant1106,Constant1107,Object1109,Lambda1110,Lambda1115,Constant1120,Constant1121,Object1123,Lambda1124,Lambda1129,Constant1134,Constant1135,Object1137,Lambda1138,Lambda1143,Constant1148,Constant1149,Object1151,Lambda1152,Lambda1157,Constant1162,Constant1163,Constant1176,Constant1177,Constant1192,Constant1193,Constant1208,Constant1209,Constant1210,Constant1222,Constant1223,Object1225,Lambda1226,Lambda1231,Constant1236,Constant1237,Object1239,Lambda1240,Lambda1245,Constant1250,Constant1251,Object1253,Lambda1254,Lambda1259,Constant1264,Constant1265,Object1267,Lambda1268,Lambda1273,Constant1278,Constant1279,Object1281,Lambda1282,Lambda1287,Constant1292,Constant1293,Constant1308,Constant1309,Object1311,Lambda1312,Lambda1317,Constant1322,Constant1323,Object1325,Lambda1326,Lambda1331,Constant1336,Constant1337,Object1339,Lambda1340,Lambda1345,Constant1350,Constant1351,Object1353,Lambda1354,Lambda1359,Constant1364,Constant1365,Object1367,Lambda1368,Lambda1373,Constant1378,Constant1379,Constant1394,Constant1395,Constant1396,Constant1405,Constant1407,Constant1408,Constant1409,Constant1410,Constant1411,Constant1412,Constant1413,Constant1414,Constant1415,Constant1416,Constant1417,Constant1418,Constant1419,Constant1420,Constant1421,Constant1422,Constant1423,Constant1424,Constant1425,Constant1426,Constant1427,Constant1428,Constant1429,Constant1430,Constant1431,Constant1432,Constant1433,Constant1434,Constant1435,Constant1436,Constant1437,Constant1438,Constant1439,Constant1440,Constant1441,Constant1442,Constant1443,Constant1444,Constant1445,Constant1446,Constant1447,Constant1448,Constant1449,Constant1450,Constant1451,Constant1452,Constant1453,Constant1454,Constant1455,Constant1456,Constant1457,Constant1458,Constant1459,Constant1460,Constant1461,Constant1462,Constant1463 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 640, 643, 658, 659, 646, 1411, 17, 648, 653, 34, 37, 40, 43<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[661], Lambda[667], Lambda[662]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Constant34,Constant37,Constant40,Constant43,Connection118,Constant129,Constant154,Constant162,Constant170,Constant178,Connection412,Condition413,Lambda414,Lambda418,List419,Object420,Lambda422,Object424,Lambda426,Object428,Lambda430,Object432,Lambda434,Object436,List437,Lambda438,Access439,__Flag440,__Flag441,Constant445,Connection501,Condition502,Lambda503,Lambda507,List508,Object509,Lambda511,Object513,Lambda515,Object517,Lambda519,Object521,Lambda523,Object525,List526,Lambda527,Access528,__Flag529,__Flag530,Constant534,Lambda640,Lambda643,Access644,Constant645,Constant646,Constant647,Object648,Lambda649,Lambda654,Constant660,Constant661,Object663,Lambda664,Lambda669,Constant675,Constant676,Constant677,Object678,Lambda679,Lambda684,Constant690,Constant691,Constant692,Object693,Lambda694,Lambda699,Constant705,Constant706,Constant707,Object708,Lambda709,Lambda714,Constant720,Constant721,Constant722,Object723,Lambda724,Lambda729,Constant735,Constant736,Constant737,Object738,Lambda739,Lambda744,Constant750,Constant751,Constant752,Object753,Lambda754,Lambda759,Constant765,Constant766,Object768,Lambda769,Lambda774,Constant780,Constant781,Object783,Lambda784,Lambda789,Constant795,Constant796,Object798,Lambda799,Lambda804,Constant810,Constant811,Object813,Lambda814,Lambda819,Constant825,Constant826,Object828,Lambda829,Lambda834,Constant840,Constant841,Object843,Lambda844,Lambda849,Constant855,Constant856,Object858,Lambda859,Lambda864,Constant870,Constant871,Object873,Lambda874,Lambda879,Constant885,Constant886,Object888,Lambda889,Lambda894,Constant900,Constant901,Object903,Lambda904,Lambda909,Constant915,Constant916,Object918,Lambda919,Lambda924,Constant930,Constant931,Object933,Lambda934,Lambda939,Constant945,Constant946,Object948,Lambda949,Lambda954,Constant960,Constant961,Object963,Lambda964,Lambda969,Constant975,Constant976,Object978,Lambda979,Lambda984,Constant990,Constant991,Object993,Lambda994,Lambda999,Constant1005,Constant1006,Object1008,Lambda1009,Lambda1014,Constant1020,Constant1021,Object1023,Lambda1024,Lambda1029,Constant1035,Constant1036,Object1038,Lambda1039,Lambda1044,Constant1050,Constant1051,Object1053,Lambda1054,Lambda1059,Constant1065,Constant1066,Object1068,Lambda1069,Lambda1074,Constant1080,Constant1081,Object1083,Lambda1084,Lambda1089,Constant1095,Constant1096,Object1098,Lambda1099,Lambda1104,Constant1110,Constant1111,Object1113,Lambda1114,Lambda1119,Constant1125,Constant1126,Object1128,Lambda1129,Lambda1134,Constant1140,Constant1141,Object1143,Lambda1144,Lambda1149,Constant1155,Constant1156,Object1158,Lambda1159,Lambda1164,Constant1170,Constant1171,Object1173,Lambda1174,Lambda1179,Constant1185,Constant1186,Object1188,Lambda1189,Lambda1194,Constant1200,Constant1201,Object1203,Lambda1204,Lambda1209,Constant1215,Constant1216,Object1218,Lambda1219,Lambda1224,Constant1232,Constant1233,Object1235,Lambda1236,Lambda1241,Constant1249,Constant1250,Constant1251,Object1252,Lambda1253,Lambda1258,Constant1264,Constant1265,Object1267,Lambda1268,Lambda1273,Constant1279,Constant1280,Object1282,Lambda1283,Lambda1288,Constant1294,Constant1295,Object1297,Lambda1298,Lambda1303,Constant1309,Constant1310,Object1312,Lambda1313,Lambda1318,Constant1324,Constant1325,Object1327,Lambda1328,Lambda1333,Constant1339,Constant1340,Object1342,Lambda1343,Lambda1348,Constant1356,Constant1357,Object1359,Lambda1360,Lambda1365,Constant1371,Constant1372,Object1374,Lambda1375,Lambda1380,Constant1386,Constant1387,Object1389,Lambda1390,Lambda1395,Constant1401,Constant1402,Object1404,Lambda1405,Lambda1410,Constant1416,Constant1417,Object1419,Lambda1420,Lambda1425,Constant1431,Constant1432,Object1434,Lambda1435,Lambda1440,Constant1448,Constant1449,Constant1450,Object1451,Lambda1452,Lambda1457,Access1458,Constant1459,Access1460,Constant1461,Constant1462,Constant1463,Constant1464,Constant1465,Constant1466,Constant1467,Constant1468,Constant1469,Constant1470,Constant1471,Constant1472,Constant1473,Constant1474,Constant1475,Constant1476,Constant1477,Constant1478,Constant1479,Constant1480,Constant1481,Constant1482,Constant1483,Constant1484,Constant1485,Constant1486,Constant1487,Constant1488,Constant1489,Constant1490,Constant1491,Constant1492,Constant1493,Constant1494,Constant1495,Constant1496,Constant1497,Constant1498,Constant1499,Constant1500,Constant1501,Constant1502,Constant1503,Constant1504,Constant1505,Constant1506,Constant1507,Constant1508,Constant1509,Constant1510,Constant1511,Constant1512,Constant1513,Constant1514,Constant1515,Constant1516,Constant1517 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 640, 644, 664, 669, 17, 649, 654, 34, 37, 40, 43<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object661,Lambda662,Lambda667 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 17, 12, 640, 643, 648, 653, 34, 37, 40, 43<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 17, 12, 640, 644, 649, 654, 34, 37, 40, 43<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 16, 17, 12, 640, 643, 648, 653, 34, 37, 40, 43<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 18, 21, 22, 19, 20, 47, 48, 64, 65, 81, 82, 98, 99<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 16, 17, 12, 640, 644, 649, 654, 34, 37, 40, 43<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 18, 21, 22, 19, 20, 47, 48, 64, 65, 81, 82, 98, 99<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,List19,Lambda20,PgClassExpression21,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,List47,Lambda48,List64,Lambda65,List81,Lambda82,List98,Lambda99 bucket3
     Bucket4("Bucket 4 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 28, 17, 34, 37, 40, 43<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression30,List31,Lambda32,PgClassExpression33,List35,Lambda36,List38,Lambda39,List41,Lambda42,List44,Lambda45 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 12, 118, 640, 643, 1162, 1163, 744, 1447, 760, 765, 129, 746, 751, 858, 863, 154, 844, 849, 956, 961, 162, 942, 947, 1054, 1059, 170, 1040, 1045, 1152, 1157, 178, 1138, 1143, 676, 681, 690, 695, 704, 709, 718, 723, 732, 737, 774, 779, 788, 793, 802, 807, 816, 821, 830, 835, 872, 877, 886, 891, 900, 905, 914, 919, 928, 933, 970, 975, 984, 989, 998, 1003, 1012, 1017, 1026, 1031, 1068, 1073, 1082, 1087, 1096, 1101, 1110, 1115, 1124, 1129<br /><br />ROOT Connectionᐸ116ᐳ[118]<br />1: <br />ᐳ: 1165, 1171, 1166<br />2: PgSelect[119]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 12, 118, 640, 644, 1204, 1209, 769, 774, 129, 754, 759, 874, 879, 154, 859, 864, 979, 984, 162, 964, 969, 1084, 1089, 170, 1069, 1074, 1189, 1194, 178, 1174, 1179, 679, 684, 694, 699, 709, 714, 724, 729, 739, 744, 784, 789, 799, 804, 814, 819, 829, 834, 844, 849, 889, 894, 904, 909, 919, 924, 934, 939, 949, 954, 994, 999, 1009, 1014, 1024, 1029, 1039, 1044, 1054, 1059, 1099, 1104, 1114, 1119, 1129, 1134, 1144, 1149, 1159, 1164<br /><br />ROOT Connectionᐸ116ᐳ[118]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgSelect119,Object1165,Lambda1166,Lambda1171 bucket5
-    Bucket6("Bucket 6 (listItem)<br />Deps: 12, 640, 643, 760, 765, 129, 746, 751, 858, 863, 154, 844, 849, 956, 961, 162, 942, 947, 1054, 1059, 170, 1040, 1045, 1152, 1157, 178, 1138, 1143, 676, 681, 690, 695, 704, 709, 718, 723, 732, 737, 774, 779, 788, 793, 802, 807, 816, 821, 830, 835, 872, 877, 886, 891, 900, 905, 914, 919, 928, 933, 970, 975, 984, 989, 998, 1003, 1012, 1017, 1026, 1031, 1068, 1073, 1082, 1087, 1096, 1101, 1110, 1115, 1124, 1129<br /><br />ROOT __Item{6}ᐸ119ᐳ[120]"):::bucket
+    class Bucket5,PgSelect119 bucket5
+    Bucket6("Bucket 6 (listItem)<br />Deps: 12, 640, 644, 769, 774, 129, 754, 759, 874, 879, 154, 859, 864, 979, 984, 162, 964, 969, 1084, 1089, 170, 1069, 1074, 1189, 1194, 178, 1174, 1179, 679, 684, 694, 699, 709, 714, 724, 729, 739, 744, 784, 789, 799, 804, 814, 819, 829, 834, 844, 849, 889, 894, 904, 909, 919, 924, 934, 939, 949, 954, 994, 999, 1009, 1014, 1024, 1029, 1039, 1044, 1054, 1059, 1099, 1104, 1114, 1119, 1129, 1134, 1144, 1149, 1159, 1164<br /><br />ROOT __Item{6}ᐸ119ᐳ[120]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item120,PgSelectSingle121 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 121, 12, 640, 643, 760, 765, 129, 746, 751, 858, 863, 154, 844, 849, 956, 961, 162, 942, 947, 1054, 1059, 170, 1040, 1045, 1152, 1157, 178, 1138, 1143, 676, 681, 690, 695, 704, 709, 718, 723, 732, 737, 774, 779, 788, 793, 802, 807, 816, 821, 830, 835, 872, 877, 886, 891, 900, 905, 914, 919, 928, 933, 970, 975, 984, 989, 998, 1003, 1012, 1017, 1026, 1031, 1068, 1073, 1082, 1087, 1096, 1101, 1110, 1115, 1124, 1129<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 122, 133<br />2: 123, 182, 238, 294, 350<br />ᐳ: 127, 128, 130, 131, 132, 184, 185, 187, 188, 189, 240, 241, 243, 244, 245, 296, 297, 299, 300, 301, 352, 353, 355, 356, 357<br />3: 134, 190, 246, 302, 358<br />ᐳ: 136, 137, 192, 193, 248, 249, 304, 305, 360, 361"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 121, 12, 640, 644, 769, 774, 129, 754, 759, 874, 879, 154, 859, 864, 979, 984, 162, 964, 969, 1084, 1089, 170, 1069, 1074, 1189, 1194, 178, 1174, 1179, 679, 684, 694, 699, 709, 714, 724, 729, 739, 744, 784, 789, 799, 804, 814, 819, 829, 834, 844, 849, 889, 894, 904, 909, 919, 924, 934, 939, 949, 954, 994, 999, 1009, 1014, 1024, 1029, 1039, 1044, 1054, 1059, 1099, 1104, 1114, 1119, 1129, 1134, 1144, 1149, 1159, 1164<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 122, 133<br />2: 123, 182, 238, 294, 350<br />ᐳ: 127, 128, 130, 131, 132, 184, 185, 187, 188, 189, 240, 241, 243, 244, 245, 296, 297, 299, 300, 301, 352, 353, 355, 356, 357<br />3: 134, 190, 246, 302, 358<br />ᐳ: 136, 137, 192, 193, 248, 249, 304, 305, 360, 361"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression122,PgSelect123,First127,PgSelectSingle128,PgClassExpression130,List131,Lambda132,PgClassExpression133,PgSelect134,First136,PgSelectSingle137,PgSelect182,First184,PgSelectSingle185,PgClassExpression187,List188,Lambda189,PgSelect190,First192,PgSelectSingle193,PgSelect238,First240,PgSelectSingle241,PgClassExpression243,List244,Lambda245,PgSelect246,First248,PgSelectSingle249,PgSelect294,First296,PgSelectSingle297,PgClassExpression299,List300,Lambda301,PgSelect302,First304,PgSelectSingle305,PgSelect350,First352,PgSelectSingle353,PgClassExpression355,List356,Lambda357,PgSelect358,First360,PgSelectSingle361 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 137, 12, 640, 643, 676, 681, 129, 690, 695, 154, 704, 709, 162, 718, 723, 170, 732, 737, 178<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 138, 149<br />2: 139, 150, 158, 166, 174<br />ᐳ: 143, 144, 146, 147, 148, 152, 153, 155, 156, 157, 160, 161, 163, 164, 165, 168, 169, 171, 172, 173, 176, 177, 179, 180, 181"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 137, 12, 640, 644, 679, 684, 129, 694, 699, 154, 709, 714, 162, 724, 729, 170, 739, 744, 178<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 138, 149<br />2: 139, 150, 158, 166, 174<br />ᐳ: 143, 144, 146, 147, 148, 152, 153, 155, 156, 157, 160, 161, 163, 164, 165, 168, 169, 171, 172, 173, 176, 177, 179, 180, 181"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression138,PgSelect139,First143,PgSelectSingle144,PgClassExpression146,List147,Lambda148,PgClassExpression149,PgSelect150,First152,PgSelectSingle153,PgClassExpression155,List156,Lambda157,PgSelect158,First160,PgSelectSingle161,PgClassExpression163,List164,Lambda165,PgSelect166,First168,PgSelectSingle169,PgClassExpression171,List172,Lambda173,PgSelect174,First176,PgSelectSingle177,PgClassExpression179,List180,Lambda181 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 193, 12, 640, 643, 774, 779, 129, 788, 793, 154, 802, 807, 162, 816, 821, 170, 830, 835, 178<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 194, 205<br />2: 195, 206, 214, 222, 230<br />ᐳ: 199, 200, 202, 203, 204, 208, 209, 211, 212, 213, 216, 217, 219, 220, 221, 224, 225, 227, 228, 229, 232, 233, 235, 236, 237"):::bucket
+    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 193, 12, 640, 644, 784, 789, 129, 799, 804, 154, 814, 819, 162, 829, 834, 170, 844, 849, 178<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 194, 205<br />2: 195, 206, 214, 222, 230<br />ᐳ: 199, 200, 202, 203, 204, 208, 209, 211, 212, 213, 216, 217, 219, 220, 221, 224, 225, 227, 228, 229, 232, 233, 235, 236, 237"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression194,PgSelect195,First199,PgSelectSingle200,PgClassExpression202,List203,Lambda204,PgClassExpression205,PgSelect206,First208,PgSelectSingle209,PgClassExpression211,List212,Lambda213,PgSelect214,First216,PgSelectSingle217,PgClassExpression219,List220,Lambda221,PgSelect222,First224,PgSelectSingle225,PgClassExpression227,List228,Lambda229,PgSelect230,First232,PgSelectSingle233,PgClassExpression235,List236,Lambda237 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 249, 12, 640, 643, 872, 877, 129, 886, 891, 154, 900, 905, 162, 914, 919, 170, 928, 933, 178<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 250, 261<br />2: 251, 262, 270, 278, 286<br />ᐳ: 255, 256, 258, 259, 260, 264, 265, 267, 268, 269, 272, 273, 275, 276, 277, 280, 281, 283, 284, 285, 288, 289, 291, 292, 293"):::bucket
+    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 249, 12, 640, 644, 889, 894, 129, 904, 909, 154, 919, 924, 162, 934, 939, 170, 949, 954, 178<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 250, 261<br />2: 251, 262, 270, 278, 286<br />ᐳ: 255, 256, 258, 259, 260, 264, 265, 267, 268, 269, 272, 273, 275, 276, 277, 280, 281, 283, 284, 285, 288, 289, 291, 292, 293"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgClassExpression250,PgSelect251,First255,PgSelectSingle256,PgClassExpression258,List259,Lambda260,PgClassExpression261,PgSelect262,First264,PgSelectSingle265,PgClassExpression267,List268,Lambda269,PgSelect270,First272,PgSelectSingle273,PgClassExpression275,List276,Lambda277,PgSelect278,First280,PgSelectSingle281,PgClassExpression283,List284,Lambda285,PgSelect286,First288,PgSelectSingle289,PgClassExpression291,List292,Lambda293 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 305, 12, 640, 643, 970, 975, 129, 984, 989, 154, 998, 1003, 162, 1012, 1017, 170, 1026, 1031, 178<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 306, 317<br />2: 307, 318, 326, 334, 342<br />ᐳ: 311, 312, 314, 315, 316, 320, 321, 323, 324, 325, 328, 329, 331, 332, 333, 336, 337, 339, 340, 341, 344, 345, 347, 348, 349"):::bucket
+    Bucket11("Bucket 11 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 305, 12, 640, 644, 994, 999, 129, 1009, 1014, 154, 1024, 1029, 162, 1039, 1044, 170, 1054, 1059, 178<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 306, 317<br />2: 307, 318, 326, 334, 342<br />ᐳ: 311, 312, 314, 315, 316, 320, 321, 323, 324, 325, 328, 329, 331, 332, 333, 336, 337, 339, 340, 341, 344, 345, 347, 348, 349"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression306,PgSelect307,First311,PgSelectSingle312,PgClassExpression314,List315,Lambda316,PgClassExpression317,PgSelect318,First320,PgSelectSingle321,PgClassExpression323,List324,Lambda325,PgSelect326,First328,PgSelectSingle329,PgClassExpression331,List332,Lambda333,PgSelect334,First336,PgSelectSingle337,PgClassExpression339,List340,Lambda341,PgSelect342,First344,PgSelectSingle345,PgClassExpression347,List348,Lambda349 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 361, 12, 640, 643, 1068, 1073, 129, 1082, 1087, 154, 1096, 1101, 162, 1110, 1115, 170, 1124, 1129, 178<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 362, 373<br />2: 363, 374, 382, 390, 398<br />ᐳ: 367, 368, 370, 371, 372, 376, 377, 379, 380, 381, 384, 385, 387, 388, 389, 392, 393, 395, 396, 397, 400, 401, 403, 404, 405"):::bucket
+    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 361, 12, 640, 644, 1099, 1104, 129, 1114, 1119, 154, 1129, 1134, 162, 1144, 1149, 170, 1159, 1164, 178<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 362, 373<br />2: 363, 374, 382, 390, 398<br />ᐳ: 367, 368, 370, 371, 372, 376, 377, 379, 380, 381, 384, 385, 387, 388, 389, 392, 393, 395, 396, 397, 400, 401, 403, 404, 405"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression362,PgSelect363,First367,PgSelectSingle368,PgClassExpression370,List371,Lambda372,PgClassExpression373,PgSelect374,First376,PgSelectSingle377,PgClassExpression379,List380,Lambda381,PgSelect382,First384,PgSelectSingle385,PgClassExpression387,List388,Lambda389,PgSelect390,First392,PgSelectSingle393,PgClassExpression395,List396,Lambda397,PgSelect398,First400,PgSelectSingle401,PgClassExpression403,List404,Lambda405 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 1405, 12, 412, 643, 640, 1176, 1177, 646, 1448, 1192, 1193, 1449, 1208, 1209, 1210, 1450, 445, 17, 34, 37, 40, 43<br /><br />ROOT Connectionᐸ410ᐳ[412]<br />1: <br />ᐳ: 413, 414, 1179, 1185, 1195, 1201, 1211, 1217, 1180, 1196, 1212, 1404, 419<br />2: 418, 422, 426, 430, 434<br />ᐳ: 420, 424, 428, 432, 436, 437, 438, 439<br />3: __Flag[440]<br />4: __Flag[441]<br />5: PgSelect[442]"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 12, 441, 412, 644, 1219, 1224, 1236, 1241, 640, 1253, 1258, 445, 17, 34, 37, 40, 43<br /><br />ROOT Connectionᐸ410ᐳ[412]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,Condition413,Lambda414,Lambda418,List419,Object420,Lambda422,Object424,Lambda426,Object428,Lambda430,Object432,Lambda434,Object436,List437,Lambda438,Access439,__Flag440,__Flag441,PgSelect442,Object1179,Lambda1180,Lambda1185,Object1195,Lambda1196,Lambda1201,Object1211,Lambda1212,Lambda1217,Access1404 bucket13
+    class Bucket13,PgSelect442 bucket13
     Bucket14("Bucket 14 (listItem)<br />Deps: 445, 17, 34, 37, 40, 43<br /><br />ROOT __Item{14}ᐸ442ᐳ[443]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item443,PgSelectSingle444 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 444, 445, 17, 34, 37, 40, 43<br /><br />ROOT PgSelectSingle{14}ᐸsingle_table_item_relationsᐳ[444]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression446,List447,Lambda448,PgSelectSingle455,PgSelectSingle477,RemapKeys1186,RemapKeys1202 bucket15
+    class Bucket15,PgClassExpression446,List447,Lambda448,PgSelectSingle455,PgSelectSingle477,RemapKeys1225,RemapKeys1242 bucket15
     Bucket16("Bucket 16 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 455, 17, 34, 37, 40, 43<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,PgClassExpression457,List458,Lambda459,PgClassExpression460,List462,Lambda463,List465,Lambda466,List468,Lambda469,List471,Lambda472 bucket16
     Bucket17("Bucket 17 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 477, 17, 34, 37, 40, 43<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgClassExpression479,List480,Lambda481,PgClassExpression482,List484,Lambda485,List487,Lambda488,List490,Lambda491,List493,Lambda494 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 1407, 12, 501, 643, 640, 1292, 1293, 744, 1456, 1378, 1379, 1462, 1394, 1395, 1396, 1463, 534, 1226, 1231, 129, 1240, 1245, 154, 1254, 1259, 162, 1268, 1273, 170, 1282, 1287, 178, 1312, 1317, 1326, 1331, 1340, 1345, 1354, 1359, 1368, 1373<br /><br />ROOT Connectionᐸ499ᐳ[501]<br />1: <br />ᐳ: 502, 503, 1295, 1301, 1381, 1387, 1397, 1403, 1296, 1382, 1398, 1406, 508<br />2: 507, 511, 515, 519, 523<br />ᐳ: 509, 513, 517, 521, 525, 526, 527, 528<br />3: __Flag[529]<br />4: __Flag[530]<br />5: PgSelect[531]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 12, 530, 501, 644, 1343, 1348, 1435, 1440, 640, 1452, 1457, 534, 1268, 1273, 129, 1283, 1288, 154, 1298, 1303, 162, 1313, 1318, 170, 1328, 1333, 178, 1360, 1365, 1375, 1380, 1390, 1395, 1405, 1410, 1420, 1425<br /><br />ROOT Connectionᐸ499ᐳ[501]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,Condition502,Lambda503,Lambda507,List508,Object509,Lambda511,Object513,Lambda515,Object517,Lambda519,Object521,Lambda523,Object525,List526,Lambda527,Access528,__Flag529,__Flag530,PgSelect531,Object1295,Lambda1296,Lambda1301,Object1381,Lambda1382,Lambda1387,Object1397,Lambda1398,Lambda1403,Access1406 bucket18
-    Bucket19("Bucket 19 (listItem)<br />Deps: 534, 12, 640, 643, 1226, 1231, 129, 1240, 1245, 154, 1254, 1259, 162, 1268, 1273, 170, 1282, 1287, 178, 1312, 1317, 1326, 1331, 1340, 1345, 1354, 1359, 1368, 1373<br /><br />ROOT __Item{19}ᐸ531ᐳ[532]"):::bucket
+    class Bucket18,PgSelect531 bucket18
+    Bucket19("Bucket 19 (listItem)<br />Deps: 534, 12, 640, 644, 1268, 1273, 129, 1283, 1288, 154, 1298, 1303, 162, 1313, 1318, 170, 1328, 1333, 178, 1360, 1365, 1375, 1380, 1390, 1395, 1405, 1410, 1420, 1425<br /><br />ROOT __Item{19}ᐸ531ᐳ[532]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item532,PgSelectSingle533 bucket19
-    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 533, 534, 12, 640, 643, 1226, 1231, 129, 1240, 1245, 154, 1254, 1259, 162, 1268, 1273, 170, 1282, 1287, 178, 1312, 1317, 1326, 1331, 1340, 1345, 1354, 1359, 1368, 1373<br /><br />ROOT PgSelectSingle{19}ᐸrelational_item_relationsᐳ[533]"):::bucket
+    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 533, 534, 12, 640, 644, 1268, 1273, 129, 1283, 1288, 154, 1298, 1303, 162, 1313, 1318, 170, 1328, 1333, 178, 1360, 1365, 1375, 1380, 1390, 1395, 1405, 1410, 1420, 1425<br /><br />ROOT PgSelectSingle{19}ᐸrelational_item_relationsᐳ[533]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression535,List536,Lambda537,PgSelectSingle544,PgSelectSingle593,RemapKeys1302,RemapKeys1388 bucket20
-    Bucket21("Bucket 21 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 544, 12, 640, 643, 1226, 1231, 129, 1240, 1245, 154, 1254, 1259, 162, 1268, 1273, 170, 1282, 1287, 178<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 545, 556<br />2: 546, 557, 565, 573, 581<br />ᐳ: 550, 551, 553, 554, 555, 559, 560, 562, 563, 564, 567, 568, 570, 571, 572, 575, 576, 578, 579, 580, 583, 584, 586, 587, 588"):::bucket
+    class Bucket20,PgClassExpression535,List536,Lambda537,PgSelectSingle544,PgSelectSingle593,RemapKeys1349,RemapKeys1441 bucket20
+    Bucket21("Bucket 21 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 544, 12, 640, 644, 1268, 1273, 129, 1283, 1288, 154, 1298, 1303, 162, 1313, 1318, 170, 1328, 1333, 178<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 545, 556<br />2: 546, 557, 565, 573, 581<br />ᐳ: 550, 551, 553, 554, 555, 559, 560, 562, 563, 564, 567, 568, 570, 571, 572, 575, 576, 578, 579, 580, 583, 584, 586, 587, 588"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression545,PgSelect546,First550,PgSelectSingle551,PgClassExpression553,List554,Lambda555,PgClassExpression556,PgSelect557,First559,PgSelectSingle560,PgClassExpression562,List563,Lambda564,PgSelect565,First567,PgSelectSingle568,PgClassExpression570,List571,Lambda572,PgSelect573,First575,PgSelectSingle576,PgClassExpression578,List579,Lambda580,PgSelect581,First583,PgSelectSingle584,PgClassExpression586,List587,Lambda588 bucket21
-    Bucket22("Bucket 22 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 593, 12, 640, 643, 1312, 1317, 129, 1326, 1331, 154, 1340, 1345, 162, 1354, 1359, 170, 1368, 1373, 178<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 594, 605<br />2: 595, 606, 614, 622, 630<br />ᐳ: 599, 600, 602, 603, 604, 608, 609, 611, 612, 613, 616, 617, 619, 620, 621, 624, 625, 627, 628, 629, 632, 633, 635, 636, 637"):::bucket
+    Bucket22("Bucket 22 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 593, 12, 640, 644, 1360, 1365, 129, 1375, 1380, 154, 1390, 1395, 162, 1405, 1410, 170, 1420, 1425, 178<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 594, 605<br />2: 595, 606, 614, 622, 630<br />ᐳ: 599, 600, 602, 603, 604, 608, 609, 611, 612, 613, 616, 617, 619, 620, 621, 624, 625, 627, 628, 629, 632, 633, 635, 636, 637"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22,PgClassExpression594,PgSelect595,First599,PgSelectSingle600,PgClassExpression602,List603,Lambda604,PgClassExpression605,PgSelect606,First608,PgSelectSingle609,PgClassExpression611,List612,Lambda613,PgSelect614,First616,PgSelectSingle617,PgClassExpression619,List620,Lambda621,PgSelect622,First624,PgSelectSingle625,PgClassExpression627,List628,Lambda629,PgSelect630,First632,PgSelectSingle633,PgClassExpression635,List636,Lambda637 bucket22
     Bucket0 --> Bucket1 & Bucket5 & Bucket13 & Bucket18

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/returns-setof.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/returns-setof.mermaid
@@ -9,48 +9,50 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection11{{"Connection[11∈0] ➊<br />ᐸ7ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”all_single_tables”)ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”all_siᐳ"}}:::plan
-    PgSelect12[["PgSelect[12∈1] ➊<br />ᐸall_single_tables(aggregate)ᐳ"]]:::plan
-    Object10{{"Object[10∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda18{{"Lambda[18∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda21{{"Lambda[21∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection11 & Lambda18 & Lambda21 & Lambda26 & Lambda31 --> PgSelect12
-    Object25{{"Object[25∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda18 & Constant22 & Constant23 & Constant24 --> Object25
-    Access8{{"Access[8∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access9{{"Access[9∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda18{{"Lambda[18∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”all_single_tables”)ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
+    Lambda18 & Constant23 & Constant24 & Constant25 --> Object26
+    Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant33 --> Lambda18
+    Lambda21{{"Lambda[21∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda21
+    Access22{{"Access[22∈0] ➊<br />ᐸ21.0ᐳ"}}:::plan
+    Lambda21 --> Access22
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object26 --> Lambda27
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”all_siᐳ"}}:::plan
+    Constant35 --> Lambda32
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection11{{"Connection[11∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    PgSelect12[["PgSelect[12∈1] ➊<br />ᐸall_single_tables(aggregate)ᐳ"]]:::plan
+    Object10 & Connection11 & Lambda18 & Access22 & Lambda27 & Lambda32 --> PgSelect12
     First13{{"First[13∈1] ➊"}}:::plan
     PgSelect12 --> First13
     PgSelectSingle14{{"PgSelectSingle[14∈1] ➊<br />ᐸall_single_tablesᐳ"}}:::plan
     First13 --> PgSelectSingle14
     PgClassExpression15{{"PgClassExpression[15∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle14 --> PgClassExpression15
-    Constant32 --> Lambda18
-    Constant33 --> Lambda21
-    Object25 --> Lambda26
-    Constant34 --> Lambda31
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/returns-setof"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection11,Constant22,Constant23,Constant24,Constant32,Constant33,Constant34 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 11, 32, 33, 22, 23, 24, 34<br /><br />ROOT Connectionᐸ7ᐳ[11]<br />1: <br />ᐳ: 8, 9, 18, 21, 31, 10, 25, 26<br />2: PgSelect[12]<br />ᐳ: 13, 14, 15"):::bucket
+    class Bucket0,__Value2,__Value4,Access8,Access9,Object10,Connection11,Lambda18,Lambda21,Access22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 10, 11, 18, 22, 27, 32<br /><br />ROOT Connectionᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access8,Access9,Object10,PgSelect12,First13,PgSelectSingle14,PgClassExpression15,Lambda18,Lambda21,Object25,Lambda26,Lambda31 bucket1
+    class Bucket1,PgSelect12,First13,PgSelectSingle14,PgClassExpression15 bucket1
     Bucket0 --> Bucket1
     end

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-log-entries.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-log-entries.mermaid
@@ -9,17 +9,22 @@ graph TD
 
 
     %% plan dependencies
-    Object52{{"Object[52∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda45 & Constant63 & Constant64 & Constant65 --> Object66
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
+    Lambda45 & Constant86 & Constant87 & Constant88 --> Object89
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -27,35 +32,34 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant87 --> Lambda45
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant96 --> Lambda45
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant88 --> Lambda48
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object52 --> Lambda53
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant89 --> Lambda58
-    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object66 --> Lambda67
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant90 --> Lambda72
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant97 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant98 --> Lambda59
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant99 --> Lambda74
+    Access80{{"Access[80∈0] ➊<br />ᐸ48.1ᐳ"}}:::plan
+    Lambda48 --> Access80
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object89 --> Lambda90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant100 --> Lambda95
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸlog_entriesᐳ"]]:::plan
-    Lambda81{{"Lambda[81∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda45 & Lambda48 & Lambda81 & Lambda86 --> PgSelect14
-    Object80{{"Object[80∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant77 & Constant78 & Constant79 --> Object80
-    Object80 --> Lambda81
-    Constant91 --> Lambda86
+    Object12 & Connection13 & Lambda45 & Access49 & Lambda90 & Lambda95 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸlog_entriesᐳ"}}:::plan
@@ -63,7 +67,7 @@ graph TD
     PgUnionAll20[["PgUnionAll[20∈3]"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__log_entr...person_id”ᐳ"}}:::plan
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__log_entr...zation_id”ᐳ"}}:::plan
-    Object12 & PgClassExpression18 & PgClassExpression19 --> PgUnionAll20
+    Object12 & PgClassExpression18 & PgClassExpression19 & Lambda45 & Access49 & Access80 --> PgUnionAll20
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__log_entries__.”id”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
     PgSelectSingle16 --> PgClassExpression18
@@ -74,10 +78,10 @@ graph TD
     First24 --> PgUnionAllSingle25
     PgSelect29[["PgSelect[29∈4]<br />ᐸorganizationsᐳ<br />ᐳOrganization"]]:::plan
     Access28{{"Access[28∈4]<br />ᐸ27.0ᐳ"}}:::plan
-    Object12 & Access28 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect29
+    Object12 & Access28 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect29
     PgSelect38[["PgSelect[38∈4]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
     Access37{{"Access[37∈4]<br />ᐸ36.0ᐳ"}}:::plan
-    Object12 & Access37 & Lambda45 & Lambda48 & Lambda67 & Lambda72 --> PgSelect38
+    Object12 & Access37 & Lambda45 & Access49 & Lambda69 & Lambda74 --> PgSelect38
     Access26{{"Access[26∈4]<br />ᐸ25.1ᐳ<br />ᐳOrganization"}}:::plan
     PgUnionAllSingle25 --> Access26
     JSONParse27[["JSONParse[27∈4]<br />ᐸ26ᐳ"]]:::plan
@@ -104,17 +108,17 @@ graph TD
     subgraph "Buckets for queries/polymorphic/simple-log-entries"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda45,Lambda48,Constant49,Constant50,Constant51,Object52,Lambda53,Lambda58,Constant63,Constant64,Constant65,Object66,Lambda67,Lambda72,Constant77,Constant78,Constant79,Constant87,Constant88,Constant89,Constant90,Constant91 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 45, 48, 77, 78, 79, 91, 53, 58, 67, 72<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[80], Lambda[86], Lambda[81]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Access80,Constant86,Constant87,Constant88,Object89,Lambda90,Lambda95,Constant96,Constant97,Constant98,Constant99,Constant100 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 45, 49, 90, 95, 80, 54, 59, 69, 74<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object80,Lambda81,Lambda86 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 45, 48, 53, 58, 67, 72<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 45, 49, 80, 54, 59, 69, 74<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 45, 48, 53, 58, 67, 72<br /><br />ROOT PgSelectSingle{2}ᐸlog_entriesᐳ[16]<br />1: <br />ᐳ: 17, 18, 19<br />2: PgUnionAll[20]<br />ᐳ: First[24]<br />3: PgUnionAllSingle[25]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 45, 49, 80, 54, 59, 69, 74<br /><br />ROOT PgSelectSingle{2}ᐸlog_entriesᐳ[16]<br />1: <br />ᐳ: 17, 18, 19<br />2: PgUnionAll[20]<br />ᐳ: First[24]<br />3: PgUnionAllSingle[25]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgUnionAll20,First24,PgUnionAllSingle25 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />Organization,Person<br />Deps: 25, 12, 45, 48, 53, 58, 67, 72<br />ᐳOrganization<br />ᐳPerson<br /><br />1: <br />ᐳ: Access[26]<br />2: JSONParse[27], JSONParse[36]<br />ᐳ: Access[28], Access[37]<br />3: PgSelect[29], PgSelect[38]<br />ᐳ: 33, 34, 35, 40, 41, 42"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />Organization,Person<br />Deps: 25, 12, 45, 49, 54, 59, 69, 74<br />ᐳOrganization<br />ᐳPerson<br /><br />1: <br />ᐳ: Access[26]<br />2: JSONParse[27], JSONParse[36]<br />ᐳ: Access[28], Access[37]<br />3: PgSelect[29], PgSelect[38]<br />ᐳ: 33, 34, 35, 40, 41, 42"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,Access26,JSONParse27,Access28,PgSelect29,First33,PgSelectSingle34,PgClassExpression35,JSONParse36,Access37,PgSelect38,First40,PgSelectSingle41,PgClassExpression42 bucket4
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
@@ -12,120 +12,124 @@ graph TD
     PgSelect63[["PgSelect[63∈0] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access61{{"Access[61∈0] ➊<br />ᐸ60.1ᐳ"}}:::plan
-    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda253{{"Lambda[253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access221{{"Access[221∈0] ➊<br />ᐸ220.0ᐳ"}}:::plan
+    Lambda256{{"Lambda[256∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda261{{"Lambda[261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda269{{"Lambda[269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda274{{"Lambda[274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda273{{"Lambda[273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda278{{"Lambda[278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect63
-    Access61 & Lambda220 & Lambda253 & Lambda258 & Lambda217 & Lambda220 & Lambda269 & Lambda274 --> PgSelect63
-    Object224{{"Object[224∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
-    Lambda217 & Constant221 & Constant222 & Constant223 --> Object224
-    Object252{{"Object[252∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant249{{"Constant[249∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant250{{"Constant[250∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda217 & Constant249 & Constant250 & Constant223 --> Object252
-    Object268{{"Object[268∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda217 & Constant265 & Constant266 & Constant223 --> Object268
-    Object282{{"Object[282∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant279{{"Constant[279∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant280{{"Constant[280∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda217 & Constant279 & Constant280 & Constant223 --> Object282
-    Object298{{"Object[298∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant295{{"Constant[295∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant296{{"Constant[296∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Lambda217 & Constant295 & Constant296 & Constant223 --> Object298
-    Object312{{"Object[312∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant309{{"Constant[309∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant311{{"Constant[311∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda217 & Constant309 & Constant310 & Constant311 --> Object312
-    Object326{{"Object[326∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant323{{"Constant[323∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant324{{"Constant[324∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
-    Constant325{{"Constant[325∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
-    Lambda217 & Constant323 & Constant324 & Constant325 --> Object326
-    Object340{{"Object[340∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant337{{"Constant[337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant338{{"Constant[338∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Constant339{{"Constant[339∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
-    Lambda217 & Constant337 & Constant338 & Constant339 --> Object340
-    Object354{{"Object[354∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant351{{"Constant[351∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant352{{"Constant[352∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant353{{"Constant[353∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda217 & Constant351 & Constant352 & Constant353 --> Object354
-    Object368{{"Object[368∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant366{{"Constant[366∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda217 & Constant365 & Constant366 & Constant367 --> Object368
-    Object382{{"Object[382∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸsql.identifier(”relational_item_relations”)ᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸRecordCodec(relationalItemRelations)ᐳ"}}:::plan
-    Lambda217 & Constant379 & Constant380 & Constant381 --> Object382
-    Object396{{"Object[396∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant393{{"Constant[393∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸsql.identifier(”relational_item_relation_composite_pks”)ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸRecordCodec(relationalItemRelationCompositePks)ᐳ"}}:::plan
-    Lambda217 & Constant393 & Constant394 & Constant395 --> Object396
-    Object410{{"Object[410∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant408{{"Constant[408∈0] ➊<br />ᐸsql.identifier(”single_table_item_relations”)ᐳ"}}:::plan
-    Constant409{{"Constant[409∈0] ➊<br />ᐸRecordCodec(singleTableItemRelations)ᐳ"}}:::plan
-    Lambda217 & Constant407 & Constant408 & Constant409 --> Object410
+    Access61 & Access221 & Lambda256 & Lambda261 & Lambda217 & Access221 & Lambda273 & Lambda278 --> PgSelect63
+    Object225{{"Object[225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
+    Lambda217 & Constant222 & Constant223 & Constant224 --> Object225
+    Object240{{"Object[240∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant237{{"Constant[237∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda217 & Constant237 & Constant238 & Constant224 --> Object240
+    Object255{{"Object[255∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant252{{"Constant[252∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant253{{"Constant[253∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda217 & Constant252 & Constant253 & Constant224 --> Object255
+    Object272{{"Object[272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant269{{"Constant[269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant270{{"Constant[270∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda217 & Constant269 & Constant270 & Constant224 --> Object272
+    Object287{{"Object[287∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant285{{"Constant[285∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda217 & Constant284 & Constant285 & Constant224 --> Object287
+    Object304{{"Object[304∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant301{{"Constant[301∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant302{{"Constant[302∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda217 & Constant301 & Constant302 & Constant224 --> Object304
+    Object319{{"Object[319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant316{{"Constant[316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant317{{"Constant[317∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant318{{"Constant[318∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda217 & Constant316 & Constant317 & Constant318 --> Object319
+    Object334{{"Object[334∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant331{{"Constant[331∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant332{{"Constant[332∈0] ➊<br />ᐸsql.identifier(”log_entries”)ᐳ"}}:::plan
+    Constant333{{"Constant[333∈0] ➊<br />ᐸRecordCodec(logEntries)ᐳ"}}:::plan
+    Lambda217 & Constant331 & Constant332 & Constant333 --> Object334
+    Object349{{"Object[349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant347{{"Constant[347∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Constant348{{"Constant[348∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
+    Lambda217 & Constant346 & Constant347 & Constant348 --> Object349
+    Object364{{"Object[364∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant362{{"Constant[362∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant363{{"Constant[363∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda217 & Constant361 & Constant362 & Constant363 --> Object364
+    Object379{{"Object[379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant377{{"Constant[377∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant378{{"Constant[378∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda217 & Constant376 & Constant377 & Constant378 --> Object379
+    Object394{{"Object[394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸsql.identifier(”relational_item_relations”)ᐳ"}}:::plan
+    Constant393{{"Constant[393∈0] ➊<br />ᐸRecordCodec(relationalItemRelations)ᐳ"}}:::plan
+    Lambda217 & Constant391 & Constant392 & Constant393 --> Object394
+    Object409{{"Object[409∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸsql.identifier(”relational_item_relation_composite_pks”)ᐳ"}}:::plan
+    Constant408{{"Constant[408∈0] ➊<br />ᐸRecordCodec(relationalItemRelationCompositePks)ᐳ"}}:::plan
+    Lambda217 & Constant406 & Constant407 & Constant408 --> Object409
     Object424{{"Object[424∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant421{{"Constant[421∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸsql.identifier(”single_table_item_relation_composite_pks”)ᐳ"}}:::plan
-    Constant423{{"Constant[423∈0] ➊<br />ᐸRecordCodec(singleTableItemRelationCompositePks)ᐳ"}}:::plan
+    Constant422{{"Constant[422∈0] ➊<br />ᐸsql.identifier(”single_table_item_relations”)ᐳ"}}:::plan
+    Constant423{{"Constant[423∈0] ➊<br />ᐸRecordCodec(singleTableItemRelations)ᐳ"}}:::plan
     Lambda217 & Constant421 & Constant422 & Constant423 --> Object424
-    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”priorities”)ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸRecordCodec(priorities)ᐳ"}}:::plan
-    Lambda217 & Constant435 & Constant436 & Constant437 --> Object438
-    Object452{{"Object[452∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant451{{"Constant[451∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
-    Lambda217 & Constant449 & Constant450 & Constant451 --> Object452
-    Object466{{"Object[466∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant463{{"Constant[463∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
-    Lambda217 & Constant463 & Constant464 & Constant465 --> Object466
-    Object480{{"Object[480∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant477{{"Constant[477∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant478{{"Constant[478∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
-    Constant479{{"Constant[479∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
-    Lambda217 & Constant477 & Constant478 & Constant479 --> Object480
-    Object494{{"Object[494∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant491{{"Constant[491∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant492{{"Constant[492∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
-    Constant493{{"Constant[493∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
-    Lambda217 & Constant491 & Constant492 & Constant493 --> Object494
-    Object508{{"Object[508∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant505{{"Constant[505∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant506{{"Constant[506∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
-    Constant507{{"Constant[507∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
-    Lambda217 & Constant505 & Constant506 & Constant507 --> Object508
-    Object522{{"Object[522∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant519{{"Constant[519∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant520{{"Constant[520∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant521{{"Constant[521∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda217 & Constant519 & Constant520 & Constant521 --> Object522
-    Object536{{"Object[536∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant533{{"Constant[533∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant534{{"Constant[534∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant535{{"Constant[535∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda217 & Constant533 & Constant534 & Constant535 --> Object536
+    Object439{{"Object[439∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant437{{"Constant[437∈0] ➊<br />ᐸsql.identifier(”single_table_item_relation_composite_pks”)ᐳ"}}:::plan
+    Constant438{{"Constant[438∈0] ➊<br />ᐸRecordCodec(singleTableItemRelationCompositePks)ᐳ"}}:::plan
+    Lambda217 & Constant436 & Constant437 & Constant438 --> Object439
+    Object454{{"Object[454∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸsql.identifier(”priorities”)ᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸRecordCodec(priorities)ᐳ"}}:::plan
+    Lambda217 & Constant451 & Constant452 & Constant453 --> Object454
+    Object469{{"Object[469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant467{{"Constant[467∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant468{{"Constant[468∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
+    Lambda217 & Constant466 & Constant467 & Constant468 --> Object469
+    Object484{{"Object[484∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant482{{"Constant[482∈0] ➊<br />ᐸsql.identifier(”relational_posts”)ᐳ"}}:::plan
+    Constant483{{"Constant[483∈0] ➊<br />ᐸRecordCodec(relationalPosts)ᐳ"}}:::plan
+    Lambda217 & Constant481 & Constant482 & Constant483 --> Object484
+    Object499{{"Object[499∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant496{{"Constant[496∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant497{{"Constant[497∈0] ➊<br />ᐸsql.identifier(”relational_dividers”)ᐳ"}}:::plan
+    Constant498{{"Constant[498∈0] ➊<br />ᐸRecordCodec(relationalDividers)ᐳ"}}:::plan
+    Lambda217 & Constant496 & Constant497 & Constant498 --> Object499
+    Object514{{"Object[514∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant511{{"Constant[511∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant512{{"Constant[512∈0] ➊<br />ᐸsql.identifier(”relational_checklists”)ᐳ"}}:::plan
+    Constant513{{"Constant[513∈0] ➊<br />ᐸRecordCodec(relationalChecklists)ᐳ"}}:::plan
+    Lambda217 & Constant511 & Constant512 & Constant513 --> Object514
+    Object529{{"Object[529∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant526{{"Constant[526∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant527{{"Constant[527∈0] ➊<br />ᐸsql.identifier(”relational_checklist_items”)ᐳ"}}:::plan
+    Constant528{{"Constant[528∈0] ➊<br />ᐸRecordCodec(relationalChecklistItems)ᐳ"}}:::plan
+    Lambda217 & Constant526 & Constant527 & Constant528 --> Object529
+    Object544{{"Object[544∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant541{{"Constant[541∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant542{{"Constant[542∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant543{{"Constant[543∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda217 & Constant541 & Constant542 & Constant543 --> Object544
+    Object559{{"Object[559∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant556{{"Constant[556∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant557{{"Constant[557∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant558{{"Constant[558∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda217 & Constant556 & Constant557 & Constant558 --> Object559
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -133,8 +137,8 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Lambda60{{"Lambda[60∈0] ➊<br />ᐸspecifier_SingleTableDivider_base64JSONᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
-    Constant543 --> Lambda60
+    Constant566{{"Constant[566∈0] ➊<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
+    Constant566 --> Lambda60
     Lambda60 --> Access61
     First65{{"First[65∈0] ➊"}}:::plan
     PgSelect63 --> First65
@@ -143,117 +147,124 @@ graph TD
     Node82{{"Node[82∈0] ➊"}}:::plan
     Lambda83{{"Lambda[83∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda83 --> Node82
-    Constant543 --> Lambda83
-    Constant546{{"Constant[546∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant546 --> Lambda217
-    Constant547{{"Constant[547∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant547 --> Lambda220
-    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object224 --> Lambda225
-    Lambda230{{"Lambda[230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant548{{"Constant[548∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant548 --> Lambda230
-    Object252 --> Lambda253
-    Constant550{{"Constant[550∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant550 --> Lambda258
-    Object268 --> Lambda269
-    Constant551{{"Constant[551∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant551 --> Lambda274
-    Lambda283{{"Lambda[283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object282 --> Lambda283
+    Constant566 --> Lambda83
+    Constant569{{"Constant[569∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant569 --> Lambda217
+    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant570{{"Constant[570∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant570 --> Lambda220
+    Lambda220 --> Access221
+    Lambda226{{"Lambda[226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object225 --> Lambda226
+    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant571{{"Constant[571∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant571 --> Lambda231
+    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object240 --> Lambda241
+    Lambda246{{"Lambda[246∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant572{{"Constant[572∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant572 --> Lambda246
+    Object255 --> Lambda256
+    Constant573{{"Constant[573∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant573 --> Lambda261
+    Object272 --> Lambda273
+    Constant574{{"Constant[574∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant574 --> Lambda278
     Lambda288{{"Lambda[288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant552{{"Constant[552∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant552 --> Lambda288
-    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object298 --> Lambda299
-    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant553{{"Constant[553∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant553 --> Lambda304
-    Lambda313{{"Lambda[313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object312 --> Lambda313
-    Lambda318{{"Lambda[318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant554{{"Constant[554∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant554 --> Lambda318
-    Lambda327{{"Lambda[327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object326 --> Lambda327
-    Lambda332{{"Lambda[332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant555{{"Constant[555∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”log_enᐳ"}}:::plan
-    Constant555 --> Lambda332
-    Lambda341{{"Lambda[341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object340 --> Lambda341
-    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant556 --> Lambda346
+    Object287 --> Lambda288
+    Lambda293{{"Lambda[293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant575{{"Constant[575∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant575 --> Lambda293
+    Lambda305{{"Lambda[305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object304 --> Lambda305
+    Lambda310{{"Lambda[310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant576{{"Constant[576∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant576 --> Lambda310
+    Lambda320{{"Lambda[320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object319 --> Lambda320
+    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant577{{"Constant[577∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant577 --> Lambda325
+    Lambda335{{"Lambda[335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object334 --> Lambda335
+    Lambda340{{"Lambda[340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”log_enᐳ"}}:::plan
+    Constant578 --> Lambda340
+    Lambda350{{"Lambda[350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object349 --> Lambda350
     Lambda355{{"Lambda[355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object354 --> Lambda355
-    Lambda360{{"Lambda[360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant557 --> Lambda360
-    Lambda369{{"Lambda[369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object368 --> Lambda369
-    Lambda374{{"Lambda[374∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant558{{"Constant[558∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant558 --> Lambda374
-    Lambda383{{"Lambda[383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object382 --> Lambda383
-    Lambda388{{"Lambda[388∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant559{{"Constant[559∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant559 --> Lambda388
-    Lambda397{{"Lambda[397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object396 --> Lambda397
-    Lambda402{{"Lambda[402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant560{{"Constant[560∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant560 --> Lambda402
-    Lambda411{{"Lambda[411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object410 --> Lambda411
-    Lambda416{{"Lambda[416∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant561{{"Constant[561∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant561 --> Lambda416
+    Constant579{{"Constant[579∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant579 --> Lambda355
+    Lambda365{{"Lambda[365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object364 --> Lambda365
+    Lambda370{{"Lambda[370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant580{{"Constant[580∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant580 --> Lambda370
+    Lambda380{{"Lambda[380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object379 --> Lambda380
+    Lambda385{{"Lambda[385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant581{{"Constant[581∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant581 --> Lambda385
+    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object394 --> Lambda395
+    Lambda400{{"Lambda[400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant582{{"Constant[582∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant582 --> Lambda400
+    Lambda410{{"Lambda[410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object409 --> Lambda410
+    Lambda415{{"Lambda[415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant583{{"Constant[583∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant583 --> Lambda415
     Lambda425{{"Lambda[425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object424 --> Lambda425
     Lambda430{{"Lambda[430∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant562{{"Constant[562∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
-    Constant562 --> Lambda430
-    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object438 --> Lambda439
-    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant563{{"Constant[563∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”prioriᐳ"}}:::plan
-    Constant563 --> Lambda444
-    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object452 --> Lambda453
-    Lambda458{{"Lambda[458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant564 --> Lambda458
-    Lambda467{{"Lambda[467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object466 --> Lambda467
-    Lambda472{{"Lambda[472∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant565{{"Constant[565∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant565 --> Lambda472
-    Lambda481{{"Lambda[481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object480 --> Lambda481
-    Lambda486{{"Lambda[486∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant566{{"Constant[566∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant566 --> Lambda486
-    Lambda495{{"Lambda[495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object494 --> Lambda495
+    Constant584{{"Constant[584∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant584 --> Lambda430
+    Lambda440{{"Lambda[440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object439 --> Lambda440
+    Lambda445{{"Lambda[445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant585{{"Constant[585∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”singleᐳ"}}:::plan
+    Constant585 --> Lambda445
+    Lambda455{{"Lambda[455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object454 --> Lambda455
+    Lambda460{{"Lambda[460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant586{{"Constant[586∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”prioriᐳ"}}:::plan
+    Constant586 --> Lambda460
+    Lambda470{{"Lambda[470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object469 --> Lambda470
+    Lambda475{{"Lambda[475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant587{{"Constant[587∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant587 --> Lambda475
+    Lambda485{{"Lambda[485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object484 --> Lambda485
+    Lambda490{{"Lambda[490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant588{{"Constant[588∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant588 --> Lambda490
     Lambda500{{"Lambda[500∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant567{{"Constant[567∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant567 --> Lambda500
-    Lambda509{{"Lambda[509∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object508 --> Lambda509
-    Lambda514{{"Lambda[514∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant568{{"Constant[568∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant568 --> Lambda514
-    Lambda523{{"Lambda[523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object522 --> Lambda523
-    Lambda528{{"Lambda[528∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant569{{"Constant[569∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant569 --> Lambda528
-    Lambda537{{"Lambda[537∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object536 --> Lambda537
-    Lambda542{{"Lambda[542∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant570{{"Constant[570∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant570 --> Lambda542
+    Object499 --> Lambda500
+    Lambda505{{"Lambda[505∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant589{{"Constant[589∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant589 --> Lambda505
+    Lambda515{{"Lambda[515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object514 --> Lambda515
+    Lambda520{{"Lambda[520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant590{{"Constant[590∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant590 --> Lambda520
+    Lambda530{{"Lambda[530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object529 --> Lambda530
+    Lambda535{{"Lambda[535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant591{{"Constant[591∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant591 --> Lambda535
+    Lambda545{{"Lambda[545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object544 --> Lambda545
+    Lambda550{{"Lambda[550∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant592{{"Constant[592∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant592 --> Lambda550
+    Lambda560{{"Lambda[560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object559 --> Lambda560
+    Lambda565{{"Lambda[565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant593{{"Constant[593∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant593 --> Lambda565
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant18{{"Constant[18∈0] ➊<br />ᐸ'SingleTableTopic'ᐳ"}}:::plan
@@ -261,24 +272,15 @@ graph TD
     Constant38{{"Constant[38∈0] ➊<br />ᐸ'SingleTableDivider'ᐳ"}}:::plan
     Constant45{{"Constant[45∈0] ➊<br />ᐸ'SingleTableChecklist'ᐳ"}}:::plan
     Constant52{{"Constant[52∈0] ➊<br />ᐸ'SingleTableChecklistItem'ᐳ"}}:::plan
-    Constant235{{"Constant[235∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant549{{"Constant[549∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    Lambda239{{"Lambda[239∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda244{{"Lambda[244∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda217 & Lambda220 & Lambda239 & Lambda244 --> PgSelect14
-    Object238{{"Object[238∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda217 & Constant235 & Constant236 & Constant223 --> Object238
-    Object238 --> Lambda239
-    Constant549 --> Lambda244
+    Object12 & Connection13 & Lambda217 & Access221 & Lambda241 & Lambda246 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
     PgSelect23[["PgSelect[23∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__single_t..._topic_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object12 & PgClassExpression22 & Lambda217 & Lambda220 & Lambda225 & Lambda230 --> PgSelect23
+    Object12 & PgClassExpression22 & Lambda217 & Access221 & Lambda226 & Lambda231 --> PgSelect23
     List19{{"List[19∈3]<br />ᐸ18,17ᐳ<br />ᐳSingleTableTopic"}}:::plan
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression17 --> List19
@@ -323,71 +325,71 @@ graph TD
     PgClassExpression72{{"PgClassExpression[72∈5] ➊<br />ᐸ__single_t..._topic_id”ᐳ"}}:::plan
     PgSelectSingle66 --> PgClassExpression72
     PgSelectSingle78{{"PgSelectSingle[78∈5] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    RemapKeys259{{"RemapKeys[259∈5] ➊<br />ᐸ66:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
-    RemapKeys259 --> PgSelectSingle78
-    PgSelectSingle66 --> RemapKeys259
+    RemapKeys262{{"RemapKeys[262∈5] ➊<br />ᐸ66:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    RemapKeys262 --> PgSelectSingle78
+    PgSelectSingle66 --> RemapKeys262
     PgClassExpression79{{"PgClassExpression[79∈6] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle78 --> PgClassExpression79
     PgClassExpression80{{"PgClassExpression[80∈6] ➊<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
     PgSelectSingle78 --> PgClassExpression80
     PgSelect87[["PgSelect[87∈7] ➊<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    Access544{{"Access[544∈7] ➊<br />ᐸ83.base64JSON.1ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Access567{{"Access[567∈7] ➊<br />ᐸ83.base64JSON.1ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object12 -->|rejectNull| PgSelect87
-    Access544 & Lambda220 & Lambda283 & Lambda288 & Lambda217 & Lambda220 & Lambda299 & Lambda304 --> PgSelect87
+    Access567 & Access221 & Lambda288 & Lambda293 & Lambda217 & Access221 & Lambda305 & Lambda310 --> PgSelect87
     PgSelect126[["PgSelect[126∈7] ➊<br />ᐸrelational_item_relation_composite_pksᐳ<br />ᐳRelationalItemRelationCompositePk"]]:::plan
-    Access545{{"Access[545∈7] ➊<br />ᐸ83.base64JSON.2ᐳ<br />ᐳRelationalItemRelationCompositePk"}}:::plan
+    Access568{{"Access[568∈7] ➊<br />ᐸ83.base64JSON.2ᐳ<br />ᐳRelationalItemRelationCompositePk"}}:::plan
     Object12 -->|rejectNull| PgSelect126
-    Access544 -->|rejectNull| PgSelect126
-    Access545 & Lambda217 & Lambda220 & Lambda397 & Lambda402 --> PgSelect126
+    Access567 -->|rejectNull| PgSelect126
+    Access568 & Lambda217 & Access221 & Lambda410 & Lambda415 --> PgSelect126
     PgSelect137[["PgSelect[137∈7] ➊<br />ᐸsingle_table_item_relation_composite_pksᐳ<br />ᐳSingleTableItemRelationCompositePk"]]:::plan
     Object12 -->|rejectNull| PgSelect137
-    Access544 -->|rejectNull| PgSelect137
-    Access545 & Lambda217 & Lambda220 & Lambda425 & Lambda430 --> PgSelect137
+    Access567 -->|rejectNull| PgSelect137
+    Access568 & Lambda217 & Access221 & Lambda440 & Lambda445 --> PgSelect137
     PgSelect94[["PgSelect[94∈7] ➊<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect94
-    Access544 & Lambda217 & Lambda220 & Lambda313 & Lambda318 --> PgSelect94
+    Access567 & Lambda217 & Access221 & Lambda320 & Lambda325 --> PgSelect94
     PgSelect99[["PgSelect[99∈7] ➊<br />ᐸlog_entriesᐳ<br />ᐳLogEntry"]]:::plan
     Object12 -->|rejectNull| PgSelect99
-    Access544 & Lambda217 & Lambda220 & Lambda327 & Lambda332 --> PgSelect99
+    Access567 & Lambda217 & Access221 & Lambda335 & Lambda340 --> PgSelect99
     PgSelect104[["PgSelect[104∈7] ➊<br />ᐸorganizationsᐳ<br />ᐳOrganization"]]:::plan
     Object12 -->|rejectNull| PgSelect104
-    Access544 & Lambda217 & Lambda220 & Lambda341 & Lambda346 --> PgSelect104
+    Access567 & Lambda217 & Access221 & Lambda350 & Lambda355 --> PgSelect104
     PgSelect109[["PgSelect[109∈7] ➊<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Object12 -->|rejectNull| PgSelect109
-    Access544 & Lambda217 & Lambda220 & Lambda355 & Lambda360 --> PgSelect109
+    Access567 & Lambda217 & Access221 & Lambda365 & Lambda370 --> PgSelect109
     PgSelect114[["PgSelect[114∈7] ➊<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Object12 -->|rejectNull| PgSelect114
-    Access544 & Lambda217 & Lambda220 & Lambda369 & Lambda374 --> PgSelect114
+    Access567 & Lambda217 & Access221 & Lambda380 & Lambda385 --> PgSelect114
     PgSelect119[["PgSelect[119∈7] ➊<br />ᐸrelational_item_relationsᐳ<br />ᐳRelationalItemRelation"]]:::plan
     Object12 -->|rejectNull| PgSelect119
-    Access544 & Lambda217 & Lambda220 & Lambda383 & Lambda388 --> PgSelect119
+    Access567 & Lambda217 & Access221 & Lambda395 & Lambda400 --> PgSelect119
     PgSelect131[["PgSelect[131∈7] ➊<br />ᐸsingle_table_item_relationsᐳ<br />ᐳSingleTableItemRelation"]]:::plan
     Object12 -->|rejectNull| PgSelect131
-    Access544 & Lambda217 & Lambda220 & Lambda411 & Lambda416 --> PgSelect131
+    Access567 & Lambda217 & Access221 & Lambda425 & Lambda430 --> PgSelect131
     PgSelect147[["PgSelect[147∈7] ➊<br />ᐸprioritiesᐳ<br />ᐳPriority"]]:::plan
     Object12 -->|rejectNull| PgSelect147
-    Access544 & Lambda217 & Lambda220 & Lambda439 & Lambda444 --> PgSelect147
+    Access567 & Lambda217 & Access221 & Lambda455 & Lambda460 --> PgSelect147
     PgSelect180[["PgSelect[180∈7] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     Object12 -->|rejectNull| PgSelect180
-    Access544 & Lambda217 & Lambda220 & Lambda453 & Lambda458 --> PgSelect180
+    Access567 & Lambda217 & Access221 & Lambda470 & Lambda475 --> PgSelect180
     PgSelect185[["PgSelect[185∈7] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object12 -->|rejectNull| PgSelect185
-    Access544 & Lambda217 & Lambda220 & Lambda467 & Lambda472 --> PgSelect185
+    Access567 & Lambda217 & Access221 & Lambda485 & Lambda490 --> PgSelect185
     PgSelect190[["PgSelect[190∈7] ➊<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object12 -->|rejectNull| PgSelect190
-    Access544 & Lambda217 & Lambda220 & Lambda481 & Lambda486 --> PgSelect190
+    Access567 & Lambda217 & Access221 & Lambda500 & Lambda505 --> PgSelect190
     PgSelect195[["PgSelect[195∈7] ➊<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object12 -->|rejectNull| PgSelect195
-    Access544 & Lambda217 & Lambda220 & Lambda495 & Lambda500 --> PgSelect195
+    Access567 & Lambda217 & Access221 & Lambda515 & Lambda520 --> PgSelect195
     PgSelect200[["PgSelect[200∈7] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object12 -->|rejectNull| PgSelect200
-    Access544 & Lambda217 & Lambda220 & Lambda509 & Lambda514 --> PgSelect200
+    Access567 & Lambda217 & Access221 & Lambda530 & Lambda535 --> PgSelect200
     PgSelect206[["PgSelect[206∈7] ➊<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Object12 -->|rejectNull| PgSelect206
-    Access544 & Lambda217 & Lambda220 & Lambda523 & Lambda528 --> PgSelect206
+    Access567 & Lambda217 & Access221 & Lambda545 & Lambda550 --> PgSelect206
     PgSelect211[["PgSelect[211∈7] ➊<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Object12 -->|rejectNull| PgSelect211
-    Access544 & Lambda217 & Lambda220 & Lambda537 & Lambda542 --> PgSelect211
+    Access567 & Lambda217 & Access221 & Lambda560 & Lambda565 --> PgSelect211
     List159{{"List[159∈7] ➊<br />ᐸ38,156ᐳ<br />ᐳSingleTableDivider"}}:::plan
     PgClassExpression156{{"PgClassExpression[156∈7] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableDivider"}}:::plan
     Constant38 & PgClassExpression156 --> List159
@@ -443,8 +445,8 @@ graph TD
     PgClassExpression162{{"PgClassExpression[162∈7] ➊<br />ᐸ__single_t..._topic_id”ᐳ<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle92 --> PgClassExpression162
     PgSelectSingle166{{"PgSelectSingle[166∈7] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    RemapKeys289{{"RemapKeys[289∈7] ➊<br />ᐸ92:{”0”:2,”1”:3,”2”:4}ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    RemapKeys289 --> PgSelectSingle166
+    RemapKeys294{{"RemapKeys[294∈7] ➊<br />ᐸ92:{”0”:2,”1”:3,”2”:4}ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    RemapKeys294 --> PgSelectSingle166
     First182{{"First[182∈7] ➊"}}:::plan
     PgSelect180 --> First182
     PgSelectSingle183{{"PgSelectSingle[183∈7] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
@@ -473,9 +475,9 @@ graph TD
     PgSelect211 --> First213
     PgSelectSingle214{{"PgSelectSingle[214∈7] ➊<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
     First213 --> PgSelectSingle214
-    PgSelectSingle92 --> RemapKeys289
-    Lambda83 --> Access544
-    Lambda83 --> Access545
+    PgSelectSingle92 --> RemapKeys294
+    Lambda83 --> Access567
+    Lambda83 --> Access568
     PgClassExpression167{{"PgClassExpression[167∈8] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle166 --> PgClassExpression167
     PgClassExpression168{{"PgClassExpression[168∈8] ➊<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
@@ -484,16 +486,16 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/simple-single-table-items-root-topic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 18, 31, 38, 45, 52, 221, 222, 223, 235, 236, 249, 250, 265, 266, 279, 280, 295, 296, 309, 310, 311, 323, 324, 325, 337, 338, 339, 351, 352, 353, 365, 366, 367, 379, 380, 381, 393, 394, 395, 407, 408, 409, 421, 422, 423, 435, 436, 437, 449, 450, 451, 463, 464, 465, 477, 478, 479, 491, 492, 493, 505, 506, 507, 519, 520, 521, 533, 534, 535, 543, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 12, 60, 61, 83, 217, 220, 224, 225, 230, 252, 253, 258, 268, 269, 274, 282, 283, 288, 298, 299, 304, 312, 313, 318, 326, 327, 332, 340, 341, 346, 354, 355, 360, 368, 369, 374, 382, 383, 388, 396, 397, 402, 410, 411, 416, 424, 425, 430, 438, 439, 444, 452, 453, 458, 466, 467, 472, 480, 481, 486, 494, 495, 500, 508, 509, 514, 522, 523, 528, 536, 537, 542, 82<br />2: PgSelect[63]<br />ᐳ: First[65], PgSelectSingle[66]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 18, 31, 38, 45, 52, 222, 223, 224, 237, 238, 252, 253, 269, 270, 284, 285, 301, 302, 316, 317, 318, 331, 332, 333, 346, 347, 348, 361, 362, 363, 376, 377, 378, 391, 392, 393, 406, 407, 408, 421, 422, 423, 436, 437, 438, 451, 452, 453, 466, 467, 468, 481, 482, 483, 496, 497, 498, 511, 512, 513, 526, 527, 528, 541, 542, 543, 556, 557, 558, 566, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 12, 60, 61, 83, 217, 220, 221, 225, 226, 231, 240, 241, 246, 255, 256, 261, 272, 273, 278, 287, 288, 293, 304, 305, 310, 319, 320, 325, 334, 335, 340, 349, 350, 355, 364, 365, 370, 379, 380, 385, 394, 395, 400, 409, 410, 415, 424, 425, 430, 439, 440, 445, 454, 455, 460, 469, 470, 475, 484, 485, 490, 499, 500, 505, 514, 515, 520, 529, 530, 535, 544, 545, 550, 559, 560, 565, 82<br />2: PgSelect[63]<br />ᐳ: First[65], PgSelectSingle[66]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant18,Constant31,Constant38,Constant45,Constant52,Lambda60,Access61,PgSelect63,First65,PgSelectSingle66,Node82,Lambda83,Lambda217,Lambda220,Constant221,Constant222,Constant223,Object224,Lambda225,Lambda230,Constant235,Constant236,Constant249,Constant250,Object252,Lambda253,Lambda258,Constant265,Constant266,Object268,Lambda269,Lambda274,Constant279,Constant280,Object282,Lambda283,Lambda288,Constant295,Constant296,Object298,Lambda299,Lambda304,Constant309,Constant310,Constant311,Object312,Lambda313,Lambda318,Constant323,Constant324,Constant325,Object326,Lambda327,Lambda332,Constant337,Constant338,Constant339,Object340,Lambda341,Lambda346,Constant351,Constant352,Constant353,Object354,Lambda355,Lambda360,Constant365,Constant366,Constant367,Object368,Lambda369,Lambda374,Constant379,Constant380,Constant381,Object382,Lambda383,Lambda388,Constant393,Constant394,Constant395,Object396,Lambda397,Lambda402,Constant407,Constant408,Constant409,Object410,Lambda411,Lambda416,Constant421,Constant422,Constant423,Object424,Lambda425,Lambda430,Constant435,Constant436,Constant437,Object438,Lambda439,Lambda444,Constant449,Constant450,Constant451,Object452,Lambda453,Lambda458,Constant463,Constant464,Constant465,Object466,Lambda467,Lambda472,Constant477,Constant478,Constant479,Object480,Lambda481,Lambda486,Constant491,Constant492,Constant493,Object494,Lambda495,Lambda500,Constant505,Constant506,Constant507,Object508,Lambda509,Lambda514,Constant519,Constant520,Constant521,Object522,Lambda523,Lambda528,Constant533,Constant534,Constant535,Object536,Lambda537,Lambda542,Constant543,Constant546,Constant547,Constant548,Constant549,Constant550,Constant551,Constant552,Constant553,Constant554,Constant555,Constant556,Constant557,Constant558,Constant559,Constant560,Constant561,Constant562,Constant563,Constant564,Constant565,Constant566,Constant567,Constant568,Constant569,Constant570 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 217, 220, 235, 236, 223, 549, 18, 225, 230, 31, 38, 45, 52<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[238], Lambda[244], Lambda[239]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant18,Constant31,Constant38,Constant45,Constant52,Lambda60,Access61,PgSelect63,First65,PgSelectSingle66,Node82,Lambda83,Lambda217,Lambda220,Access221,Constant222,Constant223,Constant224,Object225,Lambda226,Lambda231,Constant237,Constant238,Object240,Lambda241,Lambda246,Constant252,Constant253,Object255,Lambda256,Lambda261,Constant269,Constant270,Object272,Lambda273,Lambda278,Constant284,Constant285,Object287,Lambda288,Lambda293,Constant301,Constant302,Object304,Lambda305,Lambda310,Constant316,Constant317,Constant318,Object319,Lambda320,Lambda325,Constant331,Constant332,Constant333,Object334,Lambda335,Lambda340,Constant346,Constant347,Constant348,Object349,Lambda350,Lambda355,Constant361,Constant362,Constant363,Object364,Lambda365,Lambda370,Constant376,Constant377,Constant378,Object379,Lambda380,Lambda385,Constant391,Constant392,Constant393,Object394,Lambda395,Lambda400,Constant406,Constant407,Constant408,Object409,Lambda410,Lambda415,Constant421,Constant422,Constant423,Object424,Lambda425,Lambda430,Constant436,Constant437,Constant438,Object439,Lambda440,Lambda445,Constant451,Constant452,Constant453,Object454,Lambda455,Lambda460,Constant466,Constant467,Constant468,Object469,Lambda470,Lambda475,Constant481,Constant482,Constant483,Object484,Lambda485,Lambda490,Constant496,Constant497,Constant498,Object499,Lambda500,Lambda505,Constant511,Constant512,Constant513,Object514,Lambda515,Lambda520,Constant526,Constant527,Constant528,Object529,Lambda530,Lambda535,Constant541,Constant542,Constant543,Object544,Lambda545,Lambda550,Constant556,Constant557,Constant558,Object559,Lambda560,Lambda565,Constant566,Constant569,Constant570,Constant571,Constant572,Constant573,Constant574,Constant575,Constant576,Constant577,Constant578,Constant579,Constant580,Constant581,Constant582,Constant583,Constant584,Constant585,Constant586,Constant587,Constant588,Constant589,Constant590,Constant591,Constant592,Constant593 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 217, 221, 241, 246, 18, 226, 231, 31, 38, 45, 52<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object238,Lambda239,Lambda244 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 12, 217, 220, 225, 230, 31, 38, 45, 52<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 12, 217, 221, 226, 231, 31, 38, 45, 52<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 16, 18, 12, 217, 220, 225, 230, 31, 38, 45, 52<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 17, 21, 22, 19, 20, 32, 33, 39, 40, 46, 47, 53, 54<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 16, 18, 12, 217, 221, 226, 231, 31, 38, 45, 52<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 17, 21, 22, 19, 20, 32, 33, 39, 40, 46, 47, 53, 54<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,List19,Lambda20,PgClassExpression21,PgClassExpression22,PgSelect23,First27,PgSelectSingle28,List32,Lambda33,List39,Lambda40,List46,Lambda47,List53,Lambda54 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[28]"):::bucket
@@ -501,13 +503,13 @@ graph TD
     class Bucket4,PgClassExpression29,PgClassExpression30 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 66, 38<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[66]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression67,List69,Lambda70,PgClassExpression71,PgClassExpression72,PgSelectSingle78,RemapKeys259 bucket5
+    class Bucket5,PgClassExpression67,List69,Lambda70,PgClassExpression71,PgClassExpression72,PgSelectSingle78,RemapKeys262 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 78<br /><br />ROOT PgSelectSingle{5}ᐸsingle_table_itemsᐳ[78]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression79,PgClassExpression80 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,Person,LogEntry,Organization,AwsApplication,GcpApplication,RelationalItemRelation,RelationalItemRelationCompositePk,SingleTableItemRelation,SingleTableItemRelationCompositePk,SingleTablePost,Priority,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem,RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem,Query,FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 12, 220, 283, 288, 217, 299, 304, 313, 318, 327, 332, 341, 346, 355, 360, 369, 374, 383, 388, 397, 402, 411, 416, 425, 430, 439, 444, 38, 453, 458, 467, 472, 481, 486, 495, 500, 509, 514, 523, 528, 537, 542, 83, 82, 4<br />ᐳSingleTableTopic<br />ᐳPerson<br />ᐳLogEntry<br />ᐳOrganization<br />ᐳAwsApplication<br />ᐳGcpApplication<br />ᐳRelationalItemRelation<br />ᐳRelationalItemRelationCompositePk<br />ᐳSingleTableItemRelation<br />ᐳSingleTableItemRelationCompositePk<br />ᐳSingleTablePost<br />ᐳPriority<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br />ᐳQuery<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[544], Access[545]<br />2: 87, 94, 99, 104, 109, 114, 119, 126, 131, 137, 147, 180, 185, 190, 195, 200, 206, 211<br />ᐳ: 91, 92, 96, 97, 101, 102, 106, 107, 111, 112, 116, 117, 121, 122, 128, 129, 133, 134, 139, 140, 149, 150, 156, 159, 160, 161, 162, 182, 183, 187, 188, 192, 193, 197, 198, 202, 203, 208, 209, 213, 214, 289, 166"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,Person,LogEntry,Organization,AwsApplication,GcpApplication,RelationalItemRelation,RelationalItemRelationCompositePk,SingleTableItemRelation,SingleTableItemRelationCompositePk,SingleTablePost,Priority,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem,RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem,Query,FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 12, 221, 288, 293, 217, 305, 310, 320, 325, 335, 340, 350, 355, 365, 370, 380, 385, 395, 400, 410, 415, 425, 430, 440, 445, 455, 460, 38, 470, 475, 485, 490, 500, 505, 515, 520, 530, 535, 545, 550, 560, 565, 83, 82, 4<br />ᐳSingleTableTopic<br />ᐳPerson<br />ᐳLogEntry<br />ᐳOrganization<br />ᐳAwsApplication<br />ᐳGcpApplication<br />ᐳRelationalItemRelation<br />ᐳRelationalItemRelationCompositePk<br />ᐳSingleTableItemRelation<br />ᐳSingleTableItemRelationCompositePk<br />ᐳSingleTablePost<br />ᐳPriority<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br />ᐳQuery<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[567], Access[568]<br />2: 87, 94, 99, 104, 109, 114, 119, 126, 131, 137, 147, 180, 185, 190, 195, 200, 206, 211<br />ᐳ: 91, 92, 96, 97, 101, 102, 106, 107, 111, 112, 116, 117, 121, 122, 128, 129, 133, 134, 139, 140, 149, 150, 156, 159, 160, 161, 162, 182, 183, 187, 188, 192, 193, 197, 198, 202, 203, 208, 209, 213, 214, 294, 166"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelect87,First91,PgSelectSingle92,PgSelect94,First96,PgSelectSingle97,PgSelect99,First101,PgSelectSingle102,PgSelect104,First106,PgSelectSingle107,PgSelect109,First111,PgSelectSingle112,PgSelect114,First116,PgSelectSingle117,PgSelect119,First121,PgSelectSingle122,PgSelect126,First128,PgSelectSingle129,PgSelect131,First133,PgSelectSingle134,PgSelect137,First139,PgSelectSingle140,PgSelect147,First149,PgSelectSingle150,PgClassExpression156,List159,Lambda160,PgClassExpression161,PgClassExpression162,PgSelectSingle166,PgSelect180,First182,PgSelectSingle183,PgSelect185,First187,PgSelectSingle188,PgSelect190,First192,PgSelectSingle193,PgSelect195,First197,PgSelectSingle198,PgSelect200,First202,PgSelectSingle203,PgSelect206,First208,PgSelectSingle209,PgSelect211,First213,PgSelectSingle214,RemapKeys289,Access544,Access545 bucket7
+    class Bucket7,PgSelect87,First91,PgSelectSingle92,PgSelect94,First96,PgSelectSingle97,PgSelect99,First101,PgSelectSingle102,PgSelect104,First106,PgSelectSingle107,PgSelect109,First111,PgSelectSingle112,PgSelect114,First116,PgSelectSingle117,PgSelect119,First121,PgSelectSingle122,PgSelect126,First128,PgSelectSingle129,PgSelect131,First133,PgSelectSingle134,PgSelect137,First139,PgSelectSingle140,PgSelect147,First149,PgSelectSingle150,PgClassExpression156,List159,Lambda160,PgClassExpression161,PgClassExpression162,PgSelectSingle166,PgSelect180,First182,PgSelectSingle183,PgSelect185,First187,PgSelectSingle188,PgSelect190,First192,PgSelectSingle193,PgSelect195,First197,PgSelectSingle198,PgSelect200,First202,PgSelectSingle203,PgSelect206,First208,PgSelectSingle209,PgSelect211,First213,PgSelectSingle214,RemapKeys294,Access567,Access568 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 166<br /><br />ROOT PgSelectSingle{7}ᐸsingle_table_itemsᐳ[166]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression167,PgClassExpression168 bucket8

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/single-table-items-and-children.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/single-table-items-and-children.mermaid
@@ -9,12 +9,16 @@ graph TD
 
 
     %% plan dependencies
-    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object61{{"Object[61∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
-    Lambda53 & Constant57 & Constant58 & Constant59 --> Object60
+    Constant58{{"Constant[58∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸRecordCodec(singleTableItems)ᐳ"}}:::plan
+    Lambda53 & Constant58 & Constant59 & Constant60 --> Object61
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
+    Lambda53 & Constant73 & Constant74 & Constant60 --> Object76
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,36 +26,34 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda53
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda53
     Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda56
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object60 --> Lambda61
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant83 --> Lambda66
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda56
+    Access57{{"Access[57∈0] ➊<br />ᐸ56.0ᐳ"}}:::plan
+    Lambda56 --> Access57
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object61 --> Lambda62
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant85 --> Lambda67
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object76 --> Lambda77
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant86 --> Lambda82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”single_table_items”)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda53 & Lambda56 & Lambda75 & Lambda80 --> PgSelect14
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda53 & Constant71 & Constant72 & Constant59 --> Object74
-    Object74 --> Lambda75
-    Constant84 --> Lambda80
+    Object12 & Connection13 & Lambda53 & Access57 & Lambda77 & Lambda82 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
     PgSelect19[["PgSelect[19∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object12 & PgClassExpression17 & Lambda53 & Lambda56 & Lambda61 & Lambda66 --> PgSelect19
+    Object12 & PgClassExpression17 & Lambda53 & Access57 & Lambda62 & Lambda67 --> PgSelect19
     PgSelectSingle16 --> PgClassExpression17
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle16 --> PgClassExpression18
@@ -85,14 +87,14 @@ graph TD
     subgraph "Buckets for queries/polymorphic/single-table-items-and-children"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda53,Lambda56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant71,Constant72,Constant81,Constant82,Constant83,Constant84 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 53, 56, 71, 72, 59, 84, 61, 66<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[74], Lambda[80], Lambda[75]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda53,Lambda56,Access57,Constant58,Constant59,Constant60,Object61,Lambda62,Lambda67,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 53, 57, 77, 82, 62, 67<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object74,Lambda75,Lambda80 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 53, 56, 61, 66<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 53, 57, 62, 67<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 16, 12, 53, 56, 61, 66<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 17, 18<br />2: PgSelect[19]"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 16, 12, 53, 57, 62, 67<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 17, 18<br />2: PgSelect[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression18,PgSelect19 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
@@ -10,84 +10,122 @@ graph TD
 
     %% plan dependencies
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor21["PgValidateParsedCursor[21∈0] ➊"]:::plan
-    Constant187 & Lambda16 & PgValidateParsedCursor21 & PgValidateParsedCursor21 & PgValidateParsedCursor21 & PgValidateParsedCursor21 & PgValidateParsedCursor21 --> Connection15
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda122 & Constant126 & Constant127 & Constant128 --> Object129
-    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda122 & Constant140 & Constant141 & Constant142 --> Object143
-    Object166{{"Object[166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda122 & Constant163 & Constant164 & Constant128 --> Object166
-    Object180{{"Object[180∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Lambda122 & Constant177 & Constant178 & Constant142 --> Object180
+    Constant234 & Lambda16 & PgValidateParsedCursor21 & PgValidateParsedCursor21 & PgValidateParsedCursor21 & PgValidateParsedCursor21 & PgValidateParsedCursor21 --> Connection15
+    PgUnionAll94[["PgUnionAll[94∈0] ➊"]]:::plan
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Constant236{{"Constant[236∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda153{{"Lambda[153∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access232{{"Access[232∈0] ➊<br />ᐸ231.0ᐳ"}}:::plan
+    Access233{{"Access[233∈0] ➊<br />ᐸ231.1ᐳ"}}:::plan
+    Object14 & Constant234 & Constant236 & Lambda153 & Access232 & Access233 --> PgUnionAll94
+    Object130{{"Object[130∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda122 & Constant127 & Constant128 & Constant129 --> Object130
+    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda122 & Constant142 & Constant143 & Constant144 --> Object145
+    Object206{{"Object[206∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda122 & Constant203 & Constant204 & Constant129 --> Object206
+    Object221{{"Object[221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Lambda122 & Constant218 & Constant219 & Constant144 --> Object221
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access12 & Access13 --> Object14
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ'WyIzMDY3N2Q5ZTIyIiwiMTAiLCJUaGlyZFBhcnR5VnVsbmVyYWJpbGl0eSIᐳ"}}:::plan
-    Constant188 --> Lambda16
+    Constant235{{"Constant[235∈0] ➊<br />ᐸ'WyIzMDY3N2Q5ZTIyIiwiMTAiLCJUaGlyZFBhcnR5VnVsbmVyYWJpbGl0eSIᐳ"}}:::plan
+    Constant235 --> Lambda16
     Lambda16 --> PgValidateParsedCursor21
-    PgUnionAll94[["PgUnionAll[94∈0] ➊"]]:::plan
-    Object14 --> PgUnionAll94
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant189 --> Lambda122
+    Access22{{"Access[22∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access22
+    ToPg23{{"ToPg[23∈0] ➊"}}:::plan
+    Access22 --> ToPg23
+    Access24{{"Access[24∈0] ➊<br />ᐸ16.2ᐳ"}}:::plan
+    Lambda16 --> Access24
+    ToPg25{{"ToPg[25∈0] ➊"}}:::plan
+    Access24 --> ToPg25
+    Access26{{"Access[26∈0] ➊<br />ᐸ16.3ᐳ"}}:::plan
+    Lambda16 --> Access26
+    Constant237{{"Constant[237∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant237 --> Lambda122
     Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant190 --> Lambda125
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object129 --> Lambda130
-    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant191 --> Lambda135
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object143 --> Lambda144
-    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant192 --> Lambda149
-    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object166 --> Lambda167
-    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant193 --> Lambda172
-    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object180 --> Lambda181
-    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant194 --> Lambda186
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant238 --> Lambda125
+    Access126{{"Access[126∈0] ➊<br />ᐸ125.0ᐳ"}}:::plan
+    Lambda125 --> Access126
+    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object130 --> Lambda131
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant239 --> Lambda136
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object145 --> Lambda146
+    Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant240 --> Lambda151
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant243 --> Lambda153
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant244 --> Lambda155
+    Access156{{"Access[156∈0] ➊<br />ᐸ155.0ᐳ"}}:::plan
+    Lambda155 --> Access156
+    Access157{{"Access[157∈0] ➊<br />ᐸ155.1ᐳ"}}:::plan
+    Lambda155 --> Access157
+    Access163{{"Access[163∈0] ➊<br />ᐸ125.1ᐳ"}}:::plan
+    Lambda125 --> Access163
+    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant245{{"Constant[245∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant245 --> Lambda186
+    Access187{{"Access[187∈0] ➊<br />ᐸ186.0ᐳ"}}:::plan
+    Lambda186 --> Access187
+    Access188{{"Access[188∈0] ➊<br />ᐸ186.1ᐳ"}}:::plan
+    Lambda186 --> Access188
+    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object206 --> Lambda207
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant241{{"Constant[241∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant241 --> Lambda212
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object221 --> Lambda222
+    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant242 --> Lambda227
+    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant246{{"Constant[246∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant246 --> Lambda231
+    Lambda231 --> Access232
+    Lambda231 --> Access233
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     PgUnionAll17[["PgUnionAll[17∈1] ➊"]]:::plan
-    ToPg23{{"ToPg[23∈1] ➊"}}:::plan
-    ToPg25{{"ToPg[25∈1] ➊"}}:::plan
-    Access26{{"Access[26∈1] ➊<br />ᐸ16.3ᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll17
+    Object14 & Connection15 & Lambda16 & Constant234 & ToPg23 & ToPg25 & Access26 & Lambda153 & Access156 & Access157 --> PgUnionAll17
     PgUnionAll59[["PgUnionAll[59∈1] ➊"]]:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll59
+    Object14 & Connection15 & Lambda16 & Constant234 & ToPg23 & ToPg25 & Access26 & Lambda153 & Access156 & Access157 --> PgUnionAll59
     PgUnionAll70[["PgUnionAll[70∈1] ➊"]]:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll70
+    Object14 & Connection15 & Lambda16 & Constant234 & ToPg23 & ToPg25 & Access26 & Lambda153 & Access156 & Access157 --> PgUnionAll70
     PgUnionAll82[["PgUnionAll[82∈1] ➊"]]:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll82
+    Object14 & Connection15 & Lambda16 & Constant234 & ToPg23 & ToPg25 & Access26 & Lambda153 & Access187 & Access188 --> PgUnionAll82
     PgUnionAll86[["PgUnionAll[86∈1] ➊"]]:::plan
-    Object14 & Connection15 & Lambda16 & ToPg23 & ToPg25 & Access26 --> PgUnionAll86
+    Object14 & Connection15 & Lambda16 & Constant234 & ToPg23 & ToPg25 & Access26 & Lambda153 & Access187 & Access188 --> PgUnionAll86
+    PgUnionAll53[["PgUnionAll[53∈1] ➊"]]:::plan
+    Object14 & Connection15 & Lambda122 & Access126 & Access163 --> PgUnionAll53
     Object88{{"Object[88∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access87{{"Access[87∈1] ➊<br />ᐸ86.hasMoreᐳ"}}:::plan
-    Constant187 & Constant7 & Constant7 & Access87 --> Object88
+    Constant234 & Constant7 & Constant7 & Access87 --> Object88
     List69{{"List[69∈1] ➊<br />ᐸ66,67,68ᐳ"}}:::plan
     Access66{{"Access[66∈1] ➊<br />ᐸ61.0ᐳ"}}:::plan
     Access67{{"Access[67∈1] ➊<br />ᐸ61.1ᐳ"}}:::plan
@@ -100,16 +138,7 @@ graph TD
     Access77 & Access78 & Access79 --> List80
     Object84{{"Object[84∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access83{{"Access[83∈1] ➊<br />ᐸ82.hasMoreᐳ"}}:::plan
-    Constant187 & Constant7 & Access83 --> Object84
-    PgUnionAll53[["PgUnionAll[53∈1] ➊"]]:::plan
-    Object14 & Connection15 --> PgUnionAll53
-    Access22{{"Access[22∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda16 --> Access22
-    Access22 --> ToPg23
-    Access24{{"Access[24∈1] ➊<br />ᐸ16.2ᐳ"}}:::plan
-    Lambda16 --> Access24
-    Access24 --> ToPg25
-    Lambda16 --> Access26
+    Constant234 & Constant7 & Access83 --> Object84
     First54{{"First[54∈1] ➊"}}:::plan
     PgUnionAll53 --> First54
     PgUnionAllSingle55["PgUnionAllSingle[55∈1] ➊"]:::plan
@@ -158,10 +187,10 @@ graph TD
     PgUnionAllSingle19 --> Access29
     PgSelect34[["PgSelect[34∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access33{{"Access[33∈4]<br />ᐸ32.0ᐳ"}}:::plan
-    Object14 & Access33 & Lambda122 & Lambda125 & Lambda130 & Lambda135 --> PgSelect34
+    Object14 & Access33 & Lambda122 & Access126 & Lambda131 & Lambda136 --> PgSelect34
     PgSelect45[["PgSelect[45∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access44{{"Access[44∈4]<br />ᐸ43.0ᐳ"}}:::plan
-    Object14 & Access44 & Lambda122 & Lambda125 & Lambda144 & Lambda149 --> PgSelect45
+    Object14 & Access44 & Lambda122 & Access126 & Lambda146 & Lambda151 --> PgSelect45
     JSONParse32[["JSONParse[32∈4]<br />ᐸ29ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access29 --> JSONParse32
     JSONParse32 --> Access33
@@ -196,10 +225,10 @@ graph TD
     __Item96 --> PgUnionAllSingle97
     PgSelect101[["PgSelect[101∈6]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access100{{"Access[100∈6]<br />ᐸ99.0ᐳ"}}:::plan
-    Object14 & Access100 & Lambda122 & Lambda125 & Lambda167 & Lambda172 --> PgSelect101
+    Object14 & Access100 & Lambda122 & Access126 & Lambda207 & Lambda212 --> PgSelect101
     PgSelect112[["PgSelect[112∈6]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access111{{"Access[111∈6]<br />ᐸ110.0ᐳ"}}:::plan
-    Object14 & Access111 & Lambda122 & Lambda125 & Lambda181 & Lambda186 --> PgSelect112
+    Object14 & Access111 & Lambda122 & Access126 & Lambda222 & Lambda227 --> PgSelect112
     Access98{{"Access[98∈6]<br />ᐸ97.2ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle97 --> Access98
     JSONParse99[["JSONParse[99∈6]<br />ᐸ98ᐳ"]]:::plan
@@ -234,25 +263,25 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/vulns"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 12, 13, 126, 127, 128, 140, 141, 142, 163, 164, 177, 178, 187, 188, 189, 190, 191, 192, 193, 194, 14, 16, 122, 125, 129, 130, 135, 143, 144, 149, 166, 167, 172, 180, 181, 186<br />2: 21, 94<br />ᐳ: Connection[15]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 12, 13, 127, 128, 129, 142, 143, 144, 203, 204, 218, 219, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 14, 16, 22, 23, 24, 25, 26, 122, 125, 126, 130, 131, 136, 145, 146, 151, 153, 155, 156, 157, 163, 186, 187, 188, 206, 207, 212, 221, 222, 227, 231, 232, 233<br />2: 21, 94<br />ᐳ: Connection[15]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,PgUnionAll94,Lambda122,Lambda125,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant140,Constant141,Constant142,Object143,Lambda144,Lambda149,Constant163,Constant164,Object166,Lambda167,Lambda172,Constant177,Constant178,Object180,Lambda181,Lambda186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193,Constant194 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 187, 7, 122, 125, 130, 135, 144, 149<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: PgUnionAll[53]<br />ᐳ: 22, 24, 26, 58, 23, 25, 54<br />2: 17, 55, 59, 70, 82, 86<br />ᐳ: 56, 60, 71, 83, 84, 85, 87, 88, 89<br />3: 61, 72<br />ᐳ: 66, 67, 68, 69, 77, 78, 79, 80, 62, 73"):::bucket
+    class Bucket0,__Value2,__Value4,Constant7,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor21,Access22,ToPg23,Access24,ToPg25,Access26,PgUnionAll94,Lambda122,Lambda125,Access126,Constant127,Constant128,Constant129,Object130,Lambda131,Lambda136,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Lambda153,Lambda155,Access156,Access157,Access163,Lambda186,Access187,Access188,Constant203,Constant204,Object206,Lambda207,Lambda212,Constant218,Constant219,Object221,Lambda222,Lambda227,Lambda231,Access232,Access233,Constant234,Constant235,Constant236,Constant237,Constant238,Constant239,Constant240,Constant241,Constant242,Constant243,Constant244,Constant245,Constant246 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 234, 23, 25, 26, 153, 156, 157, 122, 126, 163, 187, 188, 7, 131, 136, 146, 151<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: 17, 53, 59, 70, 82, 86<br />ᐳ: 58, 54, 60, 71, 83, 84, 85, 87, 88, 89<br />2: 55, 61, 72<br />ᐳ: 56, 66, 67, 68, 69, 77, 78, 79, 80, 62, 73"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll17,Access22,ToPg23,Access24,ToPg25,Access26,PgUnionAll53,First54,PgUnionAllSingle55,PgClassExpression56,PgPageInfo58,PgUnionAll59,First60,PgUnionAllSingle61,PgCursor62,Access66,Access67,Access68,List69,PgUnionAll70,Last71,PgUnionAllSingle72,PgCursor73,Access77,Access78,Access79,List80,PgUnionAll82,Access83,Object84,Lambda85,PgUnionAll86,Access87,Object88,Lambda89 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 122, 125, 130, 135, 144, 149<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
+    class Bucket1,PgUnionAll17,PgUnionAll53,First54,PgUnionAllSingle55,PgClassExpression56,PgPageInfo58,PgUnionAll59,First60,PgUnionAllSingle61,PgCursor62,Access66,Access67,Access68,List69,PgUnionAll70,Last71,PgUnionAllSingle72,PgCursor73,Access77,Access78,Access79,List80,PgUnionAll82,Access83,Object84,Lambda85,PgUnionAll86,Access87,Object88,Lambda89 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 122, 126, 131, 136, 146, 151<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgUnionAllSingle19 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 122, 125, 130, 135, 144, 149<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 19, 14, 122, 126, 131, 136, 146, 151<br /><br />ROOT PgUnionAllSingle{2}[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor20,Access27,Access28,Access29,List30 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 122, 125, 130, 135, 144, 149, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[43]<br />ᐳ: Access[33], Access[44]<br />2: PgSelect[34], PgSelect[45]<br />ᐳ: 38, 39, 40, 41, 42, 47, 48, 49, 50, 51, 52"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 29, 14, 122, 126, 131, 136, 146, 151, 19<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[32], JSONParse[43]<br />ᐳ: Access[33], Access[44]<br />2: PgSelect[34], PgSelect[45]<br />ᐳ: 38, 39, 40, 41, 42, 47, 48, 49, 50, 51, 52"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,JSONParse32,Access33,PgSelect34,First38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,JSONParse43,Access44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,PgClassExpression50,PgClassExpression51,PgClassExpression52 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 14, 122, 125, 167, 172, 181, 186<br /><br />ROOT __Item{5}ᐸ94ᐳ[96]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 14, 122, 126, 207, 212, 222, 227<br /><br />ROOT __Item{5}ᐸ94ᐳ[96]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item96,PgUnionAllSingle97 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 97, 14, 122, 125, 167, 172, 181, 186<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[98]<br />2: JSONParse[99], JSONParse[110]<br />ᐳ: Access[100], Access[111]<br />3: PgSelect[101], PgSelect[112]<br />ᐳ: 105, 106, 107, 108, 109, 114, 115, 116, 117, 118, 119"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 97, 14, 122, 126, 207, 212, 222, 227<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[98]<br />2: JSONParse[99], JSONParse[110]<br />ᐳ: Access[100], Access[111]<br />3: PgSelect[101], PgSelect[112]<br />ᐳ: 105, 106, 107, 108, 109, 114, 115, 116, 117, 118, 119"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,Access98,JSONParse99,Access100,PgSelect101,First105,PgSelectSingle106,PgClassExpression107,PgClassExpression108,PgClassExpression109,JSONParse110,Access111,PgSelect112,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119 bucket6
     Bucket0 --> Bucket1 & Bucket5

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.sql
@@ -56,75 +56,6 @@ from (
 
 
 select
-  (count(*))::text as "0",
-  null as "1",
-  null as "2"
-from (
-    select
-      __first_party_vulnerabilities__."1",
-      __first_party_vulnerabilities__."2",
-      "n"
-    from (
-      select
-        'FirstPartyVulnerability' as "1",
-        json_build_array((__first_party_vulnerabilities__."id")::text) as "2",
-        row_number() over (
-          order by
-            __first_party_vulnerabilities__."cvss_score" desc,
-            __first_party_vulnerabilities__."id" asc
-        ) as "n"
-      from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
-      order by
-        __first_party_vulnerabilities__."cvss_score" desc,
-        __first_party_vulnerabilities__."id" asc
-    ) as __first_party_vulnerabilities__
-  union all
-    select
-      __third_party_vulnerabilities__."1",
-      __third_party_vulnerabilities__."2",
-      "n"
-    from (
-      select
-        'ThirdPartyVulnerability' as "1",
-        json_build_array((__third_party_vulnerabilities__."id")::text) as "2",
-        row_number() over (
-          order by
-            __third_party_vulnerabilities__."cvss_score" desc,
-            __third_party_vulnerabilities__."id" asc
-        ) as "n"
-      from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
-      order by
-        __third_party_vulnerabilities__."cvss_score" desc,
-        __third_party_vulnerabilities__."id" asc
-    ) as __third_party_vulnerabilities__
-) __vulnerability__
-
-
-select
-  __first_party_vulnerabilities__."id"::text as "0",
-  __first_party_vulnerabilities__."name" as "1",
-  __first_party_vulnerabilities__."cvss_score"::text as "2"
-from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
-where (
-  __first_party_vulnerabilities__."id" = $1::"int4"
-);
-
-select __third_party_vulnerabilities_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
-lateral (
-  select
-    __third_party_vulnerabilities__."id"::text as "0",
-    __third_party_vulnerabilities__."name" as "1",
-    __third_party_vulnerabilities__."cvss_score"::text as "2",
-    __third_party_vulnerabilities__."vendor_name" as "3",
-    __third_party_vulnerabilities_identifiers__.idx as "4"
-  from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
-  where (
-    __third_party_vulnerabilities__."id" = __third_party_vulnerabilities_identifiers__."id0"
-  )
-) as __third_party_vulnerabilities_result__;
-
-select
   __vulnerability__."0"::text as "0",
   __vulnerability__."1" as "1",
   __vulnerability__."2"::text as "2"
@@ -207,6 +138,51 @@ from (
     "1" asc,
     "n" asc
   limit 3
+) __vulnerability__
+
+
+select
+  (count(*))::text as "0",
+  null as "1",
+  null as "2"
+from (
+    select
+      __first_party_vulnerabilities__."1",
+      __first_party_vulnerabilities__."2",
+      "n"
+    from (
+      select
+        'FirstPartyVulnerability' as "1",
+        json_build_array((__first_party_vulnerabilities__."id")::text) as "2",
+        row_number() over (
+          order by
+            __first_party_vulnerabilities__."cvss_score" desc,
+            __first_party_vulnerabilities__."id" asc
+        ) as "n"
+      from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
+      order by
+        __first_party_vulnerabilities__."cvss_score" desc,
+        __first_party_vulnerabilities__."id" asc
+    ) as __first_party_vulnerabilities__
+  union all
+    select
+      __third_party_vulnerabilities__."1",
+      __third_party_vulnerabilities__."2",
+      "n"
+    from (
+      select
+        'ThirdPartyVulnerability' as "1",
+        json_build_array((__third_party_vulnerabilities__."id")::text) as "2",
+        row_number() over (
+          order by
+            __third_party_vulnerabilities__."cvss_score" desc,
+            __third_party_vulnerabilities__."id" asc
+        ) as "n"
+      from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+      order by
+        __third_party_vulnerabilities__."cvss_score" desc,
+        __third_party_vulnerabilities__."id" asc
+    ) as __third_party_vulnerabilities__
 ) __vulnerability__
 
 
@@ -294,3 +270,28 @@ from (
     "n" asc
   limit 4
 ) __vulnerability__
+
+
+select
+  __first_party_vulnerabilities__."id"::text as "0",
+  __first_party_vulnerabilities__."name" as "1",
+  __first_party_vulnerabilities__."cvss_score"::text as "2"
+from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
+where (
+  __first_party_vulnerabilities__."id" = $1::"int4"
+);
+
+select __third_party_vulnerabilities_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+lateral (
+  select
+    __third_party_vulnerabilities__."id"::text as "0",
+    __third_party_vulnerabilities__."name" as "1",
+    __third_party_vulnerabilities__."cvss_score"::text as "2",
+    __third_party_vulnerabilities__."vendor_name" as "3",
+    __third_party_vulnerabilities_identifiers__.idx as "4"
+  from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+  where (
+    __third_party_vulnerabilities__."id" = __third_party_vulnerabilities_identifiers__."id0"
+  )
+) as __third_party_vulnerabilities_result__;

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
@@ -9,149 +9,149 @@ graph TD
 
 
     %% plan dependencies
-    Object538{{"Object[538∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object539{{"Object[539∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda531{{"Lambda[531∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant535{{"Constant[535∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant536{{"Constant[536∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Constant537{{"Constant[537∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
-    Lambda531 & Constant535 & Constant536 & Constant537 --> Object538
-    Object552{{"Object[552∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant549{{"Constant[549∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant550{{"Constant[550∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant551{{"Constant[551∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda531 & Constant549 & Constant550 & Constant551 --> Object552
-    Object566{{"Object[566∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant563{{"Constant[563∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Constant565{{"Constant[565∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
-    Lambda531 & Constant563 & Constant564 & Constant565 --> Object566
-    Object580{{"Object[580∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant577{{"Constant[577∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant578{{"Constant[578∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant577 & Constant578 & Constant537 --> Object580
-    Object594{{"Object[594∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant591{{"Constant[591∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant592{{"Constant[592∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant591 & Constant592 & Constant551 --> Object594
-    Object608{{"Object[608∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant605{{"Constant[605∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant606{{"Constant[606∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Constant607{{"Constant[607∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
-    Lambda531 & Constant605 & Constant606 & Constant607 --> Object608
-    Object622{{"Object[622∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant619{{"Constant[619∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant620{{"Constant[620∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant619 & Constant620 & Constant537 --> Object622
-    Object636{{"Object[636∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant633{{"Constant[633∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant634{{"Constant[634∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant633 & Constant634 & Constant551 --> Object636
-    Object650{{"Object[650∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant647{{"Constant[647∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant648{{"Constant[648∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Lambda531 & Constant647 & Constant648 & Constant565 --> Object650
-    Object664{{"Object[664∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant661{{"Constant[661∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant662{{"Constant[662∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant661 & Constant662 & Constant537 --> Object664
-    Object678{{"Object[678∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant675{{"Constant[675∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant676{{"Constant[676∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant675 & Constant676 & Constant551 --> Object678
-    Object692{{"Object[692∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant689{{"Constant[689∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant690{{"Constant[690∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Lambda531 & Constant689 & Constant690 & Constant607 --> Object692
-    Object706{{"Object[706∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant703{{"Constant[703∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant704{{"Constant[704∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant703 & Constant704 & Constant537 --> Object706
-    Object720{{"Object[720∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant717{{"Constant[717∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant718{{"Constant[718∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant717 & Constant718 & Constant551 --> Object720
+    Constant536{{"Constant[536∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant537{{"Constant[537∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Constant538{{"Constant[538∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
+    Lambda531 & Constant536 & Constant537 & Constant538 --> Object539
+    Object554{{"Object[554∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant551{{"Constant[551∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant552{{"Constant[552∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant553{{"Constant[553∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda531 & Constant551 & Constant552 & Constant553 --> Object554
+    Object575{{"Object[575∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant572{{"Constant[572∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant573{{"Constant[573∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Constant574{{"Constant[574∈0] ➊<br />ᐸRecordCodec(awsApplications)ᐳ"}}:::plan
+    Lambda531 & Constant572 & Constant573 & Constant574 --> Object575
+    Object590{{"Object[590∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant587{{"Constant[587∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant588{{"Constant[588∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant587 & Constant588 & Constant538 --> Object590
+    Object605{{"Object[605∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant602{{"Constant[602∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant603{{"Constant[603∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant602 & Constant603 & Constant553 --> Object605
+    Object626{{"Object[626∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Constant625{{"Constant[625∈0] ➊<br />ᐸRecordCodec(gcpApplications)ᐳ"}}:::plan
+    Lambda531 & Constant623 & Constant624 & Constant625 --> Object626
+    Object647{{"Object[647∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant644{{"Constant[644∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant645{{"Constant[645∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant644 & Constant645 & Constant538 --> Object647
+    Object662{{"Object[662∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant659{{"Constant[659∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant660{{"Constant[660∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant659 & Constant660 & Constant553 --> Object662
+    Object683{{"Object[683∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant680{{"Constant[680∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant681{{"Constant[681∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Lambda531 & Constant680 & Constant681 & Constant574 --> Object683
+    Object698{{"Object[698∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant695{{"Constant[695∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant696{{"Constant[696∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant695 & Constant696 & Constant538 --> Object698
+    Object713{{"Object[713∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant710{{"Constant[710∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant711{{"Constant[711∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant710 & Constant711 & Constant553 --> Object713
     Object734{{"Object[734∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant731{{"Constant[731∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant732{{"Constant[732∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant731 & Constant732 & Constant537 --> Object734
-    Object748{{"Object[748∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant745{{"Constant[745∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant746{{"Constant[746∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant745 & Constant746 & Constant551 --> Object748
-    Object762{{"Object[762∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant759{{"Constant[759∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant760{{"Constant[760∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant761{{"Constant[761∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda531 & Constant759 & Constant760 & Constant761 --> Object762
-    Object776{{"Object[776∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant773{{"Constant[773∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant774{{"Constant[774∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant773 & Constant774 & Constant537 --> Object776
-    Object790{{"Object[790∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant787{{"Constant[787∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant788{{"Constant[788∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant787 & Constant788 & Constant551 --> Object790
-    Object804{{"Object[804∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant801{{"Constant[801∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant802{{"Constant[802∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Lambda531 & Constant801 & Constant802 & Constant565 --> Object804
-    Object818{{"Object[818∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant815{{"Constant[815∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant816{{"Constant[816∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant815 & Constant816 & Constant537 --> Object818
-    Object832{{"Object[832∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant829{{"Constant[829∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant830{{"Constant[830∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant829 & Constant830 & Constant551 --> Object832
-    Object846{{"Object[846∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant843{{"Constant[843∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant844{{"Constant[844∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Lambda531 & Constant843 & Constant844 & Constant607 --> Object846
-    Object860{{"Object[860∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant857{{"Constant[857∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant858{{"Constant[858∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant857 & Constant858 & Constant537 --> Object860
-    Object874{{"Object[874∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant871{{"Constant[871∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant872{{"Constant[872∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant871 & Constant872 & Constant551 --> Object874
-    Object888{{"Object[888∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant885{{"Constant[885∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant886{{"Constant[886∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
-    Lambda531 & Constant885 & Constant886 & Constant565 --> Object888
-    Object902{{"Object[902∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant899{{"Constant[899∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant900{{"Constant[900∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant899 & Constant900 & Constant537 --> Object902
-    Object916{{"Object[916∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant913{{"Constant[913∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant914{{"Constant[914∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant913 & Constant914 & Constant551 --> Object916
-    Object930{{"Object[930∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant927{{"Constant[927∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant928{{"Constant[928∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
-    Lambda531 & Constant927 & Constant928 & Constant607 --> Object930
-    Object944{{"Object[944∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant941{{"Constant[941∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant942{{"Constant[942∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant941 & Constant942 & Constant537 --> Object944
-    Object958{{"Object[958∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant955{{"Constant[955∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant956{{"Constant[956∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant955 & Constant956 & Constant551 --> Object958
-    Object972{{"Object[972∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant969{{"Constant[969∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant970{{"Constant[970∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda531 & Constant969 & Constant970 & Constant537 --> Object972
+    Constant732{{"Constant[732∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Lambda531 & Constant731 & Constant732 & Constant625 --> Object734
+    Object755{{"Object[755∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant752{{"Constant[752∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant753{{"Constant[753∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant752 & Constant753 & Constant538 --> Object755
+    Object770{{"Object[770∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant767{{"Constant[767∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant768{{"Constant[768∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant767 & Constant768 & Constant553 --> Object770
+    Object791{{"Object[791∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant788{{"Constant[788∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant789{{"Constant[789∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant788 & Constant789 & Constant538 --> Object791
+    Object806{{"Object[806∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant803{{"Constant[803∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant804{{"Constant[804∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant803 & Constant804 & Constant553 --> Object806
+    Object827{{"Object[827∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant824{{"Constant[824∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant825{{"Constant[825∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant826{{"Constant[826∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda531 & Constant824 & Constant825 & Constant826 --> Object827
+    Object842{{"Object[842∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant839{{"Constant[839∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant840{{"Constant[840∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant839 & Constant840 & Constant538 --> Object842
+    Object857{{"Object[857∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant854{{"Constant[854∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant855{{"Constant[855∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant854 & Constant855 & Constant553 --> Object857
+    Object878{{"Object[878∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant875{{"Constant[875∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant876{{"Constant[876∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Lambda531 & Constant875 & Constant876 & Constant574 --> Object878
+    Object893{{"Object[893∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant890{{"Constant[890∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant891{{"Constant[891∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant890 & Constant891 & Constant538 --> Object893
+    Object908{{"Object[908∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant905{{"Constant[905∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant906{{"Constant[906∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant905 & Constant906 & Constant553 --> Object908
+    Object929{{"Object[929∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant926{{"Constant[926∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant927{{"Constant[927∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Lambda531 & Constant926 & Constant927 & Constant625 --> Object929
+    Object950{{"Object[950∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant947{{"Constant[947∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant948{{"Constant[948∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant947 & Constant948 & Constant538 --> Object950
+    Object965{{"Object[965∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant962{{"Constant[962∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant963{{"Constant[963∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant962 & Constant963 & Constant553 --> Object965
     Object986{{"Object[986∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant983{{"Constant[983∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant984{{"Constant[984∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda531 & Constant983 & Constant984 & Constant551 --> Object986
-    Object1000{{"Object[1000∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant997{{"Constant[997∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant998{{"Constant[998∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant999{{"Constant[999∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda531 & Constant997 & Constant998 & Constant999 --> Object1000
+    Constant984{{"Constant[984∈0] ➊<br />ᐸsql.identifier(”aws_applications”)ᐳ"}}:::plan
+    Lambda531 & Constant983 & Constant984 & Constant574 --> Object986
+    Object1001{{"Object[1001∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant998{{"Constant[998∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant999{{"Constant[999∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant998 & Constant999 & Constant538 --> Object1001
+    Object1016{{"Object[1016∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1013{{"Constant[1013∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1014{{"Constant[1014∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant1013 & Constant1014 & Constant553 --> Object1016
+    Object1037{{"Object[1037∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1034{{"Constant[1034∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1035{{"Constant[1035∈0] ➊<br />ᐸsql.identifier(”gcp_applications”)ᐳ"}}:::plan
+    Lambda531 & Constant1034 & Constant1035 & Constant625 --> Object1037
+    Object1058{{"Object[1058∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1055{{"Constant[1055∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1056{{"Constant[1056∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant1055 & Constant1056 & Constant538 --> Object1058
+    Object1073{{"Object[1073∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1070{{"Constant[1070∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1071{{"Constant[1071∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant1070 & Constant1071 & Constant553 --> Object1073
+    Object1094{{"Object[1094∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1091{{"Constant[1091∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1092{{"Constant[1092∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda531 & Constant1091 & Constant1092 & Constant538 --> Object1094
+    Object1109{{"Object[1109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1106{{"Constant[1106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1107{{"Constant[1107∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda531 & Constant1106 & Constant1107 & Constant553 --> Object1109
+    Object1130{{"Object[1130∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1127{{"Constant[1127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1128{{"Constant[1128∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant1129{{"Constant[1129∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda531 & Constant1127 & Constant1128 & Constant1129 --> Object1130
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -160,183 +160,197 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant1007{{"Constant[1007∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant1007 --> Connection12
-    Constant1008{{"Constant[1008∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1008 --> Lambda531
+    Constant1143{{"Constant[1143∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant1143 --> Connection12
+    Constant1144{{"Constant[1144∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1144 --> Lambda531
     Lambda534{{"Lambda[534∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1009{{"Constant[1009∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1009 --> Lambda534
-    Lambda539{{"Lambda[539∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object538 --> Lambda539
-    Lambda544{{"Lambda[544∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1010{{"Constant[1010∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1010 --> Lambda544
-    Lambda553{{"Lambda[553∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object552 --> Lambda553
-    Lambda558{{"Lambda[558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1011{{"Constant[1011∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1011 --> Lambda558
-    Lambda567{{"Lambda[567∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object566 --> Lambda567
-    Lambda572{{"Lambda[572∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1012{{"Constant[1012∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant1012 --> Lambda572
+    Constant1145{{"Constant[1145∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1145 --> Lambda534
+    Access535{{"Access[535∈0] ➊<br />ᐸ534.0ᐳ"}}:::plan
+    Lambda534 --> Access535
+    Lambda540{{"Lambda[540∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object539 --> Lambda540
+    Lambda545{{"Lambda[545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1146{{"Constant[1146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1146 --> Lambda545
+    Lambda555{{"Lambda[555∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object554 --> Lambda555
+    Lambda560{{"Lambda[560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1147{{"Constant[1147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1147 --> Lambda560
+    Access566{{"Access[566∈0] ➊<br />ᐸ534.1ᐳ"}}:::plan
+    Lambda534 --> Access566
+    Lambda576{{"Lambda[576∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object575 --> Lambda576
     Lambda581{{"Lambda[581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object580 --> Lambda581
-    Lambda586{{"Lambda[586∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1013{{"Constant[1013∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1013 --> Lambda586
-    Lambda595{{"Lambda[595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object594 --> Lambda595
-    Lambda600{{"Lambda[600∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1014{{"Constant[1014∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1014 --> Lambda600
-    Lambda609{{"Lambda[609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object608 --> Lambda609
-    Lambda614{{"Lambda[614∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1015{{"Constant[1015∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant1015 --> Lambda614
-    Lambda623{{"Lambda[623∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object622 --> Lambda623
-    Lambda628{{"Lambda[628∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1016{{"Constant[1016∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1016 --> Lambda628
-    Lambda637{{"Lambda[637∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object636 --> Lambda637
-    Lambda642{{"Lambda[642∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1017{{"Constant[1017∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1017 --> Lambda642
-    Lambda651{{"Lambda[651∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object650 --> Lambda651
-    Lambda656{{"Lambda[656∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1018{{"Constant[1018∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant1018 --> Lambda656
-    Lambda665{{"Lambda[665∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object664 --> Lambda665
-    Lambda670{{"Lambda[670∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1019{{"Constant[1019∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1019 --> Lambda670
-    Lambda679{{"Lambda[679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object678 --> Lambda679
+    Constant1148{{"Constant[1148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant1148 --> Lambda581
+    Lambda591{{"Lambda[591∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object590 --> Lambda591
+    Lambda596{{"Lambda[596∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1149{{"Constant[1149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1149 --> Lambda596
+    Lambda606{{"Lambda[606∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object605 --> Lambda606
+    Lambda611{{"Lambda[611∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1150{{"Constant[1150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1150 --> Lambda611
+    Lambda627{{"Lambda[627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object626 --> Lambda627
+    Lambda632{{"Lambda[632∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1151{{"Constant[1151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant1151 --> Lambda632
+    Lambda648{{"Lambda[648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object647 --> Lambda648
+    Lambda653{{"Lambda[653∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1152{{"Constant[1152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1152 --> Lambda653
+    Lambda663{{"Lambda[663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object662 --> Lambda663
+    Lambda668{{"Lambda[668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1153{{"Constant[1153∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1153 --> Lambda668
     Lambda684{{"Lambda[684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1020{{"Constant[1020∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1020 --> Lambda684
-    Lambda693{{"Lambda[693∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object692 --> Lambda693
-    Lambda698{{"Lambda[698∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1021{{"Constant[1021∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant1021 --> Lambda698
-    Lambda707{{"Lambda[707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object706 --> Lambda707
-    Lambda712{{"Lambda[712∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1022{{"Constant[1022∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1022 --> Lambda712
-    Lambda721{{"Lambda[721∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object720 --> Lambda721
-    Lambda726{{"Lambda[726∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1023{{"Constant[1023∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1023 --> Lambda726
+    Object683 --> Lambda684
+    Lambda689{{"Lambda[689∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1154{{"Constant[1154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant1154 --> Lambda689
+    Lambda699{{"Lambda[699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object698 --> Lambda699
+    Lambda704{{"Lambda[704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1155{{"Constant[1155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1155 --> Lambda704
+    Lambda714{{"Lambda[714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object713 --> Lambda714
+    Lambda719{{"Lambda[719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1156{{"Constant[1156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1156 --> Lambda719
     Lambda735{{"Lambda[735∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object734 --> Lambda735
     Lambda740{{"Lambda[740∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1024{{"Constant[1024∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1024 --> Lambda740
-    Lambda749{{"Lambda[749∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object748 --> Lambda749
-    Lambda754{{"Lambda[754∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1025{{"Constant[1025∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1025 --> Lambda754
-    Lambda763{{"Lambda[763∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object762 --> Lambda763
-    Lambda768{{"Lambda[768∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1026{{"Constant[1026∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant1026 --> Lambda768
-    Lambda777{{"Lambda[777∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object776 --> Lambda777
-    Lambda782{{"Lambda[782∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1027{{"Constant[1027∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1027 --> Lambda782
-    Lambda791{{"Lambda[791∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object790 --> Lambda791
-    Lambda796{{"Lambda[796∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1028{{"Constant[1028∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1028 --> Lambda796
-    Lambda805{{"Lambda[805∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object804 --> Lambda805
-    Lambda810{{"Lambda[810∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1029{{"Constant[1029∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant1029 --> Lambda810
-    Lambda819{{"Lambda[819∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object818 --> Lambda819
-    Lambda824{{"Lambda[824∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1030{{"Constant[1030∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1030 --> Lambda824
+    Constant1157{{"Constant[1157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant1157 --> Lambda740
+    Lambda756{{"Lambda[756∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object755 --> Lambda756
+    Lambda761{{"Lambda[761∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1158{{"Constant[1158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1158 --> Lambda761
+    Lambda771{{"Lambda[771∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object770 --> Lambda771
+    Lambda776{{"Lambda[776∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1159{{"Constant[1159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1159 --> Lambda776
+    Lambda792{{"Lambda[792∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object791 --> Lambda792
+    Lambda797{{"Lambda[797∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1160{{"Constant[1160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1160 --> Lambda797
+    Lambda807{{"Lambda[807∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object806 --> Lambda807
+    Lambda812{{"Lambda[812∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1161{{"Constant[1161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1161 --> Lambda812
+    Lambda828{{"Lambda[828∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object827 --> Lambda828
     Lambda833{{"Lambda[833∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object832 --> Lambda833
-    Lambda838{{"Lambda[838∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1031{{"Constant[1031∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1031 --> Lambda838
-    Lambda847{{"Lambda[847∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object846 --> Lambda847
-    Lambda852{{"Lambda[852∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1032{{"Constant[1032∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant1032 --> Lambda852
-    Lambda861{{"Lambda[861∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object860 --> Lambda861
-    Lambda866{{"Lambda[866∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1033{{"Constant[1033∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1033 --> Lambda866
-    Lambda875{{"Lambda[875∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object874 --> Lambda875
-    Lambda880{{"Lambda[880∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1034{{"Constant[1034∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1034 --> Lambda880
-    Lambda889{{"Lambda[889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object888 --> Lambda889
+    Constant1162{{"Constant[1162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant1162 --> Lambda833
+    Lambda843{{"Lambda[843∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object842 --> Lambda843
+    Lambda848{{"Lambda[848∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1163{{"Constant[1163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1163 --> Lambda848
+    Lambda858{{"Lambda[858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object857 --> Lambda858
+    Lambda863{{"Lambda[863∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1164{{"Constant[1164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1164 --> Lambda863
+    Lambda879{{"Lambda[879∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object878 --> Lambda879
+    Lambda884{{"Lambda[884∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1165{{"Constant[1165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant1165 --> Lambda884
     Lambda894{{"Lambda[894∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1035{{"Constant[1035∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
-    Constant1035 --> Lambda894
-    Lambda903{{"Lambda[903∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object902 --> Lambda903
-    Lambda908{{"Lambda[908∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1036{{"Constant[1036∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1036 --> Lambda908
-    Lambda917{{"Lambda[917∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object916 --> Lambda917
-    Lambda922{{"Lambda[922∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1037{{"Constant[1037∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1037 --> Lambda922
-    Lambda931{{"Lambda[931∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object930 --> Lambda931
-    Lambda936{{"Lambda[936∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1038{{"Constant[1038∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
-    Constant1038 --> Lambda936
-    Lambda945{{"Lambda[945∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object944 --> Lambda945
-    Lambda950{{"Lambda[950∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1039{{"Constant[1039∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1039 --> Lambda950
-    Lambda959{{"Lambda[959∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object958 --> Lambda959
-    Lambda964{{"Lambda[964∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1040{{"Constant[1040∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1040 --> Lambda964
-    Lambda973{{"Lambda[973∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object972 --> Lambda973
-    Lambda978{{"Lambda[978∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1041{{"Constant[1041∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant1041 --> Lambda978
+    Object893 --> Lambda894
+    Lambda899{{"Lambda[899∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1166{{"Constant[1166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1166 --> Lambda899
+    Lambda909{{"Lambda[909∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object908 --> Lambda909
+    Lambda914{{"Lambda[914∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1167{{"Constant[1167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1167 --> Lambda914
+    Lambda930{{"Lambda[930∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object929 --> Lambda930
+    Lambda935{{"Lambda[935∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1168{{"Constant[1168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant1168 --> Lambda935
+    Lambda951{{"Lambda[951∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object950 --> Lambda951
+    Lambda956{{"Lambda[956∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1169{{"Constant[1169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1169 --> Lambda956
+    Lambda966{{"Lambda[966∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object965 --> Lambda966
+    Lambda971{{"Lambda[971∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1170{{"Constant[1170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1170 --> Lambda971
     Lambda987{{"Lambda[987∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object986 --> Lambda987
     Lambda992{{"Lambda[992∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1042{{"Constant[1042∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant1042 --> Lambda992
-    Lambda1001{{"Lambda[1001∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1000 --> Lambda1001
-    Lambda1006{{"Lambda[1006∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1043{{"Constant[1043∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant1043 --> Lambda1006
+    Constant1171{{"Constant[1171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”aws_apᐳ"}}:::plan
+    Constant1171 --> Lambda992
+    Lambda1002{{"Lambda[1002∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1001 --> Lambda1002
+    Lambda1007{{"Lambda[1007∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1172{{"Constant[1172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1172 --> Lambda1007
+    Lambda1017{{"Lambda[1017∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1016 --> Lambda1017
+    Lambda1022{{"Lambda[1022∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1173{{"Constant[1173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1173 --> Lambda1022
+    Lambda1038{{"Lambda[1038∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1037 --> Lambda1038
+    Lambda1043{{"Lambda[1043∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1174{{"Constant[1174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”gcp_apᐳ"}}:::plan
+    Constant1174 --> Lambda1043
+    Lambda1059{{"Lambda[1059∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1058 --> Lambda1059
+    Lambda1064{{"Lambda[1064∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1175{{"Constant[1175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1175 --> Lambda1064
+    Lambda1074{{"Lambda[1074∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1073 --> Lambda1074
+    Lambda1079{{"Lambda[1079∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1176{{"Constant[1176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1176 --> Lambda1079
+    Lambda1095{{"Lambda[1095∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1094 --> Lambda1095
+    Lambda1100{{"Lambda[1100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1177{{"Constant[1177∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant1177 --> Lambda1100
+    Lambda1110{{"Lambda[1110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1109 --> Lambda1110
+    Lambda1115{{"Lambda[1115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1178{{"Constant[1178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant1178 --> Lambda1115
+    Lambda1131{{"Lambda[1131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1130 --> Lambda1131
+    Lambda1136{{"Lambda[1136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1179{{"Constant[1179∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant1179 --> Lambda1136
+    Lambda1138{{"Lambda[1138∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1180{{"Constant[1180∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1180 --> Lambda1138
+    Lambda1140{{"Lambda[1140∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1181{{"Constant[1181∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1181 --> Lambda1140
+    Access1141{{"Access[1141∈0] ➊<br />ᐸ1140.0ᐳ"}}:::plan
+    Lambda1140 --> Access1141
+    Access1142{{"Access[1142∈0] ➊<br />ᐸ1140.1ᐳ"}}:::plan
+    Lambda1140 --> Access1142
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant25{{"Constant[25∈0] ➊<br />ᐸ'first_party_vulnerabilities'ᐳ"}}:::plan
     Constant45{{"Constant[45∈0] ➊<br />ᐸ'aws_applications'ᐳ"}}:::plan
@@ -345,43 +359,43 @@ graph TD
     Constant87{{"Constant[87∈0] ➊<br />ᐸ'gcp_applications'ᐳ"}}:::plan
     Constant280{{"Constant[280∈0] ➊<br />ᐸ'third_party_vulnerabilities'ᐳ"}}:::plan
     PgUnionAll13[["PgUnionAll[13∈1] ➊"]]:::plan
-    Object11 & Connection12 --> PgUnionAll13
+    Object11 & Connection12 & Constant1143 & Lambda1138 & Access1141 & Access1142 --> PgUnionAll13
     __Item14[/"__Item[14∈2]<br />ᐸ13ᐳ"\]:::itemplan
     PgUnionAll13 ==> __Item14
     PgUnionAllSingle15["PgUnionAllSingle[15∈2]"]:::plan
     __Item14 --> PgUnionAllSingle15
     PgSelect19[["PgSelect[19∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access18{{"Access[18∈3]<br />ᐸ17.0ᐳ"}}:::plan
-    Object11 & Access18 & Lambda531 & Lambda534 & Lambda763 & Lambda768 --> PgSelect19
-    PgSelect276[["PgSelect[276∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access275{{"Access[275∈3]<br />ᐸ274.0ᐳ"}}:::plan
-    Object11 & Access275 & Lambda531 & Lambda534 & Lambda1001 & Lambda1006 --> PgSelect276
+    Object11 & Access18 & Lambda531 & Access535 & Lambda828 & Lambda833 --> PgSelect19
     PgUnionAll33[["PgUnionAll[33∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
     Connection32{{"Connection[32∈3] ➊<br />ᐸ30ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Object11 & PgClassExpression26 & Connection32 --> PgUnionAll33
+    Object11 & PgClassExpression26 & Connection32 & Lambda531 & Access535 & Access566 --> PgUnionAll33
     PgUnionAll217[["PgUnionAll[217∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
     Connection216{{"Connection[216∈3] ➊<br />ᐸ214ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Object11 & PgClassExpression26 & Connection216 --> PgUnionAll217
+    Object11 & PgClassExpression26 & Connection216 & Lambda531 & Access535 & Access566 --> PgUnionAll217
+    PgSelect276[["PgSelect[276∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access275{{"Access[275∈3]<br />ᐸ274.0ᐳ"}}:::plan
+    Object11 & Access275 & Lambda531 & Access535 & Lambda1131 & Lambda1136 --> PgSelect276
     PgUnionAll288[["PgUnionAll[288∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
     PgClassExpression281{{"PgClassExpression[281∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
     Connection287{{"Connection[287∈3] ➊<br />ᐸ285ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Object11 & PgClassExpression281 & Connection287 --> PgUnionAll288
+    Object11 & PgClassExpression281 & Connection287 & Lambda531 & Access535 & Access566 --> PgUnionAll288
     PgUnionAll472[["PgUnionAll[472∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
     Connection471{{"Connection[471∈3] ➊<br />ᐸ469ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Object11 & PgClassExpression281 & Connection471 --> PgUnionAll472
+    Object11 & PgClassExpression281 & Connection471 & Lambda531 & Access535 & Access566 --> PgUnionAll472
+    PgUnionAll123[["PgUnionAll[123∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object11 & PgClassExpression26 & Lambda531 & Access535 & Access566 --> PgUnionAll123
+    PgUnionAll245[["PgUnionAll[245∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object11 & PgClassExpression26 & Lambda531 & Access535 & Access566 --> PgUnionAll245
+    PgUnionAll378[["PgUnionAll[378∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object11 & PgClassExpression281 & Lambda531 & Access535 & Access566 --> PgUnionAll378
+    PgUnionAll500[["PgUnionAll[500∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object11 & PgClassExpression281 & Lambda531 & Access535 & Access566 --> PgUnionAll500
     List27{{"List[27∈3]<br />ᐸ25,26ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
     Constant25 & PgClassExpression26 --> List27
-    PgUnionAll123[["PgUnionAll[123∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    Object11 & PgClassExpression26 --> PgUnionAll123
-    PgUnionAll245[["PgUnionAll[245∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    Object11 & PgClassExpression26 --> PgUnionAll245
     List282{{"List[282∈3]<br />ᐸ280,281ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
     Constant280 & PgClassExpression281 --> List282
-    PgUnionAll378[["PgUnionAll[378∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    Object11 & PgClassExpression281 --> PgUnionAll378
-    PgUnionAll500[["PgUnionAll[500∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    Object11 & PgClassExpression281 --> PgUnionAll500
     Access16{{"Access[16∈3]<br />ᐸ15.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
     PgUnionAllSingle15 --> Access16
     JSONParse17[["JSONParse[17∈3]<br />ᐸ16ᐳ"]]:::plan
@@ -414,18 +428,18 @@ graph TD
     __Item34 --> PgUnionAllSingle35
     PgSelect39[["PgSelect[39∈5]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access38{{"Access[38∈5]<br />ᐸ37.0ᐳ"}}:::plan
-    Object11 & Access38 & Lambda531 & Lambda534 & Lambda567 & Lambda572 --> PgSelect39
-    PgSelect83[["PgSelect[83∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access82{{"Access[82∈5]<br />ᐸ81.0ᐳ"}}:::plan
-    Object11 & Access82 & Lambda531 & Lambda534 & Lambda609 & Lambda614 --> PgSelect83
+    Object11 & Access38 & Lambda531 & Access535 & Lambda576 & Lambda581 --> PgSelect39
     PgUnionAll52[["PgUnionAll[52∈5]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression50 & PgClassExpression51 --> PgUnionAll52
+    Object11 & PgClassExpression50 & PgClassExpression51 & Lambda531 & Access535 & Access566 --> PgUnionAll52
+    PgSelect83[["PgSelect[83∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access82{{"Access[82∈5]<br />ᐸ81.0ᐳ"}}:::plan
+    Object11 & Access82 & Lambda531 & Access535 & Lambda627 & Lambda632 --> PgSelect83
     PgUnionAll94[["PgUnionAll[94∈5]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
     PgClassExpression92{{"PgClassExpression[92∈5]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
     PgClassExpression93{{"PgClassExpression[93∈5]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression92 & PgClassExpression93 --> PgUnionAll94
+    Object11 & PgClassExpression92 & PgClassExpression93 & Lambda531 & Access535 & Access566 --> PgUnionAll94
     List47{{"List[47∈5]<br />ᐸ45,46ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
     PgClassExpression46{{"PgClassExpression[46∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Constant45 & PgClassExpression46 --> List47
@@ -472,10 +486,10 @@ graph TD
     First96 --> PgUnionAllSingle97
     PgSelect59[["PgSelect[59∈6]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access58{{"Access[58∈6]<br />ᐸ57.0ᐳ"}}:::plan
-    Object11 & Access58 & Lambda531 & Lambda534 & Lambda539 & Lambda544 --> PgSelect59
+    Object11 & Access58 & Lambda531 & Access535 & Lambda540 & Lambda545 --> PgSelect59
     PgSelect72[["PgSelect[72∈6]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
     Access71{{"Access[71∈6]<br />ᐸ70.0ᐳ"}}:::plan
-    Object11 & Access71 & Lambda531 & Lambda534 & Lambda553 & Lambda558 --> PgSelect72
+    Object11 & Access71 & Lambda531 & Access535 & Lambda555 & Lambda560 --> PgSelect72
     List67{{"List[67∈6]<br />ᐸ65,66ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
     PgClassExpression66{{"PgClassExpression[66∈6]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression66 --> List67
@@ -510,10 +524,10 @@ graph TD
     PgSelectSingle75 --> PgClassExpression80
     PgSelect101[["PgSelect[101∈7]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access100{{"Access[100∈7]<br />ᐸ99.0ᐳ"}}:::plan
-    Object11 & Access100 & Lambda531 & Lambda534 & Lambda581 & Lambda586 --> PgSelect101
+    Object11 & Access100 & Lambda531 & Access535 & Lambda591 & Lambda596 --> PgSelect101
     PgSelect114[["PgSelect[114∈7]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
     Access113{{"Access[113∈7]<br />ᐸ112.0ᐳ"}}:::plan
-    Object11 & Access113 & Lambda531 & Lambda534 & Lambda595 & Lambda600 --> PgSelect114
+    Object11 & Access113 & Lambda531 & Access535 & Lambda606 & Lambda611 --> PgSelect114
     List109{{"List[109∈7]<br />ᐸ65,108ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
     PgClassExpression108{{"PgClassExpression[108∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression108 --> List109
@@ -552,18 +566,18 @@ graph TD
     __Item125 --> PgUnionAllSingle126
     PgSelect130[["PgSelect[130∈9]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access129{{"Access[129∈9]<br />ᐸ128.0ᐳ"}}:::plan
-    Object11 & Access129 & Lambda531 & Lambda534 & Lambda651 & Lambda656 --> PgSelect130
-    PgSelect174[["PgSelect[174∈9]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access173{{"Access[173∈9]<br />ᐸ172.0ᐳ"}}:::plan
-    Object11 & Access173 & Lambda531 & Lambda534 & Lambda693 & Lambda698 --> PgSelect174
+    Object11 & Access129 & Lambda531 & Access535 & Lambda684 & Lambda689 --> PgSelect130
     PgUnionAll143[["PgUnionAll[143∈9]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression141{{"PgClassExpression[141∈9]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression142{{"PgClassExpression[142∈9]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression141 & PgClassExpression142 --> PgUnionAll143
+    Object11 & PgClassExpression141 & PgClassExpression142 & Lambda531 & Access535 & Access566 --> PgUnionAll143
+    PgSelect174[["PgSelect[174∈9]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access173{{"Access[173∈9]<br />ᐸ172.0ᐳ"}}:::plan
+    Object11 & Access173 & Lambda531 & Access535 & Lambda735 & Lambda740 --> PgSelect174
     PgUnionAll185[["PgUnionAll[185∈9]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
     PgClassExpression183{{"PgClassExpression[183∈9]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
     PgClassExpression184{{"PgClassExpression[184∈9]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression183 & PgClassExpression184 --> PgUnionAll185
+    Object11 & PgClassExpression183 & PgClassExpression184 & Lambda531 & Access535 & Access566 --> PgUnionAll185
     List138{{"List[138∈9]<br />ᐸ45,137ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
     PgClassExpression137{{"PgClassExpression[137∈9]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Constant45 & PgClassExpression137 --> List138
@@ -610,10 +624,10 @@ graph TD
     First187 --> PgUnionAllSingle188
     PgSelect150[["PgSelect[150∈10]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access149{{"Access[149∈10]<br />ᐸ148.0ᐳ"}}:::plan
-    Object11 & Access149 & Lambda531 & Lambda534 & Lambda623 & Lambda628 --> PgSelect150
+    Object11 & Access149 & Lambda531 & Access535 & Lambda648 & Lambda653 --> PgSelect150
     PgSelect163[["PgSelect[163∈10]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
     Access162{{"Access[162∈10]<br />ᐸ161.0ᐳ"}}:::plan
-    Object11 & Access162 & Lambda531 & Lambda534 & Lambda637 & Lambda642 --> PgSelect163
+    Object11 & Access162 & Lambda531 & Access535 & Lambda663 & Lambda668 --> PgSelect163
     List158{{"List[158∈10]<br />ᐸ65,157ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
     PgClassExpression157{{"PgClassExpression[157∈10]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression157 --> List158
@@ -648,10 +662,10 @@ graph TD
     PgSelectSingle166 --> PgClassExpression171
     PgSelect192[["PgSelect[192∈11]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access191{{"Access[191∈11]<br />ᐸ190.0ᐳ"}}:::plan
-    Object11 & Access191 & Lambda531 & Lambda534 & Lambda665 & Lambda670 --> PgSelect192
+    Object11 & Access191 & Lambda531 & Access535 & Lambda699 & Lambda704 --> PgSelect192
     PgSelect205[["PgSelect[205∈11]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
     Access204{{"Access[204∈11]<br />ᐸ203.0ᐳ"}}:::plan
-    Object11 & Access204 & Lambda531 & Lambda534 & Lambda679 & Lambda684 --> PgSelect205
+    Object11 & Access204 & Lambda531 & Access535 & Lambda714 & Lambda719 --> PgSelect205
     List200{{"List[200∈11]<br />ᐸ65,199ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
     PgClassExpression199{{"PgClassExpression[199∈11]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression199 --> List200
@@ -690,10 +704,10 @@ graph TD
     __Item218 --> PgUnionAllSingle219
     PgSelect223[["PgSelect[223∈13]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access222{{"Access[222∈13]<br />ᐸ221.0ᐳ"}}:::plan
-    Object11 & Access222 & Lambda531 & Lambda534 & Lambda707 & Lambda712 --> PgSelect223
+    Object11 & Access222 & Lambda531 & Access535 & Lambda756 & Lambda761 --> PgSelect223
     PgSelect236[["PgSelect[236∈13]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
     Access235{{"Access[235∈13]<br />ᐸ234.0ᐳ"}}:::plan
-    Object11 & Access235 & Lambda531 & Lambda534 & Lambda721 & Lambda726 --> PgSelect236
+    Object11 & Access235 & Lambda531 & Access535 & Lambda771 & Lambda776 --> PgSelect236
     List231{{"List[231∈13]<br />ᐸ65,230ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
     PgClassExpression230{{"PgClassExpression[230∈13]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression230 --> List231
@@ -732,10 +746,10 @@ graph TD
     __Item247 --> PgUnionAllSingle248
     PgSelect252[["PgSelect[252∈15]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access251{{"Access[251∈15]<br />ᐸ250.0ᐳ"}}:::plan
-    Object11 & Access251 & Lambda531 & Lambda534 & Lambda735 & Lambda740 --> PgSelect252
+    Object11 & Access251 & Lambda531 & Access535 & Lambda792 & Lambda797 --> PgSelect252
     PgSelect265[["PgSelect[265∈15]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
     Access264{{"Access[264∈15]<br />ᐸ263.0ᐳ"}}:::plan
-    Object11 & Access264 & Lambda531 & Lambda534 & Lambda749 & Lambda754 --> PgSelect265
+    Object11 & Access264 & Lambda531 & Access535 & Lambda807 & Lambda812 --> PgSelect265
     List260{{"List[260∈15]<br />ᐸ65,259ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
     PgClassExpression259{{"PgClassExpression[259∈15]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression259 --> List260
@@ -774,18 +788,18 @@ graph TD
     __Item289 --> PgUnionAllSingle290
     PgSelect294[["PgSelect[294∈17]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access293{{"Access[293∈17]<br />ᐸ292.0ᐳ"}}:::plan
-    Object11 & Access293 & Lambda531 & Lambda534 & Lambda805 & Lambda810 --> PgSelect294
-    PgSelect338[["PgSelect[338∈17]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access337{{"Access[337∈17]<br />ᐸ336.0ᐳ"}}:::plan
-    Object11 & Access337 & Lambda531 & Lambda534 & Lambda847 & Lambda852 --> PgSelect338
+    Object11 & Access293 & Lambda531 & Access535 & Lambda879 & Lambda884 --> PgSelect294
     PgUnionAll307[["PgUnionAll[307∈17]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression305{{"PgClassExpression[305∈17]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression306{{"PgClassExpression[306∈17]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression305 & PgClassExpression306 --> PgUnionAll307
+    Object11 & PgClassExpression305 & PgClassExpression306 & Lambda531 & Access535 & Access566 --> PgUnionAll307
+    PgSelect338[["PgSelect[338∈17]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access337{{"Access[337∈17]<br />ᐸ336.0ᐳ"}}:::plan
+    Object11 & Access337 & Lambda531 & Access535 & Lambda930 & Lambda935 --> PgSelect338
     PgUnionAll349[["PgUnionAll[349∈17]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
     PgClassExpression347{{"PgClassExpression[347∈17]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
     PgClassExpression348{{"PgClassExpression[348∈17]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression347 & PgClassExpression348 --> PgUnionAll349
+    Object11 & PgClassExpression347 & PgClassExpression348 & Lambda531 & Access535 & Access566 --> PgUnionAll349
     List302{{"List[302∈17]<br />ᐸ45,301ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
     PgClassExpression301{{"PgClassExpression[301∈17]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Constant45 & PgClassExpression301 --> List302
@@ -832,10 +846,10 @@ graph TD
     First351 --> PgUnionAllSingle352
     PgSelect314[["PgSelect[314∈18]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access313{{"Access[313∈18]<br />ᐸ312.0ᐳ"}}:::plan
-    Object11 & Access313 & Lambda531 & Lambda534 & Lambda777 & Lambda782 --> PgSelect314
+    Object11 & Access313 & Lambda531 & Access535 & Lambda843 & Lambda848 --> PgSelect314
     PgSelect327[["PgSelect[327∈18]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
     Access326{{"Access[326∈18]<br />ᐸ325.0ᐳ"}}:::plan
-    Object11 & Access326 & Lambda531 & Lambda534 & Lambda791 & Lambda796 --> PgSelect327
+    Object11 & Access326 & Lambda531 & Access535 & Lambda858 & Lambda863 --> PgSelect327
     List322{{"List[322∈18]<br />ᐸ65,321ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
     PgClassExpression321{{"PgClassExpression[321∈18]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression321 --> List322
@@ -870,10 +884,10 @@ graph TD
     PgSelectSingle330 --> PgClassExpression335
     PgSelect356[["PgSelect[356∈19]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access355{{"Access[355∈19]<br />ᐸ354.0ᐳ"}}:::plan
-    Object11 & Access355 & Lambda531 & Lambda534 & Lambda819 & Lambda824 --> PgSelect356
+    Object11 & Access355 & Lambda531 & Access535 & Lambda894 & Lambda899 --> PgSelect356
     PgSelect369[["PgSelect[369∈19]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
     Access368{{"Access[368∈19]<br />ᐸ367.0ᐳ"}}:::plan
-    Object11 & Access368 & Lambda531 & Lambda534 & Lambda833 & Lambda838 --> PgSelect369
+    Object11 & Access368 & Lambda531 & Access535 & Lambda909 & Lambda914 --> PgSelect369
     List364{{"List[364∈19]<br />ᐸ65,363ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
     PgClassExpression363{{"PgClassExpression[363∈19]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression363 --> List364
@@ -912,18 +926,18 @@ graph TD
     __Item380 --> PgUnionAllSingle381
     PgSelect385[["PgSelect[385∈21]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access384{{"Access[384∈21]<br />ᐸ383.0ᐳ"}}:::plan
-    Object11 & Access384 & Lambda531 & Lambda534 & Lambda889 & Lambda894 --> PgSelect385
-    PgSelect429[["PgSelect[429∈21]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access428{{"Access[428∈21]<br />ᐸ427.0ᐳ"}}:::plan
-    Object11 & Access428 & Lambda531 & Lambda534 & Lambda931 & Lambda936 --> PgSelect429
+    Object11 & Access384 & Lambda531 & Access535 & Lambda987 & Lambda992 --> PgSelect385
     PgUnionAll398[["PgUnionAll[398∈21]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression396{{"PgClassExpression[396∈21]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression397{{"PgClassExpression[397∈21]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression396 & PgClassExpression397 --> PgUnionAll398
+    Object11 & PgClassExpression396 & PgClassExpression397 & Lambda531 & Access535 & Access566 --> PgUnionAll398
+    PgSelect429[["PgSelect[429∈21]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access428{{"Access[428∈21]<br />ᐸ427.0ᐳ"}}:::plan
+    Object11 & Access428 & Lambda531 & Access535 & Lambda1038 & Lambda1043 --> PgSelect429
     PgUnionAll440[["PgUnionAll[440∈21]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
     PgClassExpression438{{"PgClassExpression[438∈21]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
     PgClassExpression439{{"PgClassExpression[439∈21]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object11 & PgClassExpression438 & PgClassExpression439 --> PgUnionAll440
+    Object11 & PgClassExpression438 & PgClassExpression439 & Lambda531 & Access535 & Access566 --> PgUnionAll440
     List393{{"List[393∈21]<br />ᐸ45,392ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
     PgClassExpression392{{"PgClassExpression[392∈21]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Constant45 & PgClassExpression392 --> List393
@@ -970,10 +984,10 @@ graph TD
     First442 --> PgUnionAllSingle443
     PgSelect405[["PgSelect[405∈22]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access404{{"Access[404∈22]<br />ᐸ403.0ᐳ"}}:::plan
-    Object11 & Access404 & Lambda531 & Lambda534 & Lambda861 & Lambda866 --> PgSelect405
+    Object11 & Access404 & Lambda531 & Access535 & Lambda951 & Lambda956 --> PgSelect405
     PgSelect418[["PgSelect[418∈22]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
     Access417{{"Access[417∈22]<br />ᐸ416.0ᐳ"}}:::plan
-    Object11 & Access417 & Lambda531 & Lambda534 & Lambda875 & Lambda880 --> PgSelect418
+    Object11 & Access417 & Lambda531 & Access535 & Lambda966 & Lambda971 --> PgSelect418
     List413{{"List[413∈22]<br />ᐸ65,412ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
     PgClassExpression412{{"PgClassExpression[412∈22]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression412 --> List413
@@ -1008,10 +1022,10 @@ graph TD
     PgSelectSingle421 --> PgClassExpression426
     PgSelect447[["PgSelect[447∈23]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access446{{"Access[446∈23]<br />ᐸ445.0ᐳ"}}:::plan
-    Object11 & Access446 & Lambda531 & Lambda534 & Lambda903 & Lambda908 --> PgSelect447
+    Object11 & Access446 & Lambda531 & Access535 & Lambda1002 & Lambda1007 --> PgSelect447
     PgSelect460[["PgSelect[460∈23]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
     Access459{{"Access[459∈23]<br />ᐸ458.0ᐳ"}}:::plan
-    Object11 & Access459 & Lambda531 & Lambda534 & Lambda917 & Lambda922 --> PgSelect460
+    Object11 & Access459 & Lambda531 & Access535 & Lambda1017 & Lambda1022 --> PgSelect460
     List455{{"List[455∈23]<br />ᐸ65,454ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
     PgClassExpression454{{"PgClassExpression[454∈23]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression454 --> List455
@@ -1050,10 +1064,10 @@ graph TD
     __Item473 --> PgUnionAllSingle474
     PgSelect478[["PgSelect[478∈25]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access477{{"Access[477∈25]<br />ᐸ476.0ᐳ"}}:::plan
-    Object11 & Access477 & Lambda531 & Lambda534 & Lambda945 & Lambda950 --> PgSelect478
+    Object11 & Access477 & Lambda531 & Access535 & Lambda1059 & Lambda1064 --> PgSelect478
     PgSelect491[["PgSelect[491∈25]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
     Access490{{"Access[490∈25]<br />ᐸ489.0ᐳ"}}:::plan
-    Object11 & Access490 & Lambda531 & Lambda534 & Lambda959 & Lambda964 --> PgSelect491
+    Object11 & Access490 & Lambda531 & Access535 & Lambda1074 & Lambda1079 --> PgSelect491
     List486{{"List[486∈25]<br />ᐸ65,485ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
     PgClassExpression485{{"PgClassExpression[485∈25]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression485 --> List486
@@ -1092,10 +1106,10 @@ graph TD
     __Item502 --> PgUnionAllSingle503
     PgSelect507[["PgSelect[507∈27]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access506{{"Access[506∈27]<br />ᐸ505.0ᐳ"}}:::plan
-    Object11 & Access506 & Lambda531 & Lambda534 & Lambda973 & Lambda978 --> PgSelect507
+    Object11 & Access506 & Lambda531 & Access535 & Lambda1095 & Lambda1100 --> PgSelect507
     PgSelect520[["PgSelect[520∈27]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
     Access519{{"Access[519∈27]<br />ᐸ518.0ᐳ"}}:::plan
-    Object11 & Access519 & Lambda531 & Lambda534 & Lambda987 & Lambda992 --> PgSelect520
+    Object11 & Access519 & Lambda531 & Access535 & Lambda1110 & Lambda1115 --> PgSelect520
     List515{{"List[515∈27]<br />ᐸ65,514ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
     PgClassExpression514{{"PgClassExpression[514∈27]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant65 & PgClassExpression514 --> List515
@@ -1134,86 +1148,86 @@ graph TD
     subgraph "Buckets for queries/polymorphic/vulns.union_owners"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Connection12,Constant25,Constant45,Constant65,Constant76,Constant87,Constant280,Lambda531,Lambda534,Constant535,Constant536,Constant537,Object538,Lambda539,Lambda544,Constant549,Constant550,Constant551,Object552,Lambda553,Lambda558,Constant563,Constant564,Constant565,Object566,Lambda567,Lambda572,Constant577,Constant578,Object580,Lambda581,Lambda586,Constant591,Constant592,Object594,Lambda595,Lambda600,Constant605,Constant606,Constant607,Object608,Lambda609,Lambda614,Constant619,Constant620,Object622,Lambda623,Lambda628,Constant633,Constant634,Object636,Lambda637,Lambda642,Constant647,Constant648,Object650,Lambda651,Lambda656,Constant661,Constant662,Object664,Lambda665,Lambda670,Constant675,Constant676,Object678,Lambda679,Lambda684,Constant689,Constant690,Object692,Lambda693,Lambda698,Constant703,Constant704,Object706,Lambda707,Lambda712,Constant717,Constant718,Object720,Lambda721,Lambda726,Constant731,Constant732,Object734,Lambda735,Lambda740,Constant745,Constant746,Object748,Lambda749,Lambda754,Constant759,Constant760,Constant761,Object762,Lambda763,Lambda768,Constant773,Constant774,Object776,Lambda777,Lambda782,Constant787,Constant788,Object790,Lambda791,Lambda796,Constant801,Constant802,Object804,Lambda805,Lambda810,Constant815,Constant816,Object818,Lambda819,Lambda824,Constant829,Constant830,Object832,Lambda833,Lambda838,Constant843,Constant844,Object846,Lambda847,Lambda852,Constant857,Constant858,Object860,Lambda861,Lambda866,Constant871,Constant872,Object874,Lambda875,Lambda880,Constant885,Constant886,Object888,Lambda889,Lambda894,Constant899,Constant900,Object902,Lambda903,Lambda908,Constant913,Constant914,Object916,Lambda917,Lambda922,Constant927,Constant928,Object930,Lambda931,Lambda936,Constant941,Constant942,Object944,Lambda945,Lambda950,Constant955,Constant956,Object958,Lambda959,Lambda964,Constant969,Constant970,Object972,Lambda973,Lambda978,Constant983,Constant984,Object986,Lambda987,Lambda992,Constant997,Constant998,Constant999,Object1000,Lambda1001,Lambda1006,Constant1007,Constant1008,Constant1009,Constant1010,Constant1011,Constant1012,Constant1013,Constant1014,Constant1015,Constant1016,Constant1017,Constant1018,Constant1019,Constant1020,Constant1021,Constant1022,Constant1023,Constant1024,Constant1025,Constant1026,Constant1027,Constant1028,Constant1029,Constant1030,Constant1031,Constant1032,Constant1033,Constant1034,Constant1035,Constant1036,Constant1037,Constant1038,Constant1039,Constant1040,Constant1041,Constant1042,Constant1043 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 531, 534, 763, 768, 25, 1001, 1006, 280, 567, 572, 45, 609, 614, 87, 539, 544, 65, 553, 558, 76, 581, 586, 595, 600, 651, 656, 693, 698, 623, 628, 637, 642, 665, 670, 679, 684, 707, 712, 721, 726, 735, 740, 749, 754, 805, 810, 847, 852, 777, 782, 791, 796, 819, 824, 833, 838, 889, 894, 931, 936, 861, 866, 875, 880, 903, 908, 917, 922, 945, 950, 959, 964, 973, 978, 987, 992<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Connection12,Constant25,Constant45,Constant65,Constant76,Constant87,Constant280,Lambda531,Lambda534,Access535,Constant536,Constant537,Constant538,Object539,Lambda540,Lambda545,Constant551,Constant552,Constant553,Object554,Lambda555,Lambda560,Access566,Constant572,Constant573,Constant574,Object575,Lambda576,Lambda581,Constant587,Constant588,Object590,Lambda591,Lambda596,Constant602,Constant603,Object605,Lambda606,Lambda611,Constant623,Constant624,Constant625,Object626,Lambda627,Lambda632,Constant644,Constant645,Object647,Lambda648,Lambda653,Constant659,Constant660,Object662,Lambda663,Lambda668,Constant680,Constant681,Object683,Lambda684,Lambda689,Constant695,Constant696,Object698,Lambda699,Lambda704,Constant710,Constant711,Object713,Lambda714,Lambda719,Constant731,Constant732,Object734,Lambda735,Lambda740,Constant752,Constant753,Object755,Lambda756,Lambda761,Constant767,Constant768,Object770,Lambda771,Lambda776,Constant788,Constant789,Object791,Lambda792,Lambda797,Constant803,Constant804,Object806,Lambda807,Lambda812,Constant824,Constant825,Constant826,Object827,Lambda828,Lambda833,Constant839,Constant840,Object842,Lambda843,Lambda848,Constant854,Constant855,Object857,Lambda858,Lambda863,Constant875,Constant876,Object878,Lambda879,Lambda884,Constant890,Constant891,Object893,Lambda894,Lambda899,Constant905,Constant906,Object908,Lambda909,Lambda914,Constant926,Constant927,Object929,Lambda930,Lambda935,Constant947,Constant948,Object950,Lambda951,Lambda956,Constant962,Constant963,Object965,Lambda966,Lambda971,Constant983,Constant984,Object986,Lambda987,Lambda992,Constant998,Constant999,Object1001,Lambda1002,Lambda1007,Constant1013,Constant1014,Object1016,Lambda1017,Lambda1022,Constant1034,Constant1035,Object1037,Lambda1038,Lambda1043,Constant1055,Constant1056,Object1058,Lambda1059,Lambda1064,Constant1070,Constant1071,Object1073,Lambda1074,Lambda1079,Constant1091,Constant1092,Object1094,Lambda1095,Lambda1100,Constant1106,Constant1107,Object1109,Lambda1110,Lambda1115,Constant1127,Constant1128,Constant1129,Object1130,Lambda1131,Lambda1136,Lambda1138,Lambda1140,Access1141,Access1142,Constant1143,Constant1144,Constant1145,Constant1146,Constant1147,Constant1148,Constant1149,Constant1150,Constant1151,Constant1152,Constant1153,Constant1154,Constant1155,Constant1156,Constant1157,Constant1158,Constant1159,Constant1160,Constant1161,Constant1162,Constant1163,Constant1164,Constant1165,Constant1166,Constant1167,Constant1168,Constant1169,Constant1170,Constant1171,Constant1172,Constant1173,Constant1174,Constant1175,Constant1176,Constant1177,Constant1178,Constant1179,Constant1180,Constant1181 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 1143, 1138, 1141, 1142, 531, 535, 828, 833, 25, 566, 1131, 1136, 280, 576, 581, 45, 627, 632, 87, 540, 545, 65, 555, 560, 76, 591, 596, 606, 611, 684, 689, 735, 740, 648, 653, 663, 668, 699, 704, 714, 719, 756, 761, 771, 776, 792, 797, 807, 812, 879, 884, 930, 935, 843, 848, 858, 863, 894, 899, 909, 914, 987, 992, 1038, 1043, 951, 956, 966, 971, 1002, 1007, 1017, 1022, 1059, 1064, 1074, 1079, 1095, 1100, 1110, 1115<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUnionAll13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 531, 534, 763, 768, 25, 1001, 1006, 280, 567, 572, 45, 609, 614, 87, 539, 544, 65, 553, 558, 76, 581, 586, 595, 600, 651, 656, 693, 698, 623, 628, 637, 642, 665, 670, 679, 684, 707, 712, 721, 726, 735, 740, 749, 754, 805, 810, 847, 852, 777, 782, 791, 796, 819, 824, 833, 838, 889, 894, 931, 936, 861, 866, 875, 880, 903, 908, 917, 922, 945, 950, 959, 964, 973, 978, 987, 992<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 531, 535, 828, 833, 25, 566, 1131, 1136, 280, 576, 581, 45, 627, 632, 87, 540, 545, 65, 555, 560, 76, 591, 596, 606, 611, 684, 689, 735, 740, 648, 653, 663, 668, 699, 704, 714, 719, 756, 761, 771, 776, 792, 797, 807, 812, 879, 884, 930, 935, 843, 848, 858, 863, 894, 899, 909, 914, 987, 992, 1038, 1043, 951, 956, 966, 971, 1002, 1007, 1017, 1022, 1059, 1064, 1074, 1079, 1095, 1100, 1110, 1115<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgUnionAllSingle15 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 15, 11, 531, 534, 763, 768, 25, 1001, 1006, 280, 567, 572, 45, 609, 614, 87, 539, 544, 65, 553, 558, 76, 581, 586, 595, 600, 651, 656, 693, 698, 623, 628, 637, 642, 665, 670, 679, 684, 707, 712, 721, 726, 735, 740, 749, 754, 805, 810, 847, 852, 777, 782, 791, 796, 819, 824, 833, 838, 889, 894, 931, 936, 861, 866, 875, 880, 903, 908, 917, 922, 945, 950, 959, 964, 973, 978, 987, 992<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: 16, 32, 216, 287, 471<br />2: JSONParse[17], JSONParse[274]<br />ᐳ: Access[18], Access[275]<br />3: PgSelect[19], PgSelect[276]<br />ᐳ: 23, 24, 26, 27, 28, 29, 278, 279, 281, 282, 283, 284<br />4: 33, 123, 217, 245, 288, 378, 472, 500"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 15, 11, 531, 535, 828, 833, 25, 566, 1131, 1136, 280, 576, 581, 45, 627, 632, 87, 540, 545, 65, 555, 560, 76, 591, 596, 606, 611, 684, 689, 735, 740, 648, 653, 663, 668, 699, 704, 714, 719, 756, 761, 771, 776, 792, 797, 807, 812, 879, 884, 930, 935, 843, 848, 858, 863, 894, 899, 909, 914, 987, 992, 1038, 1043, 951, 956, 966, 971, 1002, 1007, 1017, 1022, 1059, 1064, 1074, 1079, 1095, 1100, 1110, 1115<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: 16, 32, 216, 287, 471<br />2: JSONParse[17], JSONParse[274]<br />ᐳ: Access[18], Access[275]<br />3: PgSelect[19], PgSelect[276]<br />ᐳ: 23, 24, 26, 27, 28, 29, 278, 279, 281, 282, 283, 284<br />4: 33, 123, 217, 245, 288, 378, 472, 500"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,Access16,JSONParse17,Access18,PgSelect19,First23,PgSelectSingle24,PgClassExpression26,List27,Lambda28,PgClassExpression29,Connection32,PgUnionAll33,PgUnionAll123,Connection216,PgUnionAll217,PgUnionAll245,JSONParse274,Access275,PgSelect276,First278,PgSelectSingle279,PgClassExpression281,List282,Lambda283,PgClassExpression284,Connection287,PgUnionAll288,PgUnionAll378,Connection471,PgUnionAll472,PgUnionAll500 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 531, 534, 567, 572, 45, 609, 614, 87, 539, 544, 65, 553, 558, 76, 581, 586, 595, 600<br /><br />ROOT __Item{4}ᐸ33ᐳ[34]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 531, 535, 576, 581, 45, 566, 627, 632, 87, 540, 545, 65, 555, 560, 76, 591, 596, 606, 611<br /><br />ROOT __Item{4}ᐸ33ᐳ[34]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item34,PgUnionAllSingle35 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 35, 11, 531, 534, 567, 572, 45, 609, 614, 87, 539, 544, 65, 553, 558, 76, 581, 586, 595, 600<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[36]<br />2: JSONParse[37], JSONParse[81]<br />ᐳ: Access[38], Access[82]<br />3: PgSelect[39], PgSelect[83]<br />ᐳ: 43, 44, 46, 47, 48, 49, 50, 51, 85, 86, 88, 89, 90, 91, 92, 93<br />4: PgUnionAll[52], PgUnionAll[94]<br />ᐳ: First[54], First[96]<br />5: 55, 97"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 35, 11, 531, 535, 576, 581, 45, 566, 627, 632, 87, 540, 545, 65, 555, 560, 76, 591, 596, 606, 611<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[36]<br />2: JSONParse[37], JSONParse[81]<br />ᐳ: Access[38], Access[82]<br />3: PgSelect[39], PgSelect[83]<br />ᐳ: 43, 44, 46, 47, 48, 49, 50, 51, 85, 86, 88, 89, 90, 91, 92, 93<br />4: PgUnionAll[52], PgUnionAll[94]<br />ᐳ: First[54], First[96]<br />5: 55, 97"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,Access36,JSONParse37,Access38,PgSelect39,First43,PgSelectSingle44,PgClassExpression46,List47,Lambda48,PgClassExpression49,PgClassExpression50,PgClassExpression51,PgUnionAll52,First54,PgUnionAllSingle55,JSONParse81,Access82,PgSelect83,First85,PgSelectSingle86,PgClassExpression88,List89,Lambda90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgUnionAll94,First96,PgUnionAllSingle97 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 55, 11, 531, 534, 539, 544, 65, 553, 558, 76<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[56]<br />2: JSONParse[57], JSONParse[70]<br />ᐳ: Access[58], Access[71]<br />3: PgSelect[59], PgSelect[72]<br />ᐳ: 63, 64, 66, 67, 68, 69, 74, 75, 77, 78, 79, 80"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 55, 11, 531, 535, 540, 545, 65, 555, 560, 76<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[56]<br />2: JSONParse[57], JSONParse[70]<br />ᐳ: Access[58], Access[71]<br />3: PgSelect[59], PgSelect[72]<br />ᐳ: 63, 64, 66, 67, 68, 69, 74, 75, 77, 78, 79, 80"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,Access56,JSONParse57,Access58,PgSelect59,First63,PgSelectSingle64,PgClassExpression66,List67,Lambda68,PgClassExpression69,JSONParse70,Access71,PgSelect72,First74,PgSelectSingle75,PgClassExpression77,List78,Lambda79,PgClassExpression80 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 97, 11, 531, 534, 581, 586, 65, 595, 600, 76<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[98]<br />2: JSONParse[99], JSONParse[112]<br />ᐳ: Access[100], Access[113]<br />3: PgSelect[101], PgSelect[114]<br />ᐳ: 105, 106, 108, 109, 110, 111, 116, 117, 119, 120, 121, 122"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 97, 11, 531, 535, 591, 596, 65, 606, 611, 76<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[98]<br />2: JSONParse[99], JSONParse[112]<br />ᐳ: Access[100], Access[113]<br />3: PgSelect[101], PgSelect[114]<br />ᐳ: 105, 106, 108, 109, 110, 111, 116, 117, 119, 120, 121, 122"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,Access98,JSONParse99,Access100,PgSelect101,First105,PgSelectSingle106,PgClassExpression108,List109,Lambda110,PgClassExpression111,JSONParse112,Access113,PgSelect114,First116,PgSelectSingle117,PgClassExpression119,List120,Lambda121,PgClassExpression122 bucket7
-    Bucket8("Bucket 8 (listItem)<br />Deps: 11, 531, 534, 651, 656, 45, 693, 698, 87, 623, 628, 65, 637, 642, 76, 665, 670, 679, 684<br /><br />ROOT __Item{8}ᐸ123ᐳ[125]"):::bucket
+    Bucket8("Bucket 8 (listItem)<br />Deps: 11, 531, 535, 684, 689, 45, 566, 735, 740, 87, 648, 653, 65, 663, 668, 76, 699, 704, 714, 719<br /><br />ROOT __Item{8}ᐸ123ᐳ[125]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item125,PgUnionAllSingle126 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 126, 11, 531, 534, 651, 656, 45, 693, 698, 87, 623, 628, 65, 637, 642, 76, 665, 670, 679, 684<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[127]<br />2: JSONParse[128], JSONParse[172]<br />ᐳ: Access[129], Access[173]<br />3: PgSelect[130], PgSelect[174]<br />ᐳ: 134, 135, 137, 138, 139, 140, 141, 142, 176, 177, 179, 180, 181, 182, 183, 184<br />4: PgUnionAll[143], PgUnionAll[185]<br />ᐳ: First[145], First[187]<br />5: 146, 188"):::bucket
+    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 126, 11, 531, 535, 684, 689, 45, 566, 735, 740, 87, 648, 653, 65, 663, 668, 76, 699, 704, 714, 719<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[127]<br />2: JSONParse[128], JSONParse[172]<br />ᐳ: Access[129], Access[173]<br />3: PgSelect[130], PgSelect[174]<br />ᐳ: 134, 135, 137, 138, 139, 140, 141, 142, 176, 177, 179, 180, 181, 182, 183, 184<br />4: PgUnionAll[143], PgUnionAll[185]<br />ᐳ: First[145], First[187]<br />5: 146, 188"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,Access127,JSONParse128,Access129,PgSelect130,First134,PgSelectSingle135,PgClassExpression137,List138,Lambda139,PgClassExpression140,PgClassExpression141,PgClassExpression142,PgUnionAll143,First145,PgUnionAllSingle146,JSONParse172,Access173,PgSelect174,First176,PgSelectSingle177,PgClassExpression179,List180,Lambda181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgUnionAll185,First187,PgUnionAllSingle188 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 146, 11, 531, 534, 623, 628, 65, 637, 642, 76<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[147]<br />2: JSONParse[148], JSONParse[161]<br />ᐳ: Access[149], Access[162]<br />3: PgSelect[150], PgSelect[163]<br />ᐳ: 154, 155, 157, 158, 159, 160, 165, 166, 168, 169, 170, 171"):::bucket
+    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 146, 11, 531, 535, 648, 653, 65, 663, 668, 76<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[147]<br />2: JSONParse[148], JSONParse[161]<br />ᐳ: Access[149], Access[162]<br />3: PgSelect[150], PgSelect[163]<br />ᐳ: 154, 155, 157, 158, 159, 160, 165, 166, 168, 169, 170, 171"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,Access147,JSONParse148,Access149,PgSelect150,First154,PgSelectSingle155,PgClassExpression157,List158,Lambda159,PgClassExpression160,JSONParse161,Access162,PgSelect163,First165,PgSelectSingle166,PgClassExpression168,List169,Lambda170,PgClassExpression171 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 188, 11, 531, 534, 665, 670, 65, 679, 684, 76<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[189]<br />2: JSONParse[190], JSONParse[203]<br />ᐳ: Access[191], Access[204]<br />3: PgSelect[192], PgSelect[205]<br />ᐳ: 196, 197, 199, 200, 201, 202, 207, 208, 210, 211, 212, 213"):::bucket
+    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 188, 11, 531, 535, 699, 704, 65, 714, 719, 76<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[189]<br />2: JSONParse[190], JSONParse[203]<br />ᐳ: Access[191], Access[204]<br />3: PgSelect[192], PgSelect[205]<br />ᐳ: 196, 197, 199, 200, 201, 202, 207, 208, 210, 211, 212, 213"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,Access189,JSONParse190,Access191,PgSelect192,First196,PgSelectSingle197,PgClassExpression199,List200,Lambda201,PgClassExpression202,JSONParse203,Access204,PgSelect205,First207,PgSelectSingle208,PgClassExpression210,List211,Lambda212,PgClassExpression213 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 11, 531, 534, 707, 712, 65, 721, 726, 76<br /><br />ROOT __Item{12}ᐸ217ᐳ[218]"):::bucket
+    Bucket12("Bucket 12 (listItem)<br />Deps: 11, 531, 535, 756, 761, 65, 771, 776, 76<br /><br />ROOT __Item{12}ᐸ217ᐳ[218]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,__Item218,PgUnionAllSingle219 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 219, 11, 531, 534, 707, 712, 65, 721, 726, 76<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[220]<br />2: JSONParse[221], JSONParse[234]<br />ᐳ: Access[222], Access[235]<br />3: PgSelect[223], PgSelect[236]<br />ᐳ: 227, 228, 230, 231, 232, 233, 238, 239, 241, 242, 243, 244"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 219, 11, 531, 535, 756, 761, 65, 771, 776, 76<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[220]<br />2: JSONParse[221], JSONParse[234]<br />ᐳ: Access[222], Access[235]<br />3: PgSelect[223], PgSelect[236]<br />ᐳ: 227, 228, 230, 231, 232, 233, 238, 239, 241, 242, 243, 244"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,Access220,JSONParse221,Access222,PgSelect223,First227,PgSelectSingle228,PgClassExpression230,List231,Lambda232,PgClassExpression233,JSONParse234,Access235,PgSelect236,First238,PgSelectSingle239,PgClassExpression241,List242,Lambda243,PgClassExpression244 bucket13
-    Bucket14("Bucket 14 (listItem)<br />Deps: 11, 531, 534, 735, 740, 65, 749, 754, 76<br /><br />ROOT __Item{14}ᐸ245ᐳ[247]"):::bucket
+    Bucket14("Bucket 14 (listItem)<br />Deps: 11, 531, 535, 792, 797, 65, 807, 812, 76<br /><br />ROOT __Item{14}ᐸ245ᐳ[247]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item247,PgUnionAllSingle248 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 248, 11, 531, 534, 735, 740, 65, 749, 754, 76<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[249]<br />2: JSONParse[250], JSONParse[263]<br />ᐳ: Access[251], Access[264]<br />3: PgSelect[252], PgSelect[265]<br />ᐳ: 256, 257, 259, 260, 261, 262, 267, 268, 270, 271, 272, 273"):::bucket
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 248, 11, 531, 535, 792, 797, 65, 807, 812, 76<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[249]<br />2: JSONParse[250], JSONParse[263]<br />ᐳ: Access[251], Access[264]<br />3: PgSelect[252], PgSelect[265]<br />ᐳ: 256, 257, 259, 260, 261, 262, 267, 268, 270, 271, 272, 273"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,Access249,JSONParse250,Access251,PgSelect252,First256,PgSelectSingle257,PgClassExpression259,List260,Lambda261,PgClassExpression262,JSONParse263,Access264,PgSelect265,First267,PgSelectSingle268,PgClassExpression270,List271,Lambda272,PgClassExpression273 bucket15
-    Bucket16("Bucket 16 (listItem)<br />Deps: 11, 531, 534, 805, 810, 45, 847, 852, 87, 777, 782, 65, 791, 796, 76, 819, 824, 833, 838<br /><br />ROOT __Item{16}ᐸ288ᐳ[289]"):::bucket
+    Bucket16("Bucket 16 (listItem)<br />Deps: 11, 531, 535, 879, 884, 45, 566, 930, 935, 87, 843, 848, 65, 858, 863, 76, 894, 899, 909, 914<br /><br />ROOT __Item{16}ᐸ288ᐳ[289]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,__Item289,PgUnionAllSingle290 bucket16
-    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 290, 11, 531, 534, 805, 810, 45, 847, 852, 87, 777, 782, 65, 791, 796, 76, 819, 824, 833, 838<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[291]<br />2: JSONParse[292], JSONParse[336]<br />ᐳ: Access[293], Access[337]<br />3: PgSelect[294], PgSelect[338]<br />ᐳ: 298, 299, 301, 302, 303, 304, 305, 306, 340, 341, 343, 344, 345, 346, 347, 348<br />4: PgUnionAll[307], PgUnionAll[349]<br />ᐳ: First[309], First[351]<br />5: 310, 352"):::bucket
+    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 290, 11, 531, 535, 879, 884, 45, 566, 930, 935, 87, 843, 848, 65, 858, 863, 76, 894, 899, 909, 914<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[291]<br />2: JSONParse[292], JSONParse[336]<br />ᐳ: Access[293], Access[337]<br />3: PgSelect[294], PgSelect[338]<br />ᐳ: 298, 299, 301, 302, 303, 304, 305, 306, 340, 341, 343, 344, 345, 346, 347, 348<br />4: PgUnionAll[307], PgUnionAll[349]<br />ᐳ: First[309], First[351]<br />5: 310, 352"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,Access291,JSONParse292,Access293,PgSelect294,First298,PgSelectSingle299,PgClassExpression301,List302,Lambda303,PgClassExpression304,PgClassExpression305,PgClassExpression306,PgUnionAll307,First309,PgUnionAllSingle310,JSONParse336,Access337,PgSelect338,First340,PgSelectSingle341,PgClassExpression343,List344,Lambda345,PgClassExpression346,PgClassExpression347,PgClassExpression348,PgUnionAll349,First351,PgUnionAllSingle352 bucket17
-    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 310, 11, 531, 534, 777, 782, 65, 791, 796, 76<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[311]<br />2: JSONParse[312], JSONParse[325]<br />ᐳ: Access[313], Access[326]<br />3: PgSelect[314], PgSelect[327]<br />ᐳ: 318, 319, 321, 322, 323, 324, 329, 330, 332, 333, 334, 335"):::bucket
+    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 310, 11, 531, 535, 843, 848, 65, 858, 863, 76<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[311]<br />2: JSONParse[312], JSONParse[325]<br />ᐳ: Access[313], Access[326]<br />3: PgSelect[314], PgSelect[327]<br />ᐳ: 318, 319, 321, 322, 323, 324, 329, 330, 332, 333, 334, 335"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,Access311,JSONParse312,Access313,PgSelect314,First318,PgSelectSingle319,PgClassExpression321,List322,Lambda323,PgClassExpression324,JSONParse325,Access326,PgSelect327,First329,PgSelectSingle330,PgClassExpression332,List333,Lambda334,PgClassExpression335 bucket18
-    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 352, 11, 531, 534, 819, 824, 65, 833, 838, 76<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[353]<br />2: JSONParse[354], JSONParse[367]<br />ᐳ: Access[355], Access[368]<br />3: PgSelect[356], PgSelect[369]<br />ᐳ: 360, 361, 363, 364, 365, 366, 371, 372, 374, 375, 376, 377"):::bucket
+    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 352, 11, 531, 535, 894, 899, 65, 909, 914, 76<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[353]<br />2: JSONParse[354], JSONParse[367]<br />ᐳ: Access[355], Access[368]<br />3: PgSelect[356], PgSelect[369]<br />ᐳ: 360, 361, 363, 364, 365, 366, 371, 372, 374, 375, 376, 377"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,Access353,JSONParse354,Access355,PgSelect356,First360,PgSelectSingle361,PgClassExpression363,List364,Lambda365,PgClassExpression366,JSONParse367,Access368,PgSelect369,First371,PgSelectSingle372,PgClassExpression374,List375,Lambda376,PgClassExpression377 bucket19
-    Bucket20("Bucket 20 (listItem)<br />Deps: 11, 531, 534, 889, 894, 45, 931, 936, 87, 861, 866, 65, 875, 880, 76, 903, 908, 917, 922<br /><br />ROOT __Item{20}ᐸ378ᐳ[380]"):::bucket
+    Bucket20("Bucket 20 (listItem)<br />Deps: 11, 531, 535, 987, 992, 45, 566, 1038, 1043, 87, 951, 956, 65, 966, 971, 76, 1002, 1007, 1017, 1022<br /><br />ROOT __Item{20}ᐸ378ᐳ[380]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20,__Item380,PgUnionAllSingle381 bucket20
-    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 381, 11, 531, 534, 889, 894, 45, 931, 936, 87, 861, 866, 65, 875, 880, 76, 903, 908, 917, 922<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[382]<br />2: JSONParse[383], JSONParse[427]<br />ᐳ: Access[384], Access[428]<br />3: PgSelect[385], PgSelect[429]<br />ᐳ: 389, 390, 392, 393, 394, 395, 396, 397, 431, 432, 434, 435, 436, 437, 438, 439<br />4: PgUnionAll[398], PgUnionAll[440]<br />ᐳ: First[400], First[442]<br />5: 401, 443"):::bucket
+    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 381, 11, 531, 535, 987, 992, 45, 566, 1038, 1043, 87, 951, 956, 65, 966, 971, 76, 1002, 1007, 1017, 1022<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[382]<br />2: JSONParse[383], JSONParse[427]<br />ᐳ: Access[384], Access[428]<br />3: PgSelect[385], PgSelect[429]<br />ᐳ: 389, 390, 392, 393, 394, 395, 396, 397, 431, 432, 434, 435, 436, 437, 438, 439<br />4: PgUnionAll[398], PgUnionAll[440]<br />ᐳ: First[400], First[442]<br />5: 401, 443"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,Access382,JSONParse383,Access384,PgSelect385,First389,PgSelectSingle390,PgClassExpression392,List393,Lambda394,PgClassExpression395,PgClassExpression396,PgClassExpression397,PgUnionAll398,First400,PgUnionAllSingle401,JSONParse427,Access428,PgSelect429,First431,PgSelectSingle432,PgClassExpression434,List435,Lambda436,PgClassExpression437,PgClassExpression438,PgClassExpression439,PgUnionAll440,First442,PgUnionAllSingle443 bucket21
-    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 401, 11, 531, 534, 861, 866, 65, 875, 880, 76<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[402]<br />2: JSONParse[403], JSONParse[416]<br />ᐳ: Access[404], Access[417]<br />3: PgSelect[405], PgSelect[418]<br />ᐳ: 409, 410, 412, 413, 414, 415, 420, 421, 423, 424, 425, 426"):::bucket
+    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 401, 11, 531, 535, 951, 956, 65, 966, 971, 76<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[402]<br />2: JSONParse[403], JSONParse[416]<br />ᐳ: Access[404], Access[417]<br />3: PgSelect[405], PgSelect[418]<br />ᐳ: 409, 410, 412, 413, 414, 415, 420, 421, 423, 424, 425, 426"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22,Access402,JSONParse403,Access404,PgSelect405,First409,PgSelectSingle410,PgClassExpression412,List413,Lambda414,PgClassExpression415,JSONParse416,Access417,PgSelect418,First420,PgSelectSingle421,PgClassExpression423,List424,Lambda425,PgClassExpression426 bucket22
-    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 443, 11, 531, 534, 903, 908, 65, 917, 922, 76<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[444]<br />2: JSONParse[445], JSONParse[458]<br />ᐳ: Access[446], Access[459]<br />3: PgSelect[447], PgSelect[460]<br />ᐳ: 451, 452, 454, 455, 456, 457, 462, 463, 465, 466, 467, 468"):::bucket
+    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 443, 11, 531, 535, 1002, 1007, 65, 1017, 1022, 76<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[444]<br />2: JSONParse[445], JSONParse[458]<br />ᐳ: Access[446], Access[459]<br />3: PgSelect[447], PgSelect[460]<br />ᐳ: 451, 452, 454, 455, 456, 457, 462, 463, 465, 466, 467, 468"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23,Access444,JSONParse445,Access446,PgSelect447,First451,PgSelectSingle452,PgClassExpression454,List455,Lambda456,PgClassExpression457,JSONParse458,Access459,PgSelect460,First462,PgSelectSingle463,PgClassExpression465,List466,Lambda467,PgClassExpression468 bucket23
-    Bucket24("Bucket 24 (listItem)<br />Deps: 11, 531, 534, 945, 950, 65, 959, 964, 76<br /><br />ROOT __Item{24}ᐸ472ᐳ[473]"):::bucket
+    Bucket24("Bucket 24 (listItem)<br />Deps: 11, 531, 535, 1059, 1064, 65, 1074, 1079, 76<br /><br />ROOT __Item{24}ᐸ472ᐳ[473]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,__Item473,PgUnionAllSingle474 bucket24
-    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 474, 11, 531, 534, 945, 950, 65, 959, 964, 76<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[475]<br />2: JSONParse[476], JSONParse[489]<br />ᐳ: Access[477], Access[490]<br />3: PgSelect[478], PgSelect[491]<br />ᐳ: 482, 483, 485, 486, 487, 488, 493, 494, 496, 497, 498, 499"):::bucket
+    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 474, 11, 531, 535, 1059, 1064, 65, 1074, 1079, 76<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[475]<br />2: JSONParse[476], JSONParse[489]<br />ᐳ: Access[477], Access[490]<br />3: PgSelect[478], PgSelect[491]<br />ᐳ: 482, 483, 485, 486, 487, 488, 493, 494, 496, 497, 498, 499"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,Access475,JSONParse476,Access477,PgSelect478,First482,PgSelectSingle483,PgClassExpression485,List486,Lambda487,PgClassExpression488,JSONParse489,Access490,PgSelect491,First493,PgSelectSingle494,PgClassExpression496,List497,Lambda498,PgClassExpression499 bucket25
-    Bucket26("Bucket 26 (listItem)<br />Deps: 11, 531, 534, 973, 978, 65, 987, 992, 76<br /><br />ROOT __Item{26}ᐸ500ᐳ[502]"):::bucket
+    Bucket26("Bucket 26 (listItem)<br />Deps: 11, 531, 535, 1095, 1100, 65, 1110, 1115, 76<br /><br />ROOT __Item{26}ᐸ500ᐳ[502]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,__Item502,PgUnionAllSingle503 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 503, 11, 531, 534, 973, 978, 65, 987, 992, 76<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[504]<br />2: JSONParse[505], JSONParse[518]<br />ᐳ: Access[506], Access[519]<br />3: PgSelect[507], PgSelect[520]<br />ᐳ: 511, 512, 514, 515, 516, 517, 522, 523, 525, 526, 527, 528"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 503, 11, 531, 535, 1095, 1100, 65, 1110, 1115, 76<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[504]<br />2: JSONParse[505], JSONParse[518]<br />ᐳ: Access[506], Access[519]<br />3: PgSelect[507], PgSelect[520]<br />ᐳ: 511, 512, 514, 515, 516, 517, 522, 523, 525, 526, 527, 528"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,Access504,JSONParse505,Access506,PgSelect507,First511,PgSelectSingle512,PgClassExpression514,List515,Lambda516,PgClassExpression517,JSONParse518,Access519,PgSelect520,First522,PgSelectSingle523,PgClassExpression525,List526,Lambda527,PgClassExpression528 bucket27
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
@@ -9,35 +9,35 @@ graph TD
 
 
     %% plan dependencies
-    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
-    Lambda105 & Constant109 & Constant110 & Constant111 --> Object112
-    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
-    Lambda105 & Constant123 & Constant124 & Constant125 --> Object126
-    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda105 & Constant137 & Constant138 & Constant139 --> Object140
-    Object154{{"Object[154∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
-    Lambda105 & Constant151 & Constant152 & Constant111 --> Object154
-    Object168{{"Object[168∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
-    Lambda105 & Constant165 & Constant166 & Constant125 --> Object168
-    Object182{{"Object[182∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
-    Lambda105 & Constant179 & Constant180 & Constant181 --> Object182
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸRecordCodec(organizations)ᐳ"}}:::plan
+    Lambda105 & Constant110 & Constant111 & Constant112 --> Object113
+    Object128{{"Object[128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸRecordCodec(people)ᐳ"}}:::plan
+    Lambda105 & Constant125 & Constant126 & Constant127 --> Object128
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”first_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(firstPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda105 & Constant146 & Constant147 & Constant148 --> Object149
+    Object164{{"Object[164∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant162{{"Constant[162∈0] ➊<br />ᐸsql.identifier(”organizations”)ᐳ"}}:::plan
+    Lambda105 & Constant161 & Constant162 & Constant112 --> Object164
+    Object179{{"Object[179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”people”)ᐳ"}}:::plan
+    Lambda105 & Constant176 & Constant177 & Constant127 --> Object179
+    Object200{{"Object[200∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant197{{"Constant[197∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸsql.identifier(”third_party_vulnerabilities”)ᐳ"}}:::plan
+    Constant199{{"Constant[199∈0] ➊<br />ᐸRecordCodec(thirdPartyVulnerabilities)ᐳ"}}:::plan
+    Lambda105 & Constant197 & Constant198 & Constant199 --> Object200
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -46,68 +46,82 @@ graph TD
     __Value2 --> Access9
     __Value2 --> Access10
     Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant189 --> Connection12
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant190 --> Lambda105
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant213 --> Connection12
+    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant214 --> Lambda105
     Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant191 --> Lambda108
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object112 --> Lambda113
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant192 --> Lambda118
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object126 --> Lambda127
-    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant193 --> Lambda132
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object140 --> Lambda141
-    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
-    Constant194 --> Lambda146
+    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant215 --> Lambda108
+    Access109{{"Access[109∈0] ➊<br />ᐸ108.0ᐳ"}}:::plan
+    Lambda108 --> Access109
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object113 --> Lambda114
+    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant216 --> Lambda119
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object128 --> Lambda129
+    Lambda134{{"Lambda[134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant217 --> Lambda134
+    Access140{{"Access[140∈0] ➊<br />ᐸ108.1ᐳ"}}:::plan
+    Lambda108 --> Access140
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object149 --> Lambda150
     Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object154 --> Lambda155
-    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
-    Constant195 --> Lambda160
-    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object168 --> Lambda169
-    Lambda174{{"Lambda[174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
-    Constant196 --> Lambda174
-    Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object182 --> Lambda183
-    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
-    Constant197 --> Lambda188
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”first_ᐳ"}}:::plan
+    Constant218 --> Lambda155
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object164 --> Lambda165
+    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”organiᐳ"}}:::plan
+    Constant219 --> Lambda170
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object179 --> Lambda180
+    Lambda185{{"Lambda[185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”peopleᐳ"}}:::plan
+    Constant220 --> Lambda185
+    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object200 --> Lambda201
+    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”third_ᐳ"}}:::plan
+    Constant221 --> Lambda206
+    Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant222 --> Lambda208
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant223 --> Lambda210
+    Access211{{"Access[211∈0] ➊<br />ᐸ210.0ᐳ"}}:::plan
+    Lambda210 --> Access211
+    Access212{{"Access[212∈0] ➊<br />ᐸ210.1ᐳ"}}:::plan
+    Lambda210 --> Access212
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant25{{"Constant[25∈0] ➊<br />ᐸ'first_party_vulnerabilities'ᐳ"}}:::plan
     Constant45{{"Constant[45∈0] ➊<br />ᐸ'organizations'ᐳ"}}:::plan
     Constant56{{"Constant[56∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
     Constant67{{"Constant[67∈0] ➊<br />ᐸ'third_party_vulnerabilities'ᐳ"}}:::plan
     PgUnionAll13[["PgUnionAll[13∈1] ➊"]]:::plan
-    Object11 & Connection12 --> PgUnionAll13
+    Object11 & Connection12 & Constant213 & Lambda208 & Access211 & Access212 --> PgUnionAll13
     __Item14[/"__Item[14∈2]<br />ᐸ13ᐳ"\]:::itemplan
     PgUnionAll13 ==> __Item14
     PgUnionAllSingle15["PgUnionAllSingle[15∈2]"]:::plan
     __Item14 --> PgUnionAllSingle15
     PgSelect19[["PgSelect[19∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access18{{"Access[18∈3]<br />ᐸ17.0ᐳ"}}:::plan
-    Object11 & Access18 & Lambda105 & Lambda108 & Lambda141 & Lambda146 --> PgSelect19
-    PgSelect63[["PgSelect[63∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access62{{"Access[62∈3]<br />ᐸ61.0ᐳ"}}:::plan
-    Object11 & Access62 & Lambda105 & Lambda108 & Lambda183 & Lambda188 --> PgSelect63
+    Object11 & Access18 & Lambda105 & Access109 & Lambda150 & Lambda155 --> PgSelect19
     PgUnionAll33[["PgUnionAll[33∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
     Connection32{{"Connection[32∈3] ➊<br />ᐸ30ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Object11 & PgClassExpression26 & Connection32 --> PgUnionAll33
+    Object11 & PgClassExpression26 & Connection32 & Lambda105 & Access109 & Access140 --> PgUnionAll33
+    PgSelect63[["PgSelect[63∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access62{{"Access[62∈3]<br />ᐸ61.0ᐳ"}}:::plan
+    Object11 & Access62 & Lambda105 & Access109 & Lambda201 & Lambda206 --> PgSelect63
     PgUnionAll75[["PgUnionAll[75∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
     PgClassExpression68{{"PgClassExpression[68∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
     Connection74{{"Connection[74∈3] ➊<br />ᐸ72ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Object11 & PgClassExpression68 & Connection74 --> PgUnionAll75
+    Object11 & PgClassExpression68 & Connection74 & Lambda105 & Access109 & Access140 --> PgUnionAll75
     List27{{"List[27∈3]<br />ᐸ25,26ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
     Constant25 & PgClassExpression26 --> List27
     List69{{"List[69∈3]<br />ᐸ67,68ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
@@ -144,10 +158,10 @@ graph TD
     __Item34 --> PgUnionAllSingle35
     PgSelect39[["PgSelect[39∈5]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access38{{"Access[38∈5]<br />ᐸ37.0ᐳ"}}:::plan
-    Object11 & Access38 & Lambda105 & Lambda108 & Lambda113 & Lambda118 --> PgSelect39
+    Object11 & Access38 & Lambda105 & Access109 & Lambda114 & Lambda119 --> PgSelect39
     PgSelect52[["PgSelect[52∈5]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
     Access51{{"Access[51∈5]<br />ᐸ50.0ᐳ"}}:::plan
-    Object11 & Access51 & Lambda105 & Lambda108 & Lambda127 & Lambda132 --> PgSelect52
+    Object11 & Access51 & Lambda105 & Access109 & Lambda129 & Lambda134 --> PgSelect52
     List47{{"List[47∈5]<br />ᐸ45,46ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
     PgClassExpression46{{"PgClassExpression[46∈5]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant45 & PgClassExpression46 --> List47
@@ -186,10 +200,10 @@ graph TD
     __Item76 --> PgUnionAllSingle77
     PgSelect81[["PgSelect[81∈7]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access80{{"Access[80∈7]<br />ᐸ79.0ᐳ"}}:::plan
-    Object11 & Access80 & Lambda105 & Lambda108 & Lambda155 & Lambda160 --> PgSelect81
+    Object11 & Access80 & Lambda105 & Access109 & Lambda165 & Lambda170 --> PgSelect81
     PgSelect94[["PgSelect[94∈7]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
     Access93{{"Access[93∈7]<br />ᐸ92.0ᐳ"}}:::plan
-    Object11 & Access93 & Lambda105 & Lambda108 & Lambda169 & Lambda174 --> PgSelect94
+    Object11 & Access93 & Lambda105 & Access109 & Lambda180 & Lambda185 --> PgSelect94
     List89{{"List[89∈7]<br />ᐸ45,88ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
     PgClassExpression88{{"PgClassExpression[88∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
     Constant45 & PgClassExpression88 --> List89
@@ -228,26 +242,26 @@ graph TD
     subgraph "Buckets for queries/polymorphic/vulns.union_owners.simple"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Connection12,Constant25,Constant45,Constant56,Constant67,Lambda105,Lambda108,Constant109,Constant110,Constant111,Object112,Lambda113,Lambda118,Constant123,Constant124,Constant125,Object126,Lambda127,Lambda132,Constant137,Constant138,Constant139,Object140,Lambda141,Lambda146,Constant151,Constant152,Object154,Lambda155,Lambda160,Constant165,Constant166,Object168,Lambda169,Lambda174,Constant179,Constant180,Constant181,Object182,Lambda183,Lambda188,Constant189,Constant190,Constant191,Constant192,Constant193,Constant194,Constant195,Constant196,Constant197 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 105, 108, 141, 146, 25, 183, 188, 67, 113, 118, 45, 127, 132, 56, 155, 160, 169, 174<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,Access9,Access10,Object11,Connection12,Constant25,Constant45,Constant56,Constant67,Lambda105,Lambda108,Access109,Constant110,Constant111,Constant112,Object113,Lambda114,Lambda119,Constant125,Constant126,Constant127,Object128,Lambda129,Lambda134,Access140,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant161,Constant162,Object164,Lambda165,Lambda170,Constant176,Constant177,Object179,Lambda180,Lambda185,Constant197,Constant198,Constant199,Object200,Lambda201,Lambda206,Lambda208,Lambda210,Access211,Access212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222,Constant223 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 213, 208, 211, 212, 105, 109, 150, 155, 25, 140, 201, 206, 67, 114, 119, 45, 129, 134, 56, 165, 170, 180, 185<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUnionAll13 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 105, 108, 141, 146, 25, 183, 188, 67, 113, 118, 45, 127, 132, 56, 155, 160, 169, 174<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 105, 109, 150, 155, 25, 140, 201, 206, 67, 114, 119, 45, 129, 134, 56, 165, 170, 180, 185<br /><br />ROOT __Item{2}ᐸ13ᐳ[14]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item14,PgUnionAllSingle15 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 15, 11, 105, 108, 141, 146, 25, 183, 188, 67, 113, 118, 45, 127, 132, 56, 155, 160, 169, 174<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: 16, 32, 74<br />2: JSONParse[17], JSONParse[61]<br />ᐳ: Access[18], Access[62]<br />3: PgSelect[19], PgSelect[63]<br />ᐳ: 23, 24, 26, 27, 28, 29, 65, 66, 68, 69, 70, 71<br />4: PgUnionAll[33], PgUnionAll[75]"):::bucket
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 15, 11, 105, 109, 150, 155, 25, 140, 201, 206, 67, 114, 119, 45, 129, 134, 56, 165, 170, 180, 185<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: 16, 32, 74<br />2: JSONParse[17], JSONParse[61]<br />ᐳ: Access[18], Access[62]<br />3: PgSelect[19], PgSelect[63]<br />ᐳ: 23, 24, 26, 27, 28, 29, 65, 66, 68, 69, 70, 71<br />4: PgUnionAll[33], PgUnionAll[75]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,Access16,JSONParse17,Access18,PgSelect19,First23,PgSelectSingle24,PgClassExpression26,List27,Lambda28,PgClassExpression29,Connection32,PgUnionAll33,JSONParse61,Access62,PgSelect63,First65,PgSelectSingle66,PgClassExpression68,List69,Lambda70,PgClassExpression71,Connection74,PgUnionAll75 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 105, 108, 113, 118, 45, 127, 132, 56<br /><br />ROOT __Item{4}ᐸ33ᐳ[34]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 11, 105, 109, 114, 119, 45, 129, 134, 56<br /><br />ROOT __Item{4}ᐸ33ᐳ[34]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item34,PgUnionAllSingle35 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 35, 11, 105, 108, 113, 118, 45, 127, 132, 56<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[36]<br />2: JSONParse[37], JSONParse[50]<br />ᐳ: Access[38], Access[51]<br />3: PgSelect[39], PgSelect[52]<br />ᐳ: 43, 44, 46, 47, 48, 49, 54, 55, 57, 58, 59, 60"):::bucket
+    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 35, 11, 105, 109, 114, 119, 45, 129, 134, 56<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[36]<br />2: JSONParse[37], JSONParse[50]<br />ᐳ: Access[38], Access[51]<br />3: PgSelect[39], PgSelect[52]<br />ᐳ: 43, 44, 46, 47, 48, 49, 54, 55, 57, 58, 59, 60"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,Access36,JSONParse37,Access38,PgSelect39,First43,PgSelectSingle44,PgClassExpression46,List47,Lambda48,PgClassExpression49,JSONParse50,Access51,PgSelect52,First54,PgSelectSingle55,PgClassExpression57,List58,Lambda59,PgClassExpression60 bucket5
-    Bucket6("Bucket 6 (listItem)<br />Deps: 11, 105, 108, 155, 160, 45, 169, 174, 56<br /><br />ROOT __Item{6}ᐸ75ᐳ[76]"):::bucket
+    Bucket6("Bucket 6 (listItem)<br />Deps: 11, 105, 109, 165, 170, 45, 180, 185, 56<br /><br />ROOT __Item{6}ᐸ75ᐳ[76]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item76,PgUnionAllSingle77 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 77, 11, 105, 108, 155, 160, 45, 169, 174, 56<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[78]<br />2: JSONParse[79], JSONParse[92]<br />ᐳ: Access[80], Access[93]<br />3: PgSelect[81], PgSelect[94]<br />ᐳ: 85, 86, 88, 89, 90, 91, 96, 97, 99, 100, 101, 102"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 77, 11, 105, 109, 165, 170, 45, 180, 185, 56<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[78]<br />2: JSONParse[79], JSONParse[92]<br />ᐳ: Access[80], Access[93]<br />3: PgSelect[81], PgSelect[94]<br />ᐳ: 85, 86, 88, 89, 90, 91, 96, 97, 99, 100, 101, 102"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,Access78,JSONParse79,Access80,PgSelect81,First85,PgSelectSingle86,PgClassExpression88,List89,Lambda90,PgClassExpression91,JSONParse92,Access93,PgSelect94,First96,PgSelectSingle97,PgClassExpression99,List100,Lambda101,PgClassExpression102 bucket7
     Bucket0 --> Bucket1

--- a/postgraphile/postgraphile/__tests__/queries/relay/conditionNodeId.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/relay/conditionNodeId.mermaid
@@ -9,67 +9,145 @@ graph TD
 
 
     %% plan dependencies
+    Object128{{"Object[128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda120 & Constant125 & Constant126 & Constant127 --> Object128
+    Object145{{"Object[145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda120 & Constant142 & Constant143 & Constant144 --> Object145
+    Object160{{"Object[160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda120 & Constant157 & Constant158 & Constant127 --> Object160
+    Object177{{"Object[177∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda120 & Constant174 & Constant175 & Constant144 --> Object177
+    Object192{{"Object[192∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda120 & Constant189 & Constant190 & Constant127 --> Object192
+    Object209{{"Object[209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda120 & Constant206 & Constant207 & Constant144 --> Object209
+    Object224{{"Object[224∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda120 & Constant221 & Constant222 & Constant127 --> Object224
+    Object241{{"Object[241∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda120 & Constant238 & Constant239 & Constant144 --> Object241
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
+    __Flag45[["__Flag[45∈0] ➊<br />ᐸ44, if(40), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag44[["__Flag[44∈0] ➊<br />ᐸ43, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition40{{"Condition[40∈0] ➊<br />ᐸexistsᐳ"}}:::plan
+    __Flag44 & Condition40 --> __Flag45
+    __Flag73[["__Flag[73∈0] ➊<br />ᐸ72, if(68), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag72[["__Flag[72∈0] ➊<br />ᐸ71, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition68{{"Condition[68∈0] ➊<br />ᐸexistsᐳ"}}:::plan
+    __Flag72 & Condition68 --> __Flag73
+    __Flag102[["__Flag[102∈0] ➊<br />ᐸ101, if(97), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag101[["__Flag[101∈0] ➊<br />ᐸ100, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition97{{"Condition[97∈0] ➊<br />ᐸexistsᐳ"}}:::plan
+    __Flag101 & Condition97 --> __Flag102
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access13
     __Value2 --> Access14
-    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant240 --> Lambda120
-    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant241 --> Lambda123
+    Access35{{"Access[35∈0] ➊<br />ᐸ0.aliceᐳ"}}:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
+    __Value0 --> Access35
+    Access35 --> Condition40
+    Lambda41{{"Lambda[41∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Access35 --> Lambda41
+    Access42{{"Access[42∈0] ➊<br />ᐸ41.1ᐳ"}}:::plan
+    Lambda41 --> Access42
+    __Flag43[["__Flag[43∈0] ➊<br />ᐸ42, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access42 --> __Flag43
+    __Flag43 --> __Flag44
+    Constant118{{"Constant[118∈0] ➊<br />ᐸnullᐳ"}}:::plan
+    Constant118 --> Condition68
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant118 --> Lambda69
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.1ᐳ"}}:::plan
+    Lambda69 --> Access70
+    __Flag71[["__Flag[71∈0] ➊<br />ᐸ70, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access70 --> __Flag71
+    __Flag71 --> __Flag72
+    Access92{{"Access[92∈0] ➊<br />ᐸ0.post3ᐳ"}}:::plan
+    __Value0 --> Access92
+    Access92 --> Condition97
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Access92 --> Lambda98
+    Access99{{"Access[99∈0] ➊<br />ᐸ98.1ᐳ"}}:::plan
+    Lambda98 --> Access99
+    __Flag100[["__Flag[100∈0] ➊<br />ᐸ99, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access99 --> __Flag100
+    __Flag100 --> __Flag101
+    Constant248{{"Constant[248∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant248 --> Lambda120
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant249{{"Constant[249∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant249 --> Lambda123
+    Access124{{"Access[124∈0] ➊<br />ᐸ123.0ᐳ"}}:::plan
+    Lambda123 --> Access124
+    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object128 --> Lambda129
+    Lambda134{{"Lambda[134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant250{{"Constant[250∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant250 --> Lambda134
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object145 --> Lambda146
+    Lambda151{{"Lambda[151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant251{{"Constant[251∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant251 --> Lambda151
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object160 --> Lambda161
+    Lambda166{{"Lambda[166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant252{{"Constant[252∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant252 --> Lambda166
+    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object177 --> Lambda178
+    Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant253{{"Constant[253∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant253 --> Lambda183
+    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object192 --> Lambda193
+    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant254{{"Constant[254∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant254 --> Lambda198
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object209 --> Lambda210
+    Lambda215{{"Lambda[215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant255 --> Lambda215
+    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object224 --> Lambda225
+    Lambda230{{"Lambda[230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant256{{"Constant[256∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant256 --> Lambda230
+    Lambda242{{"Lambda[242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object241 --> Lambda242
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant257{{"Constant[257∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant257 --> Lambda247
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection16{{"Connection[16∈0] ➊<br />ᐸ12ᐳ"}}:::plan
     Constant27{{"Constant[27∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
     Connection39{{"Connection[39∈0] ➊<br />ᐸ37ᐳ"}}:::plan
     Connection67{{"Connection[67∈0] ➊<br />ᐸ65ᐳ"}}:::plan
     Connection96{{"Connection[96∈0] ➊<br />ᐸ94ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant201{{"Constant[201∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant215{{"Constant[215∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant230{{"Constant[230∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant231{{"Constant[231∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant242{{"Constant[242∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant243{{"Constant[243∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant244{{"Constant[244∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant245{{"Constant[245∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant246{{"Constant[246∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant247{{"Constant[247∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant248{{"Constant[248∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant249{{"Constant[249∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda188{{"Lambda[188∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda193{{"Lambda[193∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda204{{"Lambda[204∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda209{{"Lambda[209∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Lambda123 & Lambda188 & Lambda193 & Lambda120 & Lambda123 & Lambda204 & Lambda209 --> PgSelect17
-    Object187{{"Object[187∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant184 & Constant185 & Constant126 --> Object187
-    Object203{{"Object[203∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant200 & Constant201 & Constant142 --> Object203
-    Object187 --> Lambda188
-    Constant246 --> Lambda193
-    Object203 --> Lambda204
-    Constant247 --> Lambda209
+    Object15 & Connection16 & Access124 & Lambda193 & Lambda198 & Lambda120 & Access124 & Lambda210 & Lambda215 --> PgSelect17
     __Item18[/"__Item[18∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgSelect17 ==> __Item18
     PgSelectSingle19{{"PgSelectSingle[19∈2]<br />ᐸpostᐳ"}}:::plan
@@ -85,33 +163,7 @@ graph TD
     Lambda30{{"Lambda[30∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List29 --> Lambda30
     PgSelect46[["PgSelect[46∈5] ➊<br />ᐸpostᐳ"]]:::plan
-    __Flag45[["__Flag[45∈5] ➊<br />ᐸ44, if(40), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
-    Lambda128{{"Lambda[128∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda144{{"Lambda[144∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda149{{"Lambda[149∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & __Flag45 & Connection39 & Lambda123 & Lambda128 & Lambda133 & Lambda120 & Lambda123 & Lambda144 & Lambda149 --> PgSelect46
-    Object127{{"Object[127∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant124 & Constant125 & Constant126 --> Object127
-    Object143{{"Object[143∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant140 & Constant141 & Constant142 --> Object143
-    __Flag44[["__Flag[44∈5] ➊<br />ᐸ43, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition40{{"Condition[40∈5] ➊<br />ᐸexistsᐳ"}}:::plan
-    __Flag44 & Condition40 --> __Flag45
-    Access35{{"Access[35∈5] ➊<br />ᐸ0.aliceᐳ"}}:::plan
-    __Value0 --> Access35
-    Access35 --> Condition40
-    Lambda41{{"Lambda[41∈5] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Access35 --> Lambda41
-    Access42{{"Access[42∈5] ➊<br />ᐸ41.1ᐳ"}}:::plan
-    Lambda41 --> Access42
-    __Flag43[["__Flag[43∈5] ➊<br />ᐸ42, rejectNull, onReject: INHIBITᐳ"]]:::plan
-    Access42 --> __Flag43
-    __Flag43 --> __Flag44
-    Object127 --> Lambda128
-    Constant242 --> Lambda133
-    Object143 --> Lambda144
-    Constant243 --> Lambda149
+    Object15 & __Flag45 & Connection39 & Access124 & Lambda129 & Lambda134 & Lambda120 & Access124 & Lambda146 & Lambda151 --> PgSelect46
     __Item47[/"__Item[47∈6]<br />ᐸ46ᐳ"\]:::itemplan
     PgSelect46 ==> __Item47
     PgSelectSingle48{{"PgSelectSingle[48∈6]<br />ᐸpostᐳ"}}:::plan
@@ -127,31 +179,7 @@ graph TD
     Lambda59{{"Lambda[59∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List58 --> Lambda59
     PgSelect74[["PgSelect[74∈9] ➊<br />ᐸpostᐳ"]]:::plan
-    __Flag73[["__Flag[73∈9] ➊<br />ᐸ72, if(68), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
-    Lambda218{{"Lambda[218∈9] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda223{{"Lambda[223∈9] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda234{{"Lambda[234∈9] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda239{{"Lambda[239∈9] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & __Flag73 & Connection67 & Lambda123 & Lambda218 & Lambda223 & Lambda120 & Lambda123 & Lambda234 & Lambda239 --> PgSelect74
-    Object217{{"Object[217∈9] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant214 & Constant215 & Constant126 --> Object217
-    Object233{{"Object[233∈9] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant230 & Constant231 & Constant142 --> Object233
-    __Flag72[["__Flag[72∈9] ➊<br />ᐸ71, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition68{{"Condition[68∈9] ➊<br />ᐸexistsᐳ"}}:::plan
-    __Flag72 & Condition68 --> __Flag73
-    Constant118 --> Condition68
-    Lambda69{{"Lambda[69∈9] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant118 --> Lambda69
-    Access70{{"Access[70∈9] ➊<br />ᐸ69.1ᐳ"}}:::plan
-    Lambda69 --> Access70
-    __Flag71[["__Flag[71∈9] ➊<br />ᐸ70, rejectNull, onReject: INHIBITᐳ"]]:::plan
-    Access70 --> __Flag71
-    __Flag71 --> __Flag72
-    Object217 --> Lambda218
-    Constant248 --> Lambda223
-    Object233 --> Lambda234
-    Constant249 --> Lambda239
+    Object15 & __Flag73 & Connection67 & Access124 & Lambda225 & Lambda230 & Lambda120 & Access124 & Lambda242 & Lambda247 --> PgSelect74
     __Item75[/"__Item[75∈10]<br />ᐸ74ᐳ"\]:::itemplan
     PgSelect74 ==> __Item75
     PgSelectSingle76{{"PgSelectSingle[76∈10]<br />ᐸpostᐳ"}}:::plan
@@ -167,33 +195,7 @@ graph TD
     Lambda87{{"Lambda[87∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List86 --> Lambda87
     PgSelect103[["PgSelect[103∈13] ➊<br />ᐸpostᐳ"]]:::plan
-    __Flag102[["__Flag[102∈13] ➊<br />ᐸ101, if(97), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
-    Lambda158{{"Lambda[158∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda163{{"Lambda[163∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda174{{"Lambda[174∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda179{{"Lambda[179∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & __Flag102 & Connection96 & Lambda123 & Lambda158 & Lambda163 & Lambda120 & Lambda123 & Lambda174 & Lambda179 --> PgSelect103
-    Object157{{"Object[157∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant154 & Constant155 & Constant126 --> Object157
-    Object173{{"Object[173∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda120 & Constant170 & Constant171 & Constant142 --> Object173
-    __Flag101[["__Flag[101∈13] ➊<br />ᐸ100, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition97{{"Condition[97∈13] ➊<br />ᐸexistsᐳ"}}:::plan
-    __Flag101 & Condition97 --> __Flag102
-    Access92{{"Access[92∈13] ➊<br />ᐸ0.post3ᐳ"}}:::plan
-    __Value0 --> Access92
-    Access92 --> Condition97
-    Lambda98{{"Lambda[98∈13] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Access92 --> Lambda98
-    Access99{{"Access[99∈13] ➊<br />ᐸ98.1ᐳ"}}:::plan
-    Lambda98 --> Access99
-    __Flag100[["__Flag[100∈13] ➊<br />ᐸ99, rejectNull, onReject: INHIBITᐳ"]]:::plan
-    Access99 --> __Flag100
-    __Flag100 --> __Flag101
-    Object157 --> Lambda158
-    Constant244 --> Lambda163
-    Object173 --> Lambda174
-    Constant245 --> Lambda179
+    Object15 & __Flag102 & Connection96 & Access124 & Lambda161 & Lambda166 & Lambda120 & Access124 & Lambda178 & Lambda183 --> PgSelect103
     __Item104[/"__Item[104∈14]<br />ᐸ103ᐳ"\]:::itemplan
     PgSelect103 ==> __Item104
     PgSelectSingle105{{"PgSelectSingle[105∈14]<br />ᐸpostᐳ"}}:::plan
@@ -212,12 +214,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/relay/conditionNodeId"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 13, 14, 16, 27, 35, 39, 67, 92, 96, 118, 125, 126, 127, 142, 143, 144, 157, 158, 174, 175, 189, 190, 206, 207, 221, 222, 238, 239, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 15, 40, 41, 42, 68, 69, 70, 97, 98, 99, 120, 123, 124, 128, 129, 134, 145, 146, 151, 160, 161, 166, 177, 178, 183, 192, 193, 198, 209, 210, 215, 224, 225, 230, 241, 242, 247<br />2: __Flag[43], __Flag[71], __Flag[100]<br />3: __Flag[44], __Flag[72], __Flag[101]<br />4: __Flag[45], __Flag[73], __Flag[102]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,Access13,Access14,Object15,Connection16,Constant27,Connection39,Connection67,Connection96,Constant118,Lambda120,Lambda123,Constant124,Constant125,Constant126,Constant140,Constant141,Constant142,Constant154,Constant155,Constant170,Constant171,Constant184,Constant185,Constant200,Constant201,Constant214,Constant215,Constant230,Constant231,Constant240,Constant241,Constant242,Constant243,Constant244,Constant245,Constant246,Constant247,Constant248,Constant249 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 123, 120, 184, 185, 126, 246, 200, 201, 142, 247, 27<br /><br />ROOT Connectionᐸ12ᐳ[16]<br />1: <br />ᐳ: 187, 193, 203, 209, 188, 204<br />2: PgSelect[17]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,Access13,Access14,Object15,Connection16,Constant27,Access35,Connection39,Condition40,Lambda41,Access42,__Flag43,__Flag44,__Flag45,Connection67,Condition68,Lambda69,Access70,__Flag71,__Flag72,__Flag73,Access92,Connection96,Condition97,Lambda98,Access99,__Flag100,__Flag101,__Flag102,Constant118,Lambda120,Lambda123,Access124,Constant125,Constant126,Constant127,Object128,Lambda129,Lambda134,Constant142,Constant143,Constant144,Object145,Lambda146,Lambda151,Constant157,Constant158,Object160,Lambda161,Lambda166,Constant174,Constant175,Object177,Lambda178,Lambda183,Constant189,Constant190,Object192,Lambda193,Lambda198,Constant206,Constant207,Object209,Lambda210,Lambda215,Constant221,Constant222,Object224,Lambda225,Lambda230,Constant238,Constant239,Object241,Lambda242,Lambda247,Constant248,Constant249,Constant250,Constant251,Constant252,Constant253,Constant254,Constant255,Constant256,Constant257 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 124, 193, 198, 120, 210, 215, 27<br /><br />ROOT Connectionᐸ12ᐳ[16]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect17,Object187,Lambda188,Lambda193,Object203,Lambda204,Lambda209 bucket1
+    class Bucket1,PgSelect17 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 27<br /><br />ROOT __Item{2}ᐸ17ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item18,PgSelectSingle19 bucket2
@@ -227,9 +229,9 @@ graph TD
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 26, 27<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression28,List29,Lambda30 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 0, 15, 39, 123, 120, 124, 125, 126, 242, 140, 141, 142, 243, 27<br /><br />ROOT Connectionᐸ37ᐳ[39]<br />1: <br />ᐳ: 35, 127, 133, 143, 149, 40, 41, 42, 128, 144<br />2: __Flag[43]<br />3: __Flag[44]<br />4: __Flag[45]<br />5: PgSelect[46]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 15, 45, 39, 124, 129, 134, 120, 146, 151, 27<br /><br />ROOT Connectionᐸ37ᐳ[39]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Access35,Condition40,Lambda41,Access42,__Flag43,__Flag44,__Flag45,PgSelect46,Object127,Lambda128,Lambda133,Object143,Lambda144,Lambda149 bucket5
+    class Bucket5,PgSelect46 bucket5
     Bucket6("Bucket 6 (listItem)<br />Deps: 27<br /><br />ROOT __Item{6}ᐸ46ᐳ[47]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item47,PgSelectSingle48 bucket6
@@ -239,9 +241,9 @@ graph TD
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 55, 27<br /><br />ROOT PgSelectSingle{7}ᐸpersonᐳ[55]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression57,List58,Lambda59 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 118, 15, 67, 123, 120, 214, 215, 126, 248, 230, 231, 142, 249, 27<br /><br />ROOT Connectionᐸ65ᐳ[67]<br />1: <br />ᐳ: 68, 69, 217, 223, 233, 239, 70, 218, 234<br />2: __Flag[71]<br />3: __Flag[72]<br />4: __Flag[73]<br />5: PgSelect[74]"):::bucket
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 15, 73, 67, 124, 225, 230, 120, 242, 247, 27<br /><br />ROOT Connectionᐸ65ᐳ[67]"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Condition68,Lambda69,Access70,__Flag71,__Flag72,__Flag73,PgSelect74,Object217,Lambda218,Lambda223,Object233,Lambda234,Lambda239 bucket9
+    class Bucket9,PgSelect74 bucket9
     Bucket10("Bucket 10 (listItem)<br />Deps: 27<br /><br />ROOT __Item{10}ᐸ74ᐳ[75]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item75,PgSelectSingle76 bucket10
@@ -251,9 +253,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 83, 27<br /><br />ROOT PgSelectSingle{11}ᐸpersonᐳ[83]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression85,List86,Lambda87 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 0, 15, 96, 123, 120, 154, 155, 126, 244, 170, 171, 142, 245, 27<br /><br />ROOT Connectionᐸ94ᐳ[96]<br />1: <br />ᐳ: 92, 157, 163, 173, 179, 97, 98, 99, 158, 174<br />2: __Flag[100]<br />3: __Flag[101]<br />4: __Flag[102]<br />5: PgSelect[103]"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 15, 102, 96, 124, 161, 166, 120, 178, 183, 27<br /><br />ROOT Connectionᐸ94ᐳ[96]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,Access92,Condition97,Lambda98,Access99,__Flag100,__Flag101,__Flag102,PgSelect103,Object157,Lambda158,Lambda163,Object173,Lambda174,Lambda179 bucket13
+    class Bucket13,PgSelect103 bucket13
     Bucket14("Bucket 14 (listItem)<br />Deps: 27<br /><br />ROOT __Item{14}ᐸ103ᐳ[104]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item104,PgSelectSingle105 bucket14

--- a/postgraphile/postgraphile/__tests__/queries/v4/arrays.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/arrays.mermaid
@@ -11,57 +11,59 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸlistsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access66{{"Access[66∈0] ➊<br />ᐸ65.0ᐳ"}}:::plan
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda65 & Lambda70 & Lambda75 & Lambda65 & Lambda89 & Lambda94 & Lambda62 & Lambda65 & Lambda106 & Lambda111 --> PgSelect7
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda62 & Constant66 & Constant67 & Constant68 --> Object69
-    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda62 & Constant85 & Constant86 & Constant68 --> Object88
-    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
-    Lambda62 & Constant102 & Constant103 & Constant104 --> Object105
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Access66 & Lambda71 & Lambda76 & Access66 & Lambda91 & Lambda96 & Lambda62 & Access66 & Lambda109 & Lambda114 --> PgSelect7
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda62 & Constant67 & Constant68 & Constant69 --> Object70
+    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda62 & Constant87 & Constant88 & Constant69 --> Object90
+    Object108{{"Object[108∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
+    Lambda62 & Constant105 & Constant106 & Constant107 --> Object108
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant112 --> Lambda62
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda65
-    Object69 --> Lambda70
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant114 --> Lambda75
-    Object88 --> Lambda89
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant115 --> Lambda94
-    Object105 --> Lambda106
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant116 --> Lambda111
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant115 --> Lambda62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda65
+    Lambda65 --> Access66
+    Object70 --> Lambda71
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant117 --> Lambda76
+    Object90 --> Lambda91
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant118 --> Lambda96
+    Object108 --> Lambda109
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant119 --> Lambda114
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant60{{"Constant[60∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant63{{"Constant[63∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Object79{{"Object[79∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access77{{"Access[77∈1]<br />ᐸ11.9ᐳ"}}:::plan
-    Access77 & Constant60 & Constant60 & Lambda62 & Constant63 --> Object79
-    Object96{{"Object[96∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access95{{"Access[95∈1]<br />ᐸ11.10ᐳ"}}:::plan
-    Access95 & Constant60 & Constant60 & Lambda62 & Constant63 --> Object96
+    Object80{{"Object[80∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access78{{"Access[78∈1]<br />ᐸ11.9ᐳ"}}:::plan
+    Access78 & Constant60 & Constant60 & Lambda62 & Constant63 --> Object80
+    Object98{{"Object[98∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access97{{"Access[97∈1]<br />ᐸ11.10ᐳ"}}:::plan
+    Access97 & Constant60 & Constant60 & Lambda62 & Constant63 --> Object98
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸlistsᐳ"}}:::plan
@@ -88,12 +90,12 @@ graph TD
     PgSelectSingle12 --> PgClassExpression56
     PgClassExpression58{{"PgClassExpression[58∈1]<br />ᐸ__lists__...._array_nn”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression58
-    __Item11 --> Access77
-    Lambda80{{"Lambda[80∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object79 --> Lambda80
-    __Item11 --> Access95
-    Lambda97{{"Lambda[97∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object96 --> Lambda97
+    __Item11 --> Access78
+    Lambda81{{"Lambda[81∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object80 --> Lambda81
+    __Item11 --> Access97
+    Lambda99{{"Lambda[99∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object98 --> Lambda99
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgClassExpression14 ==> __Item15
     __Item17[/"__Item[17∈3]<br />ᐸ16ᐳ"\]:::itemplan
@@ -110,8 +112,8 @@ graph TD
     PgClassExpression26 ==> __Item27
     __Item29[/"__Item[29∈9]<br />ᐸ28ᐳ"\]:::itemplan
     PgClassExpression28 ==> __Item29
-    __Item35[/"__Item[35∈10]<br />ᐸ80ᐳ"\]:::itemplan
-    Lambda80 ==> __Item35
+    __Item35[/"__Item[35∈10]<br />ᐸ81ᐳ"\]:::itemplan
+    Lambda81 ==> __Item35
     PgSelectSingle36{{"PgSelectSingle[36∈10]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     __Item35 --> PgSelectSingle36
     PgClassExpression37{{"PgClassExpression[37∈11]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
@@ -128,8 +130,8 @@ graph TD
     PgSelectSingle36 --> PgClassExpression42
     PgClassExpression43{{"PgClassExpression[43∈11]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle36 --> PgClassExpression43
-    __Item47[/"__Item[47∈12]<br />ᐸ97ᐳ"\]:::itemplan
-    Lambda97 ==> __Item47
+    __Item47[/"__Item[47∈12]<br />ᐸ99ᐳ"\]:::itemplan
+    Lambda99 ==> __Item47
     PgSelectSingle48{{"PgSelectSingle[48∈12]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     __Item47 --> PgSelectSingle48
     PgClassExpression49{{"PgClassExpression[49∈13]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
@@ -154,12 +156,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/arrays"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 60, 63, 66, 67, 68, 85, 86, 102, 103, 104, 112, 113, 114, 115, 116, 10, 62, 65, 69, 70, 75, 88, 89, 94, 105, 106, 111<br />2: PgSelect[7]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 60, 63, 67, 68, 69, 87, 88, 105, 106, 107, 115, 116, 117, 118, 119, 10, 62, 65, 66, 70, 71, 76, 90, 91, 96, 108, 109, 114<br />2: PgSelect[7]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,Constant60,Lambda62,Constant63,Lambda65,Constant66,Constant67,Constant68,Object69,Lambda70,Lambda75,Constant85,Constant86,Object88,Lambda89,Lambda94,Constant102,Constant103,Constant104,Object105,Lambda106,Lambda111,Constant112,Constant113,Constant114,Constant115,Constant116 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,Constant60,Lambda62,Constant63,Lambda65,Access66,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant87,Constant88,Object90,Lambda91,Lambda96,Constant105,Constant106,Constant107,Object108,Lambda109,Lambda114,Constant115,Constant116,Constant117,Constant118,Constant119 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 60, 62, 63<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression16,PgClassExpression18,PgClassExpression20,PgClassExpression22,PgClassExpression24,PgClassExpression26,PgClassExpression28,PgClassExpression56,PgClassExpression58,Access77,Object79,Lambda80,Access95,Object96,Lambda97 bucket1
+    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression16,PgClassExpression18,PgClassExpression20,PgClassExpression22,PgClassExpression24,PgClassExpression26,PgClassExpression28,PgClassExpression56,PgClassExpression58,Access78,Object80,Lambda81,Access97,Object98,Lambda99 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15 bucket2
@@ -184,13 +186,13 @@ graph TD
     Bucket9("Bucket 9 (listItem)<br /><br />ROOT __Item{9}ᐸ28ᐳ[29]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,__Item29 bucket9
-    Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ80ᐳ[35]"):::bucket
+    Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ81ᐳ[35]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item35,PgSelectSingle36 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{10}ᐸfrmcdc_compoundTypeᐳ[36]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgClassExpression43 bucket11
-    Bucket12("Bucket 12 (listItem)<br /><br />ROOT __Item{12}ᐸ97ᐳ[47]"):::bucket
+    Bucket12("Bucket 12 (listItem)<br /><br />ROOT __Item{12}ᐸ99ᐳ[47]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,__Item47,PgSelectSingle48 bucket12
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 48<br /><br />ROOT PgSelectSingle{12}ᐸfrmcdc_compoundTypeᐳ[48]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/badlyBehavedFunction.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/badlyBehavedFunction.mermaid
@@ -9,36 +9,38 @@ graph TD
 
 
     %% plan dependencies
+    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”badly_behaved_function”)ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda39 & Constant44 & Constant45 & Constant46 --> Object47
+    Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access8 & Access9 --> Object10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access8
+    __Value2 --> Access9
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant54 --> Lambda39
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant55 --> Lambda42
+    Access43{{"Access[43∈0] ➊<br />ᐸ42.0ᐳ"}}:::plan
+    Lambda42 --> Access43
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object47 --> Lambda48
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”badly_ᐳ"}}:::plan
+    Constant56 --> Lambda53
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection11{{"Connection[11∈0] ➊<br />ᐸ7ᐳ"}}:::plan
     Constant15{{"Constant[15∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”badly_behaved_function”)ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”badly_ᐳ"}}:::plan
     PgSelect12[["PgSelect[12∈1] ➊<br />ᐸbadly_behaved_functionᐳ"]]:::plan
-    Object10{{"Object[10∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda42{{"Lambda[42∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda47{{"Lambda[47∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection11 & Lambda39 & Lambda42 & Lambda47 & Lambda52 --> PgSelect12
-    Object46{{"Object[46∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda39 & Constant43 & Constant44 & Constant45 --> Object46
-    Access8{{"Access[8∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access9{{"Access[9∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access8 & Access9 --> Object10
-    __Value2 --> Access8
-    __Value2 --> Access9
+    Object10 & Connection11 & Lambda39 & Access43 & Lambda48 & Lambda53 --> PgSelect12
     __ListTransform22[["__ListTransform[22∈1] ➊<br />ᐸeach:21ᐳ"]]:::plan
     PgSelect12 --> __ListTransform22
-    Constant53 --> Lambda39
-    Constant54 --> Lambda42
-    Object46 --> Lambda47
-    Constant55 --> Lambda52
     __Item13[/"__Item[13∈2]<br />ᐸ12ᐳ"\]:::itemplan
     PgSelect12 ==> __Item13
     PgSelectSingle14{{"PgSelectSingle[14∈2]<br />ᐸbadly_behaved_functionᐳ"}}:::plan
@@ -81,10 +83,10 @@ graph TD
     subgraph "Buckets for queries/v4/badlyBehavedFunction"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection11,Constant15,Constant43,Constant44,Constant45,Constant53,Constant54,Constant55 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 11, 53, 54, 43, 44, 45, 55, 15<br /><br />ROOT Connectionᐸ7ᐳ[11]<br />1: <br />ᐳ: 8, 9, 39, 42, 52, 10, 46, 47<br />2: PgSelect[12]<br />3: __ListTransform[22]"):::bucket
+    class Bucket0,__Value2,__Value4,Access8,Access9,Object10,Connection11,Constant15,Lambda39,Lambda42,Access43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant54,Constant55,Constant56 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 10, 11, 39, 43, 48, 53, 15<br /><br />ROOT Connectionᐸ7ᐳ[11]<br />1: PgSelect[12]<br />2: __ListTransform[22]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access8,Access9,Object10,PgSelect12,__ListTransform22,Lambda39,Lambda42,Object46,Lambda47,Lambda52 bucket1
+    class Bucket1,PgSelect12,__ListTransform22 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 15<br /><br />ROOT __Item{2}ᐸ12ᐳ[13]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item13,PgSelectSingle14 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/bigint.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/bigint.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrange_testᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ934ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ934ᐳ"}}:::plan
     Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant36 & Lambda22 & Lambda25 & Lambda30 & Lambda35 --> PgSelect7
-    Object29{{"Object[29∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
-    Lambda22 & Constant26 & Constant27 & Constant28 --> Object29
+    Access26{{"Access[26∈0] ➊<br />ᐸ25.0ᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant37 & Lambda22 & Access26 & Lambda31 & Lambda36 --> PgSelect7
+    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
+    Lambda22 & Constant27 & Constant28 & Constant29 --> Object30
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrange_testᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda22
     Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda25
-    Object29 --> Lambda30
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
-    Constant39 --> Lambda35
+    Constant38 --> Lambda22
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda25
+    Lambda25 --> Access26
+    Object30 --> Lambda31
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
+    Constant40 --> Lambda36
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__range_test__.”int8”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -50,9 +52,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/bigint"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 26, 27, 28, 36, 37, 38, 39, 10, 22, 25, 29, 30, 35<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 27, 28, 29, 37, 38, 39, 40, 10, 22, 25, 26, 30, 31, 36<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda22,Lambda25,Constant26,Constant27,Constant28,Object29,Lambda30,Lambda35,Constant36,Constant37,Constant38,Constant39 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda22,Lambda25,Access26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant37,Constant38,Constant39,Constant40 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/classic-ids.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/classic-ids.mermaid
@@ -9,6 +9,17 @@ graph TD
 
 
     %% plan dependencies
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”edge_case”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(edgeCase)ᐳ"}}:::plan
+    Lambda37 & Constant57 & Constant58 & Constant59 --> Object60
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,34 +27,31 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant67 --> Lambda37
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant69 --> Lambda37
     Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant68 --> Lambda40
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant70 --> Lambda40
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant71 --> Lambda51
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object60 --> Lambda61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”edge_cᐳ"}}:::plan
+    Constant72 --> Lambda66
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
     Constant19{{"Constant[19∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
     Connection30{{"Connection[30∈0] ➊<br />ᐸ28ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”edge_case”)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(edgeCase)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”edge_cᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant65 & Connection15 & Lambda37 & Lambda40 & Lambda45 & Lambda50 --> PgSelect16
-    Object44{{"Object[44∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object44 --> Lambda45
-    Constant69 --> Lambda50
+    Object14 & Constant67 & Connection15 & Lambda37 & Access41 & Lambda46 & Lambda51 --> PgSelect16
     __Item17[/"__Item[17∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈2]<br />ᐸpostᐳ"}}:::plan
@@ -57,13 +65,7 @@ graph TD
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression23
     PgSelect31[["PgSelect[31∈4] ➊<br />ᐸedge_caseᐳ"]]:::plan
-    Lambda59{{"Lambda[59∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant66 & Connection30 & Lambda37 & Lambda40 & Lambda59 & Lambda64 --> PgSelect31
-    Object58{{"Object[58∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant55 & Constant56 & Constant57 --> Object58
-    Object58 --> Lambda59
-    Constant70 --> Lambda64
+    Object14 & Constant68 & Connection30 & Lambda37 & Access41 & Lambda61 & Lambda66 --> PgSelect31
     __Item32[/"__Item[32∈5]<br />ᐸ31ᐳ"\]:::itemplan
     PgSelect31 ==> __Item32
     PgSelectSingle33{{"PgSelectSingle[33∈5]<br />ᐸedge_caseᐳ"}}:::plan
@@ -76,19 +78,19 @@ graph TD
     subgraph "Buckets for queries/v4/classic-ids"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Constant19,Connection30,Lambda37,Lambda40,Constant41,Constant42,Constant43,Constant55,Constant56,Constant57,Constant65,Constant66,Constant67,Constant68,Constant69,Constant70 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 65, 15, 37, 40, 41, 42, 43, 69, 19<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: Object[44], Lambda[50], Lambda[45]<br />2: PgSelect[16]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Constant19,Connection30,Lambda37,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Constant67,Constant68,Constant69,Constant70,Constant71,Constant72 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 67, 15, 37, 41, 46, 51, 19<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,Object44,Lambda45,Lambda50 bucket1
+    class Bucket1,PgSelect16 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 19<br /><br />ROOT __Item{2}ᐸ16ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item17,PgSelectSingle18 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT PgSelectSingle{2}ᐸpostᐳ[18]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression20,List21,Lambda22,PgClassExpression23 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 66, 30, 37, 40, 55, 56, 57, 70<br /><br />ROOT Connectionᐸ28ᐳ[30]<br />1: <br />ᐳ: Object[58], Lambda[64], Lambda[59]<br />2: PgSelect[31]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 68, 30, 37, 41, 61, 66<br /><br />ROOT Connectionᐸ28ᐳ[30]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect31,Object58,Lambda59,Lambda64 bucket4
+    class Bucket4,PgSelect31 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ31ᐳ[32]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item32,PgSelectSingle33 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/composite_domains.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/composite_domains.mermaid
@@ -9,6 +9,30 @@ graph TD
 
 
     %% plan dependencies
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content_line_node”)ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸDomainCodecᐸbaseUserUpdateContentLineNodeᐳ(userUpdateContentᐳ"}}:::plan
+    Lambda60 & Constant65 & Constant66 & Constant67 --> Object68
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content”)ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸDomainCodecᐸbaseUserUpdateContentᐳ(userUpdateContent)ᐳ"}}:::plan
+    Lambda60 & Constant80 & Constant81 & Constant82 --> Object83
+    Object100{{"Object[100∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content_line_node”)ᐳ"}}:::plan
+    Lambda60 & Constant97 & Constant98 & Constant67 --> Object100
+    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content”)ᐳ"}}:::plan
+    Lambda60 & Constant112 & Constant113 & Constant82 --> Object115
+    Object135{{"Object[135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
+    Lambda60 & Constant132 & Constant133 & Constant134 --> Object135
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,93 +40,71 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant137 --> Lambda60
+    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant142 --> Lambda60
     Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant138 --> Lambda63
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant143 --> Lambda63
+    Access64{{"Access[64∈0] ➊<br />ᐸ63.0ᐳ"}}:::plan
+    Lambda63 --> Access64
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant144 --> Lambda74
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object83 --> Lambda84
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant145 --> Lambda89
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object100 --> Lambda101
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant146 --> Lambda106
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object115 --> Lambda116
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant147 --> Lambda121
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object135 --> Lambda136
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant148 --> Lambda141
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant58{{"Constant[58∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant61{{"Constant[61∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content_line_node”)ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸDomainCodecᐸbaseUserUpdateContentLineNodeᐳ(userUpdateContentᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content”)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸDomainCodecᐸbaseUserUpdateContentᐳ(userUpdateContent)ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content_line_node”)ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”frmcdc_user_update_content”)ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸsql.identifier(”posts”)ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸRecordCodec(posts)ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpostsᐳ"]]:::plan
-    Lambda82{{"Lambda[82∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda87{{"Lambda[87∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda117{{"Lambda[117∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda131{{"Lambda[131∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda136{{"Lambda[136∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda63 & Lambda82 & Lambda87 & Lambda63 & Lambda112 & Lambda117 & Lambda60 & Lambda63 & Lambda131 & Lambda136 --> PgSelect14
-    Object67{{"Object[67∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda60 & Constant64 & Constant65 & Constant66 --> Object67
-    Object81{{"Object[81∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda60 & Constant78 & Constant79 & Constant80 --> Object81
-    Object97{{"Object[97∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda60 & Constant94 & Constant95 & Constant66 --> Object97
-    Object111{{"Object[111∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda60 & Constant108 & Constant109 & Constant80 --> Object111
-    Object130{{"Object[130∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda60 & Constant127 & Constant128 & Constant129 --> Object130
-    Lambda68{{"Lambda[68∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object67 --> Lambda68
-    Lambda73{{"Lambda[73∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant139 --> Lambda73
-    Object81 --> Lambda82
-    Constant140 --> Lambda87
-    Lambda98{{"Lambda[98∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object97 --> Lambda98
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant141 --> Lambda103
-    Object111 --> Lambda112
-    Constant142 --> Lambda117
-    Object130 --> Lambda131
-    Constant143 --> Lambda136
+    Object12 & Connection13 & Access64 & Lambda84 & Lambda89 & Access64 & Lambda116 & Lambda121 & Lambda60 & Access64 & Lambda136 & Lambda141 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpostsᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
-    Object121{{"Object[121∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access119{{"Access[119∈3]<br />ᐸ15.5ᐳ"}}:::plan
-    Access119 & Constant58 & Constant58 & Lambda60 & Constant61 --> Object121
+    Object125{{"Object[125∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access123{{"Access[123∈3]<br />ᐸ15.5ᐳ"}}:::plan
+    Access123 & Constant58 & Constant58 & Lambda60 & Constant61 --> Object125
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__posts__.”id”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__posts__.”user_id”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression18
     PgSelectSingle25{{"PgSelectSingle[25∈3]<br />ᐸfrmcdc_userUpdateContentᐳ"}}:::plan
-    RemapKeys88{{"RemapKeys[88∈3]<br />ᐸ16:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
-    RemapKeys88 --> PgSelectSingle25
+    RemapKeys90{{"RemapKeys[90∈3]<br />ᐸ16:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    RemapKeys90 --> PgSelectSingle25
     PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__frmcdc_u....”img_url”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ__frmcdc_u...__.”lines”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression27
     PgClassExpression57{{"PgClassExpression[57∈3]<br />ᐸ__posts__.”created_at”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression57
-    PgSelectSingle16 --> RemapKeys88
-    __Item15 --> Access119
-    Lambda122{{"Lambda[122∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object121 --> Lambda122
+    PgSelectSingle16 --> RemapKeys90
+    __Item15 --> Access123
+    Lambda126{{"Lambda[126∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object125 --> Lambda126
     PgSelect31[["PgSelect[31∈5]<br />ᐸfrmcdc_userUpdateContentLineNodeᐳ"]]:::plan
     __Item30[/"__Item[30∈5]<br />ᐸ27ᐳ"\]:::itemplan
-    Object12 & __Item30 & Lambda60 & Lambda63 & Lambda68 & Lambda73 --> PgSelect31
+    Object12 & __Item30 & Lambda60 & Access64 & Lambda69 & Lambda74 --> PgSelect31
     PgClassExpression27 ==> __Item30
     __Item35[/"__Item[35∈6]<br />ᐸ31ᐳ"\]:::itemplan
     PgSelect31 ==> __Item35
@@ -112,8 +114,8 @@ graph TD
     PgSelectSingle36 --> PgClassExpression37
     PgClassExpression38{{"PgClassExpression[38∈6]<br />ᐸ__frmcdc_u...node_text”ᐳ"}}:::plan
     PgSelectSingle36 --> PgClassExpression38
-    __Item42[/"__Item[42∈7]<br />ᐸ122ᐳ"\]:::itemplan
-    Lambda122 ==> __Item42
+    __Item42[/"__Item[42∈7]<br />ᐸ126ᐳ"\]:::itemplan
+    Lambda126 ==> __Item42
     PgSelectSingle43{{"PgSelectSingle[43∈7]<br />ᐸfrmcdc_userUpdateContentᐳ"}}:::plan
     __Item42 --> PgSelectSingle43
     PgClassExpression44{{"PgClassExpression[44∈7]<br />ᐸ__frmcdc_u....”img_url”ᐳ"}}:::plan
@@ -122,7 +124,7 @@ graph TD
     PgSelectSingle43 --> PgClassExpression45
     PgSelect49[["PgSelect[49∈9]<br />ᐸfrmcdc_userUpdateContentLineNodeᐳ"]]:::plan
     __Item48[/"__Item[48∈9]<br />ᐸ45ᐳ"\]:::itemplan
-    Object12 & __Item48 & Lambda60 & Lambda63 & Lambda98 & Lambda103 --> PgSelect49
+    Object12 & __Item48 & Lambda60 & Access64 & Lambda101 & Lambda106 --> PgSelect49
     PgClassExpression45 ==> __Item48
     __Item53[/"__Item[53∈10]<br />ᐸ49ᐳ"\]:::itemplan
     PgSelect49 ==> __Item53
@@ -138,26 +140,26 @@ graph TD
     subgraph "Buckets for queries/v4/composite_domains"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant58,Lambda60,Constant61,Lambda63,Constant64,Constant65,Constant66,Constant78,Constant79,Constant80,Constant94,Constant95,Constant108,Constant109,Constant127,Constant128,Constant129,Constant137,Constant138,Constant139,Constant140,Constant141,Constant142,Constant143 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 63, 60, 64, 65, 66, 139, 78, 79, 80, 140, 94, 95, 141, 108, 109, 142, 127, 128, 129, 143, 58, 61<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 67, 73, 81, 87, 97, 103, 111, 117, 130, 136, 68, 82, 98, 112, 131<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant58,Lambda60,Constant61,Lambda63,Access64,Constant65,Constant66,Constant67,Object68,Lambda69,Lambda74,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant97,Constant98,Object100,Lambda101,Lambda106,Constant112,Constant113,Object115,Lambda116,Lambda121,Constant132,Constant133,Constant134,Object135,Lambda136,Lambda141,Constant142,Constant143,Constant144,Constant145,Constant146,Constant147,Constant148 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 64, 84, 89, 116, 121, 60, 136, 141, 58, 61, 69, 74, 101, 106<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object67,Lambda68,Lambda73,Object81,Lambda82,Lambda87,Object97,Lambda98,Lambda103,Object111,Lambda112,Lambda117,Object130,Lambda131,Lambda136 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 58, 60, 61, 12, 63, 68, 73, 98, 103<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 58, 60, 61, 12, 64, 69, 74, 101, 106<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 15, 58, 60, 61, 12, 63, 68, 73, 98, 103<br /><br />ROOT PgSelectSingle{2}ᐸpostsᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 15, 58, 60, 61, 12, 64, 69, 74, 101, 106<br /><br />ROOT PgSelectSingle{2}ᐸpostsᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression18,PgSelectSingle25,PgClassExpression26,PgClassExpression27,PgClassExpression57,RemapKeys88,Access119,Object121,Lambda122 bucket3
-    Bucket5("Bucket 5 (listItem)<br />Deps: 12, 60, 63, 68, 73<br /><br />ROOT __Item{5}ᐸ27ᐳ[30]"):::bucket
+    class Bucket3,PgClassExpression17,PgClassExpression18,PgSelectSingle25,PgClassExpression26,PgClassExpression27,PgClassExpression57,RemapKeys90,Access123,Object125,Lambda126 bucket3
+    Bucket5("Bucket 5 (listItem)<br />Deps: 12, 60, 64, 69, 74<br /><br />ROOT __Item{5}ᐸ27ᐳ[30]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item30,PgSelect31 bucket5
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ31ᐳ[35]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item35,PgSelectSingle36,PgClassExpression37,PgClassExpression38 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 12, 60, 63, 98, 103<br /><br />ROOT __Item{7}ᐸ122ᐳ[42]"):::bucket
+    Bucket7("Bucket 7 (listItem)<br />Deps: 12, 60, 64, 101, 106<br /><br />ROOT __Item{7}ᐸ126ᐳ[42]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item42,PgSelectSingle43,PgClassExpression44,PgClassExpression45 bucket7
-    Bucket9("Bucket 9 (listItem)<br />Deps: 12, 60, 63, 98, 103<br /><br />ROOT __Item{9}ᐸ45ᐳ[48]"):::bucket
+    Bucket9("Bucket 9 (listItem)<br />Deps: 12, 60, 64, 101, 106<br /><br />ROOT __Item{9}ᐸ45ᐳ[48]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,__Item48,PgSelect49 bucket9
     Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ49ᐳ[53]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections-blankcursor.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections-blankcursor.mermaid
@@ -10,14 +10,30 @@ graph TD
 
     %% plan dependencies
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant178{{"Constant[178∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda16{{"Lambda[16∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor18["PgValidateParsedCursor[18∈0] ➊"]:::plan
-    Constant174 & Lambda16 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 --> Connection15
+    Constant178 & Lambda16 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 & PgValidateParsedCursor18 --> Connection15
     Connection68{{"Connection[68∈0] ➊<br />ᐸ66ᐳ"}}:::plan
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor71["PgValidateParsedCursor[71∈0] ➊"]:::plan
-    Constant174 & Lambda69 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 --> Connection68
+    Constant178 & Lambda69 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 & PgValidateParsedCursor71 --> Connection68
+    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda117 & Constant122 & Constant123 & Constant124 --> Object125
+    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda134{{"Lambda[134∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda134 & Constant138 & Constant123 & Constant124 --> Object141
+    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda117 & Constant153 & Constant123 & Constant124 --> Object156
+    Object171{{"Object[171∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda134 & Constant168 & Constant123 & Constant124 --> Object171
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -25,55 +41,61 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ''ᐳ"}}:::plan
-    Constant175 --> Lambda16
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ''ᐳ"}}:::plan
+    Constant179 --> Lambda16
     Lambda16 --> PgValidateParsedCursor18
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ'27'ᐳ"}}:::plan
-    Constant176 --> Lambda69
+    Access19{{"Access[19∈0] ➊<br />ᐸ16.1ᐳ"}}:::plan
+    Lambda16 --> Access19
+    Constant180{{"Constant[180∈0] ➊<br />ᐸ'27'ᐳ"}}:::plan
+    Constant180 --> Lambda69
     Lambda69 --> PgValidateParsedCursor71
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant183 --> Lambda117
+    Access72{{"Access[72∈0] ➊<br />ᐸ69.1ᐳ"}}:::plan
+    Lambda69 --> Access72
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant187 --> Lambda117
     Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant184 --> Lambda120
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant177 --> Lambda133
-    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant178 --> Lambda135
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant188 --> Lambda120
+    Access121{{"Access[121∈0] ➊<br />ᐸ120.0ᐳ"}}:::plan
+    Lambda120 --> Access121
+    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object125 --> Lambda126
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant183 --> Lambda132
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant181 --> Lambda134
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant182 --> Lambda136
+    Access137{{"Access[137∈0] ➊<br />ᐸ136.0ᐳ"}}:::plan
+    Lambda136 --> Access137
+    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object141 --> Lambda142
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant184 --> Lambda147
+    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object156 --> Lambda157
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant185 --> Lambda162
+    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object171 --> Lambda172
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant186 --> Lambda177
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Access19{{"Access[19∈1] ➊<br />ᐸ16.1ᐳ"}}:::plan
-    Lambda125{{"Lambda[125∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda131{{"Lambda[131∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Connection15 & Lambda16 & Constant174 & Access19 & Lambda117 & Lambda120 & Lambda125 & Lambda131 --> PgSelect17
+    Object14 & Connection15 & Lambda16 & Constant178 & Access19 & Lambda117 & Access121 & Lambda126 & Lambda132 --> PgSelect17
     PgSelect46[["PgSelect[46∈1] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda140{{"Lambda[140∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Connection15 & Lambda133 & Lambda135 & Lambda140 & Lambda145 --> PgSelect46
+    Object14 & Connection15 & Lambda134 & Access137 & Lambda142 & Lambda147 --> PgSelect46
     Object43{{"Object[43∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access37{{"Access[37∈1] ➊<br />ᐸ17.hasMoreᐳ"}}:::plan
-    Constant174 & Constant7 & Constant7 & Access37 --> Object43
-    Object124{{"Object[124∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda117 & Constant121 & Constant122 & Constant123 --> Object124
-    Object139{{"Object[139∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda133 & Constant136 & Constant122 & Constant123 --> Object139
+    Constant178 & Constant7 & Constant7 & Access37 --> Object43
     Object38{{"Object[38∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant174 & Constant7 & Access37 --> Object38
-    Lambda16 --> Access19
+    Constant178 & Constant7 & Access37 --> Object38
     PgPageInfo20{{"PgPageInfo[20∈1] ➊"}}:::plan
     Connection15 --> PgPageInfo20
     First22{{"First[22∈1] ➊"}}:::plan
@@ -107,10 +129,6 @@ graph TD
     First47 --> PgSelectSingle48
     PgClassExpression49{{"PgClassExpression[49∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle48 --> PgClassExpression49
-    Object124 --> Lambda125
-    Constant179 --> Lambda131
-    Object139 --> Lambda140
-    Constant180 --> Lambda145
     __Item52[/"__Item[52∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgSelect17 ==> __Item52
     PgSelectSingle53{{"PgSelectSingle[53∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -130,24 +148,14 @@ graph TD
     PgClassExpression61{{"PgClassExpression[61∈3]<br />ᐸ__person__...n_from_ip”ᐳ"}}:::plan
     PgSelectSingle53 --> PgClassExpression61
     PgSelect70[["PgSelect[70∈4] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Access72{{"Access[72∈4] ➊<br />ᐸ69.1ᐳ"}}:::plan
-    Lambda154{{"Lambda[154∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Connection68 & Lambda69 & Constant174 & Access72 & Lambda117 & Lambda120 & Lambda154 & Lambda159 --> PgSelect70
+    Object14 & Connection68 & Lambda69 & Constant178 & Access72 & Lambda117 & Access121 & Lambda157 & Lambda162 --> PgSelect70
     PgSelect99[["PgSelect[99∈4] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda168{{"Lambda[168∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda173{{"Lambda[173∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Connection68 & Lambda133 & Lambda135 & Lambda168 & Lambda173 --> PgSelect99
+    Object14 & Connection68 & Lambda134 & Access137 & Lambda172 & Lambda177 --> PgSelect99
     Object96{{"Object[96∈4] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access90{{"Access[90∈4] ➊<br />ᐸ70.hasMoreᐳ"}}:::plan
-    Constant174 & Constant7 & Constant7 & Access90 --> Object96
-    Object153{{"Object[153∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda117 & Constant150 & Constant122 & Constant123 --> Object153
-    Object167{{"Object[167∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda133 & Constant164 & Constant122 & Constant123 --> Object167
+    Constant178 & Constant7 & Constant7 & Access90 --> Object96
     Object91{{"Object[91∈4] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant174 & Constant7 & Access90 --> Object91
-    Lambda69 --> Access72
+    Constant178 & Constant7 & Access90 --> Object91
     PgPageInfo73{{"PgPageInfo[73∈4] ➊"}}:::plan
     Connection68 --> PgPageInfo73
     First75{{"First[75∈4] ➊"}}:::plan
@@ -181,10 +189,6 @@ graph TD
     First100 --> PgSelectSingle101
     PgClassExpression102{{"PgClassExpression[102∈4] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle101 --> PgClassExpression102
-    Object153 --> Lambda154
-    Constant181 --> Lambda159
-    Object167 --> Lambda168
-    Constant182 --> Lambda173
     __Item105[/"__Item[105∈5]<br />ᐸ70ᐳ"\]:::itemplan
     PgSelect70 ==> __Item105
     PgSelectSingle106{{"PgSelectSingle[106∈5]<br />ᐸpersonᐳ"}}:::plan
@@ -207,21 +211,21 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/connections-blankcursor"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 12, 13, 121, 122, 123, 136, 150, 164, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 14, 16, 69, 117, 120, 133, 135<br />2: 18, 71<br />ᐳ: Connection[15], Connection[68]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 12, 13, 122, 123, 124, 138, 153, 168, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 14, 16, 19, 69, 72, 117, 120, 121, 125, 126, 132, 134, 136, 137, 141, 142, 147, 156, 157, 162, 171, 172, 177<br />2: 18, 71<br />ᐳ: Connection[15], Connection[68]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor18,Connection68,Lambda69,PgValidateParsedCursor71,Lambda117,Lambda120,Constant121,Constant122,Constant123,Lambda133,Lambda135,Constant136,Constant150,Constant164,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 174, 117, 120, 7, 133, 135, 121, 122, 123, 179, 136, 180<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 19, 20, 124, 131, 139, 145, 125, 140<br />2: PgSelect[17], PgSelect[46]<br />ᐳ: 22, 23, 26, 27, 29, 30, 33, 34, 37, 38, 39, 43, 44, 47, 48, 49, 24, 31"):::bucket
+    class Bucket0,__Value2,__Value4,Constant7,Access12,Access13,Object14,Connection15,Lambda16,PgValidateParsedCursor18,Access19,Connection68,Lambda69,PgValidateParsedCursor71,Access72,Lambda117,Lambda120,Access121,Constant122,Constant123,Constant124,Object125,Lambda126,Lambda132,Lambda134,Lambda136,Access137,Constant138,Object141,Lambda142,Lambda147,Constant153,Object156,Lambda157,Lambda162,Constant168,Object171,Lambda172,Lambda177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 15, 16, 178, 19, 117, 121, 126, 132, 7, 134, 137, 142, 147<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect17,Access19,PgPageInfo20,First22,PgSelectSingle23,PgCursor24,PgClassExpression26,List27,Last29,PgSelectSingle30,PgCursor31,PgClassExpression33,List34,Access37,Object38,Lambda39,Object43,Lambda44,PgSelect46,First47,PgSelectSingle48,PgClassExpression49,Object124,Lambda125,Lambda131,Object139,Lambda140,Lambda145 bucket1
+    class Bucket1,PgSelect17,PgPageInfo20,First22,PgSelectSingle23,PgCursor24,PgClassExpression26,List27,Last29,PgSelectSingle30,PgCursor31,PgClassExpression33,List34,Access37,Object38,Lambda39,Object43,Lambda44,PgSelect46,First47,PgSelectSingle48,PgClassExpression49 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ17ᐳ[52]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item52,PgSelectSingle53 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 53<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[53]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor54,PgClassExpression55,List56,PgClassExpression58,PgClassExpression59,PgClassExpression60,PgClassExpression61 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 68, 69, 174, 117, 120, 7, 133, 135, 150, 122, 123, 181, 164, 182<br /><br />ROOT Connectionᐸ66ᐳ[68]<br />1: <br />ᐳ: 72, 73, 153, 159, 167, 173, 154, 168<br />2: PgSelect[70], PgSelect[99]<br />ᐳ: 75, 76, 79, 80, 82, 83, 86, 87, 90, 91, 92, 96, 97, 100, 101, 102, 77, 84"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 68, 69, 178, 72, 117, 121, 157, 162, 7, 134, 137, 172, 177<br /><br />ROOT Connectionᐸ66ᐳ[68]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect70,Access72,PgPageInfo73,First75,PgSelectSingle76,PgCursor77,PgClassExpression79,List80,Last82,PgSelectSingle83,PgCursor84,PgClassExpression86,List87,Access90,Object91,Lambda92,Object96,Lambda97,PgSelect99,First100,PgSelectSingle101,PgClassExpression102,Object153,Lambda154,Lambda159,Object167,Lambda168,Lambda173 bucket4
+    class Bucket4,PgSelect70,PgPageInfo73,First75,PgSelectSingle76,PgCursor77,PgClassExpression79,List80,Last82,PgSelectSingle83,PgCursor84,PgClassExpression86,List87,Access90,Object91,Lambda92,Object96,Lambda97,PgSelect99,First100,PgSelectSingle101,PgClassExpression102 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ70ᐳ[105]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item105,PgSelectSingle106 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections-condition-computed-column.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections-condition-computed-column.mermaid
@@ -9,34 +9,36 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ'o1 Budd Deey'ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Object14{{"Object[14∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda23{{"Lambda[23∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda26{{"Lambda[26∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant37 & Connection15 & Lambda23 & Lambda26 & Lambda31 & Lambda36 --> PgSelect16
-    Object30{{"Object[30∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda23 & Constant27 & Constant28 & Constant29 --> Object30
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access13{{"Access[13∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object31{{"Object[31∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda23{{"Lambda[23∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda23 & Constant28 & Constant29 & Constant30 --> Object31
+    Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access12 & Access13 --> Object14
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant38 --> Lambda23
-    Constant39 --> Lambda26
-    Object30 --> Lambda31
-    Constant40 --> Lambda36
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda23
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant40 --> Lambda26
+    Access27{{"Access[27∈0] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Lambda26 --> Access27
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object31 --> Lambda32
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant41 --> Lambda37
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸ'o1 Budd Deey'ᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸpersonᐳ"]]:::plan
+    Object14 & Constant38 & Connection15 & Lambda23 & Access27 & Lambda32 & Lambda37 --> PgSelect16
     __Item17[/"__Item[17∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -51,10 +53,10 @@ graph TD
     subgraph "Buckets for queries/v4/connections-condition-computed-column"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection15,Constant27,Constant28,Constant29,Constant37,Constant38,Constant39,Constant40 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 37, 15, 38, 39, 27, 28, 29, 40<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 12, 13, 23, 26, 36, 14, 30, 31<br />2: PgSelect[16]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda23,Lambda26,Access27,Constant28,Constant29,Constant30,Object31,Lambda32,Lambda37,Constant38,Constant39,Constant40,Constant41 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 38, 15, 23, 27, 32, 37<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access12,Access13,Object14,PgSelect16,Lambda23,Lambda26,Object30,Lambda31,Lambda36 bucket1
+    class Bucket1,PgSelect16 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item17,PgSelectSingle18 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections-order-computed-column.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections-order-computed-column.mermaid
@@ -9,6 +9,16 @@ graph TD
 
 
     %% plan dependencies
+    Object39{{"Object[39∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 237ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda31 & Constant36 & Constant37 & Constant38 --> Object39
+    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 237ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda31 & Constant51 & Constant52 & Constant38 --> Object54
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,30 +26,28 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant59 --> Lambda31
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant61 --> Lambda31
     Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant60 --> Lambda34
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant62 --> Lambda34
+    Access35{{"Access[35∈0] ➊<br />ᐸ34.0ᐳ"}}:::plan
+    Lambda34 --> Access35
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object39 --> Lambda40
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
+    Constant63 --> Lambda45
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object54 --> Lambda55
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
+    Constant64 --> Lambda60
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection23{{"Connection[23∈0] ➊<br />ᐸ21ᐳ"}}:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 237ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[ { codec: Codec(text), fragment: { n: [Array], f: 0, c: 237ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(text), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda39{{"Lambda[39∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda31 & Lambda34 & Lambda39 & Lambda44 --> PgSelect14
-    Object38{{"Object[38∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda31 & Constant35 & Constant36 & Constant37 --> Object38
-    Object38 --> Lambda39
-    Constant61 --> Lambda44
+    Object12 & Connection13 & Lambda31 & Access35 & Lambda40 & Lambda45 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -49,13 +57,7 @@ graph TD
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression18
     PgSelect24[["PgSelect[24∈4] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda53{{"Lambda[53∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection23 & Lambda31 & Lambda34 & Lambda53 & Lambda58 --> PgSelect24
-    Object52{{"Object[52∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda31 & Constant49 & Constant50 & Constant37 --> Object52
-    Object52 --> Lambda53
-    Constant62 --> Lambda58
+    Object12 & Connection23 & Lambda31 & Access35 & Lambda55 & Lambda60 --> PgSelect24
     __Item25[/"__Item[25∈5]<br />ᐸ24ᐳ"\]:::itemplan
     PgSelect24 ==> __Item25
     PgSelectSingle26{{"PgSelectSingle[26∈5]<br />ᐸpersonᐳ"}}:::plan
@@ -70,19 +72,19 @@ graph TD
     subgraph "Buckets for queries/v4/connections-order-computed-column"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection23,Lambda31,Lambda34,Constant35,Constant36,Constant37,Constant49,Constant50,Constant59,Constant60,Constant61,Constant62 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 31, 34, 35, 36, 37, 61<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[38], Lambda[44], Lambda[39]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection23,Lambda31,Lambda34,Access35,Constant36,Constant37,Constant38,Object39,Lambda40,Lambda45,Constant51,Constant52,Object54,Lambda55,Lambda60,Constant61,Constant62,Constant63,Constant64 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 31, 35, 40, 45<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object38,Lambda39,Lambda44 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression18 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 23, 31, 34, 49, 50, 37, 62<br /><br />ROOT Connectionᐸ21ᐳ[23]<br />1: <br />ᐳ: Object[52], Lambda[58], Lambda[53]<br />2: PgSelect[24]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 23, 31, 35, 55, 60<br /><br />ROOT Connectionᐸ21ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect24,Object52,Lambda53,Lambda58 bucket4
+    class Bucket4,PgSelect24 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ24ᐳ[25]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item25,PgSelectSingle26 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections-totalCount.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections-totalCount.mermaid
@@ -9,6 +9,23 @@ graph TD
 
 
     %% plan dependencies
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object68{{"Object[68∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Lambda45 & Constant65 & Constant66 & Constant52 --> Object68
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda45 & Constant85 & Constant51 & Constant52 --> Object88
+    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
+    Lambda45 & Constant100 & Constant101 & Constant52 --> Object103
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,111 +33,96 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant106 --> Lambda45
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant110 --> Lambda45
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant107 --> Lambda48
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant111 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant112 --> Lambda59
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object68 --> Lambda69
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant113 --> Lambda74
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object88 --> Lambda89
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant114 --> Lambda94
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object103 --> Lambda104
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant115 --> Lambda109
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection22{{"Connection[22∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    Connection31{{"Connection[31∈0] ➊<br />ᐸ27ᐳ"}}:::plan
     Connection38{{"Connection[38∈0] ➊<br />ᐸ36ᐳ"}}:::plan
     Constant43{{"Constant[43∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant46{{"Constant[46∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda45 & Lambda48 & Lambda53 & Lambda58 --> PgSelect14
-    Object52{{"Object[52∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
+    Object12 & Connection13 & Lambda45 & Access49 & Lambda54 & Lambda59 --> PgSelect14
     First15{{"First[15∈1] ➊"}}:::plan
     PgSelect14 --> First15
     PgSelectSingle16{{"PgSelectSingle[16∈1] ➊<br />ᐸpersonᐳ"}}:::plan
     First15 --> PgSelectSingle16
     PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
-    Object52 --> Lambda53
-    Constant108 --> Lambda58
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda67{{"Lambda[67∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection22 & Lambda48 & Lambda67 & Lambda72 & Lambda45 & Lambda48 & Lambda86 & Lambda91 --> PgSelect23
-    Object66{{"Object[66∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant63 & Constant64 & Constant51 --> Object66
-    Object85{{"Object[85∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant82 & Constant50 & Constant51 --> Object85
-    Object66 --> Lambda67
-    Constant109 --> Lambda72
-    Object85 --> Lambda86
-    Constant110 --> Lambda91
-    Connection31{{"Connection[31∈2] ➊<br />ᐸ27ᐳ"}}:::plan
+    Object12 & Connection22 & Access49 & Lambda69 & Lambda74 & Lambda45 & Access49 & Lambda89 & Lambda94 --> PgSelect23
     __Item24[/"__Item[24∈3]<br />ᐸ23ᐳ"\]:::itemplan
     PgSelect23 ==> __Item24
     PgSelectSingle25{{"PgSelectSingle[25∈3]<br />ᐸpersonᐳ"}}:::plan
     __Item24 --> PgSelectSingle25
-    Object76{{"Object[76∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access74{{"Access[74∈4]<br />ᐸ24.0ᐳ"}}:::plan
-    Access74 & Constant43 & Constant43 & Lambda45 & Constant46 --> Object76
+    Object78{{"Object[78∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access76{{"Access[76∈4]<br />ᐸ24.0ᐳ"}}:::plan
+    Access76 & Constant43 & Constant43 & Lambda45 & Constant46 --> Object78
     First33{{"First[33∈4]"}}:::plan
-    Lambda77{{"Lambda[77∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda77 --> First33
+    Lambda79{{"Lambda[79∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda79 --> First33
     PgSelectSingle34{{"PgSelectSingle[34∈4]<br />ᐸperson_friendsᐳ"}}:::plan
     First33 --> PgSelectSingle34
     PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression35
-    __Item24 --> Access74
-    Object76 --> Lambda77
+    __Item24 --> Access76
+    Object78 --> Lambda79
     PgSelect39[["PgSelect[39∈5] ➊<br />ᐸtable_set_query(aggregate)ᐳ"]]:::plan
-    Lambda100{{"Lambda[100∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda105{{"Lambda[105∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection38 & Lambda45 & Lambda48 & Lambda100 & Lambda105 --> PgSelect39
-    Object99{{"Object[99∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant96 & Constant97 & Constant51 --> Object99
+    Object12 & Connection38 & Lambda45 & Access49 & Lambda104 & Lambda109 --> PgSelect39
     First40{{"First[40∈5] ➊"}}:::plan
     PgSelect39 --> First40
     PgSelectSingle41{{"PgSelectSingle[41∈5] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     First40 --> PgSelectSingle41
     PgClassExpression42{{"PgClassExpression[42∈5] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression42
-    Object99 --> Lambda100
-    Constant111 --> Lambda105
 
     %% define steps
 
     subgraph "Buckets for queries/v4/connections-totalCount"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection22,Connection38,Constant43,Lambda45,Constant46,Lambda48,Constant49,Constant50,Constant51,Constant63,Constant64,Constant82,Constant96,Constant97,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 45, 48, 49, 50, 51, 108<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[52], Lambda[58], Lambda[53]<br />2: PgSelect[14]<br />ᐳ: 15, 16, 17"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection22,Connection31,Connection38,Constant43,Lambda45,Constant46,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant65,Constant66,Object68,Lambda69,Lambda74,Constant85,Object88,Lambda89,Lambda94,Constant100,Constant101,Object103,Lambda104,Lambda109,Constant110,Constant111,Constant112,Constant113,Constant114,Constant115 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 45, 49, 54, 59<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,First15,PgSelectSingle16,PgClassExpression17,Object52,Lambda53,Lambda58 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 22, 48, 45, 63, 64, 51, 109, 82, 50, 110, 43, 46<br /><br />ROOT Connectionᐸ20ᐳ[22]<br />1: <br />ᐳ: 31, 66, 72, 85, 91, 67, 86<br />2: PgSelect[23]"):::bucket
+    class Bucket1,PgSelect14,First15,PgSelectSingle16,PgClassExpression17 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 12, 22, 49, 69, 74, 45, 89, 94, 43, 46, 31<br /><br />ROOT Connectionᐸ20ᐳ[22]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect23,Connection31,Object66,Lambda67,Lambda72,Object85,Lambda86,Lambda91 bucket2
+    class Bucket2,PgSelect23 bucket2
     Bucket3("Bucket 3 (listItem)<br />Deps: 43, 45, 46, 31<br /><br />ROOT __Item{3}ᐸ23ᐳ[24]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item24,PgSelectSingle25 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 24, 43, 45, 46, 25, 31<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,First33,PgSelectSingle34,PgClassExpression35,Access74,Object76,Lambda77 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 12, 38, 45, 48, 96, 97, 51, 111<br /><br />ROOT Connectionᐸ36ᐳ[38]<br />1: <br />ᐳ: Object[99], Lambda[105], Lambda[100]<br />2: PgSelect[39]<br />ᐳ: 40, 41, 42"):::bucket
+    class Bucket4,First33,PgSelectSingle34,PgClassExpression35,Access76,Object78,Lambda79 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 12, 38, 45, 49, 104, 109<br /><br />ROOT Connectionᐸ36ᐳ[38]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgSelect39,First40,PgSelectSingle41,PgClassExpression42,Object99,Lambda100,Lambda105 bucket5
+    class Bucket5,PgSelect39,First40,PgSelectSingle41,PgClassExpression42 bucket5
     Bucket0 --> Bucket1 & Bucket2 & Bucket5
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections.boolean.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections.boolean.mermaid
@@ -10,10 +10,26 @@ graph TD
 
     %% plan dependencies
     Connection67{{"Connection[67∈0] ➊<br />ᐸ65ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     Lambda68{{"Lambda[68∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor70["PgValidateParsedCursor[70∈0] ➊"]:::plan
-    Constant179 & Lambda68 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 --> Connection67
+    Constant183 & Lambda68 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 & PgValidateParsedCursor70 --> Connection67
+    Object130{{"Object[130∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ[ { attribute: 'extra', direction: 'ASC' }, { attribute: 'peᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda122 & Constant127 & Constant128 & Constant129 --> Object130
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda139 & Constant143 & Constant128 & Constant129 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[ { attribute: 'extra', direction: 'ASC' }, { attribute: 'peᐳ"}}:::plan
+    Lambda122 & Constant158 & Constant128 & Constant129 --> Object161
+    Object176{{"Object[176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda139 & Constant173 & Constant128 & Constant129 --> Object176
     Object15{{"Object[15∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -22,49 +38,59 @@ graph TD
     __Value2 --> Access13
     __Value2 --> Access14
     Connection16{{"Connection[16∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Constant179 --> Connection16
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ'WyIzNjY0MzE3ZDgwIixmYWxzZSwyLDFd'ᐳ"}}:::plan
-    Constant180 --> Lambda68
+    Constant183 --> Connection16
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ'WyIzNjY0MzE3ZDgwIixmYWxzZSwyLDFd'ᐳ"}}:::plan
+    Constant184 --> Lambda68
     Lambda68 --> PgValidateParsedCursor70
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant187 --> Lambda122
+    Access71{{"Access[71∈0] ➊<br />ᐸ68.1ᐳ"}}:::plan
+    Lambda68 --> Access71
+    Access72{{"Access[72∈0] ➊<br />ᐸ68.2ᐳ"}}:::plan
+    Lambda68 --> Access72
+    Access73{{"Access[73∈0] ➊<br />ᐸ68.3ᐳ"}}:::plan
+    Lambda68 --> Access73
+    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant191 --> Lambda122
     Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant188 --> Lambda125
-    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant181 --> Lambda138
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant182 --> Lambda140
+    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant192 --> Lambda125
+    Access126{{"Access[126∈0] ➊<br />ᐸ125.0ᐳ"}}:::plan
+    Lambda125 --> Access126
+    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object130 --> Lambda131
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'extra', directionᐳ"}}:::plan
+    Constant187 --> Lambda137
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant185 --> Lambda139
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant186 --> Lambda141
+    Access142{{"Access[142∈0] ➊<br />ᐸ141.0ᐳ"}}:::plan
+    Lambda141 --> Access142
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object146 --> Lambda147
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant188 --> Lambda152
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object161 --> Lambda162
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'extra', directionᐳ"}}:::plan
+    Constant189 --> Lambda167
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object176 --> Lambda177
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant190 --> Lambda182
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant7{{"Constant[7∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[ { attribute: 'extra', direction: 'ASC' }, { attribute: 'peᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ[ { attribute: 'extra', direction: 'ASC' }, { attribute: 'peᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'extra', directionᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'extra', directionᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸcompound_key+1ᐳ"]]:::plan
-    Lambda130{{"Lambda[130∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda136{{"Lambda[136∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Constant179 & Lambda122 & Lambda125 & Lambda130 & Lambda136 --> PgSelect17
+    Object15 & Connection16 & Constant183 & Lambda122 & Access126 & Lambda131 & Lambda137 --> PgSelect17
     PgSelect44[["PgSelect[44∈1] ➊<br />ᐸcompound_key(aggregate)ᐳ"]]:::plan
-    Lambda145{{"Lambda[145∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda150{{"Lambda[150∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection16 & Lambda138 & Lambda140 & Lambda145 & Lambda150 --> PgSelect44
+    Object15 & Connection16 & Lambda139 & Access142 & Lambda147 & Lambda152 --> PgSelect44
     Object42{{"Object[42∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access37{{"Access[37∈1] ➊<br />ᐸ17.hasMoreᐳ"}}:::plan
-    Constant179 & Constant7 & Constant7 & Access37 --> Object42
-    Object129{{"Object[129∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda122 & Constant126 & Constant127 & Constant128 --> Object129
-    Object144{{"Object[144∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda138 & Constant141 & Constant127 & Constant128 --> Object144
+    Constant183 & Constant7 & Constant7 & Access37 --> Object42
     List26{{"List[26∈1] ➊<br />ᐸ23,24,25ᐳ"}}:::plan
     PgClassExpression23{{"PgClassExpression[23∈1] ➊<br />ᐸ__compound...__.”extra”ᐳ"}}:::plan
     PgClassExpression24{{"PgClassExpression[24∈1] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
@@ -76,7 +102,7 @@ graph TD
     PgClassExpression33{{"PgClassExpression[33∈1] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgClassExpression31 & PgClassExpression32 & PgClassExpression33 --> List34
     Object38{{"Object[38∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant179 & Constant7 & Access37 --> Object38
+    Constant183 & Constant7 & Access37 --> Object38
     PgPageInfo18{{"PgPageInfo[18∈1] ➊"}}:::plan
     Connection16 --> PgPageInfo18
     First20{{"First[20∈1] ➊"}}:::plan
@@ -108,10 +134,6 @@ graph TD
     First45 --> PgSelectSingle46
     PgClassExpression47{{"PgClassExpression[47∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle46 --> PgClassExpression47
-    Object129 --> Lambda130
-    Constant183 --> Lambda136
-    Object144 --> Lambda145
-    Constant184 --> Lambda150
     __Item49[/"__Item[49∈2]<br />ᐸ17ᐳ"\]:::itemplan
     PgSelect17 ==> __Item49
     PgSelectSingle50{{"PgSelectSingle[50∈2]<br />ᐸcompound_keyᐳ"}}:::plan
@@ -127,23 +149,12 @@ graph TD
     PgSelectSingle50 --> PgClassExpression53
     PgSelectSingle50 --> PgClassExpression54
     PgSelect69[["PgSelect[69∈4] ➊<br />ᐸcompound_key+1ᐳ"]]:::plan
-    Access71{{"Access[71∈4] ➊<br />ᐸ68.1ᐳ"}}:::plan
-    Access72{{"Access[72∈4] ➊<br />ᐸ68.2ᐳ"}}:::plan
-    Access73{{"Access[73∈4] ➊<br />ᐸ68.3ᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda164{{"Lambda[164∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection67 & Lambda68 & Constant179 & Access71 & Access72 & Access73 & Lambda122 & Lambda125 & Lambda159 & Lambda164 --> PgSelect69
+    Object15 & Connection67 & Lambda68 & Constant183 & Access71 & Access72 & Access73 & Lambda122 & Access126 & Lambda162 & Lambda167 --> PgSelect69
     PgSelect104[["PgSelect[104∈4] ➊<br />ᐸcompound_key(aggregate)ᐳ"]]:::plan
-    Lambda173{{"Lambda[173∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda178{{"Lambda[178∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object15 & Connection67 & Lambda138 & Lambda140 & Lambda173 & Lambda178 --> PgSelect104
+    Object15 & Connection67 & Lambda139 & Access142 & Lambda177 & Lambda182 --> PgSelect104
     Object101{{"Object[101∈4] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access95{{"Access[95∈4] ➊<br />ᐸ69.hasMoreᐳ"}}:::plan
-    Constant179 & Constant7 & Constant7 & Access95 --> Object101
-    Object158{{"Object[158∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda122 & Constant155 & Constant127 & Constant128 --> Object158
-    Object172{{"Object[172∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda138 & Constant169 & Constant127 & Constant128 --> Object172
+    Constant183 & Constant7 & Constant7 & Access95 --> Object101
     List83{{"List[83∈4] ➊<br />ᐸ80,81,82ᐳ"}}:::plan
     PgClassExpression80{{"PgClassExpression[80∈4] ➊<br />ᐸ__compound...__.”extra”ᐳ"}}:::plan
     PgClassExpression81{{"PgClassExpression[81∈4] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
@@ -155,10 +166,7 @@ graph TD
     PgClassExpression91{{"PgClassExpression[91∈4] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgClassExpression89 & PgClassExpression90 & PgClassExpression91 --> List92
     Object96{{"Object[96∈4] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant179 & Constant7 & Access95 --> Object96
-    Lambda68 --> Access71
-    Lambda68 --> Access72
-    Lambda68 --> Access73
+    Constant183 & Constant7 & Access95 --> Object96
     PgPageInfo74{{"PgPageInfo[74∈4] ➊"}}:::plan
     Connection67 --> PgPageInfo74
     First76{{"First[76∈4] ➊"}}:::plan
@@ -190,10 +198,6 @@ graph TD
     First105 --> PgSelectSingle106
     PgClassExpression107{{"PgClassExpression[107∈4] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle106 --> PgClassExpression107
-    Object158 --> Lambda159
-    Constant185 --> Lambda164
-    Object172 --> Lambda173
-    Constant186 --> Lambda178
     __Item110[/"__Item[110∈5]<br />ᐸ69ᐳ"\]:::itemplan
     PgSelect69 ==> __Item110
     PgSelectSingle111{{"PgSelectSingle[111∈5]<br />ᐸcompound_keyᐳ"}}:::plan
@@ -212,21 +216,21 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/connections.boolean"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 13, 14, 126, 127, 128, 141, 155, 169, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 15, 16, 68, 122, 125, 138, 140<br />2: PgValidateParsedCursor[70]<br />ᐳ: Connection[67]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 7, 13, 14, 127, 128, 129, 143, 158, 173, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 15, 16, 68, 71, 72, 73, 122, 125, 126, 130, 131, 137, 139, 141, 142, 146, 147, 152, 161, 162, 167, 176, 177, 182<br />2: PgValidateParsedCursor[70]<br />ᐳ: Connection[67]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant7,Access13,Access14,Object15,Connection16,Connection67,Lambda68,PgValidateParsedCursor70,Lambda122,Lambda125,Constant126,Constant127,Constant128,Lambda138,Lambda140,Constant141,Constant155,Constant169,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 179, 122, 125, 7, 138, 140, 126, 127, 128, 183, 141, 184<br /><br />ROOT Connectionᐸ12ᐳ[16]<br />1: <br />ᐳ: 18, 129, 136, 144, 150, 130, 145<br />2: PgSelect[17], PgSelect[44]<br />ᐳ: 20, 21, 23, 24, 25, 26, 28, 29, 31, 32, 33, 34, 37, 38, 39, 42, 43, 45, 46, 47, 22, 30"):::bucket
+    class Bucket0,__Value2,__Value4,Constant7,Access13,Access14,Object15,Connection16,Connection67,Lambda68,PgValidateParsedCursor70,Access71,Access72,Access73,Lambda122,Lambda125,Access126,Constant127,Constant128,Constant129,Object130,Lambda131,Lambda137,Lambda139,Lambda141,Access142,Constant143,Object146,Lambda147,Lambda152,Constant158,Object161,Lambda162,Lambda167,Constant173,Object176,Lambda177,Lambda182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 15, 16, 183, 122, 126, 131, 137, 7, 139, 142, 147, 152<br /><br />ROOT Connectionᐸ12ᐳ[16]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect17,PgPageInfo18,First20,PgSelectSingle21,PgCursor22,PgClassExpression23,PgClassExpression24,PgClassExpression25,List26,Last28,PgSelectSingle29,PgCursor30,PgClassExpression31,PgClassExpression32,PgClassExpression33,List34,Access37,Object38,Lambda39,Object42,Lambda43,PgSelect44,First45,PgSelectSingle46,PgClassExpression47,Object129,Lambda130,Lambda136,Object144,Lambda145,Lambda150 bucket1
+    class Bucket1,PgSelect17,PgPageInfo18,First20,PgSelectSingle21,PgCursor22,PgClassExpression23,PgClassExpression24,PgClassExpression25,List26,Last28,PgSelectSingle29,PgCursor30,PgClassExpression31,PgClassExpression32,PgClassExpression33,List34,Access37,Object38,Lambda39,Object42,Lambda43,PgSelect44,First45,PgSelectSingle46,PgClassExpression47 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ17ᐳ[49]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item49,PgSelectSingle50 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 50<br /><br />ROOT PgSelectSingle{2}ᐸcompound_keyᐳ[50]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor51,PgClassExpression52,PgClassExpression53,PgClassExpression54,List55 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 15, 67, 68, 179, 122, 125, 7, 138, 140, 155, 127, 128, 185, 169, 186<br /><br />ROOT Connectionᐸ65ᐳ[67]<br />1: <br />ᐳ: 71, 72, 73, 74, 158, 164, 172, 178, 159, 173<br />2: PgSelect[69], PgSelect[104]<br />ᐳ: 76, 77, 80, 81, 82, 83, 85, 86, 89, 90, 91, 92, 95, 96, 97, 101, 102, 105, 106, 107, 78, 87"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 15, 67, 68, 183, 71, 72, 73, 122, 126, 162, 167, 7, 139, 142, 177, 182<br /><br />ROOT Connectionᐸ65ᐳ[67]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect69,Access71,Access72,Access73,PgPageInfo74,First76,PgSelectSingle77,PgCursor78,PgClassExpression80,PgClassExpression81,PgClassExpression82,List83,Last85,PgSelectSingle86,PgCursor87,PgClassExpression89,PgClassExpression90,PgClassExpression91,List92,Access95,Object96,Lambda97,Object101,Lambda102,PgSelect104,First105,PgSelectSingle106,PgClassExpression107,Object158,Lambda159,Lambda164,Object172,Lambda173,Lambda178 bucket4
+    class Bucket4,PgSelect69,PgPageInfo74,First76,PgSelectSingle77,PgCursor78,PgClassExpression80,PgClassExpression81,PgClassExpression82,List83,Last85,PgSelectSingle86,PgCursor87,PgClassExpression89,PgClassExpression90,PgClassExpression91,List92,Access95,Object96,Lambda97,Object101,Lambda102,PgSelect104,First105,PgSelectSingle106,PgClassExpression107 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ69ᐳ[110]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item110,PgSelectSingle111 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections.mermaid
@@ -11,90 +11,523 @@ graph TD
     %% plan dependencies
     Connection622{{"Connection[622∈0] ➊<br />ᐸ620ᐳ"}}:::plan
     Constant1057{{"Constant[1057∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant1706{{"Constant[1706∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant1752{{"Constant[1752∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda623{{"Lambda[623∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor625["PgValidateParsedCursor[625∈0] ➊"]:::plan
-    Constant1057 & Constant1706 & Lambda623 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 --> Connection622
+    Constant1057 & Constant1752 & Lambda623 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 & PgValidateParsedCursor625 --> Connection622
     Connection677{{"Connection[677∈0] ➊<br />ᐸ675ᐳ"}}:::plan
-    Constant1708{{"Constant[1708∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant1754{{"Constant[1754∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     Lambda248{{"Lambda[248∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor680["PgValidateParsedCursor[680∈0] ➊"]:::plan
-    Constant1708 & Lambda248 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 --> Connection677
+    Constant1754 & Lambda248 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 & PgValidateParsedCursor680 --> Connection677
     Connection732{{"Connection[732∈0] ➊<br />ᐸ730ᐳ"}}:::plan
     PgValidateParsedCursor735["PgValidateParsedCursor[735∈0] ➊"]:::plan
-    Constant1708 & Lambda248 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 --> Connection732
+    Constant1754 & Lambda248 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 & PgValidateParsedCursor735 --> Connection732
     Connection247{{"Connection[247∈0] ➊<br />ᐸ245ᐳ"}}:::plan
     PgValidateParsedCursor250["PgValidateParsedCursor[250∈0] ➊"]:::plan
     Lambda248 & PgValidateParsedCursor250 & PgValidateParsedCursor250 & PgValidateParsedCursor250 & PgValidateParsedCursor250 & PgValidateParsedCursor250 & PgValidateParsedCursor250 --> Connection247
     Connection301{{"Connection[301∈0] ➊<br />ᐸ299ᐳ"}}:::plan
     PgValidateParsedCursor304["PgValidateParsedCursor[304∈0] ➊"]:::plan
     Lambda248 & PgValidateParsedCursor304 & PgValidateParsedCursor304 & PgValidateParsedCursor304 & PgValidateParsedCursor304 & PgValidateParsedCursor304 & PgValidateParsedCursor304 --> Connection301
+    Object1067{{"Object[1067∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1059{{"Lambda[1059∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1064{{"Constant[1064∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1065{{"Constant[1065∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant1066{{"Constant[1066∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda1059 & Constant1064 & Constant1065 & Constant1066 --> Object1067
+    Object1083{{"Object[1083∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1080{{"Constant[1080∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1080 & Constant1065 & Constant1066 --> Object1083
+    Object1098{{"Object[1098∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1091{{"Lambda[1091∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1095{{"Constant[1095∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1091 & Constant1095 & Constant1065 & Constant1066 --> Object1098
+    Object1113{{"Object[1113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1110{{"Constant[1110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1110 & Constant1065 & Constant1066 --> Object1113
+    Object1128{{"Object[1128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1121{{"Lambda[1121∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1125{{"Constant[1125∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1121 & Constant1125 & Constant1065 & Constant1066 --> Object1128
+    Object1143{{"Object[1143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1140{{"Constant[1140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1140 & Constant1065 & Constant1066 --> Object1143
+    Object1158{{"Object[1158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1155{{"Constant[1155∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'ASC' }, { fraᐳ"}}:::plan
+    Constant1156{{"Constant[1156∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1155 & Constant1156 & Constant1066 --> Object1158
+    Object1173{{"Object[1173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1170{{"Constant[1170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1170 & Constant1156 & Constant1066 --> Object1173
+    Object1188{{"Object[1188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1185{{"Constant[1185∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'DESC' }, { frᐳ"}}:::plan
+    Constant1186{{"Constant[1186∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1185 & Constant1186 & Constant1066 --> Object1188
+    Object1203{{"Object[1203∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1200{{"Constant[1200∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1200 & Constant1186 & Constant1066 --> Object1203
+    Object1218{{"Object[1218∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1215{{"Constant[1215∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1059 & Constant1215 & Constant1065 & Constant1066 --> Object1218
+    Object1233{{"Object[1233∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1230{{"Constant[1230∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1230 & Constant1065 & Constant1066 --> Object1233
+    Object1248{{"Object[1248∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1245{{"Constant[1245∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1059 & Constant1245 & Constant1065 & Constant1066 --> Object1248
+    Object1263{{"Object[1263∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1260{{"Constant[1260∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1260 & Constant1065 & Constant1066 --> Object1263
+    Object1278{{"Object[1278∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1275{{"Constant[1275∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 181, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant1276{{"Constant[1276∈0] ➊<br />ᐸsql.identifier(”updatable_view”)ᐳ"}}:::plan
+    Constant1277{{"Constant[1277∈0] ➊<br />ᐸRecordCodec(updatableView)ᐳ"}}:::plan
+    Lambda1059 & Constant1275 & Constant1276 & Constant1277 --> Object1278
+    Object1293{{"Object[1293∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1290{{"Constant[1290∈0] ➊<br />ᐸ[ { attribute: 'constant', direction: 'ASC' }, { fragment: {ᐳ"}}:::plan
+    Constant1291{{"Constant[1291∈0] ➊<br />ᐸsql.identifier(”updatable_view”)ᐳ"}}:::plan
+    Lambda1059 & Constant1290 & Constant1291 & Constant1277 --> Object1293
+    Object1308{{"Object[1308∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1305{{"Constant[1305∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1306{{"Constant[1306∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant1307{{"Constant[1307∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda1059 & Constant1305 & Constant1306 & Constant1307 --> Object1308
+    Object1323{{"Object[1323∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1320{{"Constant[1320∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1320 & Constant1306 & Constant1307 --> Object1323
+    Object1338{{"Object[1338∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1335{{"Constant[1335∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1336{{"Constant[1336∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1091 & Constant1335 & Constant1336 & Constant1307 --> Object1338
+    Object1353{{"Object[1353∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1350{{"Constant[1350∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1350 & Constant1336 & Constant1307 --> Object1353
+    Object1368{{"Object[1368∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1361{{"Lambda[1361∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1365{{"Constant[1365∈0] ➊<br />ᐸ[ { attribute: 'headline', direction: 'ASC' }, { fragment: {ᐳ"}}:::plan
+    Constant1366{{"Constant[1366∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1361 & Constant1365 & Constant1366 & Constant1307 --> Object1368
+    Object1383{{"Object[1383∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1380{{"Constant[1380∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1380 & Constant1366 & Constant1307 --> Object1383
+    Object1398{{"Object[1398∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1391{{"Lambda[1391∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1395{{"Constant[1395∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1391 & Constant1395 & Constant1065 & Constant1066 --> Object1398
+    Object1413{{"Object[1413∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1410{{"Constant[1410∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1410 & Constant1065 & Constant1066 --> Object1413
+    Object1428{{"Object[1428∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1421{{"Lambda[1421∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1425{{"Constant[1425∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1421 & Constant1425 & Constant1065 & Constant1066 --> Object1428
+    Object1443{{"Object[1443∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1440{{"Constant[1440∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1440 & Constant1065 & Constant1066 --> Object1443
+    Object1458{{"Object[1458∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1455{{"Constant[1455∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1456{{"Constant[1456∈0] ➊<br />ᐸsql.identifier(”edge_case”)ᐳ"}}:::plan
+    Constant1457{{"Constant[1457∈0] ➊<br />ᐸRecordCodec(edgeCase)ᐳ"}}:::plan
+    Lambda1059 & Constant1455 & Constant1456 & Constant1457 --> Object1458
+    Object1473{{"Object[1473∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1470{{"Constant[1470∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1121 & Constant1470 & Constant1065 & Constant1066 --> Object1473
+    Object1488{{"Object[1488∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1485{{"Constant[1485∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1485 & Constant1065 & Constant1066 --> Object1488
+    Object1503{{"Object[1503∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1496{{"Lambda[1496∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1500{{"Constant[1500∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1496 & Constant1500 & Constant1065 & Constant1066 --> Object1503
+    Object1518{{"Object[1518∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1515{{"Constant[1515∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1515 & Constant1065 & Constant1066 --> Object1518
+    Object1533{{"Object[1533∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1530{{"Constant[1530∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda1361 & Constant1530 & Constant1065 & Constant1066 --> Object1533
+    Object1548{{"Object[1548∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1545{{"Constant[1545∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1545 & Constant1065 & Constant1066 --> Object1548
+    Object1563{{"Object[1563∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1560{{"Constant[1560∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1561{{"Constant[1561∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1560 & Constant1561 & Constant1066 --> Object1563
+    Object1578{{"Object[1578∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1575{{"Constant[1575∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1575 & Constant1561 & Constant1066 --> Object1578
+    Object1593{{"Object[1593∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1590{{"Constant[1590∈0] ➊<br />ᐸ[ { attribute: 'author_id', direction: 'DESC' }, { attributeᐳ"}}:::plan
+    Constant1591{{"Constant[1591∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1391 & Constant1590 & Constant1591 & Constant1307 --> Object1593
+    Object1608{{"Object[1608∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1605{{"Constant[1605∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1605 & Constant1591 & Constant1307 --> Object1608
+    Object1623{{"Object[1623∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1620{{"Constant[1620∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1621{{"Constant[1621∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1620 & Constant1621 & Constant1066 --> Object1623
+    Object1638{{"Object[1638∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1635{{"Constant[1635∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1635 & Constant1621 & Constant1066 --> Object1638
+    Object1653{{"Object[1653∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1650{{"Constant[1650∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1651{{"Constant[1651∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1650 & Constant1651 & Constant1066 --> Object1653
+    Object1670{{"Object[1670∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1667{{"Constant[1667∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1668{{"Constant[1668∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1091 & Constant1667 & Constant1668 & Constant1307 --> Object1670
+    Object1685{{"Object[1685∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1682{{"Constant[1682∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1683{{"Constant[1683∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1682 & Constant1683 & Constant1066 --> Object1685
+    Object1700{{"Object[1700∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1697{{"Constant[1697∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1697 & Constant1683 & Constant1066 --> Object1700
+    Object1715{{"Object[1715∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1712{{"Constant[1712∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1713{{"Constant[1713∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1059 & Constant1712 & Constant1713 & Constant1066 --> Object1715
+    Object1730{{"Object[1730∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1727{{"Constant[1727∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1059 & Constant1727 & Constant1713 & Constant1066 --> Object1730
+    Object1745{{"Object[1745∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1742{{"Constant[1742∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1743{{"Constant[1743∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Constant1744{{"Constant[1744∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
+    Lambda1059 & Constant1742 & Constant1743 & Constant1744 --> Object1745
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
     Connection516{{"Connection[516∈0] ➊<br />ᐸ514ᐳ"}}:::plan
-    Constant1709{{"Constant[1709∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant1709 & Constant1708 --> Connection516
+    Constant1755{{"Constant[1755∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant1755 & Constant1754 --> Connection516
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
     Connection59{{"Connection[59∈0] ➊<br />ᐸ57ᐳ"}}:::plan
-    Constant1706 --> Connection59
+    Constant1752 --> Connection59
     Connection105{{"Connection[105∈0] ➊<br />ᐸ103ᐳ"}}:::plan
-    Constant1706 --> Connection105
-    Constant1707{{"Constant[1707∈0] ➊<br />ᐸ'WyIwOGUwZDM0MmRlIiwyXQ=='ᐳ"}}:::plan
-    Constant1707 --> Lambda248
+    Constant1752 --> Connection105
+    Constant1753{{"Constant[1753∈0] ➊<br />ᐸ'WyIwOGUwZDM0MmRlIiwyXQ=='ᐳ"}}:::plan
+    Constant1753 --> Lambda248
     Lambda248 --> PgValidateParsedCursor250
     Access251{{"Access[251∈0] ➊<br />ᐸ248.1ᐳ"}}:::plan
     Lambda248 --> Access251
     Lambda248 --> PgValidateParsedCursor304
     Connection428{{"Connection[428∈0] ➊<br />ᐸ426ᐳ"}}:::plan
-    Constant1706 --> Connection428
+    Constant1752 --> Connection428
     Connection471{{"Connection[471∈0] ➊<br />ᐸ469ᐳ"}}:::plan
-    Constant1708 --> Connection471
+    Constant1754 --> Connection471
     Connection562{{"Connection[562∈0] ➊<br />ᐸ560ᐳ"}}:::plan
-    Constant1710{{"Constant[1710∈0] ➊<br />ᐸ0ᐳ"}}:::plan
-    Constant1710 --> Connection562
-    Constant1711{{"Constant[1711∈0] ➊<br />ᐸ'WyIwOGUwZDM0MmRlIiw2XQ=='ᐳ"}}:::plan
-    Constant1711 --> Lambda623
+    Constant1756{{"Constant[1756∈0] ➊<br />ᐸ0ᐳ"}}:::plan
+    Constant1756 --> Connection562
+    Constant1757{{"Constant[1757∈0] ➊<br />ᐸ'WyIwOGUwZDM0MmRlIiw2XQ=='ᐳ"}}:::plan
+    Constant1757 --> Lambda623
     Lambda623 --> PgValidateParsedCursor625
+    Access626{{"Access[626∈0] ➊<br />ᐸ623.1ᐳ"}}:::plan
+    Lambda623 --> Access626
     Lambda248 --> PgValidateParsedCursor680
     Lambda248 --> PgValidateParsedCursor735
     Connection834{{"Connection[834∈0] ➊<br />ᐸ832ᐳ"}}:::plan
-    Constant1709 --> Connection834
+    Constant1755 --> Connection834
     Connection928{{"Connection[928∈0] ➊<br />ᐸ926ᐳ"}}:::plan
-    Constant1706 --> Connection928
-    Lambda1059{{"Lambda[1059∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1715{{"Constant[1715∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1715 --> Lambda1059
+    Constant1752 --> Connection928
+    Constant1761{{"Constant[1761∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1761 --> Lambda1059
     Lambda1062{{"Lambda[1062∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1716{{"Constant[1716∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1716 --> Lambda1062
-    Lambda1077{{"Lambda[1077∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1717{{"Constant[1717∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1717 --> Lambda1077
-    Lambda1089{{"Lambda[1089∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1764{{"Constant[1764∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1764 --> Lambda1089
-    Lambda1091{{"Lambda[1091∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1765{{"Constant[1765∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1765 --> Lambda1091
-    Lambda1117{{"Lambda[1117∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1766{{"Constant[1766∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1766 --> Lambda1117
-    Lambda1119{{"Lambda[1119∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1767{{"Constant[1767∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1762{{"Constant[1762∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1762 --> Lambda1062
+    Access1063{{"Access[1063∈0] ➊<br />ᐸ1062.0ᐳ"}}:::plan
+    Lambda1062 --> Access1063
+    Lambda1068{{"Lambda[1068∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1067 --> Lambda1068
+    Lambda1074{{"Lambda[1074∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1764{{"Constant[1764∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1764 --> Lambda1074
+    Lambda1078{{"Lambda[1078∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1763{{"Constant[1763∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1763 --> Lambda1078
+    Access1079{{"Access[1079∈0] ➊<br />ᐸ1078.0ᐳ"}}:::plan
+    Lambda1078 --> Access1079
+    Lambda1084{{"Lambda[1084∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1083 --> Lambda1084
+    Lambda1089{{"Lambda[1089∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1765{{"Constant[1765∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1765 --> Lambda1089
+    Constant1810{{"Constant[1810∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1810 --> Lambda1091
+    Lambda1093{{"Lambda[1093∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1811{{"Constant[1811∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1811 --> Lambda1093
+    Access1094{{"Access[1094∈0] ➊<br />ᐸ1093.0ᐳ"}}:::plan
+    Lambda1093 --> Access1094
+    Lambda1099{{"Lambda[1099∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1098 --> Lambda1099
+    Lambda1104{{"Lambda[1104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1766{{"Constant[1766∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1766 --> Lambda1104
+    Lambda1114{{"Lambda[1114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1113 --> Lambda1114
+    Lambda1119{{"Lambda[1119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1767{{"Constant[1767∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
     Constant1767 --> Lambda1119
-    Lambda1341{{"Lambda[1341∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1768{{"Constant[1768∈0] ➊<br />ᐸ§{ first: null, last: 1, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1768 --> Lambda1341
-    Lambda1343{{"Lambda[1343∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1769{{"Constant[1769∈0] ➊<br />ᐸ§{ first: null, last: 1, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1769 --> Lambda1343
-    Lambda1369{{"Lambda[1369∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1770{{"Constant[1770∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1770 --> Lambda1369
+    Constant1812{{"Constant[1812∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1812 --> Lambda1121
+    Lambda1123{{"Lambda[1123∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1813{{"Constant[1813∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1813 --> Lambda1123
+    Access1124{{"Access[1124∈0] ➊<br />ᐸ1123.0ᐳ"}}:::plan
+    Lambda1123 --> Access1124
+    Lambda1129{{"Lambda[1129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1128 --> Lambda1129
+    Lambda1134{{"Lambda[1134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1768{{"Constant[1768∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1768 --> Lambda1134
+    Lambda1144{{"Lambda[1144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1143 --> Lambda1144
+    Lambda1149{{"Lambda[1149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1769{{"Constant[1769∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1769 --> Lambda1149
+    Lambda1159{{"Lambda[1159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1158 --> Lambda1159
+    Lambda1164{{"Lambda[1164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1784{{"Constant[1784∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
+    Constant1784 --> Lambda1164
+    Lambda1174{{"Lambda[1174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1173 --> Lambda1174
+    Lambda1179{{"Lambda[1179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1785{{"Constant[1785∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1785 --> Lambda1179
+    Lambda1189{{"Lambda[1189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1188 --> Lambda1189
+    Lambda1194{{"Lambda[1194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1786{{"Constant[1786∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
+    Constant1786 --> Lambda1194
+    Lambda1204{{"Lambda[1204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1203 --> Lambda1204
+    Lambda1209{{"Lambda[1209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1787{{"Constant[1787∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1787 --> Lambda1209
+    Lambda1219{{"Lambda[1219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1218 --> Lambda1219
+    Lambda1224{{"Lambda[1224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1770{{"Constant[1770∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1770 --> Lambda1224
+    Lambda1234{{"Lambda[1234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1233 --> Lambda1234
+    Lambda1239{{"Lambda[1239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1771{{"Constant[1771∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1771 --> Lambda1239
+    Lambda1249{{"Lambda[1249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1248 --> Lambda1249
+    Lambda1254{{"Lambda[1254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1772{{"Constant[1772∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1772 --> Lambda1254
+    Lambda1264{{"Lambda[1264∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1263 --> Lambda1264
+    Lambda1269{{"Lambda[1269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1773{{"Constant[1773∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1773 --> Lambda1269
+    Lambda1279{{"Lambda[1279∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1278 --> Lambda1279
+    Lambda1284{{"Lambda[1284∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1797{{"Constant[1797∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1797 --> Lambda1284
+    Lambda1294{{"Lambda[1294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1293 --> Lambda1294
+    Lambda1299{{"Lambda[1299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1798{{"Constant[1798∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'constant', directᐳ"}}:::plan
+    Constant1798 --> Lambda1299
+    Lambda1309{{"Lambda[1309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1308 --> Lambda1309
+    Lambda1314{{"Lambda[1314∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1799{{"Constant[1799∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1799 --> Lambda1314
+    Lambda1324{{"Lambda[1324∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1323 --> Lambda1324
+    Lambda1329{{"Lambda[1329∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1800{{"Constant[1800∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant1800 --> Lambda1329
+    Lambda1339{{"Lambda[1339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1338 --> Lambda1339
+    Lambda1344{{"Lambda[1344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1801{{"Constant[1801∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1801 --> Lambda1344
+    Lambda1354{{"Lambda[1354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1353 --> Lambda1354
+    Lambda1359{{"Lambda[1359∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1802{{"Constant[1802∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant1802 --> Lambda1359
+    Constant1814{{"Constant[1814∈0] ➊<br />ᐸ§{ first: null, last: 1, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1814 --> Lambda1361
+    Lambda1363{{"Lambda[1363∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1815{{"Constant[1815∈0] ➊<br />ᐸ§{ first: null, last: 1, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1815 --> Lambda1363
+    Access1364{{"Access[1364∈0] ➊<br />ᐸ1363.0ᐳ"}}:::plan
+    Lambda1363 --> Access1364
+    Lambda1369{{"Lambda[1369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1368 --> Lambda1369
+    Lambda1374{{"Lambda[1374∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1803{{"Constant[1803∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'headline', directᐳ"}}:::plan
+    Constant1803 --> Lambda1374
+    Lambda1384{{"Lambda[1384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1383 --> Lambda1384
+    Lambda1389{{"Lambda[1389∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1804{{"Constant[1804∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant1804 --> Lambda1389
+    Constant1816{{"Constant[1816∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1816 --> Lambda1391
+    Lambda1393{{"Lambda[1393∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1817{{"Constant[1817∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1817 --> Lambda1393
+    Access1394{{"Access[1394∈0] ➊<br />ᐸ1393.0ᐳ"}}:::plan
+    Lambda1393 --> Access1394
+    Lambda1399{{"Lambda[1399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1398 --> Lambda1399
+    Lambda1404{{"Lambda[1404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1774{{"Constant[1774∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1774 --> Lambda1404
+    Lambda1414{{"Lambda[1414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1413 --> Lambda1414
+    Lambda1419{{"Lambda[1419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1775{{"Constant[1775∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1775 --> Lambda1419
+    Constant1818{{"Constant[1818∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1818 --> Lambda1421
+    Lambda1423{{"Lambda[1423∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1819{{"Constant[1819∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1819 --> Lambda1423
+    Access1424{{"Access[1424∈0] ➊<br />ᐸ1423.0ᐳ"}}:::plan
+    Lambda1423 --> Access1424
+    Lambda1429{{"Lambda[1429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1428 --> Lambda1429
+    Lambda1434{{"Lambda[1434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1776{{"Constant[1776∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1776 --> Lambda1434
+    Lambda1444{{"Lambda[1444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1443 --> Lambda1444
+    Lambda1449{{"Lambda[1449∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1777{{"Constant[1777∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1777 --> Lambda1449
+    Lambda1459{{"Lambda[1459∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1458 --> Lambda1459
+    Lambda1464{{"Lambda[1464∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1805{{"Constant[1805∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”edge_cᐳ"}}:::plan
+    Constant1805 --> Lambda1464
+    Lambda1474{{"Lambda[1474∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1473 --> Lambda1474
+    Lambda1479{{"Lambda[1479∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1778{{"Constant[1778∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1778 --> Lambda1479
+    Lambda1489{{"Lambda[1489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1488 --> Lambda1489
+    Lambda1494{{"Lambda[1494∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1779{{"Constant[1779∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1779 --> Lambda1494
+    Constant1820{{"Constant[1820∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1820 --> Lambda1496
+    Lambda1498{{"Lambda[1498∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1821{{"Constant[1821∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1821 --> Lambda1498
+    Access1499{{"Access[1499∈0] ➊<br />ᐸ1498.0ᐳ"}}:::plan
+    Lambda1498 --> Access1499
+    Lambda1504{{"Lambda[1504∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1503 --> Lambda1504
+    Lambda1509{{"Lambda[1509∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1780{{"Constant[1780∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1780 --> Lambda1509
+    Lambda1519{{"Lambda[1519∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1518 --> Lambda1519
+    Lambda1524{{"Lambda[1524∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1781{{"Constant[1781∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1781 --> Lambda1524
+    Lambda1534{{"Lambda[1534∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1533 --> Lambda1534
+    Lambda1539{{"Lambda[1539∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1782{{"Constant[1782∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1782 --> Lambda1539
+    Lambda1549{{"Lambda[1549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1548 --> Lambda1549
+    Lambda1554{{"Lambda[1554∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1783{{"Constant[1783∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1783 --> Lambda1554
+    Lambda1564{{"Lambda[1564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1563 --> Lambda1564
+    Lambda1569{{"Lambda[1569∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1788{{"Constant[1788∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1788 --> Lambda1569
+    Lambda1579{{"Lambda[1579∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1578 --> Lambda1579
+    Lambda1584{{"Lambda[1584∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1789{{"Constant[1789∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1789 --> Lambda1584
+    Lambda1588{{"Lambda[1588∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1822{{"Constant[1822∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1822 --> Lambda1588
+    Access1589{{"Access[1589∈0] ➊<br />ᐸ1588.0ᐳ"}}:::plan
+    Lambda1588 --> Access1589
+    Lambda1594{{"Lambda[1594∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1593 --> Lambda1594
+    Lambda1599{{"Lambda[1599∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1806{{"Constant[1806∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'author_id', direcᐳ"}}:::plan
+    Constant1806 --> Lambda1599
+    Lambda1609{{"Lambda[1609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1608 --> Lambda1609
+    Lambda1614{{"Lambda[1614∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1807{{"Constant[1807∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant1807 --> Lambda1614
+    Lambda1624{{"Lambda[1624∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1623 --> Lambda1624
+    Lambda1629{{"Lambda[1629∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1790{{"Constant[1790∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1790 --> Lambda1629
+    Lambda1639{{"Lambda[1639∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1638 --> Lambda1639
+    Lambda1644{{"Lambda[1644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1791{{"Constant[1791∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1791 --> Lambda1644
+    Lambda1654{{"Lambda[1654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1653 --> Lambda1654
+    Lambda1659{{"Lambda[1659∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1792{{"Constant[1792∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1792 --> Lambda1659
+    Lambda1665{{"Lambda[1665∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1823{{"Constant[1823∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1823 --> Lambda1665
+    Access1666{{"Access[1666∈0] ➊<br />ᐸ1665.0ᐳ"}}:::plan
+    Lambda1665 --> Access1666
+    Lambda1671{{"Lambda[1671∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1670 --> Lambda1671
+    Lambda1676{{"Lambda[1676∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1808{{"Constant[1808∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1808 --> Lambda1676
+    Lambda1686{{"Lambda[1686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1685 --> Lambda1686
+    Lambda1691{{"Lambda[1691∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1793{{"Constant[1793∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1793 --> Lambda1691
+    Lambda1701{{"Lambda[1701∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1700 --> Lambda1701
+    Lambda1706{{"Lambda[1706∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1794{{"Constant[1794∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1794 --> Lambda1706
+    Lambda1716{{"Lambda[1716∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1715 --> Lambda1716
+    Lambda1721{{"Lambda[1721∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1795{{"Constant[1795∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1795 --> Lambda1721
+    Lambda1731{{"Lambda[1731∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1730 --> Lambda1731
+    Lambda1736{{"Lambda[1736∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1796{{"Constant[1796∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1796 --> Lambda1736
+    Lambda1746{{"Lambda[1746∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1745 --> Lambda1746
+    Lambda1751{{"Lambda[1751∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1809{{"Constant[1809∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1809 --> Lambda1751
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
@@ -110,145 +543,16 @@ graph TD
     Connection959{{"Connection[959∈0] ➊<br />ᐸ957ᐳ"}}:::plan
     Connection1006{{"Connection[1006∈0] ➊<br />ᐸ1004ᐳ"}}:::plan
     Connection1051{{"Connection[1051∈0] ➊<br />ᐸ1049ᐳ"}}:::plan
-    Constant1063{{"Constant[1063∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1064{{"Constant[1064∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1065{{"Constant[1065∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant1078{{"Constant[1078∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1092{{"Constant[1092∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1106{{"Constant[1106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1120{{"Constant[1120∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1134{{"Constant[1134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1148{{"Constant[1148∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'ASC' }, { fraᐳ"}}:::plan
-    Constant1149{{"Constant[1149∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1162{{"Constant[1162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1176{{"Constant[1176∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'DESC' }, { frᐳ"}}:::plan
-    Constant1177{{"Constant[1177∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1190{{"Constant[1190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1204{{"Constant[1204∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1218{{"Constant[1218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1232{{"Constant[1232∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1246{{"Constant[1246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1260{{"Constant[1260∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 181, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant1261{{"Constant[1261∈0] ➊<br />ᐸsql.identifier(”updatable_view”)ᐳ"}}:::plan
-    Constant1262{{"Constant[1262∈0] ➊<br />ᐸRecordCodec(updatableView)ᐳ"}}:::plan
-    Constant1274{{"Constant[1274∈0] ➊<br />ᐸ[ { attribute: 'constant', direction: 'ASC' }, { fragment: {ᐳ"}}:::plan
-    Constant1275{{"Constant[1275∈0] ➊<br />ᐸsql.identifier(”updatable_view”)ᐳ"}}:::plan
-    Constant1288{{"Constant[1288∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1289{{"Constant[1289∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1290{{"Constant[1290∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant1302{{"Constant[1302∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1316{{"Constant[1316∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1317{{"Constant[1317∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1330{{"Constant[1330∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1344{{"Constant[1344∈0] ➊<br />ᐸ[ { attribute: 'headline', direction: 'ASC' }, { fragment: {ᐳ"}}:::plan
-    Constant1345{{"Constant[1345∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1358{{"Constant[1358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1372{{"Constant[1372∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1386{{"Constant[1386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1400{{"Constant[1400∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1414{{"Constant[1414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1428{{"Constant[1428∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1429{{"Constant[1429∈0] ➊<br />ᐸsql.identifier(”edge_case”)ᐳ"}}:::plan
-    Constant1430{{"Constant[1430∈0] ➊<br />ᐸRecordCodec(edgeCase)ᐳ"}}:::plan
-    Constant1442{{"Constant[1442∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1456{{"Constant[1456∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1470{{"Constant[1470∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1484{{"Constant[1484∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1498{{"Constant[1498∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1512{{"Constant[1512∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1526{{"Constant[1526∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1527{{"Constant[1527∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1540{{"Constant[1540∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1554{{"Constant[1554∈0] ➊<br />ᐸ[ { attribute: 'author_id', direction: 'DESC' }, { attributeᐳ"}}:::plan
-    Constant1555{{"Constant[1555∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1568{{"Constant[1568∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1582{{"Constant[1582∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1583{{"Constant[1583∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1596{{"Constant[1596∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1610{{"Constant[1610∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1611{{"Constant[1611∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1626{{"Constant[1626∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1627{{"Constant[1627∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1640{{"Constant[1640∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1641{{"Constant[1641∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1654{{"Constant[1654∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1668{{"Constant[1668∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1669{{"Constant[1669∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1682{{"Constant[1682∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1696{{"Constant[1696∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1697{{"Constant[1697∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Constant1698{{"Constant[1698∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
-    Constant1712{{"Constant[1712∈0] ➊<br />ᐸ'192.168.0.1'ᐳ"}}:::plan
-    Constant1713{{"Constant[1713∈0] ➊<br />ᐸ'192.168.0.0/24'ᐳ"}}:::plan
-    Constant1714{{"Constant[1714∈0] ➊<br />ᐸ'0000.0000.0000'ᐳ"}}:::plan
-    Constant1718{{"Constant[1718∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1719{{"Constant[1719∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1720{{"Constant[1720∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1721{{"Constant[1721∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1722{{"Constant[1722∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1723{{"Constant[1723∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1724{{"Constant[1724∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1725{{"Constant[1725∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1726{{"Constant[1726∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1727{{"Constant[1727∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1728{{"Constant[1728∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1729{{"Constant[1729∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1730{{"Constant[1730∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1731{{"Constant[1731∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1732{{"Constant[1732∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1733{{"Constant[1733∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1734{{"Constant[1734∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1735{{"Constant[1735∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1736{{"Constant[1736∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1737{{"Constant[1737∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1738{{"Constant[1738∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
-    Constant1739{{"Constant[1739∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1740{{"Constant[1740∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
-    Constant1741{{"Constant[1741∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1742{{"Constant[1742∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1743{{"Constant[1743∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1744{{"Constant[1744∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1745{{"Constant[1745∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1746{{"Constant[1746∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1747{{"Constant[1747∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1748{{"Constant[1748∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1749{{"Constant[1749∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1750{{"Constant[1750∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1751{{"Constant[1751∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant1752{{"Constant[1752∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'constant', directᐳ"}}:::plan
-    Constant1753{{"Constant[1753∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1754{{"Constant[1754∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant1755{{"Constant[1755∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1756{{"Constant[1756∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant1757{{"Constant[1757∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'headline', directᐳ"}}:::plan
-    Constant1758{{"Constant[1758∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant1759{{"Constant[1759∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”edge_cᐳ"}}:::plan
-    Constant1760{{"Constant[1760∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'author_id', direcᐳ"}}:::plan
-    Constant1761{{"Constant[1761∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant1762{{"Constant[1762∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1763{{"Constant[1763∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1771{{"Constant[1771∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1772{{"Constant[1772∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1773{{"Constant[1773∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1774{{"Constant[1774∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1775{{"Constant[1775∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1776{{"Constant[1776∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1777{{"Constant[1777∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1758{{"Constant[1758∈0] ➊<br />ᐸ'192.168.0.1'ᐳ"}}:::plan
+    Constant1759{{"Constant[1759∈0] ➊<br />ᐸ'192.168.0.0/24'ᐳ"}}:::plan
+    Constant1760{{"Constant[1760∈0] ➊<br />ᐸ'0000.0000.0000'ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1067{{"Lambda[1067∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1073{{"Lambda[1073∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda1059 & Lambda1062 & Lambda1067 & Lambda1073 --> PgSelect14
+    Object12 & Connection13 & Lambda1059 & Access1063 & Lambda1068 & Lambda1074 --> PgSelect14
     PgSelect37[["PgSelect[37∈1] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1082{{"Lambda[1082∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1087{{"Lambda[1087∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda1059 & Lambda1077 & Lambda1082 & Lambda1087 --> PgSelect37
+    Object12 & Connection13 & Lambda1059 & Access1079 & Lambda1084 & Lambda1089 --> PgSelect37
     Object35{{"Object[35∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access30{{"Access[30∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access30 --> Object35
-    Object1066{{"Object[1066∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1063 & Constant1064 & Constant1065 --> Object1066
-    Object1081{{"Object[1081∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1078 & Constant1064 & Constant1065 --> Object1081
     Object31{{"Object[31∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access30 --> Object31
     PgPageInfo15{{"PgPageInfo[15∈1] ➊"}}:::plan
@@ -284,10 +588,6 @@ graph TD
     First38 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
-    Object1066 --> Lambda1067
-    Constant1718 --> Lambda1073
-    Object1081 --> Lambda1082
-    Constant1719 --> Lambda1087
     __Item42[/"__Item[42∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item42
     PgSelectSingle43{{"PgSelectSingle[43∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -311,22 +611,14 @@ graph TD
     PgClassExpression53{{"PgClassExpression[53∈3]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle43 --> PgClassExpression53
     PgSelect60[["PgSelect[60∈4] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1096{{"Lambda[1096∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1101{{"Lambda[1101∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection59 & Constant1706 & Lambda1089 & Lambda1091 & Lambda1096 & Lambda1101 --> PgSelect60
+    Object12 & Connection59 & Constant1752 & Lambda1091 & Access1094 & Lambda1099 & Lambda1104 --> PgSelect60
     PgSelect83[["PgSelect[83∈4] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1110{{"Lambda[1110∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1115{{"Lambda[1115∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection59 & Lambda1059 & Lambda1077 & Lambda1110 & Lambda1115 --> PgSelect83
+    Object12 & Connection59 & Lambda1059 & Access1079 & Lambda1114 & Lambda1119 --> PgSelect83
     Object81{{"Object[81∈4] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access76{{"Access[76∈4] ➊<br />ᐸ60.hasMoreᐳ"}}:::plan
-    Constant1706 & Constant6 & Constant6 & Access76 --> Object81
-    Object1095{{"Object[1095∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1089 & Constant1092 & Constant1064 & Constant1065 --> Object1095
-    Object1109{{"Object[1109∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1106 & Constant1064 & Constant1065 --> Object1109
+    Constant1752 & Constant6 & Constant6 & Access76 --> Object81
     Object77{{"Object[77∈4] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1706 & Constant6 & Access76 --> Object77
+    Constant1752 & Constant6 & Access76 --> Object77
     PgPageInfo61{{"PgPageInfo[61∈4] ➊"}}:::plan
     Connection59 --> PgPageInfo61
     First63{{"First[63∈4] ➊"}}:::plan
@@ -360,10 +652,6 @@ graph TD
     First84 --> PgSelectSingle85
     PgClassExpression86{{"PgClassExpression[86∈4] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle85 --> PgClassExpression86
-    Object1095 --> Lambda1096
-    Constant1720 --> Lambda1101
-    Object1109 --> Lambda1110
-    Constant1721 --> Lambda1115
     __Item88[/"__Item[88∈5]<br />ᐸ60ᐳ"\]:::itemplan
     PgSelect60 ==> __Item88
     PgSelectSingle89{{"PgSelectSingle[89∈5]<br />ᐸpersonᐳ"}}:::plan
@@ -387,22 +675,14 @@ graph TD
     PgClassExpression99{{"PgClassExpression[99∈6]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle89 --> PgClassExpression99
     PgSelect106[["PgSelect[106∈7] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1124{{"Lambda[1124∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1129{{"Lambda[1129∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection105 & Constant1706 & Lambda1117 & Lambda1119 & Lambda1124 & Lambda1129 --> PgSelect106
+    Object12 & Connection105 & Constant1752 & Lambda1121 & Access1124 & Lambda1129 & Lambda1134 --> PgSelect106
     PgSelect129[["PgSelect[129∈7] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1138{{"Lambda[1138∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1143{{"Lambda[1143∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection105 & Lambda1059 & Lambda1077 & Lambda1138 & Lambda1143 --> PgSelect129
+    Object12 & Connection105 & Lambda1059 & Access1079 & Lambda1144 & Lambda1149 --> PgSelect129
     Object127{{"Object[127∈7] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access122{{"Access[122∈7] ➊<br />ᐸ106.hasMoreᐳ"}}:::plan
-    Constant6 & Constant1706 & Constant6 & Access122 --> Object127
-    Object1123{{"Object[1123∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1117 & Constant1120 & Constant1064 & Constant1065 --> Object1123
-    Object1137{{"Object[1137∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1134 & Constant1064 & Constant1065 --> Object1137
+    Constant6 & Constant1752 & Constant6 & Access122 --> Object127
     Object123{{"Object[123∈7] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant1706 & Access122 --> Object123
+    Constant6 & Constant1752 & Access122 --> Object123
     PgPageInfo107{{"PgPageInfo[107∈7] ➊"}}:::plan
     Connection105 --> PgPageInfo107
     First109{{"First[109∈7] ➊"}}:::plan
@@ -436,10 +716,6 @@ graph TD
     First130 --> PgSelectSingle131
     PgClassExpression132{{"PgClassExpression[132∈7] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle131 --> PgClassExpression132
-    Object1123 --> Lambda1124
-    Constant1722 --> Lambda1129
-    Object1137 --> Lambda1138
-    Constant1723 --> Lambda1143
     __Item134[/"__Item[134∈8]<br />ᐸ106ᐳ"\]:::itemplan
     PgSelect106 ==> __Item134
     PgSelectSingle135{{"PgSelectSingle[135∈8]<br />ᐸpersonᐳ"}}:::plan
@@ -463,20 +739,12 @@ graph TD
     PgClassExpression145{{"PgClassExpression[145∈9]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle135 --> PgClassExpression145
     PgSelect151[["PgSelect[151∈10] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1152{{"Lambda[1152∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1157{{"Lambda[1157∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection150 & Lambda1059 & Lambda1062 & Lambda1152 & Lambda1157 --> PgSelect151
+    Object12 & Connection150 & Lambda1059 & Access1063 & Lambda1159 & Lambda1164 --> PgSelect151
     PgSelect176[["PgSelect[176∈10] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1166{{"Lambda[1166∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1171{{"Lambda[1171∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection150 & Lambda1059 & Lambda1077 & Lambda1166 & Lambda1171 --> PgSelect176
+    Object12 & Connection150 & Lambda1059 & Access1079 & Lambda1174 & Lambda1179 --> PgSelect176
     Object174{{"Object[174∈10] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access169{{"Access[169∈10] ➊<br />ᐸ151.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access169 --> Object174
-    Object1151{{"Object[1151∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1148 & Constant1149 & Constant1065 --> Object1151
-    Object1165{{"Object[1165∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1162 & Constant1149 & Constant1065 --> Object1165
     Object170{{"Object[170∈10] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access169 --> Object170
     List159{{"List[159∈10] ➊<br />ᐸ157,158ᐳ"}}:::plan
@@ -516,10 +784,6 @@ graph TD
     First177 --> PgSelectSingle178
     PgClassExpression179{{"PgClassExpression[179∈10] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle178 --> PgClassExpression179
-    Object1151 --> Lambda1152
-    Constant1738 --> Lambda1157
-    Object1165 --> Lambda1166
-    Constant1739 --> Lambda1171
     __Item181[/"__Item[181∈11]<br />ᐸ151ᐳ"\]:::itemplan
     PgSelect151 ==> __Item181
     PgSelectSingle182{{"PgSelectSingle[182∈11]<br />ᐸpersonᐳ"}}:::plan
@@ -543,20 +807,12 @@ graph TD
     PgClassExpression193{{"PgClassExpression[193∈12]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle182 --> PgClassExpression193
     PgSelect199[["PgSelect[199∈13] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1180{{"Lambda[1180∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1185{{"Lambda[1185∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection198 & Lambda1059 & Lambda1062 & Lambda1180 & Lambda1185 --> PgSelect199
+    Object12 & Connection198 & Lambda1059 & Access1063 & Lambda1189 & Lambda1194 --> PgSelect199
     PgSelect224[["PgSelect[224∈13] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1194{{"Lambda[1194∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1199{{"Lambda[1199∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection198 & Lambda1059 & Lambda1077 & Lambda1194 & Lambda1199 --> PgSelect224
+    Object12 & Connection198 & Lambda1059 & Access1079 & Lambda1204 & Lambda1209 --> PgSelect224
     Object222{{"Object[222∈13] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access217{{"Access[217∈13] ➊<br />ᐸ199.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access217 --> Object222
-    Object1179{{"Object[1179∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1176 & Constant1177 & Constant1065 --> Object1179
-    Object1193{{"Object[1193∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1190 & Constant1177 & Constant1065 --> Object1193
     Object218{{"Object[218∈13] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access217 --> Object218
     List207{{"List[207∈13] ➊<br />ᐸ205,206ᐳ"}}:::plan
@@ -596,10 +852,6 @@ graph TD
     First225 --> PgSelectSingle226
     PgClassExpression227{{"PgClassExpression[227∈13] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle226 --> PgClassExpression227
-    Object1179 --> Lambda1180
-    Constant1740 --> Lambda1185
-    Object1193 --> Lambda1194
-    Constant1741 --> Lambda1199
     __Item229[/"__Item[229∈14]<br />ᐸ199ᐳ"\]:::itemplan
     PgSelect199 ==> __Item229
     PgSelectSingle230{{"PgSelectSingle[230∈14]<br />ᐸpersonᐳ"}}:::plan
@@ -623,20 +875,12 @@ graph TD
     PgClassExpression241{{"PgClassExpression[241∈15]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle230 --> PgClassExpression241
     PgSelect249[["PgSelect[249∈16] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1208{{"Lambda[1208∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1213{{"Lambda[1213∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection247 & Lambda248 & Access251 & Lambda1059 & Lambda1062 & Lambda1208 & Lambda1213 --> PgSelect249
+    Object12 & Connection247 & Lambda248 & Access251 & Lambda1059 & Access1063 & Lambda1219 & Lambda1224 --> PgSelect249
     PgSelect278[["PgSelect[278∈16] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1222{{"Lambda[1222∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1227{{"Lambda[1227∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection247 & Lambda1059 & Lambda1077 & Lambda1222 & Lambda1227 --> PgSelect278
+    Object12 & Connection247 & Lambda1059 & Access1079 & Lambda1234 & Lambda1239 --> PgSelect278
     Object275{{"Object[275∈16] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access269{{"Access[269∈16] ➊<br />ᐸ249.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access269 --> Object275
-    Object1207{{"Object[1207∈16] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1204 & Constant1064 & Constant1065 --> Object1207
-    Object1221{{"Object[1221∈16] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1218 & Constant1064 & Constant1065 --> Object1221
     Object270{{"Object[270∈16] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access269 --> Object270
     PgPageInfo252{{"PgPageInfo[252∈16] ➊"}}:::plan
@@ -672,10 +916,6 @@ graph TD
     First279 --> PgSelectSingle280
     PgClassExpression281{{"PgClassExpression[281∈16] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle280 --> PgClassExpression281
-    Object1207 --> Lambda1208
-    Constant1724 --> Lambda1213
-    Object1221 --> Lambda1222
-    Constant1725 --> Lambda1227
     __Item284[/"__Item[284∈17]<br />ᐸ249ᐳ"\]:::itemplan
     PgSelect249 ==> __Item284
     PgSelectSingle285{{"PgSelectSingle[285∈17]<br />ᐸpersonᐳ"}}:::plan
@@ -699,20 +939,12 @@ graph TD
     PgClassExpression295{{"PgClassExpression[295∈18]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle285 --> PgClassExpression295
     PgSelect303[["PgSelect[303∈19] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1236{{"Lambda[1236∈19] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1241{{"Lambda[1241∈19] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection301 & Lambda248 & Access251 & Lambda1059 & Lambda1062 & Lambda1236 & Lambda1241 --> PgSelect303
+    Object12 & Connection301 & Lambda248 & Access251 & Lambda1059 & Access1063 & Lambda1249 & Lambda1254 --> PgSelect303
     PgSelect332[["PgSelect[332∈19] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1250{{"Lambda[1250∈19] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1255{{"Lambda[1255∈19] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection301 & Lambda1059 & Lambda1077 & Lambda1250 & Lambda1255 --> PgSelect332
+    Object12 & Connection301 & Lambda1059 & Access1079 & Lambda1264 & Lambda1269 --> PgSelect332
     Object329{{"Object[329∈19] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access323{{"Access[323∈19] ➊<br />ᐸ303.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access323 --> Object329
-    Object1235{{"Object[1235∈19] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1232 & Constant1064 & Constant1065 --> Object1235
-    Object1249{{"Object[1249∈19] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1246 & Constant1064 & Constant1065 --> Object1249
     Object324{{"Object[324∈19] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access323 --> Object324
     PgPageInfo306{{"PgPageInfo[306∈19] ➊"}}:::plan
@@ -748,10 +980,6 @@ graph TD
     First333 --> PgSelectSingle334
     PgClassExpression335{{"PgClassExpression[335∈19] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle334 --> PgClassExpression335
-    Object1235 --> Lambda1236
-    Constant1726 --> Lambda1241
-    Object1249 --> Lambda1250
-    Constant1727 --> Lambda1255
     __Item338[/"__Item[338∈20]<br />ᐸ303ᐳ"\]:::itemplan
     PgSelect303 ==> __Item338
     PgSelectSingle339{{"PgSelectSingle[339∈20]<br />ᐸpersonᐳ"}}:::plan
@@ -775,13 +1003,7 @@ graph TD
     PgClassExpression349{{"PgClassExpression[349∈21]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle339 --> PgClassExpression349
     PgSelect355[["PgSelect[355∈22] ➊<br />ᐸupdatable_viewᐳ"]]:::plan
-    Lambda1264{{"Lambda[1264∈22] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1269{{"Lambda[1269∈22] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection354 & Lambda1059 & Lambda1077 & Lambda1264 & Lambda1269 --> PgSelect355
-    Object1263{{"Object[1263∈22] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1260 & Constant1261 & Constant1262 --> Object1263
-    Object1263 --> Lambda1264
-    Constant1751 --> Lambda1269
+    Object12 & Connection354 & Lambda1059 & Access1079 & Lambda1279 & Lambda1284 --> PgSelect355
     __Item356[/"__Item[356∈23]<br />ᐸ355ᐳ"\]:::itemplan
     PgSelect355 ==> __Item356
     PgSelectSingle357{{"PgSelectSingle[357∈23]<br />ᐸupdatable_viewᐳ"}}:::plan
@@ -797,13 +1019,7 @@ graph TD
     PgClassExpression363{{"PgClassExpression[363∈24]<br />ᐸ__updatabl...”constant”ᐳ"}}:::plan
     PgSelectSingle357 --> PgClassExpression363
     PgSelect369[["PgSelect[369∈25] ➊<br />ᐸupdatable_viewᐳ"]]:::plan
-    Lambda1278{{"Lambda[1278∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1283{{"Lambda[1283∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection368 & Lambda1059 & Lambda1077 & Lambda1278 & Lambda1283 --> PgSelect369
-    Object1277{{"Object[1277∈25] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1274 & Constant1275 & Constant1262 --> Object1277
-    Object1277 --> Lambda1278
-    Constant1752 --> Lambda1283
+    Object12 & Connection368 & Lambda1059 & Access1079 & Lambda1294 & Lambda1299 --> PgSelect369
     __Item370[/"__Item[370∈26]<br />ᐸ369ᐳ"\]:::itemplan
     PgSelect369 ==> __Item370
     PgSelectSingle371{{"PgSelectSingle[371∈26]<br />ᐸupdatable_viewᐳ"}}:::plan
@@ -819,20 +1035,12 @@ graph TD
     PgClassExpression377{{"PgClassExpression[377∈27]<br />ᐸ__updatabl...w__.”name”ᐳ"}}:::plan
     PgSelectSingle371 --> PgClassExpression377
     PgSelect386[["PgSelect[386∈28] ➊<br />ᐸpost+1ᐳ"]]:::plan
-    Lambda1292{{"Lambda[1292∈28] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1297{{"Lambda[1297∈28] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1706 & Connection385 & Lambda1059 & Lambda1062 & Lambda1292 & Lambda1297 --> PgSelect386
+    Object12 & Constant1752 & Connection385 & Lambda1059 & Access1063 & Lambda1309 & Lambda1314 --> PgSelect386
     PgSelect409[["PgSelect[409∈28] ➊<br />ᐸpost(aggregate)ᐳ"]]:::plan
-    Lambda1306{{"Lambda[1306∈28] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1311{{"Lambda[1311∈28] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1706 & Connection385 & Lambda1059 & Lambda1077 & Lambda1306 & Lambda1311 --> PgSelect409
+    Object12 & Constant1752 & Connection385 & Lambda1059 & Access1079 & Lambda1324 & Lambda1329 --> PgSelect409
     Object407{{"Object[407∈28] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access402{{"Access[402∈28] ➊<br />ᐸ386.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access402 --> Object407
-    Object1291{{"Object[1291∈28] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1288 & Constant1289 & Constant1290 --> Object1291
-    Object1305{{"Object[1305∈28] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1302 & Constant1289 & Constant1290 --> Object1305
     Object403{{"Object[403∈28] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access402 --> Object403
     PgPageInfo387{{"PgPageInfo[387∈28] ➊"}}:::plan
@@ -868,10 +1076,6 @@ graph TD
     First410 --> PgSelectSingle411
     PgClassExpression412{{"PgClassExpression[412∈28] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle411 --> PgClassExpression412
-    Object1291 --> Lambda1292
-    Constant1753 --> Lambda1297
-    Object1305 --> Lambda1306
-    Constant1754 --> Lambda1311
     __Item414[/"__Item[414∈29]<br />ᐸ386ᐳ"\]:::itemplan
     PgSelect386 ==> __Item414
     PgSelectSingle415{{"PgSelectSingle[415∈29]<br />ᐸpostᐳ"}}:::plan
@@ -887,22 +1091,14 @@ graph TD
     PgClassExpression420{{"PgClassExpression[420∈30]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle415 --> PgClassExpression420
     PgSelect429[["PgSelect[429∈31] ➊<br />ᐸpost+1ᐳ"]]:::plan
-    Lambda1320{{"Lambda[1320∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1325{{"Lambda[1325∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1706 & Connection428 & Constant1706 & Lambda1089 & Lambda1091 & Lambda1320 & Lambda1325 --> PgSelect429
+    Object12 & Constant1752 & Connection428 & Constant1752 & Lambda1091 & Access1094 & Lambda1339 & Lambda1344 --> PgSelect429
     PgSelect452[["PgSelect[452∈31] ➊<br />ᐸpost(aggregate)ᐳ"]]:::plan
-    Lambda1334{{"Lambda[1334∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1339{{"Lambda[1339∈31] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1706 & Connection428 & Lambda1059 & Lambda1077 & Lambda1334 & Lambda1339 --> PgSelect452
+    Object12 & Constant1752 & Connection428 & Lambda1059 & Access1079 & Lambda1354 & Lambda1359 --> PgSelect452
     Object450{{"Object[450∈31] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access445{{"Access[445∈31] ➊<br />ᐸ429.hasMoreᐳ"}}:::plan
-    Constant1706 & Constant6 & Constant6 & Access445 --> Object450
-    Object1319{{"Object[1319∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1089 & Constant1316 & Constant1317 & Constant1290 --> Object1319
-    Object1333{{"Object[1333∈31] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1330 & Constant1317 & Constant1290 --> Object1333
+    Constant1752 & Constant6 & Constant6 & Access445 --> Object450
     Object446{{"Object[446∈31] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1706 & Constant6 & Access445 --> Object446
+    Constant1752 & Constant6 & Access445 --> Object446
     PgPageInfo430{{"PgPageInfo[430∈31] ➊"}}:::plan
     Connection428 --> PgPageInfo430
     First432{{"First[432∈31] ➊"}}:::plan
@@ -936,10 +1132,6 @@ graph TD
     First453 --> PgSelectSingle454
     PgClassExpression455{{"PgClassExpression[455∈31] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle454 --> PgClassExpression455
-    Object1319 --> Lambda1320
-    Constant1755 --> Lambda1325
-    Object1333 --> Lambda1334
-    Constant1756 --> Lambda1339
     __Item457[/"__Item[457∈32]<br />ᐸ429ᐳ"\]:::itemplan
     PgSelect429 ==> __Item457
     PgSelectSingle458{{"PgSelectSingle[458∈32]<br />ᐸpostᐳ"}}:::plan
@@ -955,22 +1147,14 @@ graph TD
     PgClassExpression463{{"PgClassExpression[463∈33]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle458 --> PgClassExpression463
     PgSelect472[["PgSelect[472∈34] ➊<br />ᐸpost+1ᐳ"]]:::plan
-    Lambda1348{{"Lambda[1348∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1353{{"Lambda[1353∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1708 & Connection471 & Constant1708 & Lambda1341 & Lambda1343 & Lambda1348 & Lambda1353 --> PgSelect472
+    Object12 & Constant1754 & Connection471 & Constant1754 & Lambda1361 & Access1364 & Lambda1369 & Lambda1374 --> PgSelect472
     PgSelect497[["PgSelect[497∈34] ➊<br />ᐸpost(aggregate)ᐳ"]]:::plan
-    Lambda1362{{"Lambda[1362∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1367{{"Lambda[1367∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1708 & Connection471 & Lambda1059 & Lambda1077 & Lambda1362 & Lambda1367 --> PgSelect497
+    Object12 & Constant1754 & Connection471 & Lambda1059 & Access1079 & Lambda1384 & Lambda1389 --> PgSelect497
     Object495{{"Object[495∈34] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access490{{"Access[490∈34] ➊<br />ᐸ472.hasMoreᐳ"}}:::plan
-    Constant6 & Constant1708 & Constant6 & Access490 --> Object495
-    Object1347{{"Object[1347∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1341 & Constant1344 & Constant1345 & Constant1290 --> Object1347
-    Object1361{{"Object[1361∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1358 & Constant1345 & Constant1290 --> Object1361
+    Constant6 & Constant1754 & Constant6 & Access490 --> Object495
     Object491{{"Object[491∈34] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant1708 & Access490 --> Object491
+    Constant6 & Constant1754 & Access490 --> Object491
     List480{{"List[480∈34] ➊<br />ᐸ478,479ᐳ"}}:::plan
     PgClassExpression478{{"PgClassExpression[478∈34] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgClassExpression479{{"PgClassExpression[479∈34] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
@@ -1008,10 +1192,6 @@ graph TD
     First498 --> PgSelectSingle499
     PgClassExpression500{{"PgClassExpression[500∈34] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle499 --> PgClassExpression500
-    Object1347 --> Lambda1348
-    Constant1757 --> Lambda1353
-    Object1361 --> Lambda1362
-    Constant1758 --> Lambda1367
     __Item502[/"__Item[502∈35]<br />ᐸ472ᐳ"\]:::itemplan
     PgSelect472 ==> __Item502
     PgSelectSingle503{{"PgSelectSingle[503∈35]<br />ᐸpostᐳ"}}:::plan
@@ -1027,23 +1207,14 @@ graph TD
     PgClassExpression509{{"PgClassExpression[509∈36]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle503 --> PgClassExpression509
     PgSelect517[["PgSelect[517∈37] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1371{{"Lambda[1371∈37] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1376{{"Lambda[1376∈37] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1381{{"Lambda[1381∈37] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection516 & Constant1709 & Constant1708 & Lambda1369 & Lambda1371 & Lambda1376 & Lambda1381 --> PgSelect517
+    Object12 & Connection516 & Constant1755 & Constant1754 & Lambda1391 & Access1394 & Lambda1399 & Lambda1404 --> PgSelect517
     PgSelect540[["PgSelect[540∈37] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1390{{"Lambda[1390∈37] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1395{{"Lambda[1395∈37] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection516 & Lambda1059 & Lambda1077 & Lambda1390 & Lambda1395 --> PgSelect540
+    Object12 & Connection516 & Lambda1059 & Access1079 & Lambda1414 & Lambda1419 --> PgSelect540
     Object538{{"Object[538∈37] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access533{{"Access[533∈37] ➊<br />ᐸ517.hasMoreᐳ"}}:::plan
-    Constant1709 & Constant6 & Constant1708 & Access533 --> Object538
-    Object1375{{"Object[1375∈37] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1369 & Constant1372 & Constant1064 & Constant1065 --> Object1375
-    Object1389{{"Object[1389∈37] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1386 & Constant1064 & Constant1065 --> Object1389
+    Constant1755 & Constant6 & Constant1754 & Access533 --> Object538
     Object534{{"Object[534∈37] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1709 & Constant6 & Access533 --> Object534
+    Constant1755 & Constant6 & Access533 --> Object534
     PgPageInfo518{{"PgPageInfo[518∈37] ➊"}}:::plan
     Connection516 --> PgPageInfo518
     First520{{"First[520∈37] ➊"}}:::plan
@@ -1077,11 +1248,6 @@ graph TD
     First541 --> PgSelectSingle542
     PgClassExpression543{{"PgClassExpression[543∈37] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle542 --> PgClassExpression543
-    Constant1771 --> Lambda1371
-    Object1375 --> Lambda1376
-    Constant1728 --> Lambda1381
-    Object1389 --> Lambda1390
-    Constant1729 --> Lambda1395
     __Item545[/"__Item[545∈38]<br />ᐸ517ᐳ"\]:::itemplan
     PgSelect517 ==> __Item545
     PgSelectSingle546{{"PgSelectSingle[546∈38]<br />ᐸpersonᐳ"}}:::plan
@@ -1105,24 +1271,14 @@ graph TD
     PgClassExpression556{{"PgClassExpression[556∈39]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle546 --> PgClassExpression556
     PgSelect563[["PgSelect[563∈40] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1397{{"Lambda[1397∈40] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1399{{"Lambda[1399∈40] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1404{{"Lambda[1404∈40] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1409{{"Lambda[1409∈40] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection562 & Constant1710 & Lambda1397 & Lambda1399 & Lambda1404 & Lambda1409 --> PgSelect563
+    Object12 & Connection562 & Constant1756 & Lambda1421 & Access1424 & Lambda1429 & Lambda1434 --> PgSelect563
     PgSelect586[["PgSelect[586∈40] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1418{{"Lambda[1418∈40] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1423{{"Lambda[1423∈40] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection562 & Lambda1059 & Lambda1077 & Lambda1418 & Lambda1423 --> PgSelect586
+    Object12 & Connection562 & Lambda1059 & Access1079 & Lambda1444 & Lambda1449 --> PgSelect586
     Object584{{"Object[584∈40] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access579{{"Access[579∈40] ➊<br />ᐸ563.hasMoreᐳ"}}:::plan
-    Constant1710 & Constant6 & Constant6 & Access579 --> Object584
-    Object1403{{"Object[1403∈40] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1397 & Constant1400 & Constant1064 & Constant1065 --> Object1403
-    Object1417{{"Object[1417∈40] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1414 & Constant1064 & Constant1065 --> Object1417
+    Constant1756 & Constant6 & Constant6 & Access579 --> Object584
     Object580{{"Object[580∈40] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1710 & Constant6 & Access579 --> Object580
+    Constant1756 & Constant6 & Access579 --> Object580
     PgPageInfo564{{"PgPageInfo[564∈40] ➊"}}:::plan
     Connection562 --> PgPageInfo564
     First566{{"First[566∈40] ➊"}}:::plan
@@ -1156,12 +1312,6 @@ graph TD
     First587 --> PgSelectSingle588
     PgClassExpression589{{"PgClassExpression[589∈40] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle588 --> PgClassExpression589
-    Constant1772 --> Lambda1397
-    Constant1773 --> Lambda1399
-    Object1403 --> Lambda1404
-    Constant1730 --> Lambda1409
-    Object1417 --> Lambda1418
-    Constant1731 --> Lambda1423
     __Item591[/"__Item[591∈41]<br />ᐸ563ᐳ"\]:::itemplan
     PgSelect563 ==> __Item591
     PgSelectSingle592{{"PgSelectSingle[592∈41]<br />ᐸpersonᐳ"}}:::plan
@@ -1185,13 +1335,7 @@ graph TD
     PgClassExpression602{{"PgClassExpression[602∈42]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle592 --> PgClassExpression602
     PgSelect610[["PgSelect[610∈43] ➊<br />ᐸedge_caseᐳ"]]:::plan
-    Lambda1432{{"Lambda[1432∈43] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1437{{"Lambda[1437∈43] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1706 & Connection609 & Lambda1059 & Lambda1077 & Lambda1432 & Lambda1437 --> PgSelect610
-    Object1431{{"Object[1431∈43] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1428 & Constant1429 & Constant1430 --> Object1431
-    Object1431 --> Lambda1432
-    Constant1759 --> Lambda1437
+    Object12 & Constant1752 & Connection609 & Lambda1059 & Access1079 & Lambda1459 & Lambda1464 --> PgSelect610
     __Item611[/"__Item[611∈44]<br />ᐸ610ᐳ"\]:::itemplan
     PgSelect610 ==> __Item611
     PgSelectSingle612{{"PgSelectSingle[612∈44]<br />ᐸedge_caseᐳ"}}:::plan
@@ -1199,24 +1343,14 @@ graph TD
     PgClassExpression613{{"PgClassExpression[613∈45]<br />ᐸ__edge_case__.”row_id”ᐳ"}}:::plan
     PgSelectSingle612 --> PgClassExpression613
     PgSelect624[["PgSelect[624∈46] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Access626{{"Access[626∈46] ➊<br />ᐸ623.1ᐳ"}}:::plan
-    Lambda1446{{"Lambda[1446∈46] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1451{{"Lambda[1451∈46] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection622 & Lambda623 & Constant1057 & Constant1706 & Access626 & Lambda1117 & Lambda1119 & Lambda1446 & Lambda1451 --> PgSelect624
+    Object12 & Connection622 & Lambda623 & Constant1057 & Constant1752 & Access626 & Lambda1121 & Access1124 & Lambda1474 & Lambda1479 --> PgSelect624
     PgSelect653[["PgSelect[653∈46] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1460{{"Lambda[1460∈46] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1465{{"Lambda[1465∈46] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection622 & Lambda1059 & Lambda1077 & Lambda1460 & Lambda1465 --> PgSelect653
+    Object12 & Connection622 & Lambda1059 & Access1079 & Lambda1489 & Lambda1494 --> PgSelect653
     Object650{{"Object[650∈46] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access643{{"Access[643∈46] ➊<br />ᐸ624.hasMoreᐳ"}}:::plan
-    Constant1057 & Constant1706 & Constant6 & Access643 --> Object650
-    Object1445{{"Object[1445∈46] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1117 & Constant1442 & Constant1064 & Constant1065 --> Object1445
-    Object1459{{"Object[1459∈46] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1456 & Constant1064 & Constant1065 --> Object1459
+    Constant1057 & Constant1752 & Constant6 & Access643 --> Object650
     Object644{{"Object[644∈46] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1057 & Constant1706 & Access643 --> Object644
-    Lambda623 --> Access626
+    Constant1057 & Constant1752 & Access643 --> Object644
     PgPageInfo627{{"PgPageInfo[627∈46] ➊"}}:::plan
     Connection622 --> PgPageInfo627
     First629{{"First[629∈46] ➊"}}:::plan
@@ -1250,10 +1384,6 @@ graph TD
     First654 --> PgSelectSingle655
     PgClassExpression656{{"PgClassExpression[656∈46] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle655 --> PgClassExpression656
-    Object1445 --> Lambda1446
-    Constant1732 --> Lambda1451
-    Object1459 --> Lambda1460
-    Constant1733 --> Lambda1465
     __Item659[/"__Item[659∈47]<br />ᐸ624ᐳ"\]:::itemplan
     PgSelect624 ==> __Item659
     PgSelectSingle660{{"PgSelectSingle[660∈47]<br />ᐸpersonᐳ"}}:::plan
@@ -1277,24 +1407,14 @@ graph TD
     PgClassExpression670{{"PgClassExpression[670∈48]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle660 --> PgClassExpression670
     PgSelect679[["PgSelect[679∈49] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1467{{"Lambda[1467∈49] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1469{{"Lambda[1469∈49] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1474{{"Lambda[1474∈49] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1479{{"Lambda[1479∈49] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection677 & Lambda248 & Constant1708 & Access251 & Lambda1467 & Lambda1469 & Lambda1474 & Lambda1479 --> PgSelect679
+    Object12 & Connection677 & Lambda248 & Constant1754 & Access251 & Lambda1496 & Access1499 & Lambda1504 & Lambda1509 --> PgSelect679
     PgSelect708[["PgSelect[708∈49] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1488{{"Lambda[1488∈49] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1493{{"Lambda[1493∈49] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection677 & Lambda1059 & Lambda1077 & Lambda1488 & Lambda1493 --> PgSelect708
+    Object12 & Connection677 & Lambda1059 & Access1079 & Lambda1519 & Lambda1524 --> PgSelect708
     Object705{{"Object[705∈49] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access699{{"Access[699∈49] ➊<br />ᐸ679.hasMoreᐳ"}}:::plan
-    Constant1708 & Constant6 & Constant6 & Access699 --> Object705
-    Object1473{{"Object[1473∈49] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1467 & Constant1470 & Constant1064 & Constant1065 --> Object1473
-    Object1487{{"Object[1487∈49] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1484 & Constant1064 & Constant1065 --> Object1487
+    Constant1754 & Constant6 & Constant6 & Access699 --> Object705
     Object700{{"Object[700∈49] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1708 & Constant6 & Access699 --> Object700
+    Constant1754 & Constant6 & Access699 --> Object700
     PgPageInfo682{{"PgPageInfo[682∈49] ➊"}}:::plan
     Connection677 --> PgPageInfo682
     First684{{"First[684∈49] ➊"}}:::plan
@@ -1328,12 +1448,6 @@ graph TD
     First709 --> PgSelectSingle710
     PgClassExpression711{{"PgClassExpression[711∈49] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle710 --> PgClassExpression711
-    Constant1774 --> Lambda1467
-    Constant1775 --> Lambda1469
-    Object1473 --> Lambda1474
-    Constant1734 --> Lambda1479
-    Object1487 --> Lambda1488
-    Constant1735 --> Lambda1493
     __Item714[/"__Item[714∈50]<br />ᐸ679ᐳ"\]:::itemplan
     PgSelect679 ==> __Item714
     PgSelectSingle715{{"PgSelectSingle[715∈50]<br />ᐸpersonᐳ"}}:::plan
@@ -1357,22 +1471,14 @@ graph TD
     PgClassExpression725{{"PgClassExpression[725∈51]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle715 --> PgClassExpression725
     PgSelect734[["PgSelect[734∈52] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1502{{"Lambda[1502∈52] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1507{{"Lambda[1507∈52] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection732 & Lambda248 & Constant1708 & Access251 & Lambda1341 & Lambda1343 & Lambda1502 & Lambda1507 --> PgSelect734
+    Object12 & Connection732 & Lambda248 & Constant1754 & Access251 & Lambda1361 & Access1364 & Lambda1534 & Lambda1539 --> PgSelect734
     PgSelect763[["PgSelect[763∈52] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1516{{"Lambda[1516∈52] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1521{{"Lambda[1521∈52] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection732 & Lambda1059 & Lambda1077 & Lambda1516 & Lambda1521 --> PgSelect763
+    Object12 & Connection732 & Lambda1059 & Access1079 & Lambda1549 & Lambda1554 --> PgSelect763
     Object760{{"Object[760∈52] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access754{{"Access[754∈52] ➊<br />ᐸ734.hasMoreᐳ"}}:::plan
-    Constant6 & Constant1708 & Constant6 & Access754 --> Object760
-    Object1501{{"Object[1501∈52] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1341 & Constant1498 & Constant1064 & Constant1065 --> Object1501
-    Object1515{{"Object[1515∈52] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1512 & Constant1064 & Constant1065 --> Object1515
+    Constant6 & Constant1754 & Constant6 & Access754 --> Object760
     Object755{{"Object[755∈52] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant6 & Constant1708 & Access754 --> Object755
+    Constant6 & Constant1754 & Access754 --> Object755
     PgPageInfo737{{"PgPageInfo[737∈52] ➊"}}:::plan
     Connection732 --> PgPageInfo737
     First739{{"First[739∈52] ➊"}}:::plan
@@ -1406,10 +1512,6 @@ graph TD
     First764 --> PgSelectSingle765
     PgClassExpression766{{"PgClassExpression[766∈52] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle765 --> PgClassExpression766
-    Object1501 --> Lambda1502
-    Constant1736 --> Lambda1507
-    Object1515 --> Lambda1516
-    Constant1737 --> Lambda1521
     __Item769[/"__Item[769∈53]<br />ᐸ734ᐳ"\]:::itemplan
     PgSelect734 ==> __Item769
     PgSelectSingle770{{"PgSelectSingle[770∈53]<br />ᐸpersonᐳ"}}:::plan
@@ -1433,20 +1535,12 @@ graph TD
     PgClassExpression780{{"PgClassExpression[780∈54]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle770 --> PgClassExpression780
     PgSelect788[["PgSelect[788∈55] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1530{{"Lambda[1530∈55] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1535{{"Lambda[1535∈55] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection787 & Lambda1059 & Lambda1062 & Lambda1530 & Lambda1535 --> PgSelect788
+    Object12 & Connection787 & Lambda1059 & Access1063 & Lambda1564 & Lambda1569 --> PgSelect788
     PgSelect811[["PgSelect[811∈55] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1544{{"Lambda[1544∈55] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1549{{"Lambda[1549∈55] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection787 & Lambda1059 & Lambda1077 & Lambda1544 & Lambda1549 --> PgSelect811
+    Object12 & Connection787 & Lambda1059 & Access1079 & Lambda1579 & Lambda1584 --> PgSelect811
     Object809{{"Object[809∈55] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access804{{"Access[804∈55] ➊<br />ᐸ788.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access804 --> Object809
-    Object1529{{"Object[1529∈55] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1526 & Constant1527 & Constant1065 --> Object1529
-    Object1543{{"Object[1543∈55] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1540 & Constant1527 & Constant1065 --> Object1543
     Object805{{"Object[805∈55] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access804 --> Object805
     PgPageInfo789{{"PgPageInfo[789∈55] ➊"}}:::plan
@@ -1482,10 +1576,6 @@ graph TD
     First812 --> PgSelectSingle813
     PgClassExpression814{{"PgClassExpression[814∈55] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle813 --> PgClassExpression814
-    Object1529 --> Lambda1530
-    Constant1742 --> Lambda1535
-    Object1543 --> Lambda1544
-    Constant1743 --> Lambda1549
     __Item816[/"__Item[816∈56]<br />ᐸ788ᐳ"\]:::itemplan
     PgSelect788 ==> __Item816
     PgSelectSingle817{{"PgSelectSingle[817∈56]<br />ᐸpersonᐳ"}}:::plan
@@ -1509,21 +1599,12 @@ graph TD
     PgClassExpression827{{"PgClassExpression[827∈57]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle817 --> PgClassExpression827
     PgSelect835[["PgSelect[835∈58] ➊<br />ᐸpost+1ᐳ"]]:::plan
-    Lambda1553{{"Lambda[1553∈58] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1558{{"Lambda[1558∈58] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1563{{"Lambda[1563∈58] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection834 & Constant1709 & Lambda1369 & Lambda1553 & Lambda1558 & Lambda1563 --> PgSelect835
+    Object12 & Connection834 & Constant1755 & Lambda1391 & Access1589 & Lambda1594 & Lambda1599 --> PgSelect835
     PgSelect862[["PgSelect[862∈58] ➊<br />ᐸpost(aggregate)ᐳ"]]:::plan
-    Lambda1572{{"Lambda[1572∈58] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1577{{"Lambda[1577∈58] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection834 & Lambda1059 & Lambda1077 & Lambda1572 & Lambda1577 --> PgSelect862
+    Object12 & Connection834 & Lambda1059 & Access1079 & Lambda1609 & Lambda1614 --> PgSelect862
     Object860{{"Object[860∈58] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access855{{"Access[855∈58] ➊<br />ᐸ835.hasMoreᐳ"}}:::plan
-    Constant1709 & Constant6 & Constant6 & Access855 --> Object860
-    Object1557{{"Object[1557∈58] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1369 & Constant1554 & Constant1555 & Constant1290 --> Object1557
-    Object1571{{"Object[1571∈58] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1568 & Constant1555 & Constant1290 --> Object1571
+    Constant1755 & Constant6 & Constant6 & Access855 --> Object860
     List844{{"List[844∈58] ➊<br />ᐸ841,842,843ᐳ"}}:::plan
     PgClassExpression841{{"PgClassExpression[841∈58] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgClassExpression842{{"PgClassExpression[842∈58] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -1535,7 +1616,7 @@ graph TD
     PgClassExpression851{{"PgClassExpression[851∈58] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgClassExpression849 & PgClassExpression850 & PgClassExpression851 --> List852
     Object856{{"Object[856∈58] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1709 & Constant6 & Access855 --> Object856
+    Constant1755 & Constant6 & Access855 --> Object856
     PgPageInfo836{{"PgPageInfo[836∈58] ➊"}}:::plan
     Connection834 --> PgPageInfo836
     First838{{"First[838∈58] ➊"}}:::plan
@@ -1567,11 +1648,6 @@ graph TD
     First863 --> PgSelectSingle864
     PgClassExpression865{{"PgClassExpression[865∈58] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle864 --> PgClassExpression865
-    Constant1776 --> Lambda1553
-    Object1557 --> Lambda1558
-    Constant1760 --> Lambda1563
-    Object1571 --> Lambda1572
-    Constant1761 --> Lambda1577
     __Item867[/"__Item[867∈59]<br />ᐸ835ᐳ"\]:::itemplan
     PgSelect835 ==> __Item867
     PgSelectSingle868{{"PgSelectSingle[868∈59]<br />ᐸpostᐳ"}}:::plan
@@ -1587,20 +1663,12 @@ graph TD
     PgSelectSingle868 --> PgClassExpression871
     PgSelectSingle868 --> PgClassExpression872
     PgSelect883[["PgSelect[883∈61] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1586{{"Lambda[1586∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1591{{"Lambda[1591∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1712 & Connection882 & Lambda1059 & Lambda1062 & Lambda1586 & Lambda1591 --> PgSelect883
+    Object12 & Constant1758 & Connection882 & Lambda1059 & Access1063 & Lambda1624 & Lambda1629 --> PgSelect883
     PgSelect906[["PgSelect[906∈61] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1600{{"Lambda[1600∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1605{{"Lambda[1605∈61] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1712 & Connection882 & Lambda1059 & Lambda1077 & Lambda1600 & Lambda1605 --> PgSelect906
+    Object12 & Constant1758 & Connection882 & Lambda1059 & Access1079 & Lambda1639 & Lambda1644 --> PgSelect906
     Object904{{"Object[904∈61] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access899{{"Access[899∈61] ➊<br />ᐸ883.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access899 --> Object904
-    Object1585{{"Object[1585∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1582 & Constant1583 & Constant1065 --> Object1585
-    Object1599{{"Object[1599∈61] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1596 & Constant1583 & Constant1065 --> Object1599
     Object900{{"Object[900∈61] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access899 --> Object900
     PgPageInfo884{{"PgPageInfo[884∈61] ➊"}}:::plan
@@ -1636,10 +1704,6 @@ graph TD
     First907 --> PgSelectSingle908
     PgClassExpression909{{"PgClassExpression[909∈61] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle908 --> PgClassExpression909
-    Object1585 --> Lambda1586
-    Constant1744 --> Lambda1591
-    Object1599 --> Lambda1600
-    Constant1745 --> Lambda1605
     __Item911[/"__Item[911∈62]<br />ᐸ883ᐳ"\]:::itemplan
     PgSelect883 ==> __Item911
     PgSelectSingle912{{"PgSelectSingle[912∈62]<br />ᐸpersonᐳ"}}:::plan
@@ -1663,21 +1727,7 @@ graph TD
     PgClassExpression922{{"PgClassExpression[922∈63]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle912 --> PgClassExpression922
     PgSelect929[["PgSelect[929∈64] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda1614{{"Lambda[1614∈64] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1619{{"Lambda[1619∈64] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1625{{"Lambda[1625∈64] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1630{{"Lambda[1630∈64] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1635{{"Lambda[1635∈64] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection928 & Constant1706 & Lambda1077 & Lambda1614 & Lambda1619 & Lambda1089 & Lambda1625 & Lambda1630 & Lambda1635 --> PgSelect929
-    Object1613{{"Object[1613∈64] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1610 & Constant1611 & Constant1065 --> Object1613
-    Object1629{{"Object[1629∈64] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1089 & Constant1626 & Constant1627 & Constant1290 --> Object1629
-    Object1613 --> Lambda1614
-    Constant1746 --> Lambda1619
-    Constant1777 --> Lambda1625
-    Object1629 --> Lambda1630
-    Constant1762 --> Lambda1635
+    Object12 & Connection928 & Constant1752 & Access1079 & Lambda1654 & Lambda1659 & Lambda1091 & Access1666 & Lambda1671 & Lambda1676 --> PgSelect929
     __Item930[/"__Item[930∈65]<br />ᐸ929ᐳ"\]:::itemplan
     PgSelect929 ==> __Item930
     PgSelectSingle931{{"PgSelectSingle[931∈65]<br />ᐸpostᐳ"}}:::plan
@@ -1685,11 +1735,11 @@ graph TD
     PgClassExpression932{{"PgClassExpression[932∈66]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle931 --> PgClassExpression932
     PgSelectSingle939{{"PgSelectSingle[939∈66]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys1620{{"RemapKeys[1620∈66]<br />ᐸ931:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1620 --> PgSelectSingle939
+    RemapKeys1660{{"RemapKeys[1660∈66]<br />ᐸ931:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1660 --> PgSelectSingle939
     PgClassExpression941{{"PgClassExpression[941∈66]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle931 --> PgClassExpression941
-    PgSelectSingle931 --> RemapKeys1620
+    PgSelectSingle931 --> RemapKeys1660
     PgClassExpression940{{"PgClassExpression[940∈67]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle939 --> PgClassExpression940
     PgClassExpression946{{"PgClassExpression[946∈67]<br />ᐸ__person__.”id”ᐳ"}}:::plan
@@ -1701,20 +1751,12 @@ graph TD
     Lambda952{{"Lambda[952∈68]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List951 --> Lambda952
     PgSelect960[["PgSelect[960∈69] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1644{{"Lambda[1644∈69] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1649{{"Lambda[1649∈69] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1713 & Connection959 & Lambda1059 & Lambda1062 & Lambda1644 & Lambda1649 --> PgSelect960
+    Object12 & Constant1759 & Connection959 & Lambda1059 & Access1063 & Lambda1686 & Lambda1691 --> PgSelect960
     PgSelect983[["PgSelect[983∈69] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1658{{"Lambda[1658∈69] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1663{{"Lambda[1663∈69] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1713 & Connection959 & Lambda1059 & Lambda1077 & Lambda1658 & Lambda1663 --> PgSelect983
+    Object12 & Constant1759 & Connection959 & Lambda1059 & Access1079 & Lambda1701 & Lambda1706 --> PgSelect983
     Object981{{"Object[981∈69] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access976{{"Access[976∈69] ➊<br />ᐸ960.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access976 --> Object981
-    Object1643{{"Object[1643∈69] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1640 & Constant1641 & Constant1065 --> Object1643
-    Object1657{{"Object[1657∈69] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1654 & Constant1641 & Constant1065 --> Object1657
     Object977{{"Object[977∈69] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access976 --> Object977
     PgPageInfo961{{"PgPageInfo[961∈69] ➊"}}:::plan
@@ -1750,10 +1792,6 @@ graph TD
     First984 --> PgSelectSingle985
     PgClassExpression986{{"PgClassExpression[986∈69] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle985 --> PgClassExpression986
-    Object1643 --> Lambda1644
-    Constant1747 --> Lambda1649
-    Object1657 --> Lambda1658
-    Constant1748 --> Lambda1663
     __Item988[/"__Item[988∈70]<br />ᐸ960ᐳ"\]:::itemplan
     PgSelect960 ==> __Item988
     PgSelectSingle989{{"PgSelectSingle[989∈70]<br />ᐸpersonᐳ"}}:::plan
@@ -1777,20 +1815,12 @@ graph TD
     PgClassExpression999{{"PgClassExpression[999∈71]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle989 --> PgClassExpression999
     PgSelect1007[["PgSelect[1007∈72] ➊<br />ᐸperson+1ᐳ"]]:::plan
-    Lambda1672{{"Lambda[1672∈72] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1677{{"Lambda[1677∈72] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1714 & Connection1006 & Lambda1059 & Lambda1062 & Lambda1672 & Lambda1677 --> PgSelect1007
+    Object12 & Constant1760 & Connection1006 & Lambda1059 & Access1063 & Lambda1716 & Lambda1721 --> PgSelect1007
     PgSelect1030[["PgSelect[1030∈72] ➊<br />ᐸperson(aggregate)ᐳ"]]:::plan
-    Lambda1686{{"Lambda[1686∈72] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1691{{"Lambda[1691∈72] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant1714 & Connection1006 & Lambda1059 & Lambda1077 & Lambda1686 & Lambda1691 --> PgSelect1030
+    Object12 & Constant1760 & Connection1006 & Lambda1059 & Access1079 & Lambda1731 & Lambda1736 --> PgSelect1030
     Object1028{{"Object[1028∈72] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access1023{{"Access[1023∈72] ➊<br />ᐸ1007.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access1023 --> Object1028
-    Object1671{{"Object[1671∈72] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1668 & Constant1669 & Constant1065 --> Object1671
-    Object1685{{"Object[1685∈72] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1682 & Constant1669 & Constant1065 --> Object1685
     Object1024{{"Object[1024∈72] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access1023 --> Object1024
     PgPageInfo1008{{"PgPageInfo[1008∈72] ➊"}}:::plan
@@ -1826,10 +1856,6 @@ graph TD
     First1031 --> PgSelectSingle1032
     PgClassExpression1033{{"PgClassExpression[1033∈72] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle1032 --> PgClassExpression1033
-    Object1671 --> Lambda1672
-    Constant1749 --> Lambda1677
-    Object1685 --> Lambda1686
-    Constant1750 --> Lambda1691
     __Item1035[/"__Item[1035∈73]<br />ᐸ1007ᐳ"\]:::itemplan
     PgSelect1007 ==> __Item1035
     PgSelectSingle1036{{"PgSelectSingle[1036∈73]<br />ᐸpersonᐳ"}}:::plan
@@ -1853,13 +1879,7 @@ graph TD
     PgClassExpression1046{{"PgClassExpression[1046∈74]<br />ᐸ__person__.”user_mac”ᐳ"}}:::plan
     PgSelectSingle1036 --> PgClassExpression1046
     PgSelect1052[["PgSelect[1052∈75] ➊<br />ᐸnull_test_recordᐳ"]]:::plan
-    Lambda1700{{"Lambda[1700∈75] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1705{{"Lambda[1705∈75] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection1051 & Lambda1059 & Lambda1077 & Lambda1700 & Lambda1705 --> PgSelect1052
-    Object1699{{"Object[1699∈75] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1059 & Constant1696 & Constant1697 & Constant1698 --> Object1699
-    Object1699 --> Lambda1700
-    Constant1763 --> Lambda1705
+    Object12 & Connection1051 & Lambda1059 & Access1079 & Lambda1746 & Lambda1751 --> PgSelect1052
     __Item1053[/"__Item[1053∈76]<br />ᐸ1052ᐳ"\]:::itemplan
     PgSelect1052 ==> __Item1053
     PgSelectSingle1054{{"PgSelectSingle[1054∈76]<br />ᐸnull_test_recordᐳ"}}:::plan
@@ -1872,234 +1892,234 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/connections"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 10, 11, 13, 150, 198, 354, 368, 385, 609, 787, 882, 949, 959, 1006, 1051, 1057, 1063, 1064, 1065, 1078, 1092, 1106, 1120, 1134, 1148, 1149, 1162, 1176, 1177, 1190, 1204, 1218, 1232, 1246, 1260, 1261, 1262, 1274, 1275, 1288, 1289, 1290, 1302, 1316, 1317, 1330, 1344, 1345, 1358, 1372, 1386, 1400, 1414, 1428, 1429, 1430, 1442, 1456, 1470, 1484, 1498, 1512, 1526, 1527, 1540, 1554, 1555, 1568, 1582, 1583, 1596, 1610, 1611, 1626, 1627, 1640, 1641, 1654, 1668, 1669, 1682, 1696, 1697, 1698, 1706, 1707, 1708, 1709, 1710, 1711, 1712, 1713, 1714, 1715, 1716, 1717, 1718, 1719, 1720, 1721, 1722, 1723, 1724, 1725, 1726, 1727, 1728, 1729, 1730, 1731, 1732, 1733, 1734, 1735, 1736, 1737, 1738, 1739, 1740, 1741, 1742, 1743, 1744, 1745, 1746, 1747, 1748, 1749, 1750, 1751, 1752, 1753, 1754, 1755, 1756, 1757, 1758, 1759, 1760, 1761, 1762, 1763, 1764, 1765, 1766, 1767, 1768, 1769, 1770, 1771, 1772, 1773, 1774, 1775, 1776, 1777, 12, 59, 105, 248, 251, 428, 471, 516, 562, 623, 834, 928, 1059, 1062, 1077, 1089, 1091, 1117, 1119, 1341, 1343, 1369<br />2: 250, 304, 625, 680, 735<br />ᐳ: 247, 301, 622, 677, 732"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 10, 11, 13, 150, 198, 354, 368, 385, 609, 787, 882, 949, 959, 1006, 1051, 1057, 1064, 1065, 1066, 1080, 1095, 1110, 1125, 1140, 1155, 1156, 1170, 1185, 1186, 1200, 1215, 1230, 1245, 1260, 1275, 1276, 1277, 1290, 1291, 1305, 1306, 1307, 1320, 1335, 1336, 1350, 1365, 1366, 1380, 1395, 1410, 1425, 1440, 1455, 1456, 1457, 1470, 1485, 1500, 1515, 1530, 1545, 1560, 1561, 1575, 1590, 1591, 1605, 1620, 1621, 1635, 1650, 1651, 1667, 1668, 1682, 1683, 1697, 1712, 1713, 1727, 1742, 1743, 1744, 1752, 1753, 1754, 1755, 1756, 1757, 1758, 1759, 1760, 1761, 1762, 1763, 1764, 1765, 1766, 1767, 1768, 1769, 1770, 1771, 1772, 1773, 1774, 1775, 1776, 1777, 1778, 1779, 1780, 1781, 1782, 1783, 1784, 1785, 1786, 1787, 1788, 1789, 1790, 1791, 1792, 1793, 1794, 1795, 1796, 1797, 1798, 1799, 1800, 1801, 1802, 1803, 1804, 1805, 1806, 1807, 1808, 1809, 1810, 1811, 1812, 1813, 1814, 1815, 1816, 1817, 1818, 1819, 1820, 1821, 1822, 1823, 12, 59, 105, 248, 251, 428, 471, 516, 562, 623, 626, 834, 928, 1059, 1062, 1063, 1067, 1068, 1074, 1078, 1079, 1083, 1084, 1089, 1091, 1093, 1094, 1098, 1099, 1104, 1113, 1114, 1119, 1121, 1123, 1124, 1128, 1129, 1134, 1143, 1144, 1149, 1158, 1159, 1164, 1173, 1174, 1179, 1188, 1189, 1194, 1203, 1204, 1209, 1218, 1219, 1224, 1233, 1234, 1239, 1248, 1249, 1254, 1263, 1264, 1269, 1278, 1279, 1284, 1293, 1294, 1299, 1308, 1309, 1314, 1323, 1324, 1329, 1338, 1339, 1344, 1353, 1354, 1359, 1361, 1363, 1364, 1368, 1369, 1374, 1383, 1384, 1389, 1391, 1393, 1394, 1398, 1399, 1404, 1413, 1414, 1419, 1421, 1423, 1424, 1428, 1429, 1434, 1443, 1444, 1449, 1458, 1459, 1464, 1473, 1474, 1479, 1488, 1489, 1494, 1496, 1498, 1499, 1503, 1504, 1509, 1518, 1519, 1524, 1533, 1534, 1539, 1548, 1549, 1554, 1563, 1564, 1569, 1578, 1579, 1584, 1588, 1589, 1593, 1594, 1599, 1608, 1609, 1614, 1623, 1624, 1629, 1638, 1639, 1644, 1653, 1654, 1659, 1665, 1666, 1670, 1671, 1676, 1685, 1686, 1691, 1700, 1701, 1706, 1715, 1716, 1721, 1730, 1731, 1736, 1745, 1746, 1751<br />2: 250, 304, 625, 680, 735<br />ᐳ: 247, 301, 622, 677, 732"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Connection59,Connection105,Connection150,Connection198,Connection247,Lambda248,PgValidateParsedCursor250,Access251,Connection301,PgValidateParsedCursor304,Connection354,Connection368,Connection385,Connection428,Connection471,Connection516,Connection562,Connection609,Connection622,Lambda623,PgValidateParsedCursor625,Connection677,PgValidateParsedCursor680,Connection732,PgValidateParsedCursor735,Connection787,Connection834,Connection882,Connection928,Constant949,Connection959,Connection1006,Connection1051,Constant1057,Lambda1059,Lambda1062,Constant1063,Constant1064,Constant1065,Lambda1077,Constant1078,Lambda1089,Lambda1091,Constant1092,Constant1106,Lambda1117,Lambda1119,Constant1120,Constant1134,Constant1148,Constant1149,Constant1162,Constant1176,Constant1177,Constant1190,Constant1204,Constant1218,Constant1232,Constant1246,Constant1260,Constant1261,Constant1262,Constant1274,Constant1275,Constant1288,Constant1289,Constant1290,Constant1302,Constant1316,Constant1317,Constant1330,Lambda1341,Lambda1343,Constant1344,Constant1345,Constant1358,Lambda1369,Constant1372,Constant1386,Constant1400,Constant1414,Constant1428,Constant1429,Constant1430,Constant1442,Constant1456,Constant1470,Constant1484,Constant1498,Constant1512,Constant1526,Constant1527,Constant1540,Constant1554,Constant1555,Constant1568,Constant1582,Constant1583,Constant1596,Constant1610,Constant1611,Constant1626,Constant1627,Constant1640,Constant1641,Constant1654,Constant1668,Constant1669,Constant1682,Constant1696,Constant1697,Constant1698,Constant1706,Constant1707,Constant1708,Constant1709,Constant1710,Constant1711,Constant1712,Constant1713,Constant1714,Constant1715,Constant1716,Constant1717,Constant1718,Constant1719,Constant1720,Constant1721,Constant1722,Constant1723,Constant1724,Constant1725,Constant1726,Constant1727,Constant1728,Constant1729,Constant1730,Constant1731,Constant1732,Constant1733,Constant1734,Constant1735,Constant1736,Constant1737,Constant1738,Constant1739,Constant1740,Constant1741,Constant1742,Constant1743,Constant1744,Constant1745,Constant1746,Constant1747,Constant1748,Constant1749,Constant1750,Constant1751,Constant1752,Constant1753,Constant1754,Constant1755,Constant1756,Constant1757,Constant1758,Constant1759,Constant1760,Constant1761,Constant1762,Constant1763,Constant1764,Constant1765,Constant1766,Constant1767,Constant1768,Constant1769,Constant1770,Constant1771,Constant1772,Constant1773,Constant1774,Constant1775,Constant1776,Constant1777 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 1059, 1062, 6, 1077, 1063, 1064, 1065, 1718, 1078, 1719<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 15, 1066, 1073, 1081, 1087, 1067, 1082<br />2: PgSelect[14], PgSelect[37]<br />ᐳ: 17, 18, 20, 21, 23, 24, 26, 27, 30, 31, 32, 35, 36, 38, 39, 40, 19, 25"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Connection59,Connection105,Connection150,Connection198,Connection247,Lambda248,PgValidateParsedCursor250,Access251,Connection301,PgValidateParsedCursor304,Connection354,Connection368,Connection385,Connection428,Connection471,Connection516,Connection562,Connection609,Connection622,Lambda623,PgValidateParsedCursor625,Access626,Connection677,PgValidateParsedCursor680,Connection732,PgValidateParsedCursor735,Connection787,Connection834,Connection882,Connection928,Constant949,Connection959,Connection1006,Connection1051,Constant1057,Lambda1059,Lambda1062,Access1063,Constant1064,Constant1065,Constant1066,Object1067,Lambda1068,Lambda1074,Lambda1078,Access1079,Constant1080,Object1083,Lambda1084,Lambda1089,Lambda1091,Lambda1093,Access1094,Constant1095,Object1098,Lambda1099,Lambda1104,Constant1110,Object1113,Lambda1114,Lambda1119,Lambda1121,Lambda1123,Access1124,Constant1125,Object1128,Lambda1129,Lambda1134,Constant1140,Object1143,Lambda1144,Lambda1149,Constant1155,Constant1156,Object1158,Lambda1159,Lambda1164,Constant1170,Object1173,Lambda1174,Lambda1179,Constant1185,Constant1186,Object1188,Lambda1189,Lambda1194,Constant1200,Object1203,Lambda1204,Lambda1209,Constant1215,Object1218,Lambda1219,Lambda1224,Constant1230,Object1233,Lambda1234,Lambda1239,Constant1245,Object1248,Lambda1249,Lambda1254,Constant1260,Object1263,Lambda1264,Lambda1269,Constant1275,Constant1276,Constant1277,Object1278,Lambda1279,Lambda1284,Constant1290,Constant1291,Object1293,Lambda1294,Lambda1299,Constant1305,Constant1306,Constant1307,Object1308,Lambda1309,Lambda1314,Constant1320,Object1323,Lambda1324,Lambda1329,Constant1335,Constant1336,Object1338,Lambda1339,Lambda1344,Constant1350,Object1353,Lambda1354,Lambda1359,Lambda1361,Lambda1363,Access1364,Constant1365,Constant1366,Object1368,Lambda1369,Lambda1374,Constant1380,Object1383,Lambda1384,Lambda1389,Lambda1391,Lambda1393,Access1394,Constant1395,Object1398,Lambda1399,Lambda1404,Constant1410,Object1413,Lambda1414,Lambda1419,Lambda1421,Lambda1423,Access1424,Constant1425,Object1428,Lambda1429,Lambda1434,Constant1440,Object1443,Lambda1444,Lambda1449,Constant1455,Constant1456,Constant1457,Object1458,Lambda1459,Lambda1464,Constant1470,Object1473,Lambda1474,Lambda1479,Constant1485,Object1488,Lambda1489,Lambda1494,Lambda1496,Lambda1498,Access1499,Constant1500,Object1503,Lambda1504,Lambda1509,Constant1515,Object1518,Lambda1519,Lambda1524,Constant1530,Object1533,Lambda1534,Lambda1539,Constant1545,Object1548,Lambda1549,Lambda1554,Constant1560,Constant1561,Object1563,Lambda1564,Lambda1569,Constant1575,Object1578,Lambda1579,Lambda1584,Lambda1588,Access1589,Constant1590,Constant1591,Object1593,Lambda1594,Lambda1599,Constant1605,Object1608,Lambda1609,Lambda1614,Constant1620,Constant1621,Object1623,Lambda1624,Lambda1629,Constant1635,Object1638,Lambda1639,Lambda1644,Constant1650,Constant1651,Object1653,Lambda1654,Lambda1659,Lambda1665,Access1666,Constant1667,Constant1668,Object1670,Lambda1671,Lambda1676,Constant1682,Constant1683,Object1685,Lambda1686,Lambda1691,Constant1697,Object1700,Lambda1701,Lambda1706,Constant1712,Constant1713,Object1715,Lambda1716,Lambda1721,Constant1727,Object1730,Lambda1731,Lambda1736,Constant1742,Constant1743,Constant1744,Object1745,Lambda1746,Lambda1751,Constant1752,Constant1753,Constant1754,Constant1755,Constant1756,Constant1757,Constant1758,Constant1759,Constant1760,Constant1761,Constant1762,Constant1763,Constant1764,Constant1765,Constant1766,Constant1767,Constant1768,Constant1769,Constant1770,Constant1771,Constant1772,Constant1773,Constant1774,Constant1775,Constant1776,Constant1777,Constant1778,Constant1779,Constant1780,Constant1781,Constant1782,Constant1783,Constant1784,Constant1785,Constant1786,Constant1787,Constant1788,Constant1789,Constant1790,Constant1791,Constant1792,Constant1793,Constant1794,Constant1795,Constant1796,Constant1797,Constant1798,Constant1799,Constant1800,Constant1801,Constant1802,Constant1803,Constant1804,Constant1805,Constant1806,Constant1807,Constant1808,Constant1809,Constant1810,Constant1811,Constant1812,Constant1813,Constant1814,Constant1815,Constant1816,Constant1817,Constant1818,Constant1819,Constant1820,Constant1821,Constant1822,Constant1823 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 1059, 1063, 1068, 1074, 6, 1079, 1084, 1089<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,PgPageInfo15,First17,PgSelectSingle18,PgCursor19,PgClassExpression20,List21,Last23,PgSelectSingle24,PgCursor25,PgClassExpression26,List27,Access30,Object31,Lambda32,Object35,Lambda36,PgSelect37,First38,PgSelectSingle39,PgClassExpression40,Object1066,Lambda1067,Lambda1073,Object1081,Lambda1082,Lambda1087 bucket1
+    class Bucket1,PgSelect14,PgPageInfo15,First17,PgSelectSingle18,PgCursor19,PgClassExpression20,List21,Last23,PgSelectSingle24,PgCursor25,PgClassExpression26,List27,Access30,Object31,Lambda32,Object35,Lambda36,PgSelect37,First38,PgSelectSingle39,PgClassExpression40 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[42]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item42,PgSelectSingle43 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 43<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[43]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor44,PgClassExpression45,List46,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression53 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 59, 1706, 1089, 1091, 6, 1059, 1077, 1092, 1064, 1065, 1720, 1106, 1721<br /><br />ROOT Connectionᐸ57ᐳ[59]<br />1: <br />ᐳ: 61, 1095, 1101, 1109, 1115, 1096, 1110<br />2: PgSelect[60], PgSelect[83]<br />ᐳ: 63, 64, 66, 67, 69, 70, 72, 73, 76, 77, 78, 81, 82, 84, 85, 86, 65, 71"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 59, 1752, 1091, 1094, 1099, 1104, 6, 1059, 1079, 1114, 1119<br /><br />ROOT Connectionᐸ57ᐳ[59]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect60,PgPageInfo61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,Access76,Object77,Lambda78,Object81,Lambda82,PgSelect83,First84,PgSelectSingle85,PgClassExpression86,Object1095,Lambda1096,Lambda1101,Object1109,Lambda1110,Lambda1115 bucket4
+    class Bucket4,PgSelect60,PgPageInfo61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,Access76,Object77,Lambda78,Object81,Lambda82,PgSelect83,First84,PgSelectSingle85,PgClassExpression86 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ60ᐳ[88]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item88,PgSelectSingle89 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 89<br /><br />ROOT PgSelectSingle{5}ᐸpersonᐳ[89]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgCursor90,PgClassExpression91,List92,PgClassExpression94,PgClassExpression95,PgClassExpression96,PgClassExpression97,PgClassExpression98,PgClassExpression99 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 12, 105, 1706, 1117, 1119, 6, 1059, 1077, 1120, 1064, 1065, 1722, 1134, 1723<br /><br />ROOT Connectionᐸ103ᐳ[105]<br />1: <br />ᐳ: 107, 1123, 1129, 1137, 1143, 1124, 1138<br />2: PgSelect[106], PgSelect[129]<br />ᐳ: 109, 110, 112, 113, 115, 116, 118, 119, 122, 123, 124, 127, 128, 130, 131, 132, 111, 117"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 12, 105, 1752, 1121, 1124, 1129, 1134, 6, 1059, 1079, 1144, 1149<br /><br />ROOT Connectionᐸ103ᐳ[105]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelect106,PgPageInfo107,First109,PgSelectSingle110,PgCursor111,PgClassExpression112,List113,Last115,PgSelectSingle116,PgCursor117,PgClassExpression118,List119,Access122,Object123,Lambda124,Object127,Lambda128,PgSelect129,First130,PgSelectSingle131,PgClassExpression132,Object1123,Lambda1124,Lambda1129,Object1137,Lambda1138,Lambda1143 bucket7
+    class Bucket7,PgSelect106,PgPageInfo107,First109,PgSelectSingle110,PgCursor111,PgClassExpression112,List113,Last115,PgSelectSingle116,PgCursor117,PgClassExpression118,List119,Access122,Object123,Lambda124,Object127,Lambda128,PgSelect129,First130,PgSelectSingle131,PgClassExpression132 bucket7
     Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ106ᐳ[134]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item134,PgSelectSingle135 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 135<br /><br />ROOT PgSelectSingle{8}ᐸpersonᐳ[135]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgCursor136,PgClassExpression137,List138,PgClassExpression140,PgClassExpression141,PgClassExpression142,PgClassExpression143,PgClassExpression144,PgClassExpression145 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 12, 150, 1059, 1062, 6, 1077, 1148, 1149, 1065, 1738, 1162, 1739<br /><br />ROOT Connectionᐸ148ᐳ[150]<br />1: <br />ᐳ: 152, 1151, 1157, 1165, 1171, 1152, 1166<br />2: PgSelect[151], PgSelect[176]<br />ᐳ: 154, 155, 157, 158, 159, 161, 162, 164, 165, 166, 169, 170, 171, 174, 175, 177, 178, 179, 156, 163"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 12, 150, 1059, 1063, 1159, 1164, 6, 1079, 1174, 1179<br /><br />ROOT Connectionᐸ148ᐳ[150]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect151,PgPageInfo152,First154,PgSelectSingle155,PgCursor156,PgClassExpression157,PgClassExpression158,List159,Last161,PgSelectSingle162,PgCursor163,PgClassExpression164,PgClassExpression165,List166,Access169,Object170,Lambda171,Object174,Lambda175,PgSelect176,First177,PgSelectSingle178,PgClassExpression179,Object1151,Lambda1152,Lambda1157,Object1165,Lambda1166,Lambda1171 bucket10
+    class Bucket10,PgSelect151,PgPageInfo152,First154,PgSelectSingle155,PgCursor156,PgClassExpression157,PgClassExpression158,List159,Last161,PgSelectSingle162,PgCursor163,PgClassExpression164,PgClassExpression165,List166,Access169,Object170,Lambda171,Object174,Lambda175,PgSelect176,First177,PgSelectSingle178,PgClassExpression179 bucket10
     Bucket11("Bucket 11 (listItem)<br /><br />ROOT __Item{11}ᐸ151ᐳ[181]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,__Item181,PgSelectSingle182 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 182<br /><br />ROOT PgSelectSingle{11}ᐸpersonᐳ[182]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgCursor183,PgClassExpression184,PgClassExpression185,List186,PgClassExpression189,PgClassExpression190,PgClassExpression191,PgClassExpression192,PgClassExpression193 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 12, 198, 1059, 1062, 6, 1077, 1176, 1177, 1065, 1740, 1190, 1741<br /><br />ROOT Connectionᐸ196ᐳ[198]<br />1: <br />ᐳ: 200, 1179, 1185, 1193, 1199, 1180, 1194<br />2: PgSelect[199], PgSelect[224]<br />ᐳ: 202, 203, 205, 206, 207, 209, 210, 212, 213, 214, 217, 218, 219, 222, 223, 225, 226, 227, 204, 211"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 12, 198, 1059, 1063, 1189, 1194, 6, 1079, 1204, 1209<br /><br />ROOT Connectionᐸ196ᐳ[198]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgSelect199,PgPageInfo200,First202,PgSelectSingle203,PgCursor204,PgClassExpression205,PgClassExpression206,List207,Last209,PgSelectSingle210,PgCursor211,PgClassExpression212,PgClassExpression213,List214,Access217,Object218,Lambda219,Object222,Lambda223,PgSelect224,First225,PgSelectSingle226,PgClassExpression227,Object1179,Lambda1180,Lambda1185,Object1193,Lambda1194,Lambda1199 bucket13
+    class Bucket13,PgSelect199,PgPageInfo200,First202,PgSelectSingle203,PgCursor204,PgClassExpression205,PgClassExpression206,List207,Last209,PgSelectSingle210,PgCursor211,PgClassExpression212,PgClassExpression213,List214,Access217,Object218,Lambda219,Object222,Lambda223,PgSelect224,First225,PgSelectSingle226,PgClassExpression227 bucket13
     Bucket14("Bucket 14 (listItem)<br /><br />ROOT __Item{14}ᐸ199ᐳ[229]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item229,PgSelectSingle230 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 230<br /><br />ROOT PgSelectSingle{14}ᐸpersonᐳ[230]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgCursor231,PgClassExpression232,PgClassExpression233,List234,PgClassExpression237,PgClassExpression238,PgClassExpression239,PgClassExpression240,PgClassExpression241 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 12, 247, 248, 251, 1059, 1062, 6, 1077, 1204, 1064, 1065, 1724, 1218, 1725<br /><br />ROOT Connectionᐸ245ᐳ[247]<br />1: <br />ᐳ: 252, 1207, 1213, 1221, 1227, 1208, 1222<br />2: PgSelect[249], PgSelect[278]<br />ᐳ: 254, 255, 258, 259, 261, 262, 265, 266, 269, 270, 271, 275, 276, 279, 280, 281, 256, 263"):::bucket
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 12, 247, 248, 251, 1059, 1063, 1219, 1224, 6, 1079, 1234, 1239<br /><br />ROOT Connectionᐸ245ᐳ[247]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgSelect249,PgPageInfo252,First254,PgSelectSingle255,PgCursor256,PgClassExpression258,List259,Last261,PgSelectSingle262,PgCursor263,PgClassExpression265,List266,Access269,Object270,Lambda271,Object275,Lambda276,PgSelect278,First279,PgSelectSingle280,PgClassExpression281,Object1207,Lambda1208,Lambda1213,Object1221,Lambda1222,Lambda1227 bucket16
+    class Bucket16,PgSelect249,PgPageInfo252,First254,PgSelectSingle255,PgCursor256,PgClassExpression258,List259,Last261,PgSelectSingle262,PgCursor263,PgClassExpression265,List266,Access269,Object270,Lambda271,Object275,Lambda276,PgSelect278,First279,PgSelectSingle280,PgClassExpression281 bucket16
     Bucket17("Bucket 17 (listItem)<br /><br />ROOT __Item{17}ᐸ249ᐳ[284]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,__Item284,PgSelectSingle285 bucket17
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 285<br /><br />ROOT PgSelectSingle{17}ᐸpersonᐳ[285]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,PgCursor286,PgClassExpression287,List288,PgClassExpression290,PgClassExpression291,PgClassExpression292,PgClassExpression293,PgClassExpression294,PgClassExpression295 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 12, 301, 248, 251, 1059, 1062, 6, 1077, 1232, 1064, 1065, 1726, 1246, 1727<br /><br />ROOT Connectionᐸ299ᐳ[301]<br />1: <br />ᐳ: 306, 1235, 1241, 1249, 1255, 1236, 1250<br />2: PgSelect[303], PgSelect[332]<br />ᐳ: 308, 309, 312, 313, 315, 316, 319, 320, 323, 324, 325, 329, 330, 333, 334, 335, 310, 317"):::bucket
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 12, 301, 248, 251, 1059, 1063, 1249, 1254, 6, 1079, 1264, 1269<br /><br />ROOT Connectionᐸ299ᐳ[301]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgSelect303,PgPageInfo306,First308,PgSelectSingle309,PgCursor310,PgClassExpression312,List313,Last315,PgSelectSingle316,PgCursor317,PgClassExpression319,List320,Access323,Object324,Lambda325,Object329,Lambda330,PgSelect332,First333,PgSelectSingle334,PgClassExpression335,Object1235,Lambda1236,Lambda1241,Object1249,Lambda1250,Lambda1255 bucket19
+    class Bucket19,PgSelect303,PgPageInfo306,First308,PgSelectSingle309,PgCursor310,PgClassExpression312,List313,Last315,PgSelectSingle316,PgCursor317,PgClassExpression319,List320,Access323,Object324,Lambda325,Object329,Lambda330,PgSelect332,First333,PgSelectSingle334,PgClassExpression335 bucket19
     Bucket20("Bucket 20 (listItem)<br /><br />ROOT __Item{20}ᐸ303ᐳ[338]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20,__Item338,PgSelectSingle339 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 339<br /><br />ROOT PgSelectSingle{20}ᐸpersonᐳ[339]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgCursor340,PgClassExpression341,List342,PgClassExpression344,PgClassExpression345,PgClassExpression346,PgClassExpression347,PgClassExpression348,PgClassExpression349 bucket21
-    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 12, 354, 1059, 1077, 1260, 1261, 1262, 1751<br /><br />ROOT Connectionᐸ352ᐳ[354]<br />1: <br />ᐳ: 1263, 1269, 1264<br />2: PgSelect[355]"):::bucket
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 12, 354, 1059, 1079, 1279, 1284<br /><br />ROOT Connectionᐸ352ᐳ[354]"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,PgSelect355,Object1263,Lambda1264,Lambda1269 bucket22
+    class Bucket22,PgSelect355 bucket22
     Bucket23("Bucket 23 (listItem)<br /><br />ROOT __Item{23}ᐸ355ᐳ[356]"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23,__Item356,PgSelectSingle357 bucket23
     Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 357<br /><br />ROOT PgSelectSingle{23}ᐸupdatable_viewᐳ[357]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,PgCursor358,PgClassExpression359,List360,PgClassExpression362,PgClassExpression363 bucket24
-    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 12, 368, 1059, 1077, 1274, 1275, 1262, 1752<br /><br />ROOT Connectionᐸ366ᐳ[368]<br />1: <br />ᐳ: 1277, 1283, 1278<br />2: PgSelect[369]"):::bucket
+    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 12, 368, 1059, 1079, 1294, 1299<br /><br />ROOT Connectionᐸ366ᐳ[368]"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,PgSelect369,Object1277,Lambda1278,Lambda1283 bucket25
+    class Bucket25,PgSelect369 bucket25
     Bucket26("Bucket 26 (listItem)<br /><br />ROOT __Item{26}ᐸ369ᐳ[370]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,__Item370,PgSelectSingle371 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 371<br /><br />ROOT PgSelectSingle{26}ᐸupdatable_viewᐳ[371]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgCursor372,PgClassExpression373,PgClassExpression374,List375,PgClassExpression377 bucket27
-    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 12, 1706, 385, 1059, 1062, 6, 1077, 1288, 1289, 1290, 1753, 1302, 1754<br /><br />ROOT Connectionᐸ383ᐳ[385]<br />1: <br />ᐳ: 387, 1291, 1297, 1305, 1311, 1292, 1306<br />2: PgSelect[386], PgSelect[409]<br />ᐳ: 389, 390, 392, 393, 395, 396, 398, 399, 402, 403, 404, 407, 408, 410, 411, 412, 391, 397"):::bucket
+    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 12, 1752, 385, 1059, 1063, 1309, 1314, 6, 1079, 1324, 1329<br /><br />ROOT Connectionᐸ383ᐳ[385]"):::bucket
     classDef bucket28 stroke:#00ffff
-    class Bucket28,PgSelect386,PgPageInfo387,First389,PgSelectSingle390,PgCursor391,PgClassExpression392,List393,Last395,PgSelectSingle396,PgCursor397,PgClassExpression398,List399,Access402,Object403,Lambda404,Object407,Lambda408,PgSelect409,First410,PgSelectSingle411,PgClassExpression412,Object1291,Lambda1292,Lambda1297,Object1305,Lambda1306,Lambda1311 bucket28
+    class Bucket28,PgSelect386,PgPageInfo387,First389,PgSelectSingle390,PgCursor391,PgClassExpression392,List393,Last395,PgSelectSingle396,PgCursor397,PgClassExpression398,List399,Access402,Object403,Lambda404,Object407,Lambda408,PgSelect409,First410,PgSelectSingle411,PgClassExpression412 bucket28
     Bucket29("Bucket 29 (listItem)<br /><br />ROOT __Item{29}ᐸ386ᐳ[414]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,__Item414,PgSelectSingle415 bucket29
     Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 415<br /><br />ROOT PgSelectSingle{29}ᐸpostᐳ[415]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,PgCursor416,PgClassExpression417,List418,PgClassExpression419,PgClassExpression420 bucket30
-    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 12, 1706, 428, 1089, 1091, 6, 1059, 1077, 1316, 1317, 1290, 1755, 1330, 1756<br /><br />ROOT Connectionᐸ426ᐳ[428]<br />1: <br />ᐳ: 430, 1319, 1325, 1333, 1339, 1320, 1334<br />2: PgSelect[429], PgSelect[452]<br />ᐳ: 432, 433, 435, 436, 438, 439, 441, 442, 445, 446, 447, 450, 451, 453, 454, 455, 434, 440"):::bucket
+    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 12, 1752, 428, 1091, 1094, 1339, 1344, 6, 1059, 1079, 1354, 1359<br /><br />ROOT Connectionᐸ426ᐳ[428]"):::bucket
     classDef bucket31 stroke:#a52a2a
-    class Bucket31,PgSelect429,PgPageInfo430,First432,PgSelectSingle433,PgCursor434,PgClassExpression435,List436,Last438,PgSelectSingle439,PgCursor440,PgClassExpression441,List442,Access445,Object446,Lambda447,Object450,Lambda451,PgSelect452,First453,PgSelectSingle454,PgClassExpression455,Object1319,Lambda1320,Lambda1325,Object1333,Lambda1334,Lambda1339 bucket31
+    class Bucket31,PgSelect429,PgPageInfo430,First432,PgSelectSingle433,PgCursor434,PgClassExpression435,List436,Last438,PgSelectSingle439,PgCursor440,PgClassExpression441,List442,Access445,Object446,Lambda447,Object450,Lambda451,PgSelect452,First453,PgSelectSingle454,PgClassExpression455 bucket31
     Bucket32("Bucket 32 (listItem)<br /><br />ROOT __Item{32}ᐸ429ᐳ[457]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32,__Item457,PgSelectSingle458 bucket32
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 458<br /><br />ROOT PgSelectSingle{32}ᐸpostᐳ[458]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgCursor459,PgClassExpression460,List461,PgClassExpression462,PgClassExpression463 bucket33
-    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 12, 1708, 471, 1341, 1343, 6, 1059, 1077, 1344, 1345, 1290, 1757, 1358, 1758<br /><br />ROOT Connectionᐸ469ᐳ[471]<br />1: <br />ᐳ: 473, 1347, 1353, 1361, 1367, 1348, 1362<br />2: PgSelect[472], PgSelect[497]<br />ᐳ: 475, 476, 478, 479, 480, 482, 483, 485, 486, 487, 490, 491, 492, 495, 496, 498, 499, 500, 477, 484"):::bucket
+    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 12, 1754, 471, 1361, 1364, 1369, 1374, 6, 1059, 1079, 1384, 1389<br /><br />ROOT Connectionᐸ469ᐳ[471]"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgSelect472,PgPageInfo473,First475,PgSelectSingle476,PgCursor477,PgClassExpression478,PgClassExpression479,List480,Last482,PgSelectSingle483,PgCursor484,PgClassExpression485,PgClassExpression486,List487,Access490,Object491,Lambda492,Object495,Lambda496,PgSelect497,First498,PgSelectSingle499,PgClassExpression500,Object1347,Lambda1348,Lambda1353,Object1361,Lambda1362,Lambda1367 bucket34
+    class Bucket34,PgSelect472,PgPageInfo473,First475,PgSelectSingle476,PgCursor477,PgClassExpression478,PgClassExpression479,List480,Last482,PgSelectSingle483,PgCursor484,PgClassExpression485,PgClassExpression486,List487,Access490,Object491,Lambda492,Object495,Lambda496,PgSelect497,First498,PgSelectSingle499,PgClassExpression500 bucket34
     Bucket35("Bucket 35 (listItem)<br /><br />ROOT __Item{35}ᐸ472ᐳ[502]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,__Item502,PgSelectSingle503 bucket35
     Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 503<br /><br />ROOT PgSelectSingle{35}ᐸpostᐳ[503]"):::bucket
     classDef bucket36 stroke:#7f007f
     class Bucket36,PgCursor504,PgClassExpression505,PgClassExpression506,List507,PgClassExpression509 bucket36
-    Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 12, 516, 1709, 1708, 1369, 6, 1059, 1077, 1771, 1372, 1064, 1065, 1728, 1386, 1729<br /><br />ROOT Connectionᐸ514ᐳ[516]<br />1: <br />ᐳ: 518, 1371, 1375, 1381, 1389, 1395, 1376, 1390<br />2: PgSelect[517], PgSelect[540]<br />ᐳ: 520, 521, 523, 524, 526, 527, 529, 530, 533, 534, 535, 538, 539, 541, 542, 543, 522, 528"):::bucket
+    Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 12, 516, 1755, 1754, 1391, 1394, 1399, 1404, 6, 1059, 1079, 1414, 1419<br /><br />ROOT Connectionᐸ514ᐳ[516]"):::bucket
     classDef bucket37 stroke:#ffa500
-    class Bucket37,PgSelect517,PgPageInfo518,First520,PgSelectSingle521,PgCursor522,PgClassExpression523,List524,Last526,PgSelectSingle527,PgCursor528,PgClassExpression529,List530,Access533,Object534,Lambda535,Object538,Lambda539,PgSelect540,First541,PgSelectSingle542,PgClassExpression543,Lambda1371,Object1375,Lambda1376,Lambda1381,Object1389,Lambda1390,Lambda1395 bucket37
+    class Bucket37,PgSelect517,PgPageInfo518,First520,PgSelectSingle521,PgCursor522,PgClassExpression523,List524,Last526,PgSelectSingle527,PgCursor528,PgClassExpression529,List530,Access533,Object534,Lambda535,Object538,Lambda539,PgSelect540,First541,PgSelectSingle542,PgClassExpression543 bucket37
     Bucket38("Bucket 38 (listItem)<br /><br />ROOT __Item{38}ᐸ517ᐳ[545]"):::bucket
     classDef bucket38 stroke:#0000ff
     class Bucket38,__Item545,PgSelectSingle546 bucket38
     Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 546<br /><br />ROOT PgSelectSingle{38}ᐸpersonᐳ[546]"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,PgCursor547,PgClassExpression548,List549,PgClassExpression551,PgClassExpression552,PgClassExpression553,PgClassExpression554,PgClassExpression555,PgClassExpression556 bucket39
-    Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 12, 562, 1710, 6, 1059, 1077, 1772, 1773, 1400, 1064, 1065, 1730, 1414, 1731<br /><br />ROOT Connectionᐸ560ᐳ[562]<br />1: <br />ᐳ: 564, 1397, 1399, 1409, 1417, 1423, 1403, 1404, 1418<br />2: PgSelect[563], PgSelect[586]<br />ᐳ: 566, 567, 569, 570, 572, 573, 575, 576, 579, 580, 581, 584, 585, 587, 588, 589, 568, 574"):::bucket
+    Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 12, 562, 1756, 1421, 1424, 1429, 1434, 6, 1059, 1079, 1444, 1449<br /><br />ROOT Connectionᐸ560ᐳ[562]"):::bucket
     classDef bucket40 stroke:#ff1493
-    class Bucket40,PgSelect563,PgPageInfo564,First566,PgSelectSingle567,PgCursor568,PgClassExpression569,List570,Last572,PgSelectSingle573,PgCursor574,PgClassExpression575,List576,Access579,Object580,Lambda581,Object584,Lambda585,PgSelect586,First587,PgSelectSingle588,PgClassExpression589,Lambda1397,Lambda1399,Object1403,Lambda1404,Lambda1409,Object1417,Lambda1418,Lambda1423 bucket40
+    class Bucket40,PgSelect563,PgPageInfo564,First566,PgSelectSingle567,PgCursor568,PgClassExpression569,List570,Last572,PgSelectSingle573,PgCursor574,PgClassExpression575,List576,Access579,Object580,Lambda581,Object584,Lambda585,PgSelect586,First587,PgSelectSingle588,PgClassExpression589 bucket40
     Bucket41("Bucket 41 (listItem)<br /><br />ROOT __Item{41}ᐸ563ᐳ[591]"):::bucket
     classDef bucket41 stroke:#808000
     class Bucket41,__Item591,PgSelectSingle592 bucket41
     Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 592<br /><br />ROOT PgSelectSingle{41}ᐸpersonᐳ[592]"):::bucket
     classDef bucket42 stroke:#dda0dd
     class Bucket42,PgCursor593,PgClassExpression594,List595,PgClassExpression597,PgClassExpression598,PgClassExpression599,PgClassExpression600,PgClassExpression601,PgClassExpression602 bucket42
-    Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 12, 1706, 609, 1059, 1077, 1428, 1429, 1430, 1759<br /><br />ROOT Connectionᐸ607ᐳ[609]<br />1: <br />ᐳ: 1431, 1437, 1432<br />2: PgSelect[610]"):::bucket
+    Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 12, 1752, 609, 1059, 1079, 1459, 1464<br /><br />ROOT Connectionᐸ607ᐳ[609]"):::bucket
     classDef bucket43 stroke:#ff0000
-    class Bucket43,PgSelect610,Object1431,Lambda1432,Lambda1437 bucket43
+    class Bucket43,PgSelect610 bucket43
     Bucket44("Bucket 44 (listItem)<br /><br />ROOT __Item{44}ᐸ610ᐳ[611]"):::bucket
     classDef bucket44 stroke:#ffff00
     class Bucket44,__Item611,PgSelectSingle612 bucket44
     Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 612<br /><br />ROOT PgSelectSingle{44}ᐸedge_caseᐳ[612]"):::bucket
     classDef bucket45 stroke:#00ffff
     class Bucket45,PgClassExpression613 bucket45
-    Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 12, 622, 623, 1057, 1706, 1117, 1119, 6, 1059, 1077, 1442, 1064, 1065, 1732, 1456, 1733<br /><br />ROOT Connectionᐸ620ᐳ[622]<br />1: <br />ᐳ: 626, 627, 1445, 1451, 1459, 1465, 1446, 1460<br />2: PgSelect[624], PgSelect[653]<br />ᐳ: 629, 630, 633, 634, 636, 637, 640, 641, 643, 644, 645, 650, 651, 654, 655, 656, 631, 638"):::bucket
+    Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 12, 622, 623, 1057, 1752, 626, 1121, 1124, 1474, 1479, 6, 1059, 1079, 1489, 1494<br /><br />ROOT Connectionᐸ620ᐳ[622]"):::bucket
     classDef bucket46 stroke:#4169e1
-    class Bucket46,PgSelect624,Access626,PgPageInfo627,First629,PgSelectSingle630,PgCursor631,PgClassExpression633,List634,Last636,PgSelectSingle637,PgCursor638,PgClassExpression640,List641,Access643,Object644,Lambda645,Object650,Lambda651,PgSelect653,First654,PgSelectSingle655,PgClassExpression656,Object1445,Lambda1446,Lambda1451,Object1459,Lambda1460,Lambda1465 bucket46
+    class Bucket46,PgSelect624,PgPageInfo627,First629,PgSelectSingle630,PgCursor631,PgClassExpression633,List634,Last636,PgSelectSingle637,PgCursor638,PgClassExpression640,List641,Access643,Object644,Lambda645,Object650,Lambda651,PgSelect653,First654,PgSelectSingle655,PgClassExpression656 bucket46
     Bucket47("Bucket 47 (listItem)<br /><br />ROOT __Item{47}ᐸ624ᐳ[659]"):::bucket
     classDef bucket47 stroke:#3cb371
     class Bucket47,__Item659,PgSelectSingle660 bucket47
     Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 660<br /><br />ROOT PgSelectSingle{47}ᐸpersonᐳ[660]"):::bucket
     classDef bucket48 stroke:#a52a2a
     class Bucket48,PgCursor661,PgClassExpression662,List663,PgClassExpression665,PgClassExpression666,PgClassExpression667,PgClassExpression668,PgClassExpression669,PgClassExpression670 bucket48
-    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 12, 677, 248, 1708, 251, 6, 1059, 1077, 1774, 1775, 1470, 1064, 1065, 1734, 1484, 1735<br /><br />ROOT Connectionᐸ675ᐳ[677]<br />1: <br />ᐳ: 682, 1467, 1469, 1479, 1487, 1493, 1473, 1474, 1488<br />2: PgSelect[679], PgSelect[708]<br />ᐳ: 684, 685, 688, 689, 691, 692, 695, 696, 699, 700, 701, 705, 706, 709, 710, 711, 686, 693"):::bucket
+    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 12, 677, 248, 1754, 251, 1496, 1499, 1504, 1509, 6, 1059, 1079, 1519, 1524<br /><br />ROOT Connectionᐸ675ᐳ[677]"):::bucket
     classDef bucket49 stroke:#ff00ff
-    class Bucket49,PgSelect679,PgPageInfo682,First684,PgSelectSingle685,PgCursor686,PgClassExpression688,List689,Last691,PgSelectSingle692,PgCursor693,PgClassExpression695,List696,Access699,Object700,Lambda701,Object705,Lambda706,PgSelect708,First709,PgSelectSingle710,PgClassExpression711,Lambda1467,Lambda1469,Object1473,Lambda1474,Lambda1479,Object1487,Lambda1488,Lambda1493 bucket49
+    class Bucket49,PgSelect679,PgPageInfo682,First684,PgSelectSingle685,PgCursor686,PgClassExpression688,List689,Last691,PgSelectSingle692,PgCursor693,PgClassExpression695,List696,Access699,Object700,Lambda701,Object705,Lambda706,PgSelect708,First709,PgSelectSingle710,PgClassExpression711 bucket49
     Bucket50("Bucket 50 (listItem)<br /><br />ROOT __Item{50}ᐸ679ᐳ[714]"):::bucket
     classDef bucket50 stroke:#f5deb3
     class Bucket50,__Item714,PgSelectSingle715 bucket50
     Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 715<br /><br />ROOT PgSelectSingle{50}ᐸpersonᐳ[715]"):::bucket
     classDef bucket51 stroke:#696969
     class Bucket51,PgCursor716,PgClassExpression717,List718,PgClassExpression720,PgClassExpression721,PgClassExpression722,PgClassExpression723,PgClassExpression724,PgClassExpression725 bucket51
-    Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 12, 732, 248, 1708, 251, 1341, 1343, 6, 1059, 1077, 1498, 1064, 1065, 1736, 1512, 1737<br /><br />ROOT Connectionᐸ730ᐳ[732]<br />1: <br />ᐳ: 737, 1501, 1507, 1515, 1521, 1502, 1516<br />2: PgSelect[734], PgSelect[763]<br />ᐳ: 739, 740, 743, 744, 746, 747, 750, 751, 754, 755, 756, 760, 761, 764, 765, 766, 741, 748"):::bucket
+    Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 12, 732, 248, 1754, 251, 1361, 1364, 1534, 1539, 6, 1059, 1079, 1549, 1554<br /><br />ROOT Connectionᐸ730ᐳ[732]"):::bucket
     classDef bucket52 stroke:#00bfff
-    class Bucket52,PgSelect734,PgPageInfo737,First739,PgSelectSingle740,PgCursor741,PgClassExpression743,List744,Last746,PgSelectSingle747,PgCursor748,PgClassExpression750,List751,Access754,Object755,Lambda756,Object760,Lambda761,PgSelect763,First764,PgSelectSingle765,PgClassExpression766,Object1501,Lambda1502,Lambda1507,Object1515,Lambda1516,Lambda1521 bucket52
+    class Bucket52,PgSelect734,PgPageInfo737,First739,PgSelectSingle740,PgCursor741,PgClassExpression743,List744,Last746,PgSelectSingle747,PgCursor748,PgClassExpression750,List751,Access754,Object755,Lambda756,Object760,Lambda761,PgSelect763,First764,PgSelectSingle765,PgClassExpression766 bucket52
     Bucket53("Bucket 53 (listItem)<br /><br />ROOT __Item{53}ᐸ734ᐳ[769]"):::bucket
     classDef bucket53 stroke:#7f007f
     class Bucket53,__Item769,PgSelectSingle770 bucket53
     Bucket54("Bucket 54 (nullableBoundary)<br />Deps: 770<br /><br />ROOT PgSelectSingle{53}ᐸpersonᐳ[770]"):::bucket
     classDef bucket54 stroke:#ffa500
     class Bucket54,PgCursor771,PgClassExpression772,List773,PgClassExpression775,PgClassExpression776,PgClassExpression777,PgClassExpression778,PgClassExpression779,PgClassExpression780 bucket54
-    Bucket55("Bucket 55 (nullableBoundary)<br />Deps: 12, 787, 1059, 1062, 6, 1077, 1526, 1527, 1065, 1742, 1540, 1743<br /><br />ROOT Connectionᐸ785ᐳ[787]<br />1: <br />ᐳ: 789, 1529, 1535, 1543, 1549, 1530, 1544<br />2: PgSelect[788], PgSelect[811]<br />ᐳ: 791, 792, 794, 795, 797, 798, 800, 801, 804, 805, 806, 809, 810, 812, 813, 814, 793, 799"):::bucket
+    Bucket55("Bucket 55 (nullableBoundary)<br />Deps: 12, 787, 1059, 1063, 1564, 1569, 6, 1079, 1579, 1584<br /><br />ROOT Connectionᐸ785ᐳ[787]"):::bucket
     classDef bucket55 stroke:#0000ff
-    class Bucket55,PgSelect788,PgPageInfo789,First791,PgSelectSingle792,PgCursor793,PgClassExpression794,List795,Last797,PgSelectSingle798,PgCursor799,PgClassExpression800,List801,Access804,Object805,Lambda806,Object809,Lambda810,PgSelect811,First812,PgSelectSingle813,PgClassExpression814,Object1529,Lambda1530,Lambda1535,Object1543,Lambda1544,Lambda1549 bucket55
+    class Bucket55,PgSelect788,PgPageInfo789,First791,PgSelectSingle792,PgCursor793,PgClassExpression794,List795,Last797,PgSelectSingle798,PgCursor799,PgClassExpression800,List801,Access804,Object805,Lambda806,Object809,Lambda810,PgSelect811,First812,PgSelectSingle813,PgClassExpression814 bucket55
     Bucket56("Bucket 56 (listItem)<br /><br />ROOT __Item{56}ᐸ788ᐳ[816]"):::bucket
     classDef bucket56 stroke:#7fff00
     class Bucket56,__Item816,PgSelectSingle817 bucket56
     Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 817<br /><br />ROOT PgSelectSingle{56}ᐸpersonᐳ[817]"):::bucket
     classDef bucket57 stroke:#ff1493
     class Bucket57,PgCursor818,PgClassExpression819,List820,PgClassExpression822,PgClassExpression823,PgClassExpression824,PgClassExpression825,PgClassExpression826,PgClassExpression827 bucket57
-    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 12, 834, 1709, 1369, 6, 1059, 1077, 1776, 1554, 1555, 1290, 1760, 1568, 1761<br /><br />ROOT Connectionᐸ832ᐳ[834]<br />1: <br />ᐳ: 836, 1553, 1557, 1563, 1571, 1577, 1558, 1572<br />2: PgSelect[835], PgSelect[862]<br />ᐳ: 838, 839, 841, 842, 843, 844, 846, 847, 849, 850, 851, 852, 855, 856, 857, 860, 861, 863, 864, 865, 840, 848"):::bucket
+    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 12, 834, 1755, 1391, 1589, 1594, 1599, 6, 1059, 1079, 1609, 1614<br /><br />ROOT Connectionᐸ832ᐳ[834]"):::bucket
     classDef bucket58 stroke:#808000
-    class Bucket58,PgSelect835,PgPageInfo836,First838,PgSelectSingle839,PgCursor840,PgClassExpression841,PgClassExpression842,PgClassExpression843,List844,Last846,PgSelectSingle847,PgCursor848,PgClassExpression849,PgClassExpression850,PgClassExpression851,List852,Access855,Object856,Lambda857,Object860,Lambda861,PgSelect862,First863,PgSelectSingle864,PgClassExpression865,Lambda1553,Object1557,Lambda1558,Lambda1563,Object1571,Lambda1572,Lambda1577 bucket58
+    class Bucket58,PgSelect835,PgPageInfo836,First838,PgSelectSingle839,PgCursor840,PgClassExpression841,PgClassExpression842,PgClassExpression843,List844,Last846,PgSelectSingle847,PgCursor848,PgClassExpression849,PgClassExpression850,PgClassExpression851,List852,Access855,Object856,Lambda857,Object860,Lambda861,PgSelect862,First863,PgSelectSingle864,PgClassExpression865 bucket58
     Bucket59("Bucket 59 (listItem)<br /><br />ROOT __Item{59}ᐸ835ᐳ[867]"):::bucket
     classDef bucket59 stroke:#dda0dd
     class Bucket59,__Item867,PgSelectSingle868 bucket59
     Bucket60("Bucket 60 (nullableBoundary)<br />Deps: 868<br /><br />ROOT PgSelectSingle{59}ᐸpostᐳ[868]"):::bucket
     classDef bucket60 stroke:#ff0000
     class Bucket60,PgCursor869,PgClassExpression870,PgClassExpression871,PgClassExpression872,List873 bucket60
-    Bucket61("Bucket 61 (nullableBoundary)<br />Deps: 12, 1712, 882, 1059, 1062, 6, 1077, 1582, 1583, 1065, 1744, 1596, 1745<br /><br />ROOT Connectionᐸ880ᐳ[882]<br />1: <br />ᐳ: 884, 1585, 1591, 1599, 1605, 1586, 1600<br />2: PgSelect[883], PgSelect[906]<br />ᐳ: 886, 887, 889, 890, 892, 893, 895, 896, 899, 900, 901, 904, 905, 907, 908, 909, 888, 894"):::bucket
+    Bucket61("Bucket 61 (nullableBoundary)<br />Deps: 12, 1758, 882, 1059, 1063, 1624, 1629, 6, 1079, 1639, 1644<br /><br />ROOT Connectionᐸ880ᐳ[882]"):::bucket
     classDef bucket61 stroke:#ffff00
-    class Bucket61,PgSelect883,PgPageInfo884,First886,PgSelectSingle887,PgCursor888,PgClassExpression889,List890,Last892,PgSelectSingle893,PgCursor894,PgClassExpression895,List896,Access899,Object900,Lambda901,Object904,Lambda905,PgSelect906,First907,PgSelectSingle908,PgClassExpression909,Object1585,Lambda1586,Lambda1591,Object1599,Lambda1600,Lambda1605 bucket61
+    class Bucket61,PgSelect883,PgPageInfo884,First886,PgSelectSingle887,PgCursor888,PgClassExpression889,List890,Last892,PgSelectSingle893,PgCursor894,PgClassExpression895,List896,Access899,Object900,Lambda901,Object904,Lambda905,PgSelect906,First907,PgSelectSingle908,PgClassExpression909 bucket61
     Bucket62("Bucket 62 (listItem)<br /><br />ROOT __Item{62}ᐸ883ᐳ[911]"):::bucket
     classDef bucket62 stroke:#00ffff
     class Bucket62,__Item911,PgSelectSingle912 bucket62
     Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 912<br /><br />ROOT PgSelectSingle{62}ᐸpersonᐳ[912]"):::bucket
     classDef bucket63 stroke:#4169e1
     class Bucket63,PgCursor913,PgClassExpression914,List915,PgClassExpression917,PgClassExpression918,PgClassExpression919,PgClassExpression920,PgClassExpression921,PgClassExpression922 bucket63
-    Bucket64("Bucket 64 (nullableBoundary)<br />Deps: 12, 928, 1706, 1077, 1089, 1059, 1610, 1611, 1065, 1746, 1777, 1626, 1627, 1290, 1762, 949<br /><br />ROOT Connectionᐸ926ᐳ[928]<br />1: <br />ᐳ: 1613, 1619, 1625, 1629, 1635, 1614, 1630<br />2: PgSelect[929]"):::bucket
+    Bucket64("Bucket 64 (nullableBoundary)<br />Deps: 12, 928, 1752, 1079, 1654, 1659, 1091, 1666, 1671, 1676, 949<br /><br />ROOT Connectionᐸ926ᐳ[928]"):::bucket
     classDef bucket64 stroke:#3cb371
-    class Bucket64,PgSelect929,Object1613,Lambda1614,Lambda1619,Lambda1625,Object1629,Lambda1630,Lambda1635 bucket64
+    class Bucket64,PgSelect929 bucket64
     Bucket65("Bucket 65 (listItem)<br />Deps: 949<br /><br />ROOT __Item{65}ᐸ929ᐳ[930]"):::bucket
     classDef bucket65 stroke:#a52a2a
     class Bucket65,__Item930,PgSelectSingle931 bucket65
     Bucket66("Bucket 66 (nullableBoundary)<br />Deps: 931<br /><br />ROOT PgSelectSingle{65}ᐸpostᐳ[931]"):::bucket
     classDef bucket66 stroke:#ff00ff
-    class Bucket66,PgClassExpression932,PgSelectSingle939,PgClassExpression941,RemapKeys1620 bucket66
+    class Bucket66,PgClassExpression932,PgSelectSingle939,PgClassExpression941,RemapKeys1660 bucket66
     Bucket67("Bucket 67 (nullableBoundary)<br />Deps: 939<br /><br />ROOT PgSelectSingle{66}ᐸpersonᐳ[939]"):::bucket
     classDef bucket67 stroke:#f5deb3
     class Bucket67,PgClassExpression940,PgClassExpression946 bucket67
     Bucket68("Bucket 68 (nullableBoundary)<br />Deps: 931, 949<br /><br />ROOT PgSelectSingle{65}ᐸpostᐳ[931]"):::bucket
     classDef bucket68 stroke:#696969
     class Bucket68,PgClassExpression950,List951,Lambda952 bucket68
-    Bucket69("Bucket 69 (nullableBoundary)<br />Deps: 12, 1713, 959, 1059, 1062, 6, 1077, 1640, 1641, 1065, 1747, 1654, 1748<br /><br />ROOT Connectionᐸ957ᐳ[959]<br />1: <br />ᐳ: 961, 1643, 1649, 1657, 1663, 1644, 1658<br />2: PgSelect[960], PgSelect[983]<br />ᐳ: 963, 964, 966, 967, 969, 970, 972, 973, 976, 977, 978, 981, 982, 984, 985, 986, 965, 971"):::bucket
+    Bucket69("Bucket 69 (nullableBoundary)<br />Deps: 12, 1759, 959, 1059, 1063, 1686, 1691, 6, 1079, 1701, 1706<br /><br />ROOT Connectionᐸ957ᐳ[959]"):::bucket
     classDef bucket69 stroke:#00bfff
-    class Bucket69,PgSelect960,PgPageInfo961,First963,PgSelectSingle964,PgCursor965,PgClassExpression966,List967,Last969,PgSelectSingle970,PgCursor971,PgClassExpression972,List973,Access976,Object977,Lambda978,Object981,Lambda982,PgSelect983,First984,PgSelectSingle985,PgClassExpression986,Object1643,Lambda1644,Lambda1649,Object1657,Lambda1658,Lambda1663 bucket69
+    class Bucket69,PgSelect960,PgPageInfo961,First963,PgSelectSingle964,PgCursor965,PgClassExpression966,List967,Last969,PgSelectSingle970,PgCursor971,PgClassExpression972,List973,Access976,Object977,Lambda978,Object981,Lambda982,PgSelect983,First984,PgSelectSingle985,PgClassExpression986 bucket69
     Bucket70("Bucket 70 (listItem)<br /><br />ROOT __Item{70}ᐸ960ᐳ[988]"):::bucket
     classDef bucket70 stroke:#7f007f
     class Bucket70,__Item988,PgSelectSingle989 bucket70
     Bucket71("Bucket 71 (nullableBoundary)<br />Deps: 989<br /><br />ROOT PgSelectSingle{70}ᐸpersonᐳ[989]"):::bucket
     classDef bucket71 stroke:#ffa500
     class Bucket71,PgCursor990,PgClassExpression991,List992,PgClassExpression994,PgClassExpression995,PgClassExpression996,PgClassExpression997,PgClassExpression998,PgClassExpression999 bucket71
-    Bucket72("Bucket 72 (nullableBoundary)<br />Deps: 12, 1714, 1006, 1059, 1062, 6, 1077, 1668, 1669, 1065, 1749, 1682, 1750<br /><br />ROOT Connectionᐸ1004ᐳ[1006]<br />1: <br />ᐳ: 1008, 1671, 1677, 1685, 1691, 1672, 1686<br />2: PgSelect[1007], PgSelect[1030]<br />ᐳ: 1010, 1011, 1013, 1014, 1016, 1017, 1019, 1020, 1023, 1024, 1025, 1028, 1029, 1031, 1032, 1033, 1012, 1018"):::bucket
+    Bucket72("Bucket 72 (nullableBoundary)<br />Deps: 12, 1760, 1006, 1059, 1063, 1716, 1721, 6, 1079, 1731, 1736<br /><br />ROOT Connectionᐸ1004ᐳ[1006]"):::bucket
     classDef bucket72 stroke:#0000ff
-    class Bucket72,PgSelect1007,PgPageInfo1008,First1010,PgSelectSingle1011,PgCursor1012,PgClassExpression1013,List1014,Last1016,PgSelectSingle1017,PgCursor1018,PgClassExpression1019,List1020,Access1023,Object1024,Lambda1025,Object1028,Lambda1029,PgSelect1030,First1031,PgSelectSingle1032,PgClassExpression1033,Object1671,Lambda1672,Lambda1677,Object1685,Lambda1686,Lambda1691 bucket72
+    class Bucket72,PgSelect1007,PgPageInfo1008,First1010,PgSelectSingle1011,PgCursor1012,PgClassExpression1013,List1014,Last1016,PgSelectSingle1017,PgCursor1018,PgClassExpression1019,List1020,Access1023,Object1024,Lambda1025,Object1028,Lambda1029,PgSelect1030,First1031,PgSelectSingle1032,PgClassExpression1033 bucket72
     Bucket73("Bucket 73 (listItem)<br /><br />ROOT __Item{73}ᐸ1007ᐳ[1035]"):::bucket
     classDef bucket73 stroke:#7fff00
     class Bucket73,__Item1035,PgSelectSingle1036 bucket73
     Bucket74("Bucket 74 (nullableBoundary)<br />Deps: 1036<br /><br />ROOT PgSelectSingle{73}ᐸpersonᐳ[1036]"):::bucket
     classDef bucket74 stroke:#ff1493
     class Bucket74,PgCursor1037,PgClassExpression1038,List1039,PgClassExpression1041,PgClassExpression1042,PgClassExpression1043,PgClassExpression1044,PgClassExpression1045,PgClassExpression1046 bucket74
-    Bucket75("Bucket 75 (nullableBoundary)<br />Deps: 12, 1051, 1059, 1077, 1696, 1697, 1698, 1763<br /><br />ROOT Connectionᐸ1049ᐳ[1051]<br />1: <br />ᐳ: 1699, 1705, 1700<br />2: PgSelect[1052]"):::bucket
+    Bucket75("Bucket 75 (nullableBoundary)<br />Deps: 12, 1051, 1059, 1079, 1746, 1751<br /><br />ROOT Connectionᐸ1049ᐳ[1051]"):::bucket
     classDef bucket75 stroke:#808000
-    class Bucket75,PgSelect1052,Object1699,Lambda1700,Lambda1705 bucket75
+    class Bucket75,PgSelect1052 bucket75
     Bucket76("Bucket 76 (listItem)<br /><br />ROOT __Item{76}ᐸ1052ᐳ[1053]"):::bucket
     classDef bucket76 stroke:#dda0dd
     class Bucket76,__Item1053,PgSelectSingle1054 bucket76

--- a/postgraphile/postgraphile/__tests__/queries/v4/d.filter.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/d.filter.mermaid
@@ -9,34 +9,36 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ'col_no_create1'ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Object14{{"Object[14∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda33{{"Lambda[33∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda38{{"Lambda[38∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant44 & Connection15 & Lambda30 & Lambda33 & Lambda38 & Lambda43 --> PgSelect16
-    Object37{{"Object[37∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda30 & Constant34 & Constant35 & Constant36 --> Object37
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access13{{"Access[13∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object38{{"Object[38∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda30 & Constant35 & Constant36 & Constant37 --> Object38
+    Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access12 & Access13 --> Object14
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Constant45 --> Lambda30
-    Constant46 --> Lambda33
-    Object37 --> Lambda38
-    Constant47 --> Lambda43
+    Constant46{{"Constant[46∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant46 --> Lambda30
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant47 --> Lambda33
+    Access34{{"Access[34∈0] ➊<br />ᐸ33.0ᐳ"}}:::plan
+    Lambda33 --> Access34
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object38 --> Lambda39
+    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant48{{"Constant[48∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant48 --> Lambda44
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ'col_no_create1'ᐳ"}}:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸpersonᐳ"]]:::plan
+    Object14 & Constant45 & Connection15 & Lambda30 & Access34 & Lambda39 & Lambda44 --> PgSelect16
     __Item17[/"__Item[17∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -65,10 +67,10 @@ graph TD
     subgraph "Buckets for queries/v4/d.filter"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection15,Constant34,Constant35,Constant36,Constant44,Constant45,Constant46,Constant47 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 44, 15, 45, 46, 34, 35, 36, 47<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 12, 13, 30, 33, 43, 14, 37, 38<br />2: PgSelect[16]"):::bucket
+    class Bucket0,__Value2,__Value4,Access12,Access13,Object14,Connection15,Lambda30,Lambda33,Access34,Constant35,Constant36,Constant37,Object38,Lambda39,Lambda44,Constant45,Constant46,Constant47,Constant48 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 45, 15, 30, 34, 39, 44<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access12,Access13,Object14,PgSelect16,Lambda30,Lambda33,Object37,Lambda38,Lambda43 bucket1
+    class Bucket1,PgSelect16 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item17,PgSelectSingle18 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/d.order.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/d.order.mermaid
@@ -9,33 +9,35 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ[ { attribute: 'col_no_create_update', direction: 'DESC' }, ᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col_no_create_updᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda28{{"Lambda[28∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda31{{"Lambda[31∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda36{{"Lambda[36∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda41{{"Lambda[41∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda28 & Lambda31 & Lambda36 & Lambda41 --> PgSelect14
-    Object35{{"Object[35∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda28 & Constant32 & Constant33 & Constant34 --> Object35
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object36{{"Object[36∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ[ { attribute: 'col_no_create_update', direction: 'DESC' }, ᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda28 & Constant33 & Constant34 & Constant35 --> Object36
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant42 --> Lambda28
-    Constant43 --> Lambda31
-    Object35 --> Lambda36
-    Constant44 --> Lambda41
+    Constant43{{"Constant[43∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant43 --> Lambda28
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant44 --> Lambda31
+    Access32{{"Access[32∈0] ➊<br />ᐸ31.0ᐳ"}}:::plan
+    Lambda31 --> Access32
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object36 --> Lambda37
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col_no_create_updᐳ"}}:::plan
+    Constant45 --> Lambda42
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpersonᐳ"]]:::plan
+    Object12 & Connection13 & Lambda28 & Access32 & Lambda37 & Lambda42 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -64,10 +66,10 @@ graph TD
     subgraph "Buckets for queries/v4/d.order"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant32,Constant33,Constant34,Constant42,Constant43,Constant44 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 42, 43, 32, 33, 34, 44<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 28, 31, 41, 12, 35, 36<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda28,Lambda31,Access32,Constant33,Constant34,Constant35,Object36,Lambda37,Lambda42,Constant43,Constant44,Constant45 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 28, 32, 37, 42<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda28,Lambda31,Object35,Lambda36,Lambda41 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/dynamic-json.condition-json-field-variable.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/dynamic-json.condition-json-field-variable.mermaid
@@ -9,46 +9,63 @@ graph TD
 
 
     %% plan dependencies
+    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
+    Lambda50 & Constant55 & Constant56 & Constant57 --> Object58
+    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda50 & Constant70 & Constant71 & Constant57 --> Object73
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda50 & Constant85 & Constant86 & Constant57 --> Object88
     Object16{{"Object[16∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access14 & Access15 --> Object16
+    __InputDynamicScalar10{{"__InputDynamicScalar[10∈0] ➊"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ0.myValᐳ"}}:::plan
+    Access11 --> __InputDynamicScalar10
+    __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
+    __Value0 --> Access11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access14
     __Value2 --> Access15
-    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant92 --> Lambda50
+    Access38{{"Access[38∈0] ➊<br />ᐸ0.myVal2ᐳ"}}:::plan
+    __Value0 --> Access38
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant95 --> Lambda50
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant93 --> Lambda53
-    __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant96 --> Lambda53
+    Access54{{"Access[54∈0] ➊<br />ᐸ53.0ᐳ"}}:::plan
+    Lambda53 --> Access54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object58 --> Lambda59
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant97 --> Lambda64
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object73 --> Lambda74
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant98 --> Lambda79
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object88 --> Lambda89
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant99 --> Lambda94
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection17{{"Connection[17∈0] ➊<br />ᐸ13ᐳ"}}:::plan
+    __InputDynamicScalar26{{"__InputDynamicScalar[26∈0] ➊"}}:::plan
     Connection29{{"Connection[29∈0] ➊<br />ᐸ27ᐳ"}}:::plan
     Connection42{{"Connection[42∈0] ➊<br />ᐸ40ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect18[["PgSelect[18∈1] ➊<br />ᐸmy_tableᐳ"]]:::plan
-    __InputDynamicScalar10{{"__InputDynamicScalar[10∈1] ➊"}}:::plan
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object16 & __InputDynamicScalar10 & Connection17 & Lambda50 & Lambda53 & Lambda58 & Lambda63 --> PgSelect18
-    Object57{{"Object[57∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda50 & Constant54 & Constant55 & Constant56 --> Object57
-    Access11{{"Access[11∈1] ➊<br />ᐸ0.myValᐳ"}}:::plan
-    Access11 --> __InputDynamicScalar10
-    __Value0 --> Access11
-    Object57 --> Lambda58
-    Constant94 --> Lambda63
+    Object16 & __InputDynamicScalar10 & Connection17 & Lambda50 & Access54 & Lambda59 & Lambda64 --> PgSelect18
     __Item19[/"__Item[19∈2]<br />ᐸ18ᐳ"\]:::itemplan
     PgSelect18 ==> __Item19
     PgSelectSingle20{{"PgSelectSingle[20∈2]<br />ᐸmy_tableᐳ"}}:::plan
@@ -58,14 +75,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__my_table...json_data”ᐳ"}}:::plan
     PgSelectSingle20 --> PgClassExpression22
     PgSelect30[["PgSelect[30∈4] ➊<br />ᐸmy_tableᐳ"]]:::plan
-    __InputDynamicScalar26{{"__InputDynamicScalar[26∈4] ➊"}}:::plan
-    Lambda86{{"Lambda[86∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object16 & __InputDynamicScalar26 & Connection29 & Lambda50 & Lambda53 & Lambda86 & Lambda91 --> PgSelect30
-    Object85{{"Object[85∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda50 & Constant82 & Constant83 & Constant56 --> Object85
-    Object85 --> Lambda86
-    Constant96 --> Lambda91
+    Object16 & __InputDynamicScalar26 & Connection29 & Lambda50 & Access54 & Lambda89 & Lambda94 --> PgSelect30
     __Item31[/"__Item[31∈5]<br />ᐸ30ᐳ"\]:::itemplan
     PgSelect30 ==> __Item31
     PgSelectSingle32{{"PgSelectSingle[32∈5]<br />ᐸmy_tableᐳ"}}:::plan
@@ -75,15 +85,7 @@ graph TD
     PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__my_table...json_data”ᐳ"}}:::plan
     PgSelectSingle32 --> PgClassExpression34
     PgSelect43[["PgSelect[43∈7] ➊<br />ᐸmy_tableᐳ"]]:::plan
-    Access38{{"Access[38∈7] ➊<br />ᐸ0.myVal2ᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object16 & Access38 & Connection42 & Lambda50 & Lambda53 & Lambda72 & Lambda77 --> PgSelect43
-    Object71{{"Object[71∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda50 & Constant68 & Constant69 & Constant56 --> Object71
-    __Value0 --> Access38
-    Object71 --> Lambda72
-    Constant95 --> Lambda77
+    Object16 & Access38 & Connection42 & Lambda50 & Access54 & Lambda74 & Lambda79 --> PgSelect43
     __Item44[/"__Item[44∈8]<br />ᐸ43ᐳ"\]:::itemplan
     PgSelect43 ==> __Item44
     PgSelectSingle45{{"PgSelectSingle[45∈8]<br />ᐸmy_tableᐳ"}}:::plan
@@ -98,28 +100,28 @@ graph TD
     subgraph "Buckets for queries/v4/dynamic-json.condition-json-field-variable"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value2,__Value4,Access14,Access15,Object16,Connection17,Connection29,Connection42,Lambda50,Lambda53,Constant54,Constant55,Constant56,Constant68,Constant69,Constant82,Constant83,Constant92,Constant93,Constant94,Constant95,Constant96 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 0, 16, 17, 50, 53, 54, 55, 56, 94<br /><br />ROOT Connectionᐸ13ᐳ[17]<br />1: <br />ᐳ: 11, 57, 63, 10, 58<br />2: PgSelect[18]"):::bucket
+    class Bucket0,__Value0,__Value2,__Value4,__InputDynamicScalar10,Access11,Access14,Access15,Object16,Connection17,__InputDynamicScalar26,Connection29,Access38,Connection42,Lambda50,Lambda53,Access54,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant70,Constant71,Object73,Lambda74,Lambda79,Constant85,Constant86,Object88,Lambda89,Lambda94,Constant95,Constant96,Constant97,Constant98,Constant99 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 16, 10, 17, 50, 54, 59, 64<br /><br />ROOT Connectionᐸ13ᐳ[17]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__InputDynamicScalar10,Access11,PgSelect18,Object57,Lambda58,Lambda63 bucket1
+    class Bucket1,PgSelect18 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ18ᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item19,PgSelectSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{2}ᐸmy_tableᐳ[20]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression21,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 16, 29, 50, 53, 82, 83, 56, 96<br /><br />ROOT Connectionᐸ27ᐳ[29]<br />1: <br />ᐳ: 26, 85, 91, 86<br />2: PgSelect[30]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 16, 26, 29, 50, 54, 89, 94<br /><br />ROOT Connectionᐸ27ᐳ[29]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__InputDynamicScalar26,PgSelect30,Object85,Lambda86,Lambda91 bucket4
+    class Bucket4,PgSelect30 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ30ᐳ[31]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item31,PgSelectSingle32 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{5}ᐸmy_tableᐳ[32]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression33,PgClassExpression34 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 0, 16, 42, 50, 53, 68, 69, 56, 95<br /><br />ROOT Connectionᐸ40ᐳ[42]<br />1: <br />ᐳ: 38, 71, 77, 72<br />2: PgSelect[43]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 16, 38, 42, 50, 54, 74, 79<br /><br />ROOT Connectionᐸ40ᐳ[42]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Access38,PgSelect43,Object71,Lambda72,Lambda77 bucket7
+    class Bucket7,PgSelect43 bucket7
     Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ43ᐳ[44]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item44,PgSelectSingle45 bucket8

--- a/postgraphile/postgraphile/__tests__/queries/v4/dynamic-json.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/dynamic-json.mermaid
@@ -11,117 +11,122 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant275{{"Constant[275∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant288{{"Constant[288∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant275 & Lambda93 & Lambda96 & Lambda101 & Lambda106 --> PgSelect7
+    Access97{{"Access[97∈0] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant288 & Lambda93 & Access97 & Lambda102 & Lambda107 --> PgSelect7
     PgSelect15[["PgSelect[15∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     Constant94{{"Constant[94∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant94 & Lambda93 & Lambda96 & Lambda115 & Lambda120 --> PgSelect15
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant94 & Lambda93 & Access97 & Lambda117 & Lambda122 --> PgSelect15
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
-    Constant276{{"Constant[276∈0] ➊<br />ᐸ42ᐳ"}}:::plan
-    Lambda129{{"Lambda[129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda134{{"Lambda[134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant276 & Lambda93 & Lambda96 & Lambda129 & Lambda134 --> PgSelect21
+    Constant289{{"Constant[289∈0] ➊<br />ᐸ42ᐳ"}}:::plan
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant289 & Lambda93 & Access97 & Lambda132 & Lambda137 --> PgSelect21
     PgSelect27[["PgSelect[27∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
-    Constant277{{"Constant[277∈0] ➊<br />ᐸ3.1415ᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant277 & Lambda93 & Lambda96 & Lambda143 & Lambda148 --> PgSelect27
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ3.1415ᐳ"}}:::plan
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant290 & Lambda93 & Access97 & Lambda147 & Lambda152 --> PgSelect27
     PgSelect33[["PgSelect[33∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
-    Constant278{{"Constant[278∈0] ➊<br />ᐸ'hello, world!'ᐳ"}}:::plan
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant291{{"Constant[291∈0] ➊<br />ᐸ'hello, world!'ᐳ"}}:::plan
     Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant278 & Lambda93 & Lambda96 & Lambda157 & Lambda162 --> PgSelect33
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant291 & Lambda93 & Access97 & Lambda162 & Lambda167 --> PgSelect33
     PgSelect39[["PgSelect[39∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     __InputDynamicScalar38{{"__InputDynamicScalar[38∈0] ➊"}}:::plan
-    Lambda171{{"Lambda[171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda176{{"Lambda[176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar38 & Lambda93 & Lambda96 & Lambda171 & Lambda176 --> PgSelect39
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar38 & Lambda93 & Access97 & Lambda177 & Lambda182 --> PgSelect39
     PgSelect45[["PgSelect[45∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     __InputDynamicScalar44{{"__InputDynamicScalar[44∈0] ➊"}}:::plan
-    Lambda185{{"Lambda[185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar44 & Lambda93 & Lambda96 & Lambda185 & Lambda190 --> PgSelect45
+    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar44 & Lambda93 & Access97 & Lambda192 & Lambda197 --> PgSelect45
     PgSelect51[["PgSelect[51∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     __InputDynamicScalar50{{"__InputDynamicScalar[50∈0] ➊"}}:::plan
-    Lambda199{{"Lambda[199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda204{{"Lambda[204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar50 & Lambda93 & Lambda96 & Lambda199 & Lambda204 --> PgSelect51
+    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar50 & Lambda93 & Access97 & Lambda207 & Lambda212 --> PgSelect51
     PgSelect57[["PgSelect[57∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     __InputDynamicScalar56{{"__InputDynamicScalar[56∈0] ➊"}}:::plan
-    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda218{{"Lambda[218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar56 & Lambda93 & Lambda96 & Lambda213 & Lambda218 --> PgSelect57
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar56 & Lambda93 & Access97 & Lambda222 & Lambda227 --> PgSelect57
     PgSelect63[["PgSelect[63∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
     __InputDynamicScalar62{{"__InputDynamicScalar[62∈0] ➊"}}:::plan
-    Lambda227{{"Lambda[227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar62 & Lambda93 & Lambda96 & Lambda227 & Lambda232 --> PgSelect63
+    Lambda237{{"Lambda[237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda242{{"Lambda[242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar62 & Lambda93 & Access97 & Lambda237 & Lambda242 --> PgSelect63
     PgSelect69[["PgSelect[69∈0] ➊<br />ᐸjsonb_identityᐳ"]]:::plan
     __InputDynamicScalar68{{"__InputDynamicScalar[68∈0] ➊"}}:::plan
-    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda246{{"Lambda[246∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar68 & Lambda93 & Lambda96 & Lambda241 & Lambda246 --> PgSelect69
+    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda257{{"Lambda[257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar68 & Lambda93 & Access97 & Lambda252 & Lambda257 --> PgSelect69
     PgSelect75[["PgSelect[75∈0] ➊<br />ᐸjsonb_identityᐳ"]]:::plan
     __InputDynamicScalar74{{"__InputDynamicScalar[74∈0] ➊"}}:::plan
-    Lambda255{{"Lambda[255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda260{{"Lambda[260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & __InputDynamicScalar74 & Lambda93 & Lambda96 & Lambda255 & Lambda260 --> PgSelect75
-    Object100{{"Object[100∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸCodec(json)ᐳ"}}:::plan
-    Lambda93 & Constant97 & Constant98 & Constant99 --> Object100
-    Object114{{"Object[114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant111 & Constant112 & Constant99 --> Object114
-    Object128{{"Object[128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant125 & Constant126 & Constant99 --> Object128
-    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant139 & Constant140 & Constant99 --> Object142
-    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant153 & Constant154 & Constant99 --> Object156
-    Object170{{"Object[170∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant167 & Constant168 & Constant99 --> Object170
-    Object184{{"Object[184∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant181 & Constant182 & Constant99 --> Object184
-    Object198{{"Object[198∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant195 & Constant196 & Constant99 --> Object198
-    Object212{{"Object[212∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant209 & Constant210 & Constant99 --> Object212
-    Object226{{"Object[226∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant223 & Constant224 & Constant99 --> Object226
-    Object240{{"Object[240∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant237{{"Constant[237∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant238{{"Constant[238∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
-    Constant239{{"Constant[239∈0] ➊<br />ᐸCodec(jsonb)ᐳ"}}:::plan
-    Lambda93 & Constant237 & Constant238 & Constant239 --> Object240
-    Object254{{"Object[254∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant251{{"Constant[251∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant252{{"Constant[252∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
-    Lambda93 & Constant251 & Constant252 & Constant239 --> Object254
+    Lambda267{{"Lambda[267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda272{{"Lambda[272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & __InputDynamicScalar74 & Lambda93 & Access97 & Lambda267 & Lambda272 --> PgSelect75
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸCodec(json)ᐳ"}}:::plan
+    Lambda93 & Constant98 & Constant99 & Constant100 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant113 & Constant114 & Constant100 --> Object116
+    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant128 & Constant129 & Constant100 --> Object131
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant143 & Constant144 & Constant100 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant158 & Constant159 & Constant100 --> Object161
+    Object176{{"Object[176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant173 & Constant174 & Constant100 --> Object176
+    Object191{{"Object[191∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant188 & Constant189 & Constant100 --> Object191
+    Object206{{"Object[206∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant203 & Constant204 & Constant100 --> Object206
+    Object221{{"Object[221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant218 & Constant219 & Constant100 --> Object221
+    Object236{{"Object[236∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant233{{"Constant[233∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant233 & Constant234 & Constant100 --> Object236
+    Object251{{"Object[251∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant248{{"Constant[248∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant249{{"Constant[249∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
+    Constant250{{"Constant[250∈0] ➊<br />ᐸCodec(jsonb)ᐳ"}}:::plan
+    Lambda93 & Constant248 & Constant249 & Constant250 --> Object251
+    Object266{{"Object[266∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant263{{"Constant[263∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant264{{"Constant[264∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
+    Lambda93 & Constant263 & Constant264 & Constant250 --> Object266
+    Object281{{"Object[281∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant278{{"Constant[278∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda93 & Constant278 & Constant279 & Constant280 --> Object281
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -200,60 +205,57 @@ graph TD
     First77 --> PgSelectSingle78
     PgClassExpression79{{"PgClassExpression[79∈0] ➊<br />ᐸ__jsonb_identity__.vᐳ"}}:::plan
     PgSelectSingle78 --> PgClassExpression79
-    Constant279{{"Constant[279∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant279 --> Lambda93
-    Constant280{{"Constant[280∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant280 --> Lambda96
-    Object100 --> Lambda101
-    Constant281{{"Constant[281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant281 --> Lambda106
-    Object114 --> Lambda115
-    Constant282{{"Constant[282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant282 --> Lambda120
-    Object128 --> Lambda129
-    Constant283{{"Constant[283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant283 --> Lambda134
-    Object142 --> Lambda143
-    Constant284{{"Constant[284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant284 --> Lambda148
-    Object156 --> Lambda157
-    Constant285{{"Constant[285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant285 --> Lambda162
-    Object170 --> Lambda171
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant286 --> Lambda176
-    Object184 --> Lambda185
-    Constant287{{"Constant[287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant287 --> Lambda190
-    Object198 --> Lambda199
-    Constant288{{"Constant[288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant288 --> Lambda204
-    Object212 --> Lambda213
-    Constant289{{"Constant[289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant289 --> Lambda218
-    Object226 --> Lambda227
-    Constant290{{"Constant[290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant290 --> Lambda232
-    Object240 --> Lambda241
-    Constant291{{"Constant[291∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant291 --> Lambda246
-    Object254 --> Lambda255
-    Constant292{{"Constant[292∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant292 --> Lambda260
+    Constant292{{"Constant[292∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant292 --> Lambda93
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant293 --> Lambda96
+    Lambda96 --> Access97
+    Object101 --> Lambda102
+    Constant294{{"Constant[294∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant294 --> Lambda107
+    Object116 --> Lambda117
+    Constant295{{"Constant[295∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant295 --> Lambda122
+    Object131 --> Lambda132
+    Constant296{{"Constant[296∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant296 --> Lambda137
+    Object146 --> Lambda147
+    Constant297{{"Constant[297∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant297 --> Lambda152
+    Object161 --> Lambda162
+    Constant298{{"Constant[298∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant298 --> Lambda167
+    Object176 --> Lambda177
+    Constant299{{"Constant[299∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant299 --> Lambda182
+    Object191 --> Lambda192
+    Constant300{{"Constant[300∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant300 --> Lambda197
+    Object206 --> Lambda207
+    Constant301{{"Constant[301∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant301 --> Lambda212
+    Object221 --> Lambda222
+    Constant302{{"Constant[302∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant302 --> Lambda227
+    Object236 --> Lambda237
+    Constant303{{"Constant[303∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant303 --> Lambda242
+    Object251 --> Lambda252
+    Constant304{{"Constant[304∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant304 --> Lambda257
+    Object266 --> Lambda267
+    Constant305{{"Constant[305∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant305 --> Lambda272
+    Lambda282{{"Lambda[282∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object281 --> Lambda282
+    Lambda287{{"Lambda[287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant306{{"Constant[306∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant306 --> Lambda287
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection85{{"Connection[85∈0] ➊<br />ᐸ83ᐳ"}}:::plan
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Constant293{{"Constant[293∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect86[["PgSelect[86∈1] ➊<br />ᐸtypesᐳ"]]:::plan
-    Lambda269{{"Lambda[269∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda274{{"Lambda[274∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection85 & Lambda93 & Lambda96 & Lambda269 & Lambda274 --> PgSelect86
-    Object268{{"Object[268∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda93 & Constant265 & Constant266 & Constant267 --> Object268
-    Object268 --> Lambda269
-    Constant293 --> Lambda274
+    Object10 & Connection85 & Lambda93 & Access97 & Lambda282 & Lambda287 --> PgSelect86
     __Item87[/"__Item[87∈2]<br />ᐸ86ᐳ"\]:::itemplan
     PgSelect86 ==> __Item87
     PgSelectSingle88{{"PgSelectSingle[88∈2]<br />ᐸtypesᐳ"}}:::plan
@@ -266,12 +268,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/dynamic-json"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 38, 44, 50, 56, 62, 68, 74, 85, 94, 97, 98, 99, 111, 112, 125, 126, 139, 140, 153, 154, 167, 168, 181, 182, 195, 196, 209, 210, 223, 224, 237, 238, 239, 251, 252, 265, 266, 267, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 10, 93, 96, 100, 101, 106, 114, 115, 120, 128, 129, 134, 142, 143, 148, 156, 157, 162, 170, 171, 176, 184, 185, 190, 198, 199, 204, 212, 213, 218, 226, 227, 232, 240, 241, 246, 254, 255, 260<br />2: 7, 15, 21, 27, 33, 39, 45, 51, 57, 63, 69, 75<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25, 29, 30, 31, 35, 36, 37, 41, 42, 43, 47, 48, 49, 53, 54, 55, 59, 60, 61, 65, 66, 67, 71, 72, 73, 77, 78, 79"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 38, 44, 50, 56, 62, 68, 74, 85, 94, 98, 99, 100, 113, 114, 128, 129, 143, 144, 158, 159, 173, 174, 188, 189, 203, 204, 218, 219, 233, 234, 248, 249, 250, 263, 264, 278, 279, 280, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 10, 93, 96, 97, 101, 102, 107, 116, 117, 122, 131, 132, 137, 146, 147, 152, 161, 162, 167, 176, 177, 182, 191, 192, 197, 206, 207, 212, 221, 222, 227, 236, 237, 242, 251, 252, 257, 266, 267, 272, 281, 282, 287<br />2: 7, 15, 21, 27, 33, 39, 45, 51, 57, 63, 69, 75<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25, 29, 30, 31, 35, 36, 37, 41, 42, 43, 47, 48, 49, 53, 54, 55, 59, 60, 61, 65, 66, 67, 71, 72, 73, 77, 78, 79"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect27,First29,PgSelectSingle30,PgClassExpression31,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,__InputDynamicScalar38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,__InputDynamicScalar44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,__InputDynamicScalar50,PgSelect51,First53,PgSelectSingle54,PgClassExpression55,__InputDynamicScalar56,PgSelect57,First59,PgSelectSingle60,PgClassExpression61,__InputDynamicScalar62,PgSelect63,First65,PgSelectSingle66,PgClassExpression67,__InputDynamicScalar68,PgSelect69,First71,PgSelectSingle72,PgClassExpression73,__InputDynamicScalar74,PgSelect75,First77,PgSelectSingle78,PgClassExpression79,Connection85,Lambda93,Constant94,Lambda96,Constant97,Constant98,Constant99,Object100,Lambda101,Lambda106,Constant111,Constant112,Object114,Lambda115,Lambda120,Constant125,Constant126,Object128,Lambda129,Lambda134,Constant139,Constant140,Object142,Lambda143,Lambda148,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant167,Constant168,Object170,Lambda171,Lambda176,Constant181,Constant182,Object184,Lambda185,Lambda190,Constant195,Constant196,Object198,Lambda199,Lambda204,Constant209,Constant210,Object212,Lambda213,Lambda218,Constant223,Constant224,Object226,Lambda227,Lambda232,Constant237,Constant238,Constant239,Object240,Lambda241,Lambda246,Constant251,Constant252,Object254,Lambda255,Lambda260,Constant265,Constant266,Constant267,Constant275,Constant276,Constant277,Constant278,Constant279,Constant280,Constant281,Constant282,Constant283,Constant284,Constant285,Constant286,Constant287,Constant288,Constant289,Constant290,Constant291,Constant292,Constant293 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 10, 85, 93, 96, 265, 266, 267, 293<br /><br />ROOT Connectionᐸ83ᐳ[85]<br />1: <br />ᐳ: Object[268], Lambda[274], Lambda[269]<br />2: PgSelect[86]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect27,First29,PgSelectSingle30,PgClassExpression31,PgSelect33,First35,PgSelectSingle36,PgClassExpression37,__InputDynamicScalar38,PgSelect39,First41,PgSelectSingle42,PgClassExpression43,__InputDynamicScalar44,PgSelect45,First47,PgSelectSingle48,PgClassExpression49,__InputDynamicScalar50,PgSelect51,First53,PgSelectSingle54,PgClassExpression55,__InputDynamicScalar56,PgSelect57,First59,PgSelectSingle60,PgClassExpression61,__InputDynamicScalar62,PgSelect63,First65,PgSelectSingle66,PgClassExpression67,__InputDynamicScalar68,PgSelect69,First71,PgSelectSingle72,PgClassExpression73,__InputDynamicScalar74,PgSelect75,First77,PgSelectSingle78,PgClassExpression79,Connection85,Lambda93,Constant94,Lambda96,Access97,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant128,Constant129,Object131,Lambda132,Lambda137,Constant143,Constant144,Object146,Lambda147,Lambda152,Constant158,Constant159,Object161,Lambda162,Lambda167,Constant173,Constant174,Object176,Lambda177,Lambda182,Constant188,Constant189,Object191,Lambda192,Lambda197,Constant203,Constant204,Object206,Lambda207,Lambda212,Constant218,Constant219,Object221,Lambda222,Lambda227,Constant233,Constant234,Object236,Lambda237,Lambda242,Constant248,Constant249,Constant250,Object251,Lambda252,Lambda257,Constant263,Constant264,Object266,Lambda267,Lambda272,Constant278,Constant279,Constant280,Object281,Lambda282,Lambda287,Constant288,Constant289,Constant290,Constant291,Constant292,Constant293,Constant294,Constant295,Constant296,Constant297,Constant298,Constant299,Constant300,Constant301,Constant302,Constant303,Constant304,Constant305,Constant306 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 10, 85, 93, 97, 282, 287<br /><br />ROOT Connectionᐸ83ᐳ[85]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect86,Object268,Lambda269,Lambda274 bucket1
+    class Bucket1,PgSelect86 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ86ᐳ[87]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item87,PgSelectSingle88 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/empty-array.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/empty-array.mermaid
@@ -9,35 +9,37 @@ graph TD
 
 
     %% plan dependencies
-    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant38 --> Connection14
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant38 & Lambda24 & Lambda27 & Lambda32 & Lambda37 --> PgSelect15
-    Object31{{"Object[31∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda24 & Constant28 & Constant29 & Constant30 --> Object31
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda24 & Constant29 & Constant30 & Constant31 --> Object32
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant40 --> Lambda24
-    Constant41 --> Lambda27
-    Object31 --> Lambda32
-    Constant39 --> Lambda37
+    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant39 --> Connection14
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant41 --> Lambda24
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant42 --> Lambda27
+    Access28{{"Access[28∈0] ➊<br />ᐸ27.0ᐳ"}}:::plan
+    Lambda27 --> Access28
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object32 --> Lambda33
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant40 --> Lambda38
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpersonᐳ"]]:::plan
+    Object13 & Connection14 & Constant39 & Lambda24 & Access28 & Lambda33 & Lambda38 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -56,10 +58,10 @@ graph TD
     subgraph "Buckets for queries/v4/empty-array"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection14,Constant28,Constant29,Constant30,Constant38,Constant39,Constant40,Constant41 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 38, 40, 41, 28, 29, 30, 39<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 24, 27, 37, 13, 31, 32<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda24,Lambda27,Access28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41,Constant42 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 39, 24, 28, 33, 38<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect15,Lambda24,Lambda27,Object31,Lambda32,Lambda37 bucket1
+    class Bucket1,PgSelect15 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/enum_tables.queries.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/enum_tables.queries.mermaid
@@ -11,25 +11,45 @@ graph TD
     %% plan dependencies
     PgSelect46[["PgSelect[46∈0] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸ'B'ᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸ'B'ᐳ"}}:::plan
     Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant191 & Lambda93 & Lambda96 & Lambda143 & Lambda148 --> PgSelect46
+    Access97{{"Access[97∈0] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant198 & Lambda93 & Access97 & Lambda147 & Lambda152 --> PgSelect46
     PgSelect55[["PgSelect[55∈0] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
-    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant191 & Lambda93 & Lambda96 & Lambda157 & Lambda162 --> PgSelect55
-    Object142{{"Object[142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸRecordCodec(letterDescriptions)ᐳ"}}:::plan
-    Lambda93 & Constant139 & Constant140 & Constant99 --> Object142
-    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Lambda93 & Constant153 & Constant154 & Constant99 --> Object156
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant198 & Lambda93 & Access97 & Lambda162 & Lambda167 --> PgSelect55
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸRecordCodec(letterDescriptions)ᐳ"}}:::plan
+    Lambda93 & Constant98 & Constant99 & Constant100 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { attribute: 'letter', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Lambda93 & Constant113 & Constant114 & Constant100 --> Object116
+    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ[ { attribute: 'letter_via_view', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Lambda93 & Constant128 & Constant129 & Constant100 --> Object131
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Lambda93 & Constant143 & Constant144 & Constant100 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Lambda93 & Constant158 & Constant159 & Constant100 --> Object161
+    Object176{{"Object[176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Lambda93 & Constant173 & Constant174 & Constant100 --> Object176
+    Object191{{"Object[191∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
+    Lambda93 & Constant188 & Constant189 & Constant100 --> Object191
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -44,46 +64,52 @@ graph TD
     PgSelect55 --> First57
     PgSelectSingle58{{"PgSelectSingle[58∈0] ➊<br />ᐸletter_descriptionsᐳ"}}:::plan
     First57 --> PgSelectSingle58
-    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant193 --> Lambda93
-    Constant194{{"Constant[194∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant194 --> Lambda96
-    Object142 --> Lambda143
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”letterᐳ"}}:::plan
-    Constant198 --> Lambda148
-    Object156 --> Lambda157
-    Constant199{{"Constant[199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”letterᐳ"}}:::plan
-    Constant199 --> Lambda162
+    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant200 --> Lambda93
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant201 --> Lambda96
+    Lambda96 --> Access97
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object101 --> Lambda102
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant202{{"Constant[202∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant202 --> Lambda107
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object116 --> Lambda117
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'letter', directioᐳ"}}:::plan
+    Constant203 --> Lambda122
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object131 --> Lambda132
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'letter_via_view',ᐳ"}}:::plan
+    Constant204 --> Lambda137
+    Object146 --> Lambda147
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”letterᐳ"}}:::plan
+    Constant205 --> Lambda152
+    Object161 --> Lambda162
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”letterᐳ"}}:::plan
+    Constant206 --> Lambda167
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object176 --> Lambda177
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant207 --> Lambda182
+    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object191 --> Lambda192
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant208 --> Lambda197
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection25{{"Connection[25∈0] ➊<br />ᐸ23ᐳ"}}:::plan
     Connection37{{"Connection[37∈0] ➊<br />ᐸ35ᐳ"}}:::plan
     Connection69{{"Connection[69∈0] ➊<br />ᐸ67ᐳ"}}:::plan
     Connection83{{"Connection[83∈0] ➊<br />ᐸ81ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ[ { attribute: 'letter', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ[ { attribute: 'letter_via_view', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant168{{"Constant[168∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸsql.identifier(”letter_descriptions”)ᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸ'C'ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'letter', directioᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'letter_via_view',ᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant199{{"Constant[199∈0] ➊<br />ᐸ'C'ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
-    Lambda101{{"Lambda[101∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda93 & Lambda96 & Lambda101 & Lambda106 --> PgSelect14
-    Object100{{"Object[100∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda93 & Constant97 & Constant98 & Constant99 --> Object100
-    Object100 --> Lambda101
-    Constant195 --> Lambda106
+    Object12 & Connection13 & Lambda93 & Access97 & Lambda102 & Lambda107 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸletter_descriptionsᐳ"}}:::plan
@@ -97,13 +123,7 @@ graph TD
     PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__letter_d...scription”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression20
     PgSelect26[["PgSelect[26∈4] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
-    Lambda115{{"Lambda[115∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda120{{"Lambda[120∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection25 & Lambda93 & Lambda96 & Lambda115 & Lambda120 --> PgSelect26
-    Object114{{"Object[114∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda93 & Constant111 & Constant112 & Constant99 --> Object114
-    Object114 --> Lambda115
-    Constant196 --> Lambda120
+    Object12 & Connection25 & Lambda93 & Access97 & Lambda117 & Lambda122 --> PgSelect26
     __Item27[/"__Item[27∈5]<br />ᐸ26ᐳ"\]:::itemplan
     PgSelect26 ==> __Item27
     PgSelectSingle28{{"PgSelectSingle[28∈5]<br />ᐸletter_descriptionsᐳ"}}:::plan
@@ -117,13 +137,7 @@ graph TD
     PgClassExpression32{{"PgClassExpression[32∈6]<br />ᐸ__letter_d...scription”ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression32
     PgSelect38[["PgSelect[38∈7] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
-    Lambda129{{"Lambda[129∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda134{{"Lambda[134∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection37 & Lambda93 & Lambda96 & Lambda129 & Lambda134 --> PgSelect38
-    Object128{{"Object[128∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda93 & Constant125 & Constant126 & Constant99 --> Object128
-    Object128 --> Lambda129
-    Constant197 --> Lambda134
+    Object12 & Connection37 & Lambda93 & Access97 & Lambda132 & Lambda137 --> PgSelect38
     __Item39[/"__Item[39∈8]<br />ᐸ38ᐳ"\]:::itemplan
     PgSelect38 ==> __Item39
     PgSelectSingle40{{"PgSelectSingle[40∈8]<br />ᐸletter_descriptionsᐳ"}}:::plan
@@ -153,13 +167,7 @@ graph TD
     PgClassExpression62{{"PgClassExpression[62∈11] ➊<br />ᐸ__letter_d...scription”ᐳ"}}:::plan
     PgSelectSingle58 --> PgClassExpression62
     PgSelect70[["PgSelect[70∈12] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
-    Lambda171{{"Lambda[171∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda176{{"Lambda[176∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant192 & Connection69 & Lambda93 & Lambda96 & Lambda171 & Lambda176 --> PgSelect70
-    Object170{{"Object[170∈12] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda93 & Constant167 & Constant168 & Constant99 --> Object170
-    Object170 --> Lambda171
-    Constant200 --> Lambda176
+    Object12 & Constant199 & Connection69 & Lambda93 & Access97 & Lambda177 & Lambda182 --> PgSelect70
     __Item71[/"__Item[71∈13]<br />ᐸ70ᐳ"\]:::itemplan
     PgSelect70 ==> __Item71
     PgSelectSingle72{{"PgSelectSingle[72∈13]<br />ᐸletter_descriptionsᐳ"}}:::plan
@@ -173,13 +181,7 @@ graph TD
     PgClassExpression76{{"PgClassExpression[76∈14]<br />ᐸ__letter_d...scription”ᐳ"}}:::plan
     PgSelectSingle72 --> PgClassExpression76
     PgSelect84[["PgSelect[84∈15] ➊<br />ᐸletter_descriptionsᐳ"]]:::plan
-    Lambda185{{"Lambda[185∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda190{{"Lambda[190∈15] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant192 & Connection83 & Lambda93 & Lambda96 & Lambda185 & Lambda190 --> PgSelect84
-    Object184{{"Object[184∈15] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda93 & Constant181 & Constant182 & Constant99 --> Object184
-    Object184 --> Lambda185
-    Constant201 --> Lambda190
+    Object12 & Constant199 & Connection83 & Lambda93 & Access97 & Lambda192 & Lambda197 --> PgSelect84
     __Item85[/"__Item[85∈16]<br />ᐸ84ᐳ"\]:::itemplan
     PgSelect84 ==> __Item85
     PgSelectSingle86{{"PgSelectSingle[86∈16]<br />ᐸletter_descriptionsᐳ"}}:::plan
@@ -196,30 +198,30 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/enum_tables.queries"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 25, 37, 69, 83, 97, 98, 99, 111, 112, 125, 126, 139, 140, 153, 154, 167, 168, 181, 182, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 12, 93, 96, 142, 143, 148, 156, 157, 162<br />2: PgSelect[46], PgSelect[55]<br />ᐳ: 48, 49, 57, 58"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 25, 37, 69, 83, 98, 99, 100, 113, 114, 128, 129, 143, 144, 158, 159, 173, 174, 188, 189, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 12, 93, 96, 97, 101, 102, 107, 116, 117, 122, 131, 132, 137, 146, 147, 152, 161, 162, 167, 176, 177, 182, 191, 192, 197<br />2: PgSelect[46], PgSelect[55]<br />ᐳ: 48, 49, 57, 58"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection25,Connection37,PgSelect46,First48,PgSelectSingle49,PgSelect55,First57,PgSelectSingle58,Connection69,Connection83,Lambda93,Lambda96,Constant97,Constant98,Constant99,Constant111,Constant112,Constant125,Constant126,Constant139,Constant140,Object142,Lambda143,Lambda148,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant167,Constant168,Constant181,Constant182,Constant191,Constant192,Constant193,Constant194,Constant195,Constant196,Constant197,Constant198,Constant199,Constant200,Constant201 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 93, 96, 97, 98, 99, 195<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[100], Lambda[106], Lambda[101]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection25,Connection37,PgSelect46,First48,PgSelectSingle49,PgSelect55,First57,PgSelectSingle58,Connection69,Connection83,Lambda93,Lambda96,Access97,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant128,Constant129,Object131,Lambda132,Lambda137,Constant143,Constant144,Object146,Lambda147,Lambda152,Constant158,Constant159,Object161,Lambda162,Lambda167,Constant173,Constant174,Object176,Lambda177,Lambda182,Constant188,Constant189,Object191,Lambda192,Lambda197,Constant198,Constant199,Constant200,Constant201,Constant202,Constant203,Constant204,Constant205,Constant206,Constant207,Constant208 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 93, 97, 102, 107<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object100,Lambda101,Lambda106 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸletter_descriptionsᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 25, 93, 96, 111, 112, 99, 196<br /><br />ROOT Connectionᐸ23ᐳ[25]<br />1: <br />ᐳ: Object[114], Lambda[120], Lambda[115]<br />2: PgSelect[26]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 25, 93, 97, 117, 122<br /><br />ROOT Connectionᐸ23ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect26,Object114,Lambda115,Lambda120 bucket4
+    class Bucket4,PgSelect26 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ26ᐳ[27]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item27,PgSelectSingle28 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{5}ᐸletter_descriptionsᐳ[28]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 12, 37, 93, 96, 125, 126, 99, 197<br /><br />ROOT Connectionᐸ35ᐳ[37]<br />1: <br />ᐳ: Object[128], Lambda[134], Lambda[129]<br />2: PgSelect[38]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 12, 37, 93, 97, 132, 137<br /><br />ROOT Connectionᐸ35ᐳ[37]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelect38,Object128,Lambda129,Lambda134 bucket7
+    class Bucket7,PgSelect38 bucket7
     Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ38ᐳ[39]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item39,PgSelectSingle40 bucket8
@@ -232,18 +234,18 @@ graph TD
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 58<br /><br />ROOT PgSelectSingleᐸletter_descriptionsᐳ[58]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression59,PgClassExpression60,PgClassExpression61,PgClassExpression62 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 12, 192, 69, 93, 96, 167, 168, 99, 200<br /><br />ROOT Connectionᐸ67ᐳ[69]<br />1: <br />ᐳ: Object[170], Lambda[176], Lambda[171]<br />2: PgSelect[70]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 12, 199, 69, 93, 97, 177, 182<br /><br />ROOT Connectionᐸ67ᐳ[69]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgSelect70,Object170,Lambda171,Lambda176 bucket12
+    class Bucket12,PgSelect70 bucket12
     Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ70ᐳ[71]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item71,PgSelectSingle72 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 72<br /><br />ROOT PgSelectSingle{13}ᐸletter_descriptionsᐳ[72]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression73,PgClassExpression74,PgClassExpression75,PgClassExpression76 bucket14
-    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 12, 192, 83, 93, 96, 181, 182, 99, 201<br /><br />ROOT Connectionᐸ81ᐳ[83]<br />1: <br />ᐳ: Object[184], Lambda[190], Lambda[185]<br />2: PgSelect[84]"):::bucket
+    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 12, 199, 83, 93, 97, 192, 197<br /><br />ROOT Connectionᐸ81ᐳ[83]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgSelect84,Object184,Lambda185,Lambda190 bucket15
+    class Bucket15,PgSelect84 bucket15
     Bucket16("Bucket 16 (listItem)<br /><br />ROOT __Item{16}ᐸ84ᐳ[85]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,__Item85,PgSelectSingle86 bucket16

--- a/postgraphile/postgraphile/__tests__/queries/v4/enum_tables.queries2.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/enum_tables.queries2.mermaid
@@ -9,33 +9,35 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant29{{"Constant[29∈0] ➊<br />ᐸsql.identifier(”referencing_table”)ᐳ"}}:::plan
-    Constant30{{"Constant[30∈0] ➊<br />ᐸRecordCodec(referencingTable)ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸreferencing_tableᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda24{{"Lambda[24∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda37{{"Lambda[37∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda24 & Lambda27 & Lambda32 & Lambda37 --> PgSelect14
-    Object31{{"Object[31∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda24 & Constant28 & Constant29 & Constant30 --> Object31
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object32{{"Object[32∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda24{{"Lambda[24∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant30{{"Constant[30∈0] ➊<br />ᐸsql.identifier(”referencing_table”)ᐳ"}}:::plan
+    Constant31{{"Constant[31∈0] ➊<br />ᐸRecordCodec(referencingTable)ᐳ"}}:::plan
+    Lambda24 & Constant29 & Constant30 & Constant31 --> Object32
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant38 --> Lambda24
-    Constant39 --> Lambda27
-    Object31 --> Lambda32
-    Constant40 --> Lambda37
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda24
+    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant40 --> Lambda27
+    Access28{{"Access[28∈0] ➊<br />ᐸ27.0ᐳ"}}:::plan
+    Lambda27 --> Access28
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object32 --> Lambda33
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant41 --> Lambda38
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸreferencing_tableᐳ"]]:::plan
+    Object12 & Connection13 & Lambda24 & Access28 & Lambda33 & Lambda38 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸreferencing_tableᐳ"}}:::plan
@@ -56,10 +58,10 @@ graph TD
     subgraph "Buckets for queries/v4/enum_tables.queries2"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant28,Constant29,Constant30,Constant38,Constant39,Constant40 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 38, 39, 28, 29, 30, 40<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 24, 27, 37, 12, 31, 32<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda24,Lambda27,Access28,Constant29,Constant30,Constant31,Object32,Lambda33,Lambda38,Constant39,Constant40,Constant41 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 24, 28, 33, 38<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda24,Lambda27,Object31,Lambda32,Lambda37 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/function-return-types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/function-return-types.mermaid
@@ -11,294 +11,351 @@ graph TD
     %% plan dependencies
     PgSelect226[["PgSelect[226∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant1276{{"Constant[1276∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant1277{{"Constant[1277∈0] ➊<br />ᐸ'test'ᐳ"}}:::plan
-    Lambda456{{"Lambda[456∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda887{{"Lambda[887∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda892{{"Lambda[892∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda903{{"Lambda[903∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda908{{"Lambda[908∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1330{{"Constant[1330∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant1331{{"Constant[1331∈0] ➊<br />ᐸ'test'ᐳ"}}:::plan
+    Access457{{"Access[457∈0] ➊<br />ᐸ456.0ᐳ"}}:::plan
+    Lambda917{{"Lambda[917∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda922{{"Lambda[922∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda927{{"Lambda[927∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda938{{"Lambda[938∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda943{{"Lambda[943∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda934{{"Lambda[934∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda939{{"Lambda[939∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda954{{"Lambda[954∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda959{{"Lambda[959∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda970{{"Lambda[970∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda975{{"Lambda[975∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda986{{"Lambda[986∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda991{{"Lambda[991∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1002{{"Lambda[1002∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1007{{"Lambda[1007∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1018{{"Lambda[1018∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1023{{"Lambda[1023∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1034{{"Lambda[1034∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda971{{"Lambda[971∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda976{{"Lambda[976∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda988{{"Lambda[988∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda993{{"Lambda[993∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1005{{"Lambda[1005∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1010{{"Lambda[1010∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1022{{"Lambda[1022∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1027{{"Lambda[1027∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1039{{"Lambda[1039∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1276 & Constant1277 & Constant1276 & Constant1277 & Lambda456 & Lambda887 & Lambda892 & Lambda903 & Lambda908 & Lambda922 & Lambda927 & Lambda456 & Lambda938 & Lambda943 & Lambda456 & Lambda954 & Lambda959 & Lambda970 & Lambda975 & Lambda456 & Lambda986 & Lambda991 & Constant1277 & Lambda456 & Lambda1002 & Lambda1007 & Lambda456 & Lambda1018 & Lambda1023 & Lambda453 & Lambda456 & Lambda1034 & Lambda1039 --> PgSelect226
+    Lambda1044{{"Lambda[1044∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1056{{"Lambda[1056∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1061{{"Lambda[1061∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda1073{{"Lambda[1073∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1078{{"Lambda[1078∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1330 & Constant1331 & Constant1330 & Constant1331 & Access457 & Lambda917 & Lambda922 & Lambda934 & Lambda939 & Lambda954 & Lambda959 & Access457 & Lambda971 & Lambda976 & Access457 & Lambda988 & Lambda993 & Lambda1005 & Lambda1010 & Access457 & Lambda1022 & Lambda1027 & Constant1331 & Access457 & Lambda1039 & Lambda1044 & Access457 & Lambda1056 & Lambda1061 & Lambda453 & Access457 & Lambda1073 & Lambda1078 --> PgSelect226
     PgSelect324[["PgSelect[324∈0] ➊<br />ᐸquery_output_two_rowsᐳ"]]:::plan
-    Constant1279{{"Constant[1279∈0] ➊<br />ᐸ42ᐳ"}}:::plan
-    Constant1280{{"Constant[1280∈0] ➊<br />ᐸ'Hi'ᐳ"}}:::plan
-    Lambda1048{{"Lambda[1048∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1053{{"Lambda[1053∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1064{{"Lambda[1064∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1069{{"Lambda[1069∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1080{{"Lambda[1080∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1085{{"Lambda[1085∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1096{{"Lambda[1096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1101{{"Lambda[1101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1112{{"Lambda[1112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1117{{"Lambda[1117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1128{{"Lambda[1128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1133{{"Lambda[1133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1333{{"Constant[1333∈0] ➊<br />ᐸ42ᐳ"}}:::plan
+    Constant1334{{"Constant[1334∈0] ➊<br />ᐸ'Hi'ᐳ"}}:::plan
+    Lambda1088{{"Lambda[1088∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1093{{"Lambda[1093∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1105{{"Lambda[1105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1110{{"Lambda[1110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1122{{"Lambda[1122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1127{{"Lambda[1127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1139{{"Lambda[1139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1144{{"Lambda[1144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1149{{"Lambda[1149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1279 & Constant1276 & Constant1280 & Lambda456 & Lambda1048 & Lambda1053 & Lambda1064 & Lambda1069 & Lambda456 & Lambda1080 & Lambda1085 & Lambda1096 & Lambda1101 & Lambda1112 & Lambda1117 & Lambda456 & Lambda1128 & Lambda1133 & Lambda453 & Lambda456 & Lambda1144 & Lambda1149 --> PgSelect324
-    PgSelect385[["PgSelect[385∈0] ➊<br />ᐸquery_output_two_rowsᐳ"]]:::plan
-    Constant1281{{"Constant[1281∈0] ➊<br />ᐸ999999999ᐳ"}}:::plan
-    Constant1282{{"Constant[1282∈0] ➊<br />ᐸ”Don't fail me now...”ᐳ"}}:::plan
-    Lambda1158{{"Lambda[1158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1163{{"Lambda[1163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1174{{"Lambda[1174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1179{{"Lambda[1179∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1156{{"Lambda[1156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1161{{"Lambda[1161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1173{{"Lambda[1173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1178{{"Lambda[1178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1190{{"Lambda[1190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1195{{"Lambda[1195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1206{{"Lambda[1206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1211{{"Lambda[1211∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1333 & Constant1330 & Constant1334 & Access457 & Lambda1088 & Lambda1093 & Lambda1105 & Lambda1110 & Access457 & Lambda1122 & Lambda1127 & Lambda1139 & Lambda1144 & Lambda1156 & Lambda1161 & Access457 & Lambda1173 & Lambda1178 & Lambda453 & Access457 & Lambda1190 & Lambda1195 --> PgSelect324
+    PgSelect385[["PgSelect[385∈0] ➊<br />ᐸquery_output_two_rowsᐳ"]]:::plan
+    Constant1335{{"Constant[1335∈0] ➊<br />ᐸ999999999ᐳ"}}:::plan
+    Constant1336{{"Constant[1336∈0] ➊<br />ᐸ”Don't fail me now...”ᐳ"}}:::plan
+    Lambda1205{{"Lambda[1205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1210{{"Lambda[1210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1222{{"Lambda[1222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1227{{"Lambda[1227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1238{{"Lambda[1238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1243{{"Lambda[1243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1254{{"Lambda[1254∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1259{{"Lambda[1259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1281 & Constant1281 & Constant1282 & Lambda456 & Lambda1158 & Lambda1163 & Lambda1174 & Lambda1179 & Lambda456 & Lambda1190 & Lambda1195 & Lambda1206 & Lambda1211 & Lambda1222 & Lambda1227 & Lambda456 & Lambda1238 & Lambda1243 & Lambda453 & Lambda456 & Lambda1254 & Lambda1259 --> PgSelect385
-    PgSelect28[["PgSelect[28∈0] ➊<br />ᐸfunc_out_complexᐳ"]]:::plan
-    Lambda503{{"Lambda[503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda508{{"Lambda[508∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda519{{"Lambda[519∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda524{{"Lambda[524∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda538{{"Lambda[538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda543{{"Lambda[543∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda554{{"Lambda[554∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda559{{"Lambda[559∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1276 & Constant1277 & Lambda456 & Lambda503 & Lambda508 & Lambda519 & Lambda524 & Lambda456 & Lambda538 & Lambda543 & Lambda453 & Lambda456 & Lambda554 & Lambda559 --> PgSelect28
-    PgSelect122[["PgSelect[122∈0] ➊<br />ᐸfunc_out_out_compound_typeᐳ"]]:::plan
-    Constant1274{{"Constant[1274∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Lambda661{{"Lambda[661∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda666{{"Lambda[666∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda677{{"Lambda[677∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda682{{"Lambda[682∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1274 & Lambda456 & Lambda661 & Lambda666 & Lambda453 & Lambda456 & Lambda677 & Lambda682 --> PgSelect122
-    PgSelect8[["PgSelect[8∈0] ➊<br />ᐸfunc_in_inoutᐳ"]]:::plan
-    Constant1275{{"Constant[1275∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Lambda461{{"Lambda[461∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda466{{"Lambda[466∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1274 & Constant1275 & Lambda453 & Lambda456 & Lambda461 & Lambda466 --> PgSelect8
-    PgSelect16[["PgSelect[16∈0] ➊<br />ᐸfunc_in_outᐳ"]]:::plan
-    Lambda475{{"Lambda[475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda480{{"Lambda[480∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1274 & Lambda453 & Lambda456 & Lambda475 & Lambda480 --> PgSelect16
-    PgSelect21[["PgSelect[21∈0] ➊<br />ᐸfunc_outᐳ"]]:::plan
-    Lambda489{{"Lambda[489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda494{{"Lambda[494∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda489 & Lambda494 --> PgSelect21
-    PgSelect115[["PgSelect[115∈0] ➊<br />ᐸfunc_out_outᐳ"]]:::plan
-    Lambda647{{"Lambda[647∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda652{{"Lambda[652∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda647 & Lambda652 --> PgSelect115
-    PgSelect149[["PgSelect[149∈0] ➊<br />ᐸfunc_out_out_unnamedᐳ"]]:::plan
-    Lambda719{{"Lambda[719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda724{{"Lambda[724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda719 & Lambda724 --> PgSelect149
-    PgSelect166[["PgSelect[166∈0] ➊<br />ᐸfunc_out_tableᐳ"]]:::plan
-    Lambda761{{"Lambda[761∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda766{{"Lambda[766∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda761 & Lambda766 --> PgSelect166
-    PgSelect188[["PgSelect[188∈0] ➊<br />ᐸfunc_out_unnamedᐳ"]]:::plan
-    Lambda803{{"Lambda[803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda808{{"Lambda[808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda803 & Lambda808 --> PgSelect188
-    PgSelect193[["PgSelect[193∈0] ➊<br />ᐸfunc_out_unnamed_out_out_unnamedᐳ"]]:::plan
-    Lambda817{{"Lambda[817∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda822{{"Lambda[822∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda817 & Lambda822 --> PgSelect193
-    PgSelect443[["PgSelect[443∈0] ➊<br />ᐸsearch_test_summariesᐳ"]]:::plan
-    Lambda1268{{"Lambda[1268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1239{{"Lambda[1239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1244{{"Lambda[1244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1256{{"Lambda[1256∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1261{{"Lambda[1261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1273{{"Lambda[1273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda453 & Lambda456 & Lambda1268 & Lambda1273 --> PgSelect443
-    Object460{{"Object[460∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant457{{"Constant[457∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant458{{"Constant[458∈0] ➊<br />ᐸsql.identifier(”func_in_inout”)ᐳ"}}:::plan
-    Constant459{{"Constant[459∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda453 & Constant457 & Constant458 & Constant459 --> Object460
-    Object474{{"Object[474∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸsql.identifier(”func_in_out”)ᐳ"}}:::plan
-    Lambda453 & Constant471 & Constant472 & Constant459 --> Object474
-    Object488{{"Object[488∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant485{{"Constant[485∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸsql.identifier(”func_out”)ᐳ"}}:::plan
-    Lambda453 & Constant485 & Constant486 & Constant459 --> Object488
-    Object502{{"Object[502∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant499{{"Constant[499∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant500{{"Constant[500∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant501{{"Constant[501∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda453 & Constant499 & Constant500 & Constant501 --> Object502
-    Object518{{"Object[518∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant515{{"Constant[515∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant516{{"Constant[516∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant517{{"Constant[517∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda453 & Constant515 & Constant516 & Constant517 --> Object518
-    Object537{{"Object[537∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant534{{"Constant[534∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant535{{"Constant[535∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant536{{"Constant[536∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda453 & Constant534 & Constant535 & Constant536 --> Object537
-    Object553{{"Object[553∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant550{{"Constant[550∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant551{{"Constant[551∈0] ➊<br />ᐸsql.identifier(”func_out_complex”)ᐳ"}}:::plan
-    Constant552{{"Constant[552∈0] ➊<br />ᐸRecordCodec(FuncOutComplexRecord)ᐳ"}}:::plan
-    Lambda453 & Constant550 & Constant551 & Constant552 --> Object553
-    Object646{{"Object[646∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant643{{"Constant[643∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant644{{"Constant[644∈0] ➊<br />ᐸsql.identifier(”func_out_out”)ᐳ"}}:::plan
-    Constant645{{"Constant[645∈0] ➊<br />ᐸRecordCodec(FuncOutOutRecord)ᐳ"}}:::plan
-    Lambda453 & Constant643 & Constant644 & Constant645 --> Object646
-    Object660{{"Object[660∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant657{{"Constant[657∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant658{{"Constant[658∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda453 & Constant657 & Constant658 & Constant501 --> Object660
-    Object676{{"Object[676∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant673{{"Constant[673∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant674{{"Constant[674∈0] ➊<br />ᐸsql.identifier(”func_out_out_compound_type”)ᐳ"}}:::plan
-    Constant675{{"Constant[675∈0] ➊<br />ᐸRecordCodec(FuncOutOutCompoundTypeRecord)ᐳ"}}:::plan
-    Lambda453 & Constant673 & Constant674 & Constant675 --> Object676
-    Object718{{"Object[718∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant715{{"Constant[715∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant716{{"Constant[716∈0] ➊<br />ᐸsql.identifier(”func_out_out_unnamed”)ᐳ"}}:::plan
-    Constant717{{"Constant[717∈0] ➊<br />ᐸRecordCodec(FuncOutOutUnnamedRecord)ᐳ"}}:::plan
-    Lambda453 & Constant715 & Constant716 & Constant717 --> Object718
-    Object760{{"Object[760∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant757{{"Constant[757∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant758{{"Constant[758∈0] ➊<br />ᐸsql.identifier(”func_out_table”)ᐳ"}}:::plan
-    Lambda453 & Constant757 & Constant758 & Constant536 --> Object760
-    Object802{{"Object[802∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant800{{"Constant[800∈0] ➊<br />ᐸsql.identifier(”func_out_unnamed”)ᐳ"}}:::plan
-    Lambda453 & Constant799 & Constant800 & Constant459 --> Object802
-    Object816{{"Object[816∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant813{{"Constant[813∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant814{{"Constant[814∈0] ➊<br />ᐸsql.identifier(”func_out_unnamed_out_out_unnamed”)ᐳ"}}:::plan
-    Constant815{{"Constant[815∈0] ➊<br />ᐸRecordCodec(FuncOutUnnamedOutOutUnnamedRecord)ᐳ"}}:::plan
-    Lambda453 & Constant813 & Constant814 & Constant815 --> Object816
+    Lambda1278{{"Lambda[1278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1290{{"Lambda[1290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1295{{"Lambda[1295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1307{{"Lambda[1307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1312{{"Lambda[1312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1335 & Constant1335 & Constant1336 & Access457 & Lambda1205 & Lambda1210 & Lambda1222 & Lambda1227 & Access457 & Lambda1239 & Lambda1244 & Lambda1256 & Lambda1261 & Lambda1273 & Lambda1278 & Access457 & Lambda1290 & Lambda1295 & Lambda453 & Access457 & Lambda1307 & Lambda1312 --> PgSelect385
+    PgSelect28[["PgSelect[28∈0] ➊<br />ᐸfunc_out_complexᐳ"]]:::plan
+    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda512{{"Lambda[512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda524{{"Lambda[524∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda529{{"Lambda[529∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda544{{"Lambda[544∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda549{{"Lambda[549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda561{{"Lambda[561∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda566{{"Lambda[566∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1330 & Constant1331 & Access457 & Lambda507 & Lambda512 & Lambda524 & Lambda529 & Access457 & Lambda544 & Lambda549 & Lambda453 & Access457 & Lambda561 & Lambda566 --> PgSelect28
+    PgSelect122[["PgSelect[122∈0] ➊<br />ᐸfunc_out_out_compound_typeᐳ"]]:::plan
+    Constant1328{{"Constant[1328∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Lambda675{{"Lambda[675∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda680{{"Lambda[680∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda692{{"Lambda[692∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda697{{"Lambda[697∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1328 & Access457 & Lambda675 & Lambda680 & Lambda453 & Access457 & Lambda692 & Lambda697 --> PgSelect122
+    PgSelect8[["PgSelect[8∈0] ➊<br />ᐸfunc_in_inoutᐳ"]]:::plan
+    Constant1329{{"Constant[1329∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Lambda462{{"Lambda[462∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda467{{"Lambda[467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1328 & Constant1329 & Lambda453 & Access457 & Lambda462 & Lambda467 --> PgSelect8
+    PgSelect16[["PgSelect[16∈0] ➊<br />ᐸfunc_in_outᐳ"]]:::plan
+    Lambda477{{"Lambda[477∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda482{{"Lambda[482∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant1328 & Lambda453 & Access457 & Lambda477 & Lambda482 --> PgSelect16
+    PgSelect21[["PgSelect[21∈0] ➊<br />ᐸfunc_outᐳ"]]:::plan
+    Lambda492{{"Lambda[492∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda497{{"Lambda[497∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda492 & Lambda497 --> PgSelect21
+    PgSelect115[["PgSelect[115∈0] ➊<br />ᐸfunc_out_outᐳ"]]:::plan
+    Lambda660{{"Lambda[660∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda665{{"Lambda[665∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda660 & Lambda665 --> PgSelect115
+    PgSelect149[["PgSelect[149∈0] ➊<br />ᐸfunc_out_out_unnamedᐳ"]]:::plan
+    Lambda737{{"Lambda[737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda742{{"Lambda[742∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda737 & Lambda742 --> PgSelect149
+    PgSelect166[["PgSelect[166∈0] ➊<br />ᐸfunc_out_tableᐳ"]]:::plan
+    Lambda782{{"Lambda[782∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda787{{"Lambda[787∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda782 & Lambda787 --> PgSelect166
+    PgSelect188[["PgSelect[188∈0] ➊<br />ᐸfunc_out_unnamedᐳ"]]:::plan
+    Lambda827{{"Lambda[827∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda832{{"Lambda[832∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda827 & Lambda832 --> PgSelect188
+    PgSelect193[["PgSelect[193∈0] ➊<br />ᐸfunc_out_unnamed_out_out_unnamedᐳ"]]:::plan
+    Lambda842{{"Lambda[842∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda847{{"Lambda[847∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda842 & Lambda847 --> PgSelect193
+    PgSelect443[["PgSelect[443∈0] ➊<br />ᐸsearch_test_summariesᐳ"]]:::plan
+    Lambda1322{{"Lambda[1322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1327{{"Lambda[1327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda453 & Access457 & Lambda1322 & Lambda1327 --> PgSelect443
+    Object461{{"Object[461∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant458{{"Constant[458∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸsql.identifier(”func_in_inout”)ᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda453 & Constant458 & Constant459 & Constant460 --> Object461
+    Object476{{"Object[476∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸsql.identifier(”func_in_out”)ᐳ"}}:::plan
+    Lambda453 & Constant473 & Constant474 & Constant460 --> Object476
+    Object491{{"Object[491∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant488{{"Constant[488∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant489{{"Constant[489∈0] ➊<br />ᐸsql.identifier(”func_out”)ᐳ"}}:::plan
+    Lambda453 & Constant488 & Constant489 & Constant460 --> Object491
+    Object506{{"Object[506∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant503{{"Constant[503∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant504{{"Constant[504∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant505{{"Constant[505∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda453 & Constant503 & Constant504 & Constant505 --> Object506
+    Object523{{"Object[523∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant520{{"Constant[520∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant521{{"Constant[521∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant522{{"Constant[522∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda453 & Constant520 & Constant521 & Constant522 --> Object523
+    Object543{{"Object[543∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant540{{"Constant[540∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant541{{"Constant[541∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant542{{"Constant[542∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda453 & Constant540 & Constant541 & Constant542 --> Object543
+    Object560{{"Object[560∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant557{{"Constant[557∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant558{{"Constant[558∈0] ➊<br />ᐸsql.identifier(”func_out_complex”)ᐳ"}}:::plan
+    Constant559{{"Constant[559∈0] ➊<br />ᐸRecordCodec(FuncOutComplexRecord)ᐳ"}}:::plan
+    Lambda453 & Constant557 & Constant558 & Constant559 --> Object560
+    Object575{{"Object[575∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant572{{"Constant[572∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant573{{"Constant[573∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda453 & Constant572 & Constant573 & Constant505 --> Object575
+    Object592{{"Object[592∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant589{{"Constant[589∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant590{{"Constant[590∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda453 & Constant589 & Constant590 & Constant522 --> Object592
+    Object612{{"Object[612∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant609{{"Constant[609∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant610{{"Constant[610∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant609 & Constant610 & Constant542 --> Object612
+    Object629{{"Object[629∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant626{{"Constant[626∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant627{{"Constant[627∈0] ➊<br />ᐸsql.identifier(”func_out_complex_setof”)ᐳ"}}:::plan
+    Constant628{{"Constant[628∈0] ➊<br />ᐸRecordCodec(FuncOutComplexSetofRecord)ᐳ"}}:::plan
+    Lambda453 & Constant626 & Constant627 & Constant628 --> Object629
+    Object644{{"Object[644∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant641{{"Constant[641∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda453 & Constant641 & Constant627 & Constant628 --> Object644
+    Object659{{"Object[659∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant656{{"Constant[656∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant657{{"Constant[657∈0] ➊<br />ᐸsql.identifier(”func_out_out”)ᐳ"}}:::plan
+    Constant658{{"Constant[658∈0] ➊<br />ᐸRecordCodec(FuncOutOutRecord)ᐳ"}}:::plan
+    Lambda453 & Constant656 & Constant657 & Constant658 --> Object659
+    Object674{{"Object[674∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant671{{"Constant[671∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant672{{"Constant[672∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda453 & Constant671 & Constant672 & Constant505 --> Object674
+    Object691{{"Object[691∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant688{{"Constant[688∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant689{{"Constant[689∈0] ➊<br />ᐸsql.identifier(”func_out_out_compound_type”)ᐳ"}}:::plan
+    Constant690{{"Constant[690∈0] ➊<br />ᐸRecordCodec(FuncOutOutCompoundTypeRecord)ᐳ"}}:::plan
+    Lambda453 & Constant688 & Constant689 & Constant690 --> Object691
+    Object706{{"Object[706∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant703{{"Constant[703∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant704{{"Constant[704∈0] ➊<br />ᐸsql.identifier(”func_out_out_setof”)ᐳ"}}:::plan
+    Constant705{{"Constant[705∈0] ➊<br />ᐸRecordCodec(FuncOutOutSetofRecord)ᐳ"}}:::plan
+    Lambda453 & Constant703 & Constant704 & Constant705 --> Object706
+    Object721{{"Object[721∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant718{{"Constant[718∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda453 & Constant718 & Constant704 & Constant705 --> Object721
+    Object736{{"Object[736∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant733{{"Constant[733∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant734{{"Constant[734∈0] ➊<br />ᐸsql.identifier(”func_out_out_unnamed”)ᐳ"}}:::plan
+    Constant735{{"Constant[735∈0] ➊<br />ᐸRecordCodec(FuncOutOutUnnamedRecord)ᐳ"}}:::plan
+    Lambda453 & Constant733 & Constant734 & Constant735 --> Object736
+    Object751{{"Object[751∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant748{{"Constant[748∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant749{{"Constant[749∈0] ➊<br />ᐸsql.identifier(”func_out_setof”)ᐳ"}}:::plan
+    Lambda453 & Constant748 & Constant749 & Constant460 --> Object751
+    Object766{{"Object[766∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant763{{"Constant[763∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda453 & Constant763 & Constant749 & Constant460 --> Object766
+    Object781{{"Object[781∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant778{{"Constant[778∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant779{{"Constant[779∈0] ➊<br />ᐸsql.identifier(”func_out_table”)ᐳ"}}:::plan
+    Lambda453 & Constant778 & Constant779 & Constant542 --> Object781
+    Object796{{"Object[796∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant793{{"Constant[793∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant794{{"Constant[794∈0] ➊<br />ᐸsql.identifier(”func_out_table_setof”)ᐳ"}}:::plan
+    Lambda453 & Constant793 & Constant794 & Constant542 --> Object796
+    Object811{{"Object[811∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant808{{"Constant[808∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda453 & Constant808 & Constant794 & Constant542 --> Object811
+    Object826{{"Object[826∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant823{{"Constant[823∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant824{{"Constant[824∈0] ➊<br />ᐸsql.identifier(”func_out_unnamed”)ᐳ"}}:::plan
+    Lambda453 & Constant823 & Constant824 & Constant460 --> Object826
+    Object841{{"Object[841∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant838{{"Constant[838∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant839{{"Constant[839∈0] ➊<br />ᐸsql.identifier(”func_out_unnamed_out_out_unnamed”)ᐳ"}}:::plan
+    Constant840{{"Constant[840∈0] ➊<br />ᐸRecordCodec(FuncOutUnnamedOutOutUnnamedRecord)ᐳ"}}:::plan
+    Lambda453 & Constant838 & Constant839 & Constant840 --> Object841
+    Object856{{"Object[856∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant853{{"Constant[853∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant854{{"Constant[854∈0] ➊<br />ᐸsql.identifier(”func_returns_table_multi_col”)ᐳ"}}:::plan
+    Constant855{{"Constant[855∈0] ➊<br />ᐸRecordCodec(FuncReturnsTableMultiColRecord)ᐳ"}}:::plan
+    Lambda453 & Constant853 & Constant854 & Constant855 --> Object856
+    Object871{{"Object[871∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant868{{"Constant[868∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda453 & Constant868 & Constant854 & Constant855 --> Object871
     Object886{{"Object[886∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant883{{"Constant[883∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant884{{"Constant[884∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda453 & Constant883 & Constant884 & Constant501 --> Object886
-    Object902{{"Object[902∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant899{{"Constant[899∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant900{{"Constant[900∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda453 & Constant899 & Constant900 & Constant517 --> Object902
-    Object921{{"Object[921∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant918{{"Constant[918∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant919{{"Constant[919∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant918 & Constant919 & Constant536 --> Object921
-    Object937{{"Object[937∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant934{{"Constant[934∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant935{{"Constant[935∈0] ➊<br />ᐸsql.identifier(”person_computed_complex”)ᐳ"}}:::plan
-    Constant936{{"Constant[936∈0] ➊<br />ᐸRecordCodec(PersonComputedComplexRecord)ᐳ"}}:::plan
-    Lambda453 & Constant934 & Constant935 & Constant936 --> Object937
+    Constant884{{"Constant[884∈0] ➊<br />ᐸsql.identifier(”func_returns_table_one_col”)ᐳ"}}:::plan
+    Lambda453 & Constant883 & Constant884 & Constant460 --> Object886
+    Object901{{"Object[901∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant898{{"Constant[898∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda453 & Constant898 & Constant884 & Constant460 --> Object901
+    Object916{{"Object[916∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant913{{"Constant[913∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant914{{"Constant[914∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda453 & Constant913 & Constant914 & Constant505 --> Object916
+    Object933{{"Object[933∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant930{{"Constant[930∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant931{{"Constant[931∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda453 & Constant930 & Constant931 & Constant522 --> Object933
     Object953{{"Object[953∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant950{{"Constant[950∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant951{{"Constant[951∈0] ➊<br />ᐸsql.identifier(”person_computed_first_arg_inout”)ᐳ"}}:::plan
-    Lambda453 & Constant950 & Constant951 & Constant536 --> Object953
-    Object969{{"Object[969∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant966{{"Constant[966∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant967{{"Constant[967∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant966 & Constant967 & Constant536 --> Object969
-    Object985{{"Object[985∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant982{{"Constant[982∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant983{{"Constant[983∈0] ➊<br />ᐸsql.identifier(”person_computed_first_arg_inout_out”)ᐳ"}}:::plan
-    Constant984{{"Constant[984∈0] ➊<br />ᐸRecordCodec(PersonComputedFirstArgInoutOutRecord)ᐳ"}}:::plan
-    Lambda453 & Constant982 & Constant983 & Constant984 --> Object985
-    Object1001{{"Object[1001∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant998{{"Constant[998∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant999{{"Constant[999∈0] ➊<br />ᐸsql.identifier(”person_computed_inout_out”)ᐳ"}}:::plan
-    Constant1000{{"Constant[1000∈0] ➊<br />ᐸRecordCodec(PersonComputedInoutOutRecord)ᐳ"}}:::plan
-    Lambda453 & Constant998 & Constant999 & Constant1000 --> Object1001
-    Object1017{{"Object[1017∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1014{{"Constant[1014∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1015{{"Constant[1015∈0] ➊<br />ᐸsql.identifier(”person_computed_out_out”)ᐳ"}}:::plan
-    Constant1016{{"Constant[1016∈0] ➊<br />ᐸRecordCodec(PersonComputedOutOutRecord)ᐳ"}}:::plan
-    Lambda453 & Constant1014 & Constant1015 & Constant1016 --> Object1017
-    Object1033{{"Object[1033∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1030{{"Constant[1030∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1031{{"Constant[1031∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant1030 & Constant1031 & Constant536 --> Object1033
-    Object1047{{"Object[1047∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1044{{"Constant[1044∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1045{{"Constant[1045∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant1046{{"Constant[1046∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Lambda453 & Constant1044 & Constant1045 & Constant1046 --> Object1047
-    Object1063{{"Object[1063∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1060{{"Constant[1060∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1061{{"Constant[1061∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant1060 & Constant1061 & Constant536 --> Object1063
-    Object1079{{"Object[1079∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1076{{"Constant[1076∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1077{{"Constant[1077∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant1078{{"Constant[1078∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda453 & Constant1076 & Constant1077 & Constant1078 --> Object1079
-    Object1095{{"Object[1095∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1092{{"Constant[1092∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1093{{"Constant[1093∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda453 & Constant1092 & Constant1093 & Constant1046 --> Object1095
-    Object1111{{"Object[1111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1108{{"Constant[1108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1109{{"Constant[1109∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant1108 & Constant1109 & Constant536 --> Object1111
-    Object1127{{"Object[1127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1124{{"Constant[1124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1125{{"Constant[1125∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda453 & Constant1124 & Constant1125 & Constant517 --> Object1127
-    Object1143{{"Object[1143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1140{{"Constant[1140∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1141{{"Constant[1141∈0] ➊<br />ᐸsql.identifier(”query_output_two_rows”)ᐳ"}}:::plan
-    Constant1142{{"Constant[1142∈0] ➊<br />ᐸRecordCodec(QueryOutputTwoRowsRecord)ᐳ"}}:::plan
-    Lambda453 & Constant1140 & Constant1141 & Constant1142 --> Object1143
-    Object1157{{"Object[1157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1154{{"Constant[1154∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1155{{"Constant[1155∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda453 & Constant1154 & Constant1155 & Constant1046 --> Object1157
-    Object1173{{"Object[1173∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1170{{"Constant[1170∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1171{{"Constant[1171∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant1170 & Constant1171 & Constant536 --> Object1173
+    Constant951{{"Constant[951∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant950 & Constant951 & Constant542 --> Object953
+    Object970{{"Object[970∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant967{{"Constant[967∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant968{{"Constant[968∈0] ➊<br />ᐸsql.identifier(”person_computed_complex”)ᐳ"}}:::plan
+    Constant969{{"Constant[969∈0] ➊<br />ᐸRecordCodec(PersonComputedComplexRecord)ᐳ"}}:::plan
+    Lambda453 & Constant967 & Constant968 & Constant969 --> Object970
+    Object987{{"Object[987∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant984{{"Constant[984∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant985{{"Constant[985∈0] ➊<br />ᐸsql.identifier(”person_computed_first_arg_inout”)ᐳ"}}:::plan
+    Lambda453 & Constant984 & Constant985 & Constant542 --> Object987
+    Object1004{{"Object[1004∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1001{{"Constant[1001∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1002{{"Constant[1002∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant1001 & Constant1002 & Constant542 --> Object1004
+    Object1021{{"Object[1021∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1018{{"Constant[1018∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1019{{"Constant[1019∈0] ➊<br />ᐸsql.identifier(”person_computed_first_arg_inout_out”)ᐳ"}}:::plan
+    Constant1020{{"Constant[1020∈0] ➊<br />ᐸRecordCodec(PersonComputedFirstArgInoutOutRecord)ᐳ"}}:::plan
+    Lambda453 & Constant1018 & Constant1019 & Constant1020 --> Object1021
+    Object1038{{"Object[1038∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1035{{"Constant[1035∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1036{{"Constant[1036∈0] ➊<br />ᐸsql.identifier(”person_computed_inout_out”)ᐳ"}}:::plan
+    Constant1037{{"Constant[1037∈0] ➊<br />ᐸRecordCodec(PersonComputedInoutOutRecord)ᐳ"}}:::plan
+    Lambda453 & Constant1035 & Constant1036 & Constant1037 --> Object1038
+    Object1055{{"Object[1055∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1052{{"Constant[1052∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1053{{"Constant[1053∈0] ➊<br />ᐸsql.identifier(”person_computed_out_out”)ᐳ"}}:::plan
+    Constant1054{{"Constant[1054∈0] ➊<br />ᐸRecordCodec(PersonComputedOutOutRecord)ᐳ"}}:::plan
+    Lambda453 & Constant1052 & Constant1053 & Constant1054 --> Object1055
+    Object1072{{"Object[1072∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1069{{"Constant[1069∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1070{{"Constant[1070∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant1069 & Constant1070 & Constant542 --> Object1072
+    Object1087{{"Object[1087∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1084{{"Constant[1084∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1085{{"Constant[1085∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant1086{{"Constant[1086∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda453 & Constant1084 & Constant1085 & Constant1086 --> Object1087
+    Object1104{{"Object[1104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1101{{"Constant[1101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1102{{"Constant[1102∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant1101 & Constant1102 & Constant542 --> Object1104
+    Object1121{{"Object[1121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1118{{"Constant[1118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1119{{"Constant[1119∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant1120{{"Constant[1120∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda453 & Constant1118 & Constant1119 & Constant1120 --> Object1121
+    Object1138{{"Object[1138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1135{{"Constant[1135∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1136{{"Constant[1136∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda453 & Constant1135 & Constant1136 & Constant1086 --> Object1138
+    Object1155{{"Object[1155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1152{{"Constant[1152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1153{{"Constant[1153∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant1152 & Constant1153 & Constant542 --> Object1155
+    Object1172{{"Object[1172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1169{{"Constant[1169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1170{{"Constant[1170∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda453 & Constant1169 & Constant1170 & Constant522 --> Object1172
     Object1189{{"Object[1189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1186{{"Constant[1186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1187{{"Constant[1187∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda453 & Constant1186 & Constant1187 & Constant1078 --> Object1189
-    Object1205{{"Object[1205∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1202{{"Constant[1202∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1203{{"Constant[1203∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda453 & Constant1202 & Constant1203 & Constant1046 --> Object1205
+    Constant1187{{"Constant[1187∈0] ➊<br />ᐸsql.identifier(”query_output_two_rows”)ᐳ"}}:::plan
+    Constant1188{{"Constant[1188∈0] ➊<br />ᐸRecordCodec(QueryOutputTwoRowsRecord)ᐳ"}}:::plan
+    Lambda453 & Constant1186 & Constant1187 & Constant1188 --> Object1189
+    Object1204{{"Object[1204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1201{{"Constant[1201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1202{{"Constant[1202∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda453 & Constant1201 & Constant1202 & Constant1086 --> Object1204
     Object1221{{"Object[1221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1218{{"Constant[1218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
     Constant1219{{"Constant[1219∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda453 & Constant1218 & Constant1219 & Constant536 --> Object1221
-    Object1237{{"Object[1237∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1234{{"Constant[1234∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1235{{"Constant[1235∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda453 & Constant1234 & Constant1235 & Constant517 --> Object1237
-    Object1253{{"Object[1253∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1250{{"Constant[1250∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1251{{"Constant[1251∈0] ➊<br />ᐸsql.identifier(”query_output_two_rows”)ᐳ"}}:::plan
-    Lambda453 & Constant1250 & Constant1251 & Constant1142 --> Object1253
-    Object1267{{"Object[1267∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1264{{"Constant[1264∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1265{{"Constant[1265∈0] ➊<br />ᐸsql.identifier(”search_test_summaries”)ᐳ"}}:::plan
-    Constant1266{{"Constant[1266∈0] ➊<br />ᐸRecordCodec(SearchTestSummariesRecord)ᐳ"}}:::plan
-    Lambda453 & Constant1264 & Constant1265 & Constant1266 --> Object1267
+    Lambda453 & Constant1218 & Constant1219 & Constant542 --> Object1221
+    Object1238{{"Object[1238∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1235{{"Constant[1235∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1236{{"Constant[1236∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda453 & Constant1235 & Constant1236 & Constant1120 --> Object1238
+    Object1255{{"Object[1255∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1252{{"Constant[1252∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1253{{"Constant[1253∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda453 & Constant1252 & Constant1253 & Constant1086 --> Object1255
+    Object1272{{"Object[1272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1269{{"Constant[1269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1270{{"Constant[1270∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda453 & Constant1269 & Constant1270 & Constant542 --> Object1272
+    Object1289{{"Object[1289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1286{{"Constant[1286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1287{{"Constant[1287∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda453 & Constant1286 & Constant1287 & Constant522 --> Object1289
+    Object1306{{"Object[1306∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1303{{"Constant[1303∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1304{{"Constant[1304∈0] ➊<br />ᐸsql.identifier(”query_output_two_rows”)ᐳ"}}:::plan
+    Lambda453 & Constant1303 & Constant1304 & Constant1188 --> Object1306
+    Object1321{{"Object[1321∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1318{{"Constant[1318∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1319{{"Constant[1319∈0] ➊<br />ᐸsql.identifier(”search_test_summaries”)ᐳ"}}:::plan
+    Constant1320{{"Constant[1320∈0] ➊<br />ᐸRecordCodec(SearchTestSummariesRecord)ᐳ"}}:::plan
+    Lambda453 & Constant1318 & Constant1319 & Constant1320 --> Object1321
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
@@ -365,201 +422,238 @@ graph TD
     PgSelect385 --> First387
     PgSelectSingle388{{"PgSelectSingle[388∈0] ➊<br />ᐸquery_output_two_rowsᐳ"}}:::plan
     First387 --> PgSelectSingle388
-    Constant1283{{"Constant[1283∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1283 --> Lambda453
-    Constant1284{{"Constant[1284∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1284 --> Lambda456
-    Object460 --> Lambda461
-    Constant1285{{"Constant[1285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_iᐳ"}}:::plan
-    Constant1285 --> Lambda466
-    Object474 --> Lambda475
-    Constant1286{{"Constant[1286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_iᐳ"}}:::plan
-    Constant1286 --> Lambda480
-    Object488 --> Lambda489
-    Constant1287{{"Constant[1287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1287 --> Lambda494
-    Object502 --> Lambda503
-    Constant1288{{"Constant[1288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1288 --> Lambda508
-    Object518 --> Lambda519
-    Constant1289{{"Constant[1289∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1289 --> Lambda524
-    Object537 --> Lambda538
-    Constant1290{{"Constant[1290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1290 --> Lambda543
-    Object553 --> Lambda554
-    Constant1291{{"Constant[1291∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1291 --> Lambda559
-    Object646 --> Lambda647
-    Constant1297{{"Constant[1297∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1297 --> Lambda652
-    Object660 --> Lambda661
-    Constant1298{{"Constant[1298∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1298 --> Lambda666
-    Object676 --> Lambda677
-    Constant1299{{"Constant[1299∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1299 --> Lambda682
-    Object718 --> Lambda719
-    Constant1302{{"Constant[1302∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1302 --> Lambda724
-    Object760 --> Lambda761
-    Constant1305{{"Constant[1305∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1305 --> Lambda766
-    Object802 --> Lambda803
-    Constant1308{{"Constant[1308∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1308 --> Lambda808
-    Object816 --> Lambda817
-    Constant1309{{"Constant[1309∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1309 --> Lambda822
+    Constant1337{{"Constant[1337∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1337 --> Lambda453
+    Lambda456{{"Lambda[456∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1338{{"Constant[1338∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1338 --> Lambda456
+    Lambda456 --> Access457
+    Object461 --> Lambda462
+    Constant1339{{"Constant[1339∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_iᐳ"}}:::plan
+    Constant1339 --> Lambda467
+    Object476 --> Lambda477
+    Constant1340{{"Constant[1340∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_iᐳ"}}:::plan
+    Constant1340 --> Lambda482
+    Object491 --> Lambda492
+    Constant1341{{"Constant[1341∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1341 --> Lambda497
+    Object506 --> Lambda507
+    Constant1342{{"Constant[1342∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1342 --> Lambda512
+    Object523 --> Lambda524
+    Constant1343{{"Constant[1343∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1343 --> Lambda529
+    Object543 --> Lambda544
+    Constant1344{{"Constant[1344∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1344 --> Lambda549
+    Object560 --> Lambda561
+    Constant1345{{"Constant[1345∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1345 --> Lambda566
+    Lambda576{{"Lambda[576∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object575 --> Lambda576
+    Lambda581{{"Lambda[581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1346{{"Constant[1346∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1346 --> Lambda581
+    Lambda593{{"Lambda[593∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object592 --> Lambda593
+    Lambda598{{"Lambda[598∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1347{{"Constant[1347∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1347 --> Lambda598
+    Lambda613{{"Lambda[613∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object612 --> Lambda613
+    Lambda618{{"Lambda[618∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1348{{"Constant[1348∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1348 --> Lambda618
+    Lambda630{{"Lambda[630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object629 --> Lambda630
+    Lambda635{{"Lambda[635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1349{{"Constant[1349∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1349 --> Lambda635
+    Lambda645{{"Lambda[645∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object644 --> Lambda645
+    Lambda650{{"Lambda[650∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1350{{"Constant[1350∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1350 --> Lambda650
+    Object659 --> Lambda660
+    Constant1351{{"Constant[1351∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1351 --> Lambda665
+    Object674 --> Lambda675
+    Constant1352{{"Constant[1352∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1352 --> Lambda680
+    Object691 --> Lambda692
+    Constant1353{{"Constant[1353∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1353 --> Lambda697
+    Lambda707{{"Lambda[707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object706 --> Lambda707
+    Lambda712{{"Lambda[712∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1354{{"Constant[1354∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1354 --> Lambda712
+    Lambda722{{"Lambda[722∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object721 --> Lambda722
+    Lambda727{{"Lambda[727∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1355{{"Constant[1355∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1355 --> Lambda727
+    Object736 --> Lambda737
+    Constant1356{{"Constant[1356∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1356 --> Lambda742
+    Lambda752{{"Lambda[752∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object751 --> Lambda752
+    Lambda757{{"Lambda[757∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1357{{"Constant[1357∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1357 --> Lambda757
+    Lambda767{{"Lambda[767∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object766 --> Lambda767
+    Lambda772{{"Lambda[772∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1358{{"Constant[1358∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1358 --> Lambda772
+    Object781 --> Lambda782
+    Constant1359{{"Constant[1359∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1359 --> Lambda787
+    Lambda797{{"Lambda[797∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object796 --> Lambda797
+    Lambda802{{"Lambda[802∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1360{{"Constant[1360∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1360 --> Lambda802
+    Lambda812{{"Lambda[812∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object811 --> Lambda812
+    Lambda817{{"Lambda[817∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1361{{"Constant[1361∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1361 --> Lambda817
+    Object826 --> Lambda827
+    Constant1362{{"Constant[1362∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1362 --> Lambda832
+    Object841 --> Lambda842
+    Constant1363{{"Constant[1363∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
+    Constant1363 --> Lambda847
+    Lambda857{{"Lambda[857∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object856 --> Lambda857
+    Lambda862{{"Lambda[862∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1364{{"Constant[1364∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
+    Constant1364 --> Lambda862
+    Lambda872{{"Lambda[872∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object871 --> Lambda872
+    Lambda877{{"Lambda[877∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1365{{"Constant[1365∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
+    Constant1365 --> Lambda877
+    Lambda887{{"Lambda[887∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object886 --> Lambda887
-    Constant1314{{"Constant[1314∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1314 --> Lambda892
-    Object902 --> Lambda903
-    Constant1315{{"Constant[1315∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1315 --> Lambda908
-    Object921 --> Lambda922
-    Constant1316{{"Constant[1316∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1316 --> Lambda927
-    Object937 --> Lambda938
-    Constant1317{{"Constant[1317∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1317 --> Lambda943
+    Lambda892{{"Lambda[892∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1366{{"Constant[1366∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
+    Constant1366 --> Lambda892
+    Lambda902{{"Lambda[902∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object901 --> Lambda902
+    Lambda907{{"Lambda[907∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1367{{"Constant[1367∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
+    Constant1367 --> Lambda907
+    Object916 --> Lambda917
+    Constant1368{{"Constant[1368∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant1368 --> Lambda922
+    Object933 --> Lambda934
+    Constant1369{{"Constant[1369∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1369 --> Lambda939
     Object953 --> Lambda954
-    Constant1318{{"Constant[1318∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1318 --> Lambda959
-    Object969 --> Lambda970
-    Constant1319{{"Constant[1319∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1319 --> Lambda975
-    Object985 --> Lambda986
-    Constant1320{{"Constant[1320∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1320 --> Lambda991
-    Object1001 --> Lambda1002
-    Constant1321{{"Constant[1321∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1321 --> Lambda1007
-    Object1017 --> Lambda1018
-    Constant1322{{"Constant[1322∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1322 --> Lambda1023
-    Object1033 --> Lambda1034
-    Constant1323{{"Constant[1323∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1323 --> Lambda1039
-    Object1047 --> Lambda1048
-    Constant1324{{"Constant[1324∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1324 --> Lambda1053
-    Object1063 --> Lambda1064
-    Constant1325{{"Constant[1325∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1325 --> Lambda1069
-    Object1079 --> Lambda1080
-    Constant1326{{"Constant[1326∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant1326 --> Lambda1085
-    Object1095 --> Lambda1096
-    Constant1327{{"Constant[1327∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1327 --> Lambda1101
-    Object1111 --> Lambda1112
-    Constant1328{{"Constant[1328∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1328 --> Lambda1117
-    Object1127 --> Lambda1128
-    Constant1329{{"Constant[1329∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant1329 --> Lambda1133
-    Object1143 --> Lambda1144
-    Constant1330{{"Constant[1330∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1330 --> Lambda1149
-    Object1157 --> Lambda1158
-    Constant1331{{"Constant[1331∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1331 --> Lambda1163
-    Object1173 --> Lambda1174
-    Constant1332{{"Constant[1332∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1332 --> Lambda1179
+    Constant1370{{"Constant[1370∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1370 --> Lambda959
+    Object970 --> Lambda971
+    Constant1371{{"Constant[1371∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1371 --> Lambda976
+    Object987 --> Lambda988
+    Constant1372{{"Constant[1372∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1372 --> Lambda993
+    Object1004 --> Lambda1005
+    Constant1373{{"Constant[1373∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1373 --> Lambda1010
+    Object1021 --> Lambda1022
+    Constant1374{{"Constant[1374∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1374 --> Lambda1027
+    Object1038 --> Lambda1039
+    Constant1375{{"Constant[1375∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1375 --> Lambda1044
+    Object1055 --> Lambda1056
+    Constant1376{{"Constant[1376∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1376 --> Lambda1061
+    Object1072 --> Lambda1073
+    Constant1377{{"Constant[1377∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1377 --> Lambda1078
+    Object1087 --> Lambda1088
+    Constant1378{{"Constant[1378∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1378 --> Lambda1093
+    Object1104 --> Lambda1105
+    Constant1379{{"Constant[1379∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1379 --> Lambda1110
+    Object1121 --> Lambda1122
+    Constant1380{{"Constant[1380∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant1380 --> Lambda1127
+    Object1138 --> Lambda1139
+    Constant1381{{"Constant[1381∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1381 --> Lambda1144
+    Object1155 --> Lambda1156
+    Constant1382{{"Constant[1382∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1382 --> Lambda1161
+    Object1172 --> Lambda1173
+    Constant1383{{"Constant[1383∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant1383 --> Lambda1178
     Object1189 --> Lambda1190
-    Constant1333{{"Constant[1333∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant1333 --> Lambda1195
-    Object1205 --> Lambda1206
-    Constant1334{{"Constant[1334∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1334 --> Lambda1211
+    Constant1384{{"Constant[1384∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1384 --> Lambda1195
+    Object1204 --> Lambda1205
+    Constant1385{{"Constant[1385∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1385 --> Lambda1210
     Object1221 --> Lambda1222
-    Constant1335{{"Constant[1335∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1335 --> Lambda1227
-    Object1237 --> Lambda1238
-    Constant1336{{"Constant[1336∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant1336 --> Lambda1243
-    Object1253 --> Lambda1254
-    Constant1337{{"Constant[1337∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1337 --> Lambda1259
-    Object1267 --> Lambda1268
-    Constant1338{{"Constant[1338∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”searchᐳ"}}:::plan
-    Constant1338 --> Lambda1273
+    Constant1386{{"Constant[1386∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1386 --> Lambda1227
+    Object1238 --> Lambda1239
+    Constant1387{{"Constant[1387∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant1387 --> Lambda1244
+    Object1255 --> Lambda1256
+    Constant1388{{"Constant[1388∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1388 --> Lambda1261
+    Object1272 --> Lambda1273
+    Constant1389{{"Constant[1389∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1389 --> Lambda1278
+    Object1289 --> Lambda1290
+    Constant1390{{"Constant[1390∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant1390 --> Lambda1295
+    Object1306 --> Lambda1307
+    Constant1391{{"Constant[1391∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1391 --> Lambda1312
+    Object1321 --> Lambda1322
+    Constant1392{{"Constant[1392∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”searchᐳ"}}:::plan
+    Constant1392 --> Lambda1327
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant48{{"Constant[48∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
+    Connection60{{"Connection[60∈0] ➊<br />ᐸ56ᐳ"}}:::plan
     Constant64{{"Constant[64∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
     Connection72{{"Connection[72∈0] ➊<br />ᐸ70ᐳ"}}:::plan
+    Connection103{{"Connection[103∈0] ➊<br />ᐸ99ᐳ"}}:::plan
     Connection139{{"Connection[139∈0] ➊<br />ᐸ137ᐳ"}}:::plan
     Connection157{{"Connection[157∈0] ➊<br />ᐸ155ᐳ"}}:::plan
     Connection176{{"Connection[176∈0] ➊<br />ᐸ174ᐳ"}}:::plan
     Connection203{{"Connection[203∈0] ➊<br />ᐸ201ᐳ"}}:::plan
     Connection216{{"Connection[216∈0] ➊<br />ᐸ214ᐳ"}}:::plan
+    Connection271{{"Connection[271∈0] ➊<br />ᐸ267ᐳ"}}:::plan
     Constant451{{"Constant[451∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant454{{"Constant[454∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant565{{"Constant[565∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant580{{"Constant[580∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant581{{"Constant[581∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant599{{"Constant[599∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant600{{"Constant[600∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant615{{"Constant[615∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant616{{"Constant[616∈0] ➊<br />ᐸsql.identifier(”func_out_complex_setof”)ᐳ"}}:::plan
-    Constant617{{"Constant[617∈0] ➊<br />ᐸRecordCodec(FuncOutComplexSetofRecord)ᐳ"}}:::plan
-    Constant629{{"Constant[629∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant687{{"Constant[687∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant688{{"Constant[688∈0] ➊<br />ᐸsql.identifier(”func_out_out_setof”)ᐳ"}}:::plan
-    Constant689{{"Constant[689∈0] ➊<br />ᐸRecordCodec(FuncOutOutSetofRecord)ᐳ"}}:::plan
-    Constant701{{"Constant[701∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant729{{"Constant[729∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant730{{"Constant[730∈0] ➊<br />ᐸsql.identifier(”func_out_setof”)ᐳ"}}:::plan
-    Constant743{{"Constant[743∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant771{{"Constant[771∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant772{{"Constant[772∈0] ➊<br />ᐸsql.identifier(”func_out_table_setof”)ᐳ"}}:::plan
-    Constant785{{"Constant[785∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant827{{"Constant[827∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant828{{"Constant[828∈0] ➊<br />ᐸsql.identifier(”func_returns_table_multi_col”)ᐳ"}}:::plan
-    Constant829{{"Constant[829∈0] ➊<br />ᐸRecordCodec(FuncReturnsTableMultiColRecord)ᐳ"}}:::plan
-    Constant841{{"Constant[841∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant855{{"Constant[855∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant856{{"Constant[856∈0] ➊<br />ᐸsql.identifier(”func_returns_table_one_col”)ᐳ"}}:::plan
-    Constant869{{"Constant[869∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1278{{"Constant[1278∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant1292{{"Constant[1292∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant1293{{"Constant[1293∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1294{{"Constant[1294∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1295{{"Constant[1295∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1296{{"Constant[1296∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1300{{"Constant[1300∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1301{{"Constant[1301∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1303{{"Constant[1303∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1304{{"Constant[1304∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1306{{"Constant[1306∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1307{{"Constant[1307∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_oᐳ"}}:::plan
-    Constant1310{{"Constant[1310∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
-    Constant1311{{"Constant[1311∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
-    Constant1312{{"Constant[1312∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
-    Constant1313{{"Constant[1313∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”func_rᐳ"}}:::plan
+    Constant1332{{"Constant[1332∈0] ➊<br />ᐸ20ᐳ"}}:::plan
     PgClassExpression32{{"PgClassExpression[32∈1] ➊<br />ᐸ__func_out...plex__.”x”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression32
     PgSelectSingle39{{"PgSelectSingle[39∈1] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys509{{"RemapKeys[509∈1] ➊<br />ᐸ31:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
-    RemapKeys509 --> PgSelectSingle39
+    RemapKeys513{{"RemapKeys[513∈1] ➊<br />ᐸ31:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
+    RemapKeys513 --> PgSelectSingle39
     PgSelectSingle47{{"PgSelectSingle[47∈1] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys544{{"RemapKeys[544∈1] ➊<br />ᐸ31:{”0”:5,”1”:6,”2”:7}ᐳ"}}:::plan
-    RemapKeys544 --> PgSelectSingle47
-    PgSelectSingle31 --> RemapKeys509
-    PgSelectSingle31 --> RemapKeys544
-    Connection60{{"Connection[60∈1] ➊<br />ᐸ56ᐳ"}}:::plan
+    RemapKeys550{{"RemapKeys[550∈1] ➊<br />ᐸ31:{”0”:5,”1”:6,”2”:7}ᐳ"}}:::plan
+    RemapKeys550 --> PgSelectSingle47
+    PgSelectSingle31 --> RemapKeys513
+    PgSelectSingle31 --> RemapKeys550
     PgClassExpression40{{"PgClassExpression[40∈2] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
     PgClassExpression41{{"PgClassExpression[41∈2] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈2] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression42
-    Object528{{"Object[528∈3] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access526{{"Access[526∈3] ➊<br />ᐸ544.0ᐳ"}}:::plan
-    Access526 & Constant451 & Constant451 & Lambda453 & Constant454 --> Object528
+    Object533{{"Object[533∈3] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access531{{"Access[531∈3] ➊<br />ᐸ550.0ᐳ"}}:::plan
+    Access531 & Constant451 & Constant451 & Lambda453 & Constant454 --> Object533
     List50{{"List[50∈3] ➊<br />ᐸ48,49ᐳ"}}:::plan
     PgClassExpression49{{"PgClassExpression[49∈3] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant48 & PgClassExpression49 --> List50
@@ -568,11 +662,11 @@ graph TD
     List50 --> Lambda51
     PgClassExpression52{{"PgClassExpression[52∈3] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle47 --> PgClassExpression52
-    RemapKeys544 --> Access526
-    Lambda529{{"Lambda[529∈3] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object528 --> Lambda529
-    __Item62[/"__Item[62∈4]<br />ᐸ529ᐳ"\]:::itemplan
-    Lambda529 ==> __Item62
+    RemapKeys550 --> Access531
+    Lambda534{{"Lambda[534∈3] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object533 --> Lambda534
+    __Item62[/"__Item[62∈4]<br />ᐸ534ᐳ"\]:::itemplan
+    Lambda534 ==> __Item62
     PgSelectSingle63{{"PgSelectSingle[63∈4]<br />ᐸpostᐳ"}}:::plan
     __Item62 --> PgSelectSingle63
     List66{{"List[66∈5]<br />ᐸ64,65ᐳ"}}:::plan
@@ -582,46 +676,15 @@ graph TD
     Lambda67{{"Lambda[67∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List66 --> Lambda67
     PgSelect73[["PgSelect[73∈6] ➊<br />ᐸfunc_out_complex_setofᐳ"]]:::plan
-    Lambda568{{"Lambda[568∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda573{{"Lambda[573∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda584{{"Lambda[584∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda589{{"Lambda[589∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda603{{"Lambda[603∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda608{{"Lambda[608∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda619{{"Lambda[619∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda624{{"Lambda[624∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1276 & Constant1277 & Connection72 & Lambda456 & Lambda568 & Lambda573 & Lambda584 & Lambda589 & Lambda456 & Lambda603 & Lambda608 & Lambda453 & Lambda456 & Lambda619 & Lambda624 --> PgSelect73
+    Object11 & Constant1330 & Constant1331 & Connection72 & Access457 & Lambda576 & Lambda581 & Lambda593 & Lambda598 & Access457 & Lambda613 & Lambda618 & Lambda453 & Access457 & Lambda630 & Lambda635 --> PgSelect73
     PgSelect111[["PgSelect[111∈6] ➊<br />ᐸfunc_out_complex_setof(aggregate)ᐳ"]]:::plan
-    Lambda633{{"Lambda[633∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda638{{"Lambda[638∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1276 & Constant1277 & Connection72 & Lambda453 & Lambda456 & Lambda633 & Lambda638 --> PgSelect111
-    Object567{{"Object[567∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant564 & Constant565 & Constant501 --> Object567
-    Object583{{"Object[583∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant580 & Constant581 & Constant517 --> Object583
-    Object602{{"Object[602∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant599 & Constant600 & Constant536 --> Object602
-    Object618{{"Object[618∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant615 & Constant616 & Constant617 --> Object618
-    Object632{{"Object[632∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant629 & Constant616 & Constant617 --> Object632
+    Object11 & Constant1330 & Constant1331 & Connection72 & Lambda453 & Access457 & Lambda645 & Lambda650 --> PgSelect111
     First112{{"First[112∈6] ➊"}}:::plan
     PgSelect111 --> First112
     PgSelectSingle113{{"PgSelectSingle[113∈6] ➊<br />ᐸfunc_out_complex_setofᐳ"}}:::plan
     First112 --> PgSelectSingle113
     PgClassExpression114{{"PgClassExpression[114∈6] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle113 --> PgClassExpression114
-    Object567 --> Lambda568
-    Constant1292 --> Lambda573
-    Object583 --> Lambda584
-    Constant1293 --> Lambda589
-    Object602 --> Lambda603
-    Constant1294 --> Lambda608
-    Object618 --> Lambda619
-    Constant1295 --> Lambda624
-    Object632 --> Lambda633
-    Constant1296 --> Lambda638
-    Connection103{{"Connection[103∈6] ➊<br />ᐸ99ᐳ"}}:::plan
     __Item74[/"__Item[74∈7]<br />ᐸ73ᐳ"\]:::itemplan
     PgSelect73 ==> __Item74
     PgSelectSingle75{{"PgSelectSingle[75∈7]<br />ᐸfunc_out_complex_setofᐳ"}}:::plan
@@ -629,22 +692,22 @@ graph TD
     PgClassExpression76{{"PgClassExpression[76∈8]<br />ᐸ__func_out...etof__.”x”ᐳ"}}:::plan
     PgSelectSingle75 --> PgClassExpression76
     PgSelectSingle83{{"PgSelectSingle[83∈8]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys574{{"RemapKeys[574∈8]<br />ᐸ75:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
-    RemapKeys574 --> PgSelectSingle83
+    RemapKeys582{{"RemapKeys[582∈8]<br />ᐸ75:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
+    RemapKeys582 --> PgSelectSingle83
     PgSelectSingle91{{"PgSelectSingle[91∈8]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys609{{"RemapKeys[609∈8]<br />ᐸ75:{”0”:5,”1”:6,”2”:7}ᐳ"}}:::plan
-    RemapKeys609 --> PgSelectSingle91
-    PgSelectSingle75 --> RemapKeys574
-    PgSelectSingle75 --> RemapKeys609
+    RemapKeys619{{"RemapKeys[619∈8]<br />ᐸ75:{”0”:5,”1”:6,”2”:7}ᐳ"}}:::plan
+    RemapKeys619 --> PgSelectSingle91
+    PgSelectSingle75 --> RemapKeys582
+    PgSelectSingle75 --> RemapKeys619
     PgClassExpression84{{"PgClassExpression[84∈9]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle83 --> PgClassExpression84
     PgClassExpression85{{"PgClassExpression[85∈9]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle83 --> PgClassExpression85
     PgClassExpression86{{"PgClassExpression[86∈9]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle83 --> PgClassExpression86
-    Object593{{"Object[593∈10]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access591{{"Access[591∈10]<br />ᐸ609.0ᐳ"}}:::plan
-    Access591 & Constant451 & Constant451 & Lambda453 & Constant454 --> Object593
+    Object602{{"Object[602∈10]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access600{{"Access[600∈10]<br />ᐸ619.0ᐳ"}}:::plan
+    Access600 & Constant451 & Constant451 & Lambda453 & Constant454 --> Object602
     List94{{"List[94∈10]<br />ᐸ48,93ᐳ"}}:::plan
     PgClassExpression93{{"PgClassExpression[93∈10]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant48 & PgClassExpression93 --> List94
@@ -653,11 +716,11 @@ graph TD
     List94 --> Lambda95
     PgClassExpression96{{"PgClassExpression[96∈10]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle91 --> PgClassExpression96
-    RemapKeys609 --> Access591
-    Lambda594{{"Lambda[594∈10]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object593 --> Lambda594
-    __Item105[/"__Item[105∈11]<br />ᐸ594ᐳ"\]:::itemplan
-    Lambda594 ==> __Item105
+    RemapKeys619 --> Access600
+    Lambda603{{"Lambda[603∈10]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object602 --> Lambda603
+    __Item105[/"__Item[105∈11]<br />ᐸ603ᐳ"\]:::itemplan
+    Lambda603 ==> __Item105
     PgSelectSingle106{{"PgSelectSingle[106∈11]<br />ᐸpostᐳ"}}:::plan
     __Item105 --> PgSelectSingle106
     List109{{"List[109∈12]<br />ᐸ64,108ᐳ"}}:::plan
@@ -673,9 +736,9 @@ graph TD
     PgClassExpression126{{"PgClassExpression[126∈14] ➊<br />ᐸ__func_out...ype__.”o1”ᐳ"}}:::plan
     PgSelectSingle125 --> PgClassExpression126
     PgSelectSingle133{{"PgSelectSingle[133∈14] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys667{{"RemapKeys[667∈14] ➊<br />ᐸ125:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
-    RemapKeys667 --> PgSelectSingle133
-    PgSelectSingle125 --> RemapKeys667
+    RemapKeys681{{"RemapKeys[681∈14] ➊<br />ᐸ125:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
+    RemapKeys681 --> PgSelectSingle133
+    PgSelectSingle125 --> RemapKeys681
     PgClassExpression134{{"PgClassExpression[134∈15] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle133 --> PgClassExpression134
     PgClassExpression135{{"PgClassExpression[135∈15] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -683,27 +746,15 @@ graph TD
     PgClassExpression136{{"PgClassExpression[136∈15] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle133 --> PgClassExpression136
     PgSelect140[["PgSelect[140∈16] ➊<br />ᐸfunc_out_out_setofᐳ"]]:::plan
-    Lambda691{{"Lambda[691∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda696{{"Lambda[696∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection139 & Lambda453 & Lambda456 & Lambda691 & Lambda696 --> PgSelect140
+    Object11 & Connection139 & Lambda453 & Access457 & Lambda707 & Lambda712 --> PgSelect140
     PgSelect145[["PgSelect[145∈16] ➊<br />ᐸfunc_out_out_setof(aggregate)ᐳ"]]:::plan
-    Lambda705{{"Lambda[705∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda710{{"Lambda[710∈16] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection139 & Lambda453 & Lambda456 & Lambda705 & Lambda710 --> PgSelect145
-    Object690{{"Object[690∈16] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant687 & Constant688 & Constant689 --> Object690
-    Object704{{"Object[704∈16] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant701 & Constant688 & Constant689 --> Object704
+    Object11 & Connection139 & Lambda453 & Access457 & Lambda722 & Lambda727 --> PgSelect145
     First146{{"First[146∈16] ➊"}}:::plan
     PgSelect145 --> First146
     PgSelectSingle147{{"PgSelectSingle[147∈16] ➊<br />ᐸfunc_out_out_setofᐳ"}}:::plan
     First146 --> PgSelectSingle147
     PgClassExpression148{{"PgClassExpression[148∈16] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle147 --> PgClassExpression148
-    Object690 --> Lambda691
-    Constant1300 --> Lambda696
-    Object704 --> Lambda705
-    Constant1301 --> Lambda710
     __Item141[/"__Item[141∈17]<br />ᐸ140ᐳ"\]:::itemplan
     PgSelect140 ==> __Item141
     PgSelectSingle142{{"PgSelectSingle[142∈17]<br />ᐸfunc_out_out_setofᐳ"}}:::plan
@@ -717,27 +768,15 @@ graph TD
     PgClassExpression154{{"PgClassExpression[154∈19] ➊<br />ᐸ__func_out....”column2”ᐳ"}}:::plan
     PgSelectSingle152 --> PgClassExpression154
     PgSelect158[["PgSelect[158∈20] ➊<br />ᐸfunc_out_setofᐳ"]]:::plan
-    Lambda733{{"Lambda[733∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda738{{"Lambda[738∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection157 & Lambda453 & Lambda456 & Lambda733 & Lambda738 --> PgSelect158
+    Object11 & Connection157 & Lambda453 & Access457 & Lambda752 & Lambda757 --> PgSelect158
     PgSelect162[["PgSelect[162∈20] ➊<br />ᐸfunc_out_setof(aggregate)ᐳ"]]:::plan
-    Lambda747{{"Lambda[747∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda752{{"Lambda[752∈20] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection157 & Lambda453 & Lambda456 & Lambda747 & Lambda752 --> PgSelect162
-    Object732{{"Object[732∈20] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant729 & Constant730 & Constant459 --> Object732
-    Object746{{"Object[746∈20] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant743 & Constant730 & Constant459 --> Object746
+    Object11 & Connection157 & Lambda453 & Access457 & Lambda767 & Lambda772 --> PgSelect162
     First163{{"First[163∈20] ➊"}}:::plan
     PgSelect162 --> First163
     PgSelectSingle164{{"PgSelectSingle[164∈20] ➊<br />ᐸfunc_out_setofᐳ"}}:::plan
     First163 --> PgSelectSingle164
     PgClassExpression165{{"PgClassExpression[165∈20] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle164 --> PgClassExpression165
-    Object732 --> Lambda733
-    Constant1303 --> Lambda738
-    Object746 --> Lambda747
-    Constant1304 --> Lambda752
     __Item159[/"__Item[159∈21]<br />ᐸ158ᐳ"\]:::itemplan
     PgSelect158 ==> __Item159
     PgSelectSingle160{{"PgSelectSingle[160∈21]<br />ᐸfunc_out_setofᐳ"}}:::plan
@@ -751,27 +790,15 @@ graph TD
     Lambda173{{"Lambda[173∈22] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List172 --> Lambda173
     PgSelect177[["PgSelect[177∈23] ➊<br />ᐸfunc_out_table_setofᐳ"]]:::plan
-    Lambda775{{"Lambda[775∈23] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda780{{"Lambda[780∈23] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection176 & Lambda453 & Lambda456 & Lambda775 & Lambda780 --> PgSelect177
+    Object11 & Connection176 & Lambda453 & Access457 & Lambda797 & Lambda802 --> PgSelect177
     PgSelect184[["PgSelect[184∈23] ➊<br />ᐸfunc_out_table_setof(aggregate)ᐳ"]]:::plan
-    Lambda789{{"Lambda[789∈23] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda794{{"Lambda[794∈23] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Connection176 & Lambda453 & Lambda456 & Lambda789 & Lambda794 --> PgSelect184
-    Object774{{"Object[774∈23] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant771 & Constant772 & Constant536 --> Object774
-    Object788{{"Object[788∈23] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant785 & Constant772 & Constant536 --> Object788
+    Object11 & Connection176 & Lambda453 & Access457 & Lambda812 & Lambda817 --> PgSelect184
     First185{{"First[185∈23] ➊"}}:::plan
     PgSelect184 --> First185
     PgSelectSingle186{{"PgSelectSingle[186∈23] ➊<br />ᐸfunc_out_table_setofᐳ"}}:::plan
     First185 --> PgSelectSingle186
     PgClassExpression187{{"PgClassExpression[187∈23] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle186 --> PgClassExpression187
-    Object774 --> Lambda775
-    Constant1306 --> Lambda780
-    Object788 --> Lambda789
-    Constant1307 --> Lambda794
     __Item178[/"__Item[178∈24]<br />ᐸ177ᐳ"\]:::itemplan
     PgSelect177 ==> __Item178
     PgSelectSingle179{{"PgSelectSingle[179∈24]<br />ᐸfunc_out_table_setofᐳ"}}:::plan
@@ -789,27 +816,15 @@ graph TD
     PgClassExpression199{{"PgClassExpression[199∈26] ➊<br />ᐸ__func_out...med__.”o2”ᐳ"}}:::plan
     PgSelectSingle196 --> PgClassExpression199
     PgSelect204[["PgSelect[204∈27] ➊<br />ᐸfunc_returns_table_multi_colᐳ"]]:::plan
-    Lambda831{{"Lambda[831∈27] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda836{{"Lambda[836∈27] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1278 & Connection203 & Lambda453 & Lambda456 & Lambda831 & Lambda836 --> PgSelect204
+    Object11 & Constant1332 & Connection203 & Lambda453 & Access457 & Lambda857 & Lambda862 --> PgSelect204
     PgSelect209[["PgSelect[209∈27] ➊<br />ᐸfunc_returns_table_multi_col(aggregate)ᐳ"]]:::plan
-    Lambda845{{"Lambda[845∈27] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda850{{"Lambda[850∈27] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1278 & Connection203 & Lambda453 & Lambda456 & Lambda845 & Lambda850 --> PgSelect209
-    Object830{{"Object[830∈27] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant827 & Constant828 & Constant829 --> Object830
-    Object844{{"Object[844∈27] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant841 & Constant828 & Constant829 --> Object844
+    Object11 & Constant1332 & Connection203 & Lambda453 & Access457 & Lambda872 & Lambda877 --> PgSelect209
     First210{{"First[210∈27] ➊"}}:::plan
     PgSelect209 --> First210
     PgSelectSingle211{{"PgSelectSingle[211∈27] ➊<br />ᐸfunc_returns_table_multi_colᐳ"}}:::plan
     First210 --> PgSelectSingle211
     PgClassExpression212{{"PgClassExpression[212∈27] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle211 --> PgClassExpression212
-    Object830 --> Lambda831
-    Constant1310 --> Lambda836
-    Object844 --> Lambda845
-    Constant1311 --> Lambda850
     __Item205[/"__Item[205∈28]<br />ᐸ204ᐳ"\]:::itemplan
     PgSelect204 ==> __Item205
     PgSelectSingle206{{"PgSelectSingle[206∈28]<br />ᐸfunc_returns_table_multi_colᐳ"}}:::plan
@@ -819,27 +834,15 @@ graph TD
     PgClassExpression208{{"PgClassExpression[208∈29]<br />ᐸ__func_ret...l__.”col2”ᐳ"}}:::plan
     PgSelectSingle206 --> PgClassExpression208
     PgSelect217[["PgSelect[217∈30] ➊<br />ᐸfunc_returns_table_one_colᐳ"]]:::plan
-    Lambda859{{"Lambda[859∈30] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda864{{"Lambda[864∈30] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1278 & Connection216 & Lambda453 & Lambda456 & Lambda859 & Lambda864 --> PgSelect217
+    Object11 & Constant1332 & Connection216 & Lambda453 & Access457 & Lambda887 & Lambda892 --> PgSelect217
     PgSelect221[["PgSelect[221∈30] ➊<br />ᐸfunc_returns_table_one_col(aggregate)ᐳ"]]:::plan
-    Lambda873{{"Lambda[873∈30] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda878{{"Lambda[878∈30] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant1278 & Connection216 & Lambda453 & Lambda456 & Lambda873 & Lambda878 --> PgSelect221
-    Object858{{"Object[858∈30] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant855 & Constant856 & Constant459 --> Object858
-    Object872{{"Object[872∈30] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda453 & Constant869 & Constant856 & Constant459 --> Object872
+    Object11 & Constant1332 & Connection216 & Lambda453 & Access457 & Lambda902 & Lambda907 --> PgSelect221
     First222{{"First[222∈30] ➊"}}:::plan
     PgSelect221 --> First222
     PgSelectSingle223{{"PgSelectSingle[223∈30] ➊<br />ᐸfunc_returns_table_one_colᐳ"}}:::plan
     First222 --> PgSelectSingle223
     PgClassExpression224{{"PgClassExpression[224∈30] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle223 --> PgClassExpression224
-    Object858 --> Lambda859
-    Constant1312 --> Lambda864
-    Object872 --> Lambda873
-    Constant1313 --> Lambda878
     __Item218[/"__Item[218∈31]<br />ᐸ217ᐳ"\]:::itemplan
     PgSelect217 ==> __Item218
     PgSelectSingle219{{"PgSelectSingle[219∈31]<br />ᐸfunc_returns_table_one_colᐳ"}}:::plan
@@ -855,49 +858,48 @@ graph TD
     PgClassExpression234{{"PgClassExpression[234∈32] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle229 --> PgClassExpression234
     PgSelectSingle243{{"PgSelectSingle[243∈32] ➊<br />ᐸperson_computed_complexᐳ"}}:::plan
-    RemapKeys944{{"RemapKeys[944∈32] ➊<br />ᐸ229:{”0”:2,”1”:3,”2”:4,”3”:5,”4”:6,”5”:7,”6”:8,”7”:9,”8”:10}ᐳ"}}:::plan
-    RemapKeys944 --> PgSelectSingle243
+    RemapKeys977{{"RemapKeys[977∈32] ➊<br />ᐸ229:{”0”:2,”1”:3,”2”:4,”3”:5,”4”:6,”5”:7,”6”:8,”7”:9,”8”:10}ᐳ"}}:::plan
+    RemapKeys977 --> PgSelectSingle243
     PgSelectSingle283{{"PgSelectSingle[283∈32] ➊<br />ᐸperson_computed_first_arg_inoutᐳ"}}:::plan
-    RemapKeys960{{"RemapKeys[960∈32] ➊<br />ᐸ229:{”0”:11,”1”:12}ᐳ"}}:::plan
-    RemapKeys960 --> PgSelectSingle283
+    RemapKeys994{{"RemapKeys[994∈32] ➊<br />ᐸ229:{”0”:11,”1”:12}ᐳ"}}:::plan
+    RemapKeys994 --> PgSelectSingle283
     PgSelectSingle290{{"PgSelectSingle[290∈32] ➊<br />ᐸperson_computed_first_arg_inout_outᐳ"}}:::plan
-    RemapKeys992{{"RemapKeys[992∈32] ➊<br />ᐸ229:{”0”:13,”1”:14,”2”:15,”3”:16}ᐳ"}}:::plan
-    RemapKeys992 --> PgSelectSingle290
+    RemapKeys1028{{"RemapKeys[1028∈32] ➊<br />ᐸ229:{”0”:13,”1”:14,”2”:15,”3”:16}ᐳ"}}:::plan
+    RemapKeys1028 --> PgSelectSingle290
     PgClassExpression303{{"PgClassExpression[303∈32] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle229 --> PgClassExpression303
     PgSelectSingle309{{"PgSelectSingle[309∈32] ➊<br />ᐸperson_computed_inout_outᐳ"}}:::plan
-    RemapKeys1008{{"RemapKeys[1008∈32] ➊<br />ᐸ229:{”0”:17,”1”:18,”2”:19}ᐳ"}}:::plan
-    RemapKeys1008 --> PgSelectSingle309
+    RemapKeys1045{{"RemapKeys[1045∈32] ➊<br />ᐸ229:{”0”:17,”1”:18,”2”:19}ᐳ"}}:::plan
+    RemapKeys1045 --> PgSelectSingle309
     PgClassExpression313{{"PgClassExpression[313∈32] ➊<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle229 --> PgClassExpression313
     PgSelectSingle318{{"PgSelectSingle[318∈32] ➊<br />ᐸperson_computed_out_outᐳ"}}:::plan
-    RemapKeys1024{{"RemapKeys[1024∈32] ➊<br />ᐸ229:{”0”:20,”1”:21,”2”:22}ᐳ"}}:::plan
-    RemapKeys1024 --> PgSelectSingle318
-    PgSelectSingle229 --> RemapKeys944
-    PgSelectSingle229 --> RemapKeys960
-    PgSelectSingle229 --> RemapKeys992
-    PgSelectSingle229 --> RemapKeys1008
-    PgSelectSingle229 --> RemapKeys1024
-    Connection271{{"Connection[271∈32] ➊<br />ᐸ267ᐳ"}}:::plan
+    RemapKeys1062{{"RemapKeys[1062∈32] ➊<br />ᐸ229:{”0”:20,”1”:21,”2”:22}ᐳ"}}:::plan
+    RemapKeys1062 --> PgSelectSingle318
+    PgSelectSingle229 --> RemapKeys977
+    PgSelectSingle229 --> RemapKeys994
+    PgSelectSingle229 --> RemapKeys1028
+    PgSelectSingle229 --> RemapKeys1045
+    PgSelectSingle229 --> RemapKeys1062
     PgClassExpression244{{"PgClassExpression[244∈33] ➊<br />ᐸ__person_c...plex__.”x”ᐳ"}}:::plan
     PgSelectSingle243 --> PgClassExpression244
     PgSelectSingle251{{"PgSelectSingle[251∈33] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys893{{"RemapKeys[893∈33] ➊<br />ᐸ243:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
-    RemapKeys893 --> PgSelectSingle251
+    RemapKeys923{{"RemapKeys[923∈33] ➊<br />ᐸ243:{”0”:1,”1”:2,”2”:3,”3”:4}ᐳ"}}:::plan
+    RemapKeys923 --> PgSelectSingle251
     PgSelectSingle259{{"PgSelectSingle[259∈33] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys928{{"RemapKeys[928∈33] ➊<br />ᐸ243:{”0”:5,”1”:6,”2”:7}ᐳ"}}:::plan
-    RemapKeys928 --> PgSelectSingle259
-    PgSelectSingle243 --> RemapKeys893
-    PgSelectSingle243 --> RemapKeys928
+    RemapKeys960{{"RemapKeys[960∈33] ➊<br />ᐸ243:{”0”:5,”1”:6,”2”:7}ᐳ"}}:::plan
+    RemapKeys960 --> PgSelectSingle259
+    PgSelectSingle243 --> RemapKeys923
+    PgSelectSingle243 --> RemapKeys960
     PgClassExpression252{{"PgClassExpression[252∈34] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle251 --> PgClassExpression252
     PgClassExpression253{{"PgClassExpression[253∈34] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle251 --> PgClassExpression253
     PgClassExpression254{{"PgClassExpression[254∈34] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle251 --> PgClassExpression254
-    Object912{{"Object[912∈35] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access910{{"Access[910∈35] ➊<br />ᐸ928.0ᐳ"}}:::plan
-    Access910 & Constant451 & Constant451 & Lambda453 & Constant454 --> Object912
+    Object943{{"Object[943∈35] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access941{{"Access[941∈35] ➊<br />ᐸ960.0ᐳ"}}:::plan
+    Access941 & Constant451 & Constant451 & Lambda453 & Constant454 --> Object943
     List262{{"List[262∈35] ➊<br />ᐸ48,261ᐳ"}}:::plan
     PgClassExpression261{{"PgClassExpression[261∈35] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant48 & PgClassExpression261 --> List262
@@ -906,11 +908,11 @@ graph TD
     List262 --> Lambda263
     PgClassExpression264{{"PgClassExpression[264∈35] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle259 --> PgClassExpression264
-    RemapKeys928 --> Access910
-    Lambda913{{"Lambda[913∈35] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object912 --> Lambda913
-    __Item273[/"__Item[273∈36]<br />ᐸ913ᐳ"\]:::itemplan
-    Lambda913 ==> __Item273
+    RemapKeys960 --> Access941
+    Lambda944{{"Lambda[944∈35] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object943 --> Lambda944
+    __Item273[/"__Item[273∈36]<br />ᐸ944ᐳ"\]:::itemplan
+    Lambda944 ==> __Item273
     PgSelectSingle274{{"PgSelectSingle[274∈36]<br />ᐸpostᐳ"}}:::plan
     __Item273 --> PgSelectSingle274
     List277{{"List[277∈37]<br />ᐸ64,276ᐳ"}}:::plan
@@ -942,11 +944,11 @@ graph TD
     PgSelectSingle334{{"PgSelectSingle[334∈43] ➊<br />ᐸleft_armᐳ"}}:::plan
     PgSelectSingle327 --> PgSelectSingle334
     PgSelectSingle362{{"PgSelectSingle[362∈43] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys1134{{"RemapKeys[1134∈43] ➊<br />ᐸ327:{”0”:7,”1”:8,”2”:9,”3”:10,”4”:11,”5”:12}ᐳ"}}:::plan
-    RemapKeys1134 --> PgSelectSingle362
+    RemapKeys1179{{"RemapKeys[1179∈43] ➊<br />ᐸ327:{”0”:7,”1”:8,”2”:9,”3”:10,”4”:11,”5”:12}ᐳ"}}:::plan
+    RemapKeys1179 --> PgSelectSingle362
     PgClassExpression381{{"PgClassExpression[381∈43] ➊<br />ᐸ__query_ou...ws__.”txt”ᐳ"}}:::plan
     PgSelectSingle327 --> PgClassExpression381
-    PgSelectSingle327 --> RemapKeys1134
+    PgSelectSingle327 --> RemapKeys1179
     PgClassExpression335{{"PgClassExpression[335∈44] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     PgSelectSingle334 --> PgClassExpression335
     PgClassExpression336{{"PgClassExpression[336∈44] ➊<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
@@ -956,15 +958,15 @@ graph TD
     PgClassExpression338{{"PgClassExpression[338∈44] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
     PgSelectSingle334 --> PgClassExpression338
     PgSelectSingle344{{"PgSelectSingle[344∈44] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys1070{{"RemapKeys[1070∈44] ➊<br />ᐸ334:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
-    RemapKeys1070 --> PgSelectSingle344
-    PgSelectSingle334 --> RemapKeys1070
+    RemapKeys1111{{"RemapKeys[1111∈44] ➊<br />ᐸ334:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
+    RemapKeys1111 --> PgSelectSingle344
+    PgSelectSingle334 --> RemapKeys1111
     PgClassExpression345{{"PgClassExpression[345∈45] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle344 --> PgClassExpression345
     PgSelectSingle352{{"PgSelectSingle[352∈45] ➊<br />ᐸperson_secretᐳ"}}:::plan
-    RemapKeys1054{{"RemapKeys[1054∈45] ➊<br />ᐸ344:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1054 --> PgSelectSingle352
-    PgSelectSingle344 --> RemapKeys1054
+    RemapKeys1094{{"RemapKeys[1094∈45] ➊<br />ᐸ344:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1094 --> PgSelectSingle352
+    PgSelectSingle344 --> RemapKeys1094
     PgClassExpression353{{"PgClassExpression[353∈46] ➊<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle352 --> PgClassExpression353
     PgClassExpression363{{"PgClassExpression[363∈47] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
@@ -974,25 +976,25 @@ graph TD
     PgClassExpression365{{"PgClassExpression[365∈47] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle362 --> PgClassExpression365
     PgSelectSingle371{{"PgSelectSingle[371∈47] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys1118{{"RemapKeys[1118∈47] ➊<br />ᐸ362:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
-    RemapKeys1118 --> PgSelectSingle371
-    PgSelectSingle362 --> RemapKeys1118
+    RemapKeys1162{{"RemapKeys[1162∈47] ➊<br />ᐸ362:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    RemapKeys1162 --> PgSelectSingle371
+    PgSelectSingle362 --> RemapKeys1162
     PgClassExpression372{{"PgClassExpression[372∈48] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle371 --> PgClassExpression372
     PgSelectSingle379{{"PgSelectSingle[379∈48] ➊<br />ᐸperson_secretᐳ"}}:::plan
-    RemapKeys1102{{"RemapKeys[1102∈48] ➊<br />ᐸ371:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1102 --> PgSelectSingle379
-    PgSelectSingle371 --> RemapKeys1102
+    RemapKeys1145{{"RemapKeys[1145∈48] ➊<br />ᐸ371:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1145 --> PgSelectSingle379
+    PgSelectSingle371 --> RemapKeys1145
     PgClassExpression380{{"PgClassExpression[380∈49] ➊<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle379 --> PgClassExpression380
     PgSelectSingle395{{"PgSelectSingle[395∈50] ➊<br />ᐸleft_armᐳ"}}:::plan
     PgSelectSingle388 --> PgSelectSingle395
     PgSelectSingle423{{"PgSelectSingle[423∈50] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys1244{{"RemapKeys[1244∈50] ➊<br />ᐸ388:{”0”:7,”1”:8,”2”:9,”3”:10,”4”:11,”5”:12}ᐳ"}}:::plan
-    RemapKeys1244 --> PgSelectSingle423
+    RemapKeys1296{{"RemapKeys[1296∈50] ➊<br />ᐸ388:{”0”:7,”1”:8,”2”:9,”3”:10,”4”:11,”5”:12}ᐳ"}}:::plan
+    RemapKeys1296 --> PgSelectSingle423
     PgClassExpression442{{"PgClassExpression[442∈50] ➊<br />ᐸ__query_ou...ws__.”txt”ᐳ"}}:::plan
     PgSelectSingle388 --> PgClassExpression442
-    PgSelectSingle388 --> RemapKeys1244
+    PgSelectSingle388 --> RemapKeys1296
     PgClassExpression396{{"PgClassExpression[396∈51] ➊<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     PgSelectSingle395 --> PgClassExpression396
     PgClassExpression397{{"PgClassExpression[397∈51] ➊<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
@@ -1002,15 +1004,15 @@ graph TD
     PgClassExpression399{{"PgClassExpression[399∈51] ➊<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
     PgSelectSingle395 --> PgClassExpression399
     PgSelectSingle405{{"PgSelectSingle[405∈51] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys1180{{"RemapKeys[1180∈51] ➊<br />ᐸ395:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
-    RemapKeys1180 --> PgSelectSingle405
-    PgSelectSingle395 --> RemapKeys1180
+    RemapKeys1228{{"RemapKeys[1228∈51] ➊<br />ᐸ395:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
+    RemapKeys1228 --> PgSelectSingle405
+    PgSelectSingle395 --> RemapKeys1228
     PgClassExpression406{{"PgClassExpression[406∈52] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle405 --> PgClassExpression406
     PgSelectSingle413{{"PgSelectSingle[413∈52] ➊<br />ᐸperson_secretᐳ"}}:::plan
-    RemapKeys1164{{"RemapKeys[1164∈52] ➊<br />ᐸ405:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1164 --> PgSelectSingle413
-    PgSelectSingle405 --> RemapKeys1164
+    RemapKeys1211{{"RemapKeys[1211∈52] ➊<br />ᐸ405:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1211 --> PgSelectSingle413
+    PgSelectSingle405 --> RemapKeys1211
     PgClassExpression414{{"PgClassExpression[414∈53] ➊<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle413 --> PgClassExpression414
     PgClassExpression424{{"PgClassExpression[424∈54] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
@@ -1020,15 +1022,15 @@ graph TD
     PgClassExpression426{{"PgClassExpression[426∈54] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle423 --> PgClassExpression426
     PgSelectSingle432{{"PgSelectSingle[432∈54] ➊<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys1228{{"RemapKeys[1228∈54] ➊<br />ᐸ423:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
-    RemapKeys1228 --> PgSelectSingle432
-    PgSelectSingle423 --> RemapKeys1228
+    RemapKeys1279{{"RemapKeys[1279∈54] ➊<br />ᐸ423:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    RemapKeys1279 --> PgSelectSingle432
+    PgSelectSingle423 --> RemapKeys1279
     PgClassExpression433{{"PgClassExpression[433∈55] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle432 --> PgClassExpression433
     PgSelectSingle440{{"PgSelectSingle[440∈55] ➊<br />ᐸperson_secretᐳ"}}:::plan
-    RemapKeys1212{{"RemapKeys[1212∈55] ➊<br />ᐸ432:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys1212 --> PgSelectSingle440
-    PgSelectSingle432 --> RemapKeys1212
+    RemapKeys1262{{"RemapKeys[1262∈55] ➊<br />ᐸ432:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys1262 --> PgSelectSingle440
+    PgSelectSingle432 --> RemapKeys1262
     PgClassExpression441{{"PgClassExpression[441∈56] ➊<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle440 --> PgClassExpression441
     __Item445[/"__Item[445∈57]<br />ᐸ443ᐳ"\]:::itemplan
@@ -1043,40 +1045,40 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/function-return-types"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 48, 64, 72, 139, 157, 176, 203, 216, 451, 454, 457, 458, 459, 471, 472, 485, 486, 499, 500, 501, 515, 516, 517, 534, 535, 536, 550, 551, 552, 564, 565, 580, 581, 599, 600, 615, 616, 617, 629, 643, 644, 645, 657, 658, 673, 674, 675, 687, 688, 689, 701, 715, 716, 717, 729, 730, 743, 757, 758, 771, 772, 785, 799, 800, 813, 814, 815, 827, 828, 829, 841, 855, 856, 869, 883, 884, 899, 900, 918, 919, 934, 935, 936, 950, 951, 966, 967, 982, 983, 984, 998, 999, 1000, 1014, 1015, 1016, 1030, 1031, 1044, 1045, 1046, 1060, 1061, 1076, 1077, 1078, 1092, 1093, 1108, 1109, 1124, 1125, 1140, 1141, 1142, 1154, 1155, 1170, 1171, 1186, 1187, 1202, 1203, 1218, 1219, 1234, 1235, 1250, 1251, 1264, 1265, 1266, 1274, 1275, 1276, 1277, 1278, 1279, 1280, 1281, 1282, 1283, 1284, 1285, 1286, 1287, 1288, 1289, 1290, 1291, 1292, 1293, 1294, 1295, 1296, 1297, 1298, 1299, 1300, 1301, 1302, 1303, 1304, 1305, 1306, 1307, 1308, 1309, 1310, 1311, 1312, 1313, 1314, 1315, 1316, 1317, 1318, 1319, 1320, 1321, 1322, 1323, 1324, 1325, 1326, 1327, 1328, 1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 11, 453, 456, 460, 461, 466, 474, 475, 480, 488, 489, 494, 502, 503, 508, 518, 519, 524, 537, 538, 543, 553, 554, 559, 646, 647, 652, 660, 661, 666, 676, 677, 682, 718, 719, 724, 760, 761, 766, 802, 803, 808, 816, 817, 822, 886, 887, 892, 902, 903, 908, 921, 922, 927, 937, 938, 943, 953, 954, 959, 969, 970, 975, 985, 986, 991, 1001, 1002, 1007, 1017, 1018, 1023, 1033, 1034, 1039, 1047, 1048, 1053, 1063, 1064, 1069, 1079, 1080, 1085, 1095, 1096, 1101, 1111, 1112, 1117, 1127, 1128, 1133, 1143, 1144, 1149, 1157, 1158, 1163, 1173, 1174, 1179, 1189, 1190, 1195, 1205, 1206, 1211, 1221, 1222, 1227, 1237, 1238, 1243, 1253, 1254, 1259, 1267, 1268, 1273<br />2: 8, 16, 21, 28, 115, 122, 149, 166, 188, 193, 226, 324, 385, 443<br />ᐳ: 12, 13, 14, 18, 19, 20, 23, 24, 25, 30, 31, 117, 118, 124, 125, 151, 152, 168, 169, 190, 191, 192, 195, 196, 228, 229, 326, 327, 387, 388"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 48, 60, 64, 72, 103, 139, 157, 176, 203, 216, 271, 451, 454, 458, 459, 460, 473, 474, 488, 489, 503, 504, 505, 520, 521, 522, 540, 541, 542, 557, 558, 559, 572, 573, 589, 590, 609, 610, 626, 627, 628, 641, 656, 657, 658, 671, 672, 688, 689, 690, 703, 704, 705, 718, 733, 734, 735, 748, 749, 763, 778, 779, 793, 794, 808, 823, 824, 838, 839, 840, 853, 854, 855, 868, 883, 884, 898, 913, 914, 930, 931, 950, 951, 967, 968, 969, 984, 985, 1001, 1002, 1018, 1019, 1020, 1035, 1036, 1037, 1052, 1053, 1054, 1069, 1070, 1084, 1085, 1086, 1101, 1102, 1118, 1119, 1120, 1135, 1136, 1152, 1153, 1169, 1170, 1186, 1187, 1188, 1201, 1202, 1218, 1219, 1235, 1236, 1252, 1253, 1269, 1270, 1286, 1287, 1303, 1304, 1318, 1319, 1320, 1328, 1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346, 1347, 1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364, 1365, 1366, 1367, 1368, 1369, 1370, 1371, 1372, 1373, 1374, 1375, 1376, 1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 11, 453, 456, 457, 461, 462, 467, 476, 477, 482, 491, 492, 497, 506, 507, 512, 523, 524, 529, 543, 544, 549, 560, 561, 566, 575, 576, 581, 592, 593, 598, 612, 613, 618, 629, 630, 635, 644, 645, 650, 659, 660, 665, 674, 675, 680, 691, 692, 697, 706, 707, 712, 721, 722, 727, 736, 737, 742, 751, 752, 757, 766, 767, 772, 781, 782, 787, 796, 797, 802, 811, 812, 817, 826, 827, 832, 841, 842, 847, 856, 857, 862, 871, 872, 877, 886, 887, 892, 901, 902, 907, 916, 917, 922, 933, 934, 939, 953, 954, 959, 970, 971, 976, 987, 988, 993, 1004, 1005, 1010, 1021, 1022, 1027, 1038, 1039, 1044, 1055, 1056, 1061, 1072, 1073, 1078, 1087, 1088, 1093, 1104, 1105, 1110, 1121, 1122, 1127, 1138, 1139, 1144, 1155, 1156, 1161, 1172, 1173, 1178, 1189, 1190, 1195, 1204, 1205, 1210, 1221, 1222, 1227, 1238, 1239, 1244, 1255, 1256, 1261, 1272, 1273, 1278, 1289, 1290, 1295, 1306, 1307, 1312, 1321, 1322, 1327<br />2: 8, 16, 21, 28, 115, 122, 149, 166, 188, 193, 226, 324, 385, 443<br />ᐳ: 12, 13, 14, 18, 19, 20, 23, 24, 25, 30, 31, 117, 118, 124, 125, 151, 152, 168, 169, 190, 191, 192, 195, 196, 228, 229, 326, 327, 387, 388"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,PgClassExpression14,PgSelect16,First18,PgSelectSingle19,PgClassExpression20,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect28,First30,PgSelectSingle31,Constant48,Constant64,Connection72,PgSelect115,First117,PgSelectSingle118,PgSelect122,First124,PgSelectSingle125,Connection139,PgSelect149,First151,PgSelectSingle152,Connection157,PgSelect166,First168,PgSelectSingle169,Connection176,PgSelect188,First190,PgSelectSingle191,PgClassExpression192,PgSelect193,First195,PgSelectSingle196,Connection203,Connection216,PgSelect226,First228,PgSelectSingle229,PgSelect324,First326,PgSelectSingle327,PgSelect385,First387,PgSelectSingle388,PgSelect443,Constant451,Lambda453,Constant454,Lambda456,Constant457,Constant458,Constant459,Object460,Lambda461,Lambda466,Constant471,Constant472,Object474,Lambda475,Lambda480,Constant485,Constant486,Object488,Lambda489,Lambda494,Constant499,Constant500,Constant501,Object502,Lambda503,Lambda508,Constant515,Constant516,Constant517,Object518,Lambda519,Lambda524,Constant534,Constant535,Constant536,Object537,Lambda538,Lambda543,Constant550,Constant551,Constant552,Object553,Lambda554,Lambda559,Constant564,Constant565,Constant580,Constant581,Constant599,Constant600,Constant615,Constant616,Constant617,Constant629,Constant643,Constant644,Constant645,Object646,Lambda647,Lambda652,Constant657,Constant658,Object660,Lambda661,Lambda666,Constant673,Constant674,Constant675,Object676,Lambda677,Lambda682,Constant687,Constant688,Constant689,Constant701,Constant715,Constant716,Constant717,Object718,Lambda719,Lambda724,Constant729,Constant730,Constant743,Constant757,Constant758,Object760,Lambda761,Lambda766,Constant771,Constant772,Constant785,Constant799,Constant800,Object802,Lambda803,Lambda808,Constant813,Constant814,Constant815,Object816,Lambda817,Lambda822,Constant827,Constant828,Constant829,Constant841,Constant855,Constant856,Constant869,Constant883,Constant884,Object886,Lambda887,Lambda892,Constant899,Constant900,Object902,Lambda903,Lambda908,Constant918,Constant919,Object921,Lambda922,Lambda927,Constant934,Constant935,Constant936,Object937,Lambda938,Lambda943,Constant950,Constant951,Object953,Lambda954,Lambda959,Constant966,Constant967,Object969,Lambda970,Lambda975,Constant982,Constant983,Constant984,Object985,Lambda986,Lambda991,Constant998,Constant999,Constant1000,Object1001,Lambda1002,Lambda1007,Constant1014,Constant1015,Constant1016,Object1017,Lambda1018,Lambda1023,Constant1030,Constant1031,Object1033,Lambda1034,Lambda1039,Constant1044,Constant1045,Constant1046,Object1047,Lambda1048,Lambda1053,Constant1060,Constant1061,Object1063,Lambda1064,Lambda1069,Constant1076,Constant1077,Constant1078,Object1079,Lambda1080,Lambda1085,Constant1092,Constant1093,Object1095,Lambda1096,Lambda1101,Constant1108,Constant1109,Object1111,Lambda1112,Lambda1117,Constant1124,Constant1125,Object1127,Lambda1128,Lambda1133,Constant1140,Constant1141,Constant1142,Object1143,Lambda1144,Lambda1149,Constant1154,Constant1155,Object1157,Lambda1158,Lambda1163,Constant1170,Constant1171,Object1173,Lambda1174,Lambda1179,Constant1186,Constant1187,Object1189,Lambda1190,Lambda1195,Constant1202,Constant1203,Object1205,Lambda1206,Lambda1211,Constant1218,Constant1219,Object1221,Lambda1222,Lambda1227,Constant1234,Constant1235,Object1237,Lambda1238,Lambda1243,Constant1250,Constant1251,Object1253,Lambda1254,Lambda1259,Constant1264,Constant1265,Constant1266,Object1267,Lambda1268,Lambda1273,Constant1274,Constant1275,Constant1276,Constant1277,Constant1278,Constant1279,Constant1280,Constant1281,Constant1282,Constant1283,Constant1284,Constant1285,Constant1286,Constant1287,Constant1288,Constant1289,Constant1290,Constant1291,Constant1292,Constant1293,Constant1294,Constant1295,Constant1296,Constant1297,Constant1298,Constant1299,Constant1300,Constant1301,Constant1302,Constant1303,Constant1304,Constant1305,Constant1306,Constant1307,Constant1308,Constant1309,Constant1310,Constant1311,Constant1312,Constant1313,Constant1314,Constant1315,Constant1316,Constant1317,Constant1318,Constant1319,Constant1320,Constant1321,Constant1322,Constant1323,Constant1324,Constant1325,Constant1326,Constant1327,Constant1328,Constant1329,Constant1330,Constant1331,Constant1332,Constant1333,Constant1334,Constant1335,Constant1336,Constant1337,Constant1338 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 31, 48, 451, 453, 454, 64<br /><br />ROOT PgSelectSingleᐸfunc_out_complexᐳ[31]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,PgClassExpression14,PgSelect16,First18,PgSelectSingle19,PgClassExpression20,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect28,First30,PgSelectSingle31,Constant48,Connection60,Constant64,Connection72,Connection103,PgSelect115,First117,PgSelectSingle118,PgSelect122,First124,PgSelectSingle125,Connection139,PgSelect149,First151,PgSelectSingle152,Connection157,PgSelect166,First168,PgSelectSingle169,Connection176,PgSelect188,First190,PgSelectSingle191,PgClassExpression192,PgSelect193,First195,PgSelectSingle196,Connection203,Connection216,PgSelect226,First228,PgSelectSingle229,Connection271,PgSelect324,First326,PgSelectSingle327,PgSelect385,First387,PgSelectSingle388,PgSelect443,Constant451,Lambda453,Constant454,Lambda456,Access457,Constant458,Constant459,Constant460,Object461,Lambda462,Lambda467,Constant473,Constant474,Object476,Lambda477,Lambda482,Constant488,Constant489,Object491,Lambda492,Lambda497,Constant503,Constant504,Constant505,Object506,Lambda507,Lambda512,Constant520,Constant521,Constant522,Object523,Lambda524,Lambda529,Constant540,Constant541,Constant542,Object543,Lambda544,Lambda549,Constant557,Constant558,Constant559,Object560,Lambda561,Lambda566,Constant572,Constant573,Object575,Lambda576,Lambda581,Constant589,Constant590,Object592,Lambda593,Lambda598,Constant609,Constant610,Object612,Lambda613,Lambda618,Constant626,Constant627,Constant628,Object629,Lambda630,Lambda635,Constant641,Object644,Lambda645,Lambda650,Constant656,Constant657,Constant658,Object659,Lambda660,Lambda665,Constant671,Constant672,Object674,Lambda675,Lambda680,Constant688,Constant689,Constant690,Object691,Lambda692,Lambda697,Constant703,Constant704,Constant705,Object706,Lambda707,Lambda712,Constant718,Object721,Lambda722,Lambda727,Constant733,Constant734,Constant735,Object736,Lambda737,Lambda742,Constant748,Constant749,Object751,Lambda752,Lambda757,Constant763,Object766,Lambda767,Lambda772,Constant778,Constant779,Object781,Lambda782,Lambda787,Constant793,Constant794,Object796,Lambda797,Lambda802,Constant808,Object811,Lambda812,Lambda817,Constant823,Constant824,Object826,Lambda827,Lambda832,Constant838,Constant839,Constant840,Object841,Lambda842,Lambda847,Constant853,Constant854,Constant855,Object856,Lambda857,Lambda862,Constant868,Object871,Lambda872,Lambda877,Constant883,Constant884,Object886,Lambda887,Lambda892,Constant898,Object901,Lambda902,Lambda907,Constant913,Constant914,Object916,Lambda917,Lambda922,Constant930,Constant931,Object933,Lambda934,Lambda939,Constant950,Constant951,Object953,Lambda954,Lambda959,Constant967,Constant968,Constant969,Object970,Lambda971,Lambda976,Constant984,Constant985,Object987,Lambda988,Lambda993,Constant1001,Constant1002,Object1004,Lambda1005,Lambda1010,Constant1018,Constant1019,Constant1020,Object1021,Lambda1022,Lambda1027,Constant1035,Constant1036,Constant1037,Object1038,Lambda1039,Lambda1044,Constant1052,Constant1053,Constant1054,Object1055,Lambda1056,Lambda1061,Constant1069,Constant1070,Object1072,Lambda1073,Lambda1078,Constant1084,Constant1085,Constant1086,Object1087,Lambda1088,Lambda1093,Constant1101,Constant1102,Object1104,Lambda1105,Lambda1110,Constant1118,Constant1119,Constant1120,Object1121,Lambda1122,Lambda1127,Constant1135,Constant1136,Object1138,Lambda1139,Lambda1144,Constant1152,Constant1153,Object1155,Lambda1156,Lambda1161,Constant1169,Constant1170,Object1172,Lambda1173,Lambda1178,Constant1186,Constant1187,Constant1188,Object1189,Lambda1190,Lambda1195,Constant1201,Constant1202,Object1204,Lambda1205,Lambda1210,Constant1218,Constant1219,Object1221,Lambda1222,Lambda1227,Constant1235,Constant1236,Object1238,Lambda1239,Lambda1244,Constant1252,Constant1253,Object1255,Lambda1256,Lambda1261,Constant1269,Constant1270,Object1272,Lambda1273,Lambda1278,Constant1286,Constant1287,Object1289,Lambda1290,Lambda1295,Constant1303,Constant1304,Object1306,Lambda1307,Lambda1312,Constant1318,Constant1319,Constant1320,Object1321,Lambda1322,Lambda1327,Constant1328,Constant1329,Constant1330,Constant1331,Constant1332,Constant1333,Constant1334,Constant1335,Constant1336,Constant1337,Constant1338,Constant1339,Constant1340,Constant1341,Constant1342,Constant1343,Constant1344,Constant1345,Constant1346,Constant1347,Constant1348,Constant1349,Constant1350,Constant1351,Constant1352,Constant1353,Constant1354,Constant1355,Constant1356,Constant1357,Constant1358,Constant1359,Constant1360,Constant1361,Constant1362,Constant1363,Constant1364,Constant1365,Constant1366,Constant1367,Constant1368,Constant1369,Constant1370,Constant1371,Constant1372,Constant1373,Constant1374,Constant1375,Constant1376,Constant1377,Constant1378,Constant1379,Constant1380,Constant1381,Constant1382,Constant1383,Constant1384,Constant1385,Constant1386,Constant1387,Constant1388,Constant1389,Constant1390,Constant1391,Constant1392 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 31, 48, 451, 453, 454, 64, 60<br /><br />ROOT PgSelectSingleᐸfunc_out_complexᐳ[31]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression32,PgSelectSingle39,PgSelectSingle47,Connection60,RemapKeys509,RemapKeys544 bucket1
+    class Bucket1,PgClassExpression32,PgSelectSingle39,PgSelectSingle47,RemapKeys513,RemapKeys550 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 39<br /><br />ROOT PgSelectSingle{1}ᐸfrmcdc_compoundTypeᐳ[39]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression40,PgClassExpression41,PgClassExpression42 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 47, 48, 544, 451, 453, 454, 64, 60<br /><br />ROOT PgSelectSingle{1}ᐸpersonᐳ[47]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 47, 48, 550, 451, 453, 454, 64, 60<br /><br />ROOT PgSelectSingle{1}ᐸpersonᐳ[47]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression49,List50,Lambda51,PgClassExpression52,Access526,Object528,Lambda529 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 64<br /><br />ROOT __Item{4}ᐸ529ᐳ[62]"):::bucket
+    class Bucket3,PgClassExpression49,List50,Lambda51,PgClassExpression52,Access531,Object533,Lambda534 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 64<br /><br />ROOT __Item{4}ᐸ534ᐳ[62]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item62,PgSelectSingle63 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 63, 64<br /><br />ROOT PgSelectSingle{4}ᐸpostᐳ[63]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression65,List66,Lambda67 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 11, 1276, 1277, 72, 456, 453, 564, 565, 501, 1292, 580, 581, 517, 1293, 599, 600, 536, 1294, 615, 616, 617, 1295, 629, 1296, 48, 451, 454, 64<br /><br />ROOT Connectionᐸ70ᐳ[72]<br />1: <br />ᐳ: 103, 567, 573, 583, 589, 602, 608, 618, 624, 632, 638, 568, 584, 603, 619, 633<br />2: PgSelect[73], PgSelect[111]<br />ᐳ: 112, 113, 114"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 11, 1330, 1331, 72, 457, 576, 581, 593, 598, 613, 618, 453, 630, 635, 645, 650, 48, 451, 454, 64, 103<br /><br />ROOT Connectionᐸ70ᐳ[72]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgSelect73,Connection103,PgSelect111,First112,PgSelectSingle113,PgClassExpression114,Object567,Lambda568,Lambda573,Object583,Lambda584,Lambda589,Object602,Lambda603,Lambda608,Object618,Lambda619,Lambda624,Object632,Lambda633,Lambda638 bucket6
+    class Bucket6,PgSelect73,PgSelect111,First112,PgSelectSingle113,PgClassExpression114 bucket6
     Bucket7("Bucket 7 (listItem)<br />Deps: 48, 451, 453, 454, 64, 103<br /><br />ROOT __Item{7}ᐸ73ᐳ[74]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item74,PgSelectSingle75 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 75, 48, 451, 453, 454, 64, 103<br /><br />ROOT PgSelectSingle{7}ᐸfunc_out_complex_setofᐳ[75]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression76,PgSelectSingle83,PgSelectSingle91,RemapKeys574,RemapKeys609 bucket8
+    class Bucket8,PgClassExpression76,PgSelectSingle83,PgSelectSingle91,RemapKeys582,RemapKeys619 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 83<br /><br />ROOT PgSelectSingle{8}ᐸfrmcdc_compoundTypeᐳ[83]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression84,PgClassExpression85,PgClassExpression86 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 91, 48, 609, 451, 453, 454, 64, 103<br /><br />ROOT PgSelectSingle{8}ᐸpersonᐳ[91]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 91, 48, 619, 451, 453, 454, 64, 103<br /><br />ROOT PgSelectSingle{8}ᐸpersonᐳ[91]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression93,List94,Lambda95,PgClassExpression96,Access591,Object593,Lambda594 bucket10
-    Bucket11("Bucket 11 (listItem)<br />Deps: 64<br /><br />ROOT __Item{11}ᐸ594ᐳ[105]"):::bucket
+    class Bucket10,PgClassExpression93,List94,Lambda95,PgClassExpression96,Access600,Object602,Lambda603 bucket10
+    Bucket11("Bucket 11 (listItem)<br />Deps: 64<br /><br />ROOT __Item{11}ᐸ603ᐳ[105]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,__Item105,PgSelectSingle106 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 106, 64<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[106]"):::bucket
@@ -1087,13 +1089,13 @@ graph TD
     class Bucket13,PgClassExpression119,PgClassExpression120 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 125<br /><br />ROOT PgSelectSingleᐸfunc_out_out_compound_typeᐳ[125]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression126,PgSelectSingle133,RemapKeys667 bucket14
+    class Bucket14,PgClassExpression126,PgSelectSingle133,RemapKeys681 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 133<br /><br />ROOT PgSelectSingle{14}ᐸfrmcdc_compoundTypeᐳ[133]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression134,PgClassExpression135,PgClassExpression136 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 11, 139, 453, 456, 687, 688, 689, 1300, 701, 1301<br /><br />ROOT Connectionᐸ137ᐳ[139]<br />1: <br />ᐳ: 690, 696, 704, 710, 691, 705<br />2: PgSelect[140], PgSelect[145]<br />ᐳ: 146, 147, 148"):::bucket
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 11, 139, 453, 457, 707, 712, 722, 727<br /><br />ROOT Connectionᐸ137ᐳ[139]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgSelect140,PgSelect145,First146,PgSelectSingle147,PgClassExpression148,Object690,Lambda691,Lambda696,Object704,Lambda705,Lambda710 bucket16
+    class Bucket16,PgSelect140,PgSelect145,First146,PgSelectSingle147,PgClassExpression148 bucket16
     Bucket17("Bucket 17 (listItem)<br /><br />ROOT __Item{17}ᐸ140ᐳ[141]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,__Item141,PgSelectSingle142 bucket17
@@ -1103,18 +1105,18 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 152<br /><br />ROOT PgSelectSingleᐸfunc_out_out_unnamedᐳ[152]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression153,PgClassExpression154 bucket19
-    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 11, 157, 453, 456, 729, 730, 459, 1303, 743, 1304<br /><br />ROOT Connectionᐸ155ᐳ[157]<br />1: <br />ᐳ: 732, 738, 746, 752, 733, 747<br />2: PgSelect[158], PgSelect[162]<br />ᐳ: 163, 164, 165"):::bucket
+    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 11, 157, 453, 457, 752, 757, 767, 772<br /><br />ROOT Connectionᐸ155ᐳ[157]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgSelect158,PgSelect162,First163,PgSelectSingle164,PgClassExpression165,Object732,Lambda733,Lambda738,Object746,Lambda747,Lambda752 bucket20
+    class Bucket20,PgSelect158,PgSelect162,First163,PgSelectSingle164,PgClassExpression165 bucket20
     Bucket21("Bucket 21 (listItem)<br /><br />ROOT __Item{21}ᐸ158ᐳ[159]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,__Item159,PgSelectSingle160,PgClassExpression161 bucket21
     Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 169, 48<br /><br />ROOT PgSelectSingleᐸfunc_out_tableᐳ[169]"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22,PgClassExpression171,List172,Lambda173 bucket22
-    Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 11, 176, 453, 456, 771, 772, 536, 1306, 785, 1307, 48<br /><br />ROOT Connectionᐸ174ᐳ[176]<br />1: <br />ᐳ: 774, 780, 788, 794, 775, 789<br />2: PgSelect[177], PgSelect[184]<br />ᐳ: 185, 186, 187"):::bucket
+    Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 11, 176, 453, 457, 797, 802, 812, 817, 48<br /><br />ROOT Connectionᐸ174ᐳ[176]"):::bucket
     classDef bucket23 stroke:#ff1493
-    class Bucket23,PgSelect177,PgSelect184,First185,PgSelectSingle186,PgClassExpression187,Object774,Lambda775,Lambda780,Object788,Lambda789,Lambda794 bucket23
+    class Bucket23,PgSelect177,PgSelect184,First185,PgSelectSingle186,PgClassExpression187 bucket23
     Bucket24("Bucket 24 (listItem)<br />Deps: 48<br /><br />ROOT __Item{24}ᐸ177ᐳ[178]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,__Item178,PgSelectSingle179 bucket24
@@ -1124,34 +1126,34 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 196<br /><br />ROOT PgSelectSingleᐸfunc_out_unnamed_out_out_unnamedᐳ[196]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression197,PgClassExpression198,PgClassExpression199 bucket26
-    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 11, 1278, 203, 453, 456, 827, 828, 829, 1310, 841, 1311<br /><br />ROOT Connectionᐸ201ᐳ[203]<br />1: <br />ᐳ: 830, 836, 844, 850, 831, 845<br />2: PgSelect[204], PgSelect[209]<br />ᐳ: 210, 211, 212"):::bucket
+    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 11, 1332, 203, 453, 457, 857, 862, 872, 877<br /><br />ROOT Connectionᐸ201ᐳ[203]"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgSelect204,PgSelect209,First210,PgSelectSingle211,PgClassExpression212,Object830,Lambda831,Lambda836,Object844,Lambda845,Lambda850 bucket27
+    class Bucket27,PgSelect204,PgSelect209,First210,PgSelectSingle211,PgClassExpression212 bucket27
     Bucket28("Bucket 28 (listItem)<br /><br />ROOT __Item{28}ᐸ204ᐳ[205]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,__Item205,PgSelectSingle206 bucket28
     Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 206<br /><br />ROOT PgSelectSingle{28}ᐸfunc_returns_table_multi_colᐳ[206]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,PgClassExpression207,PgClassExpression208 bucket29
-    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 11, 1278, 216, 453, 456, 855, 856, 459, 1312, 869, 1313<br /><br />ROOT Connectionᐸ214ᐳ[216]<br />1: <br />ᐳ: 858, 864, 872, 878, 859, 873<br />2: PgSelect[217], PgSelect[221]<br />ᐳ: 222, 223, 224"):::bucket
+    Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 11, 1332, 216, 453, 457, 887, 892, 902, 907<br /><br />ROOT Connectionᐸ214ᐳ[216]"):::bucket
     classDef bucket30 stroke:#3cb371
-    class Bucket30,PgSelect217,PgSelect221,First222,PgSelectSingle223,PgClassExpression224,Object858,Lambda859,Lambda864,Object872,Lambda873,Lambda878 bucket30
+    class Bucket30,PgSelect217,PgSelect221,First222,PgSelectSingle223,PgClassExpression224 bucket30
     Bucket31("Bucket 31 (listItem)<br /><br />ROOT __Item{31}ᐸ217ᐳ[218]"):::bucket
     classDef bucket31 stroke:#a52a2a
     class Bucket31,__Item218,PgSelectSingle219,PgClassExpression220 bucket31
-    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 229, 48, 451, 453, 454, 64<br /><br />ROOT PgSelectSingleᐸpersonᐳ[229]"):::bucket
+    Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 229, 48, 451, 453, 454, 64, 271<br /><br />ROOT PgSelectSingleᐸpersonᐳ[229]"):::bucket
     classDef bucket32 stroke:#ff00ff
-    class Bucket32,PgClassExpression231,List232,Lambda233,PgClassExpression234,PgSelectSingle243,Connection271,PgSelectSingle283,PgSelectSingle290,PgClassExpression303,PgSelectSingle309,PgClassExpression313,PgSelectSingle318,RemapKeys944,RemapKeys960,RemapKeys992,RemapKeys1008,RemapKeys1024 bucket32
+    class Bucket32,PgClassExpression231,List232,Lambda233,PgClassExpression234,PgSelectSingle243,PgSelectSingle283,PgSelectSingle290,PgClassExpression303,PgSelectSingle309,PgClassExpression313,PgSelectSingle318,RemapKeys977,RemapKeys994,RemapKeys1028,RemapKeys1045,RemapKeys1062 bucket32
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 243, 48, 451, 453, 454, 64, 271<br /><br />ROOT PgSelectSingle{32}ᐸperson_computed_complexᐳ[243]"):::bucket
     classDef bucket33 stroke:#f5deb3
-    class Bucket33,PgClassExpression244,PgSelectSingle251,PgSelectSingle259,RemapKeys893,RemapKeys928 bucket33
+    class Bucket33,PgClassExpression244,PgSelectSingle251,PgSelectSingle259,RemapKeys923,RemapKeys960 bucket33
     Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 251<br /><br />ROOT PgSelectSingle{33}ᐸfrmcdc_compoundTypeᐳ[251]"):::bucket
     classDef bucket34 stroke:#696969
     class Bucket34,PgClassExpression252,PgClassExpression253,PgClassExpression254 bucket34
-    Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 259, 48, 928, 451, 453, 454, 64, 271<br /><br />ROOT PgSelectSingle{33}ᐸpersonᐳ[259]"):::bucket
+    Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 259, 48, 960, 451, 453, 454, 64, 271<br /><br />ROOT PgSelectSingle{33}ᐸpersonᐳ[259]"):::bucket
     classDef bucket35 stroke:#00bfff
-    class Bucket35,PgClassExpression261,List262,Lambda263,PgClassExpression264,Access910,Object912,Lambda913 bucket35
-    Bucket36("Bucket 36 (listItem)<br />Deps: 64<br /><br />ROOT __Item{36}ᐸ913ᐳ[273]"):::bucket
+    class Bucket35,PgClassExpression261,List262,Lambda263,PgClassExpression264,Access941,Object943,Lambda944 bucket35
+    Bucket36("Bucket 36 (listItem)<br />Deps: 64<br /><br />ROOT __Item{36}ᐸ944ᐳ[273]"):::bucket
     classDef bucket36 stroke:#7f007f
     class Bucket36,__Item273,PgSelectSingle274 bucket36
     Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 274, 64<br /><br />ROOT PgSelectSingle{36}ᐸpostᐳ[274]"):::bucket
@@ -1174,43 +1176,43 @@ graph TD
     class Bucket42,PgClassExpression319,PgClassExpression320 bucket42
     Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 327<br /><br />ROOT PgSelectSingleᐸquery_output_two_rowsᐳ[327]"):::bucket
     classDef bucket43 stroke:#ff0000
-    class Bucket43,PgSelectSingle334,PgSelectSingle362,PgClassExpression381,RemapKeys1134 bucket43
+    class Bucket43,PgSelectSingle334,PgSelectSingle362,PgClassExpression381,RemapKeys1179 bucket43
     Bucket44("Bucket 44 (nullableBoundary)<br />Deps: 334<br /><br />ROOT PgSelectSingle{43}ᐸleft_armᐳ[334]"):::bucket
     classDef bucket44 stroke:#ffff00
-    class Bucket44,PgClassExpression335,PgClassExpression336,PgClassExpression337,PgClassExpression338,PgSelectSingle344,RemapKeys1070 bucket44
+    class Bucket44,PgClassExpression335,PgClassExpression336,PgClassExpression337,PgClassExpression338,PgSelectSingle344,RemapKeys1111 bucket44
     Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 344<br /><br />ROOT PgSelectSingle{44}ᐸpersonᐳ[344]"):::bucket
     classDef bucket45 stroke:#00ffff
-    class Bucket45,PgClassExpression345,PgSelectSingle352,RemapKeys1054 bucket45
+    class Bucket45,PgClassExpression345,PgSelectSingle352,RemapKeys1094 bucket45
     Bucket46("Bucket 46 (nullableBoundary)<br />Deps: 352<br /><br />ROOT PgSelectSingle{45}ᐸperson_secretᐳ[352]"):::bucket
     classDef bucket46 stroke:#4169e1
     class Bucket46,PgClassExpression353 bucket46
     Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 362<br /><br />ROOT PgSelectSingle{43}ᐸpostᐳ[362]"):::bucket
     classDef bucket47 stroke:#3cb371
-    class Bucket47,PgClassExpression363,PgClassExpression364,PgClassExpression365,PgSelectSingle371,RemapKeys1118 bucket47
+    class Bucket47,PgClassExpression363,PgClassExpression364,PgClassExpression365,PgSelectSingle371,RemapKeys1162 bucket47
     Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 371<br /><br />ROOT PgSelectSingle{47}ᐸpersonᐳ[371]"):::bucket
     classDef bucket48 stroke:#a52a2a
-    class Bucket48,PgClassExpression372,PgSelectSingle379,RemapKeys1102 bucket48
+    class Bucket48,PgClassExpression372,PgSelectSingle379,RemapKeys1145 bucket48
     Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 379<br /><br />ROOT PgSelectSingle{48}ᐸperson_secretᐳ[379]"):::bucket
     classDef bucket49 stroke:#ff00ff
     class Bucket49,PgClassExpression380 bucket49
     Bucket50("Bucket 50 (nullableBoundary)<br />Deps: 388<br /><br />ROOT PgSelectSingleᐸquery_output_two_rowsᐳ[388]"):::bucket
     classDef bucket50 stroke:#f5deb3
-    class Bucket50,PgSelectSingle395,PgSelectSingle423,PgClassExpression442,RemapKeys1244 bucket50
+    class Bucket50,PgSelectSingle395,PgSelectSingle423,PgClassExpression442,RemapKeys1296 bucket50
     Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 395<br /><br />ROOT PgSelectSingle{50}ᐸleft_armᐳ[395]"):::bucket
     classDef bucket51 stroke:#696969
-    class Bucket51,PgClassExpression396,PgClassExpression397,PgClassExpression398,PgClassExpression399,PgSelectSingle405,RemapKeys1180 bucket51
+    class Bucket51,PgClassExpression396,PgClassExpression397,PgClassExpression398,PgClassExpression399,PgSelectSingle405,RemapKeys1228 bucket51
     Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 405<br /><br />ROOT PgSelectSingle{51}ᐸpersonᐳ[405]"):::bucket
     classDef bucket52 stroke:#00bfff
-    class Bucket52,PgClassExpression406,PgSelectSingle413,RemapKeys1164 bucket52
+    class Bucket52,PgClassExpression406,PgSelectSingle413,RemapKeys1211 bucket52
     Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 413<br /><br />ROOT PgSelectSingle{52}ᐸperson_secretᐳ[413]"):::bucket
     classDef bucket53 stroke:#7f007f
     class Bucket53,PgClassExpression414 bucket53
     Bucket54("Bucket 54 (nullableBoundary)<br />Deps: 423<br /><br />ROOT PgSelectSingle{50}ᐸpostᐳ[423]"):::bucket
     classDef bucket54 stroke:#ffa500
-    class Bucket54,PgClassExpression424,PgClassExpression425,PgClassExpression426,PgSelectSingle432,RemapKeys1228 bucket54
+    class Bucket54,PgClassExpression424,PgClassExpression425,PgClassExpression426,PgSelectSingle432,RemapKeys1279 bucket54
     Bucket55("Bucket 55 (nullableBoundary)<br />Deps: 432<br /><br />ROOT PgSelectSingle{54}ᐸpersonᐳ[432]"):::bucket
     classDef bucket55 stroke:#0000ff
-    class Bucket55,PgClassExpression433,PgSelectSingle440,RemapKeys1212 bucket55
+    class Bucket55,PgClassExpression433,PgSelectSingle440,RemapKeys1262 bucket55
     Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 440<br /><br />ROOT PgSelectSingle{55}ᐸperson_secretᐳ[440]"):::bucket
     classDef bucket56 stroke:#7fff00
     class Bucket56,PgClassExpression441 bucket56

--- a/postgraphile/postgraphile/__tests__/queries/v4/geometry.queries.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/geometry.queries.mermaid
@@ -9,33 +9,35 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”geom”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸRecordCodec(geom)ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸgeomᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda66 & Lambda69 & Lambda74 & Lambda79 --> PgSelect14
-    Object73{{"Object[73∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda66 & Constant70 & Constant71 & Constant72 --> Object73
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”geom”)ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(geom)ᐳ"}}:::plan
+    Lambda66 & Constant71 & Constant72 & Constant73 --> Object74
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant80 --> Lambda66
-    Constant81 --> Lambda69
-    Object73 --> Lambda74
-    Constant82 --> Lambda79
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant81 --> Lambda66
+    Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant82 --> Lambda69
+    Access70{{"Access[70∈0] ➊<br />ᐸ69.0ᐳ"}}:::plan
+    Lambda69 --> Access70
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object74 --> Lambda75
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant83 --> Lambda80
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸgeomᐳ"]]:::plan
+    Object12 & Connection13 & Lambda66 & Access70 & Lambda75 & Lambda80 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸgeomᐳ"}}:::plan
@@ -76,10 +78,10 @@ graph TD
     subgraph "Buckets for queries/v4/geometry.queries"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant70,Constant71,Constant72,Constant80,Constant81,Constant82 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 80, 81, 70, 71, 72, 82<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 66, 69, 79, 12, 73, 74<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda66,Lambda69,Access70,Constant71,Constant72,Constant73,Object74,Lambda75,Lambda80,Constant81,Constant82,Constant83 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 66, 70, 75, 80<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda66,Lambda69,Object73,Lambda74,Lambda79 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/issue2210.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/issue2210.mermaid
@@ -9,6 +9,18 @@ graph TD
 
 
     %% plan dependencies
+    Object54{{"Object[54∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸsql.identifier(”test_user”)ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸRecordCodec(testUser)ᐳ"}}:::plan
+    Lambda46 & Constant51 & Constant52 & Constant53 --> Object54
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”some_messages”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(testMessage)ᐳ"}}:::plan
+    Lambda62 & Constant67 & Constant68 & Constant69 --> Object70
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -17,38 +29,40 @@ graph TD
     __Value2 --> Access12
     __Value2 --> Access13
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ50ᐳ"}}:::plan
-    Constant76 --> Connection15
-    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant77 --> Lambda46
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ50ᐳ"}}:::plan
+    Constant78 --> Connection15
+    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant79 --> Lambda46
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant80 --> Lambda49
+    Access50{{"Access[50∈0] ➊<br />ᐸ49.0ᐳ"}}:::plan
+    Lambda49 --> Access50
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object54 --> Lambda55
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”test_uᐳ"}}:::plan
+    Constant81 --> Lambda60
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: 50, last: null, cursorLower: null, cursorUpper: nuᐳ"}}:::plan
+    Constant83 --> Lambda62
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: 50, last: null, cursorLower: null, cursorUpper: nuᐳ"}}:::plan
+    Constant84 --> Lambda65
+    Access66{{"Access[66∈0] ➊<br />ᐸ65.0ᐳ"}}:::plan
+    Lambda65 --> Access66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”some_mᐳ"}}:::plan
+    Constant82 --> Lambda76
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant8{{"Constant[8∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”test_user”)ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(testUser)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”some_messages”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(testMessage)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ'0d126c0c-9710-478c-9aee-0be34b250573'ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”test_uᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”some_mᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: 50, last: null, cursorLower: null, cursorUpper: nuᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: 50, last: null, cursorLower: null, cursorUpper: nuᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ'0d126c0c-9710-478c-9aee-0be34b250573'ᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸsome_messages+1ᐳ"]]:::plan
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant75 & Connection15 & Constant76 & Lambda61 & Lambda64 & Lambda69 & Lambda74 --> PgSelect16
-    Object53{{"Object[53∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda46 & Constant50 & Constant51 & Constant52 --> Object53
-    Object68{{"Object[68∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda61 & Constant65 & Constant66 & Constant67 --> Object68
+    Object14 & Constant77 & Connection15 & Constant78 & Lambda62 & Access66 & Lambda71 & Lambda76 --> PgSelect16
     Object36{{"Object[36∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access35{{"Access[35∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
-    Constant76 & Constant8 & Access35 --> Object36
+    Constant78 & Constant8 & Access35 --> Object36
     PgPageInfo32{{"PgPageInfo[32∈1] ➊"}}:::plan
     Connection15 --> PgPageInfo32
     PgSelect16 --> Access35
@@ -64,23 +78,13 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈1] ➊<br />ᐸrow_number...tion by 1)ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression42
     PgClassExpression42 --> List43
-    Lambda49{{"Lambda[49∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant78 --> Lambda49
-    Lambda54{{"Lambda[54∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object53 --> Lambda54
-    Lambda59{{"Lambda[59∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant79 --> Lambda59
-    Constant81 --> Lambda61
-    Constant82 --> Lambda64
-    Object68 --> Lambda69
-    Constant80 --> Lambda74
     __Item17[/"__Item[17∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item17
     PgSelectSingle18{{"PgSelectSingle[18∈2]<br />ᐸsome_messagesᐳ"}}:::plan
     __Item17 --> PgSelectSingle18
     PgSelect23[["PgSelect[23∈3]<br />ᐸtest_userᐳ"]]:::plan
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__some_mes...t_user_id”ᐳ"}}:::plan
-    Object14 & PgClassExpression22 & Lambda46 & Lambda49 & Lambda54 & Lambda59 --> PgSelect23
+    Object14 & PgClassExpression22 & Lambda46 & Access50 & Lambda55 & Lambda60 --> PgSelect23
     PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__some_messages__.”id”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression19
     PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__some_mes....”message”ᐳ"}}:::plan
@@ -102,14 +106,14 @@ graph TD
     subgraph "Buckets for queries/v4/issue2210"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant8,Access12,Access13,Object14,Connection15,Lambda46,Constant50,Constant51,Constant52,Constant65,Constant66,Constant67,Constant75,Constant76,Constant77,Constant78,Constant79,Constant80,Constant81,Constant82 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 75, 15, 76, 8, 78, 46, 50, 51, 52, 79, 81, 82, 65, 66, 67, 80<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 32, 49, 53, 59, 61, 64, 74, 54, 68, 69<br />2: PgSelect[16]<br />ᐳ: 35, 36, 37, 39, 40, 42, 43, 41"):::bucket
+    class Bucket0,__Value2,__Value4,Constant8,Access12,Access13,Object14,Connection15,Lambda46,Lambda49,Access50,Constant51,Constant52,Constant53,Object54,Lambda55,Lambda60,Lambda62,Lambda65,Access66,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant77,Constant78,Constant79,Constant80,Constant81,Constant82,Constant83,Constant84 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 77, 15, 78, 62, 66, 71, 76, 8, 46, 50, 55, 60<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,PgPageInfo32,Access35,Object36,Lambda37,Last39,PgSelectSingle40,PgCursor41,PgClassExpression42,List43,Lambda49,Object53,Lambda54,Lambda59,Lambda61,Lambda64,Object68,Lambda69,Lambda74 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 46, 49, 54, 59<br /><br />ROOT __Item{2}ᐸ16ᐳ[17]"):::bucket
+    class Bucket1,PgSelect16,PgPageInfo32,Access35,Object36,Lambda37,Last39,PgSelectSingle40,PgCursor41,PgClassExpression42,List43 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 14, 46, 50, 55, 60<br /><br />ROOT __Item{2}ᐸ16ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item17,PgSelectSingle18 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 14, 46, 49, 54, 59<br /><br />ROOT PgSelectSingle{2}ᐸsome_messagesᐳ[18]<br />1: <br />ᐳ: 19, 20, 21, 22<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 14, 46, 50, 55, 60<br /><br />ROOT PgSelectSingle{2}ᐸsome_messagesᐳ[18]<br />1: <br />ᐳ: 19, 20, 21, 22<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{3}ᐸtest_userᐳ[28]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-function-names.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-function-names.mermaid
@@ -11,48 +11,48 @@ graph TD
     %% plan dependencies
     PgSelect36[["PgSelect[36∈0] ➊<br />ᐸnullᐳ"]]:::plan
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Constant106 & Constant105 & Constant106 & Constant107 & Constant108 & Lambda49 & Lambda52 & Lambda99 & Lambda104 --> PgSelect36
+    Access53{{"Access[53∈0] ➊<br />ᐸ52.0ᐳ"}}:::plan
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object13 & Constant110 & Constant109 & Constant110 & Constant111 & Constant112 & Lambda49 & Access53 & Lambda103 & Lambda108 --> PgSelect36
     PgSelect10[["PgSelect[10∈0] ➊<br />ᐸawaitᐳ"]]:::plan
-    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Constant105 & Constant106 & Constant107 & Constant108 & Lambda49 & Lambda52 & Lambda57 & Lambda62 --> PgSelect10
+    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object13 & Constant109 & Constant110 & Constant111 & Constant112 & Lambda49 & Access53 & Lambda58 & Lambda63 --> PgSelect10
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸcaseᐳ"]]:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Constant109 & Constant109 & Constant109 & Constant109 & Lambda49 & Lambda52 & Lambda71 & Lambda76 --> PgSelect21
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object13 & Constant113 & Constant113 & Constant113 & Constant113 & Lambda49 & Access53 & Lambda73 & Lambda78 --> PgSelect21
     PgSelect30[["PgSelect[30∈0] ➊<br />ᐸvalueOfᐳ"]]:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Constant110 & Constant107 & Constant105 & Constant111 & Lambda49 & Lambda52 & Lambda85 & Lambda90 --> PgSelect30
-    Object56{{"Object[56∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸsql.identifier(”await”)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda49 & Constant53 & Constant54 & Constant55 --> Object56
-    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”case”)ᐳ"}}:::plan
-    Lambda49 & Constant67 & Constant68 & Constant55 --> Object70
-    Object84{{"Object[84∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”value_of”)ᐳ"}}:::plan
-    Lambda49 & Constant81 & Constant82 & Constant55 --> Object84
-    Object98{{"Object[98∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸRecordCodec(null)ᐳ"}}:::plan
-    Lambda49 & Constant95 & Constant96 & Constant97 --> Object98
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object13 & Constant114 & Constant111 & Constant109 & Constant115 & Lambda49 & Access53 & Lambda88 & Lambda93 --> PgSelect30
+    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”await”)ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda49 & Constant54 & Constant55 & Constant56 --> Object57
+    Object72{{"Object[72∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸsql.identifier(”case”)ᐳ"}}:::plan
+    Lambda49 & Constant69 & Constant70 & Constant56 --> Object72
+    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”value_of”)ᐳ"}}:::plan
+    Lambda49 & Constant84 & Constant85 & Constant56 --> Object87
+    Object102{{"Object[102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸRecordCodec(null)ᐳ"}}:::plan
+    Lambda49 & Constant99 & Constant100 & Constant101 --> Object102
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
@@ -81,22 +81,24 @@ graph TD
     PgSelect36 --> First38
     PgSelectSingle39{{"PgSelectSingle[39∈0] ➊<br />ᐸnullᐳ"}}:::plan
     First38 --> PgSelectSingle39
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant112 --> Lambda49
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant113 --> Lambda52
-    Object56 --> Lambda57
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”await”ᐳ"}}:::plan
-    Constant114 --> Lambda62
-    Object70 --> Lambda71
-    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”case”)ᐳ"}}:::plan
-    Constant115 --> Lambda76
-    Object84 --> Lambda85
-    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”value_ᐳ"}}:::plan
-    Constant116 --> Lambda90
-    Object98 --> Lambda99
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
-    Constant117 --> Lambda104
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant116 --> Lambda49
+    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant117 --> Lambda52
+    Lambda52 --> Access53
+    Object57 --> Lambda58
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”await”ᐳ"}}:::plan
+    Constant118 --> Lambda63
+    Object72 --> Lambda73
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”case”)ᐳ"}}:::plan
+    Constant119 --> Lambda78
+    Object87 --> Lambda88
+    Constant120{{"Constant[120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”value_ᐳ"}}:::plan
+    Constant120 --> Lambda93
+    Object102 --> Lambda103
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
+    Constant121 --> Lambda108
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression45{{"PgClassExpression[45∈1] ➊<br />ᐸ”js_reserv...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression45
@@ -106,9 +108,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/js-reserved-function-names"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 53, 54, 55, 67, 68, 81, 82, 95, 96, 97, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 13, 49, 52, 56, 57, 62, 70, 71, 76, 84, 85, 90, 98, 99, 104<br />2: 10, 21, 30, 36<br />ᐳ: 14, 15, 16, 23, 24, 25, 32, 33, 34, 38, 39"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 11, 12, 54, 55, 56, 69, 70, 84, 85, 99, 100, 101, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 13, 49, 52, 53, 57, 58, 63, 72, 73, 78, 87, 88, 93, 102, 103, 108<br />2: 10, 21, 30, 36<br />ᐳ: 14, 15, 16, 23, 24, 25, 32, 33, 34, 38, 39"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect10,Access11,Access12,Object13,First14,PgSelectSingle15,PgClassExpression16,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect30,First32,PgSelectSingle33,PgClassExpression34,PgSelect36,First38,PgSelectSingle39,Lambda49,Lambda52,Constant53,Constant54,Constant55,Object56,Lambda57,Lambda62,Constant67,Constant68,Object70,Lambda71,Lambda76,Constant81,Constant82,Object84,Lambda85,Lambda90,Constant95,Constant96,Constant97,Object98,Lambda99,Lambda104,Constant105,Constant106,Constant107,Constant108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect10,Access11,Access12,Object13,First14,PgSelectSingle15,PgClassExpression16,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect30,First32,PgSelectSingle33,PgClassExpression34,PgSelect36,First38,PgSelectSingle39,Lambda49,Lambda52,Access53,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant69,Constant70,Object72,Lambda73,Lambda78,Constant84,Constant85,Object87,Lambda88,Lambda93,Constant99,Constant100,Constant101,Object102,Lambda103,Lambda108,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117,Constant118,Constant119,Constant120,Constant121 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 39<br /><br />ROOT PgSelectSingleᐸnullᐳ[39]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression45,PgClassExpression46 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords-as-columns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords-as-columns.mermaid
@@ -11,53 +11,57 @@ graph TD
     %% plan dependencies
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸmaterialᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ'concrete'ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸ'concrete'ᐳ"}}:::plan
     Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant141 & Lambda57 & Lambda60 & Lambda79 & Lambda84 --> PgSelect21
+    Access61{{"Access[61∈0] ➊<br />ᐸ60.0ᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant147 & Lambda57 & Access61 & Lambda81 & Lambda86 --> PgSelect21
     PgSelect28[["PgSelect[28∈0] ➊<br />ᐸmaterialᐳ"]]:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸ'spongy'ᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant142 & Lambda57 & Lambda60 & Lambda93 & Lambda98 --> PgSelect28
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ'spongy'ᐳ"}}:::plan
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant148 & Lambda57 & Access61 & Lambda96 & Lambda101 --> PgSelect28
     PgSelect42[["PgSelect[42∈0] ➊<br />ᐸcropᐳ"]]:::plan
-    Constant143{{"Constant[143∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant143 & Lambda57 & Lambda60 & Lambda121 & Lambda126 --> PgSelect42
+    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant149 & Lambda57 & Access61 & Lambda126 & Lambda131 --> PgSelect42
     PgSelect49[["PgSelect[49∈0] ➊<br />ᐸcropᐳ"]]:::plan
-    Constant144{{"Constant[144∈0] ➊<br />ᐸ'corn'ᐳ"}}:::plan
-    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant144 & Lambda57 & Lambda60 & Lambda135 & Lambda140 --> PgSelect49
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ'corn'ᐳ"}}:::plan
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant150 & Lambda57 & Access61 & Lambda141 & Lambda146 --> PgSelect49
     PgSelect34[["PgSelect[34∈0] ➊<br />ᐸcropᐳ"]]:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Lambda57 & Lambda60 & Lambda107 & Lambda112 --> PgSelect34
-    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”material”)ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸRecordCodec(material)ᐳ"}}:::plan
-    Lambda57 & Constant75 & Constant76 & Constant63 --> Object78
-    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”material”)ᐳ"}}:::plan
-    Lambda57 & Constant89 & Constant90 & Constant63 --> Object92
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”crop”)ᐳ"}}:::plan
-    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(crop)ᐳ"}}:::plan
-    Lambda57 & Constant103 & Constant104 & Constant105 --> Object106
-    Object120{{"Object[120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant117{{"Constant[117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸsql.identifier(”crop”)ᐳ"}}:::plan
-    Lambda57 & Constant117 & Constant118 & Constant105 --> Object120
-    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”crop”)ᐳ"}}:::plan
-    Lambda57 & Constant131 & Constant132 & Constant105 --> Object134
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Lambda57 & Access61 & Lambda111 & Lambda116 --> PgSelect34
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”material”)ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(material)ᐳ"}}:::plan
+    Lambda57 & Constant62 & Constant63 & Constant64 --> Object65
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”material”)ᐳ"}}:::plan
+    Lambda57 & Constant77 & Constant78 & Constant64 --> Object80
+    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”material”)ᐳ"}}:::plan
+    Lambda57 & Constant92 & Constant93 & Constant64 --> Object95
+    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”crop”)ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(crop)ᐳ"}}:::plan
+    Lambda57 & Constant107 & Constant108 & Constant109 --> Object110
+    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”crop”)ᐳ"}}:::plan
+    Lambda57 & Constant122 & Constant123 & Constant109 --> Object125
+    Object140{{"Object[140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸsql.identifier(”crop”)ᐳ"}}:::plan
+    Lambda57 & Constant137 & Constant138 & Constant109 --> Object140
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -80,38 +84,36 @@ graph TD
     PgSelect49 --> First51
     PgSelectSingle52{{"PgSelectSingle[52∈0] ➊<br />ᐸcropᐳ"}}:::plan
     First51 --> PgSelectSingle52
-    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant145 --> Lambda57
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant146 --> Lambda60
-    Object78 --> Lambda79
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”materiᐳ"}}:::plan
-    Constant148 --> Lambda84
-    Object92 --> Lambda93
-    Constant149{{"Constant[149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”materiᐳ"}}:::plan
-    Constant149 --> Lambda98
-    Object106 --> Lambda107
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant150 --> Lambda112
-    Object120 --> Lambda121
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”crop”)ᐳ"}}:::plan
-    Constant151 --> Lambda126
-    Object134 --> Lambda135
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”crop”)ᐳ"}}:::plan
-    Constant152 --> Lambda140
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant151 --> Lambda57
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant152 --> Lambda60
+    Lambda60 --> Access61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object65 --> Lambda66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant153 --> Lambda71
+    Object80 --> Lambda81
+    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”materiᐳ"}}:::plan
+    Constant154 --> Lambda86
+    Object95 --> Lambda96
+    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”materiᐳ"}}:::plan
+    Constant155 --> Lambda101
+    Object110 --> Lambda111
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant156 --> Lambda116
+    Object125 --> Lambda126
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”crop”)ᐳ"}}:::plan
+    Constant157 --> Lambda131
+    Object140 --> Lambda141
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”crop”)ᐳ"}}:::plan
+    Constant158 --> Lambda146
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸsql.identifier(”material”)ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸmaterialᐳ"]]:::plan
-    Lambda65{{"Lambda[65∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda57 & Lambda60 & Lambda65 & Lambda70 --> PgSelect14
-    Object64{{"Object[64∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda57 & Constant61 & Constant62 & Constant63 --> Object64
-    Object64 --> Lambda65
-    Constant147 --> Lambda70
+    Object12 & Connection13 & Lambda57 & Access61 & Lambda66 & Lambda71 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸmaterialᐳ"}}:::plan
@@ -152,12 +154,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/js-reserved-keywords-as-columns"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 61, 62, 63, 75, 76, 89, 90, 103, 104, 105, 117, 118, 131, 132, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 12, 57, 60, 78, 79, 84, 92, 93, 98, 106, 107, 112, 120, 121, 126, 134, 135, 140<br />2: 21, 28, 34, 42, 49<br />ᐳ: 23, 24, 30, 31, 44, 45, 51, 52"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 62, 63, 64, 77, 78, 92, 93, 107, 108, 109, 122, 123, 137, 138, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 12, 57, 60, 61, 65, 66, 71, 80, 81, 86, 95, 96, 101, 110, 111, 116, 125, 126, 131, 140, 141, 146<br />2: 21, 28, 34, 42, 49<br />ᐳ: 23, 24, 30, 31, 44, 45, 51, 52"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,PgSelect21,First23,PgSelectSingle24,PgSelect28,First30,PgSelectSingle31,PgSelect34,PgSelect42,First44,PgSelectSingle45,PgSelect49,First51,PgSelectSingle52,Lambda57,Lambda60,Constant61,Constant62,Constant63,Constant75,Constant76,Object78,Lambda79,Lambda84,Constant89,Constant90,Object92,Lambda93,Lambda98,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant117,Constant118,Object120,Lambda121,Lambda126,Constant131,Constant132,Object134,Lambda135,Lambda140,Constant141,Constant142,Constant143,Constant144,Constant145,Constant146,Constant147,Constant148,Constant149,Constant150,Constant151,Constant152 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 57, 60, 61, 62, 63, 147<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[64], Lambda[70], Lambda[65]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,PgSelect21,First23,PgSelectSingle24,PgSelect28,First30,PgSelectSingle31,PgSelect34,PgSelect42,First44,PgSelectSingle45,PgSelect49,First51,PgSelectSingle52,Lambda57,Lambda60,Access61,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant77,Constant78,Object80,Lambda81,Lambda86,Constant92,Constant93,Object95,Lambda96,Lambda101,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Constant122,Constant123,Object125,Lambda126,Lambda131,Constant137,Constant138,Object140,Lambda141,Lambda146,Constant147,Constant148,Constant149,Constant150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 57, 61, 66, 71<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object64,Lambda65,Lambda70 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords.mermaid
@@ -11,49 +11,54 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸmachineᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Access73{{"Access[73∈0] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda69{{"Lambda[69∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant174 & Lambda72 & Lambda77 & Lambda82 & Lambda69 & Lambda72 & Lambda93 & Lambda98 --> PgSelect7
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant181 & Access73 & Lambda78 & Lambda83 & Lambda69 & Access73 & Lambda95 & Lambda100 --> PgSelect7
     PgSelect24[["PgSelect[24∈0] ➊<br />ᐸbuildingᐳ"]]:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda126{{"Lambda[126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant175 & Lambda72 & Lambda107 & Lambda112 & Lambda69 & Lambda72 & Lambda126 & Lambda131 --> PgSelect24
-    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”building”)ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸRecordCodec(building)ᐳ"}}:::plan
-    Lambda69 & Constant73 & Constant74 & Constant75 --> Object76
-    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”machine”)ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(machine)ᐳ"}}:::plan
-    Lambda69 & Constant89 & Constant90 & Constant91 --> Object92
-    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”machine”)ᐳ"}}:::plan
-    Lambda69 & Constant103 & Constant104 & Constant91 --> Object106
-    Object125{{"Object[125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸsql.identifier(”building”)ᐳ"}}:::plan
-    Lambda69 & Constant122 & Constant123 & Constant75 --> Object125
-    Object139{{"Object[139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
-    Lambda69 & Constant136 & Constant137 & Constant138 --> Object139
-    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”relational_status”)ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸRecordCodec(relationalStatus)ᐳ"}}:::plan
-    Lambda69 & Constant150 & Constant151 & Constant152 --> Object153
+    Constant182{{"Constant[182∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant182 & Access73 & Lambda110 & Lambda115 & Lambda69 & Access73 & Lambda130 & Lambda135 --> PgSelect24
+    Object77{{"Object[77∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸsql.identifier(”building”)ᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸRecordCodec(building)ᐳ"}}:::plan
+    Lambda69 & Constant74 & Constant75 & Constant76 --> Object77
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”machine”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸRecordCodec(machine)ᐳ"}}:::plan
+    Lambda69 & Constant91 & Constant92 & Constant93 --> Object94
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸsql.identifier(”machine”)ᐳ"}}:::plan
+    Lambda69 & Constant106 & Constant107 & Constant93 --> Object109
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”building”)ᐳ"}}:::plan
+    Lambda69 & Constant126 & Constant127 & Constant76 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”relational_topics”)ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸRecordCodec(relationalTopics)ᐳ"}}:::plan
+    Lambda69 & Constant141 & Constant142 & Constant143 --> Object144
+    Object159{{"Object[159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸsql.identifier(”relational_status”)ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸRecordCodec(relationalStatus)ᐳ"}}:::plan
+    Lambda69 & Constant156 & Constant157 & Constant158 --> Object159
+    Object174{{"Object[174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant171{{"Constant[171∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant172{{"Constant[172∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
+    Lambda69 & Constant171 & Constant172 & Constant173 --> Object174
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -68,40 +73,44 @@ graph TD
     PgSelect24 --> First26
     PgSelectSingle27{{"PgSelectSingle[27∈0] ➊<br />ᐸbuildingᐳ"}}:::plan
     First26 --> PgSelectSingle27
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant176 --> Lambda69
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant177 --> Lambda72
-    Object76 --> Lambda77
-    Constant178{{"Constant[178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”buildiᐳ"}}:::plan
-    Constant178 --> Lambda82
-    Object92 --> Lambda93
-    Constant179{{"Constant[179∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”machinᐳ"}}:::plan
-    Constant179 --> Lambda98
-    Object106 --> Lambda107
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant180 --> Lambda112
-    Object125 --> Lambda126
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”buildiᐳ"}}:::plan
-    Constant181 --> Lambda131
-    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object139 --> Lambda140
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant183 --> Lambda69
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant184 --> Lambda72
+    Lambda72 --> Access73
+    Object77 --> Lambda78
+    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”buildiᐳ"}}:::plan
+    Constant185 --> Lambda83
+    Object94 --> Lambda95
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”machinᐳ"}}:::plan
+    Constant186 --> Lambda100
+    Object109 --> Lambda110
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant187 --> Lambda115
+    Object129 --> Lambda130
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”buildiᐳ"}}:::plan
+    Constant188 --> Lambda135
     Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant182 --> Lambda145
-    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object153 --> Lambda154
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
-    Constant183 --> Lambda159
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant189 --> Lambda150
+    Lambda160{{"Lambda[160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object159 --> Lambda160
+    Lambda165{{"Lambda[165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”relatiᐳ"}}:::plan
+    Constant190 --> Lambda165
+    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object174 --> Lambda175
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant191 --> Lambda180
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection36{{"Connection[36∈0] ➊<br />ᐸ32ᐳ"}}:::plan
     Connection48{{"Connection[48∈0] ➊<br />ᐸ46ᐳ"}}:::plan
     Constant67{{"Constant[67∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant70{{"Constant[70∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸsql.identifier(”relational_items”)ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸRecordCodec(relationalItems)ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__machine_...nstructor”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle19{{"PgSelectSingle[19∈1] ➊<br />ᐸbuildingᐳ"}}:::plan
@@ -112,17 +121,16 @@ graph TD
     PgSelectSingle19 --> PgClassExpression20
     PgClassExpression21{{"PgClassExpression[21∈2] ➊<br />ᐸ__building...nstructor”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression21
-    Object116{{"Object[116∈3] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access114{{"Access[114∈3] ➊<br />ᐸ26.0ᐳ"}}:::plan
-    Access114 & Constant67 & Constant67 & Lambda69 & Constant70 --> Object116
+    Object119{{"Object[119∈3] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access117{{"Access[117∈3] ➊<br />ᐸ26.0ᐳ"}}:::plan
+    Access117 & Constant67 & Constant67 & Lambda69 & Constant70 --> Object119
     PgClassExpression43{{"PgClassExpression[43∈3] ➊<br />ᐸ__building__.”name”ᐳ"}}:::plan
     PgSelectSingle27 --> PgClassExpression43
-    First26 --> Access114
-    Lambda117{{"Lambda[117∈3] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object116 --> Lambda117
-    Connection36{{"Connection[36∈3] ➊<br />ᐸ32ᐳ"}}:::plan
-    __Item38[/"__Item[38∈4]<br />ᐸ117ᐳ"\]:::itemplan
-    Lambda117 ==> __Item38
+    First26 --> Access117
+    Lambda120{{"Lambda[120∈3] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object119 --> Lambda120
+    __Item38[/"__Item[38∈4]<br />ᐸ120ᐳ"\]:::itemplan
+    Lambda120 ==> __Item38
     PgSelectSingle39{{"PgSelectSingle[39∈4]<br />ᐸmachineᐳ"}}:::plan
     __Item38 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ__machine__.”id”ᐳ"}}:::plan
@@ -132,22 +140,16 @@ graph TD
     PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__machine__.”input”ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression42
     PgSelect49[["PgSelect[49∈6] ➊<br />ᐸrelational_itemsᐳ"]]:::plan
-    Lambda168{{"Lambda[168∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda173{{"Lambda[173∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection48 & Lambda69 & Lambda72 & Lambda168 & Lambda173 --> PgSelect49
-    Object167{{"Object[167∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda69 & Constant164 & Constant165 & Constant166 --> Object167
-    Object167 --> Lambda168
-    Constant184 --> Lambda173
+    Object10 & Connection48 & Lambda69 & Access73 & Lambda175 & Lambda180 --> PgSelect49
     __Item50[/"__Item[50∈7]<br />ᐸ49ᐳ"\]:::itemplan
     PgSelect49 ==> __Item50
     PgSelectSingle51{{"PgSelectSingle[51∈7]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item50 --> PgSelectSingle51
     PgSelect53[["PgSelect[53∈8]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
     PgClassExpression52{{"PgClassExpression[52∈8]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Object10 & PgClassExpression52 & Lambda69 & Lambda72 & Lambda140 & Lambda145 --> PgSelect53
+    Object10 & PgClassExpression52 & Lambda69 & Access73 & Lambda145 & Lambda150 --> PgSelect53
     PgSelect62[["PgSelect[62∈8]<br />ᐸrelational_statusᐳ<br />ᐳRelationalStatus"]]:::plan
-    Object10 & PgClassExpression52 & Lambda69 & Lambda72 & Lambda154 & Lambda159 --> PgSelect62
+    Object10 & PgClassExpression52 & Lambda69 & Access73 & Lambda160 & Lambda165 --> PgSelect62
     PgSelectSingle51 --> PgClassExpression52
     First57{{"First[57∈8]"}}:::plan
     PgSelect53 --> First57
@@ -169,31 +171,31 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/js-reserved-keywords"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 48, 67, 70, 73, 74, 75, 89, 90, 91, 103, 104, 122, 123, 136, 137, 138, 150, 151, 152, 164, 165, 166, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 10, 69, 72, 76, 77, 82, 92, 93, 98, 106, 107, 112, 125, 126, 131, 139, 140, 145, 153, 154, 159<br />2: PgSelect[7], PgSelect[24]<br />ᐳ: 11, 12, 26, 27"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 36, 48, 67, 70, 74, 75, 76, 91, 92, 93, 106, 107, 126, 127, 141, 142, 143, 156, 157, 158, 171, 172, 173, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 10, 69, 72, 73, 77, 78, 83, 94, 95, 100, 109, 110, 115, 129, 130, 135, 144, 145, 150, 159, 160, 165, 174, 175, 180<br />2: PgSelect[7], PgSelect[24]<br />ᐳ: 11, 12, 26, 27"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgSelect24,First26,PgSelectSingle27,Connection48,Constant67,Lambda69,Constant70,Lambda72,Constant73,Constant74,Constant75,Object76,Lambda77,Lambda82,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant103,Constant104,Object106,Lambda107,Lambda112,Constant122,Constant123,Object125,Lambda126,Lambda131,Constant136,Constant137,Constant138,Object139,Lambda140,Lambda145,Constant150,Constant151,Constant152,Object153,Lambda154,Lambda159,Constant164,Constant165,Constant166,Constant174,Constant175,Constant176,Constant177,Constant178,Constant179,Constant180,Constant181,Constant182,Constant183,Constant184 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgSelect24,First26,PgSelectSingle27,Connection36,Connection48,Constant67,Lambda69,Constant70,Lambda72,Access73,Constant74,Constant75,Constant76,Object77,Lambda78,Lambda83,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant106,Constant107,Object109,Lambda110,Lambda115,Constant126,Constant127,Object129,Lambda130,Lambda135,Constant141,Constant142,Constant143,Object144,Lambda145,Lambda150,Constant156,Constant157,Constant158,Object159,Lambda160,Lambda165,Constant171,Constant172,Constant173,Object174,Lambda175,Lambda180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187,Constant188,Constant189,Constant190,Constant191 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸmachineᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgSelectSingle19,PgClassExpression22 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19<br /><br />ROOT PgSelectSingle{1}ᐸbuildingᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression20,PgClassExpression21 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 27, 26, 67, 69, 70<br /><br />ROOT PgSelectSingleᐸbuildingᐳ[27]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 27, 26, 67, 69, 70, 36<br /><br />ROOT PgSelectSingleᐸbuildingᐳ[27]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Connection36,PgClassExpression43,Access114,Object116,Lambda117 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ117ᐳ[38]"):::bucket
+    class Bucket3,PgClassExpression43,Access117,Object119,Lambda120 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ120ᐳ[38]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item38,PgSelectSingle39 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 39<br /><br />ROOT PgSelectSingle{4}ᐸmachineᐳ[39]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression40,PgClassExpression41,PgClassExpression42 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 10, 48, 69, 72, 164, 165, 166, 184, 140, 145, 154, 159<br /><br />ROOT Connectionᐸ46ᐳ[48]<br />1: <br />ᐳ: Object[167], Lambda[173], Lambda[168]<br />2: PgSelect[49]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 10, 48, 69, 73, 175, 180, 145, 150, 160, 165<br /><br />ROOT Connectionᐸ46ᐳ[48]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgSelect49,Object167,Lambda168,Lambda173 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 10, 69, 72, 140, 145, 154, 159<br /><br />ROOT __Item{7}ᐸ49ᐳ[50]"):::bucket
+    class Bucket6,PgSelect49 bucket6
+    Bucket7("Bucket 7 (listItem)<br />Deps: 10, 69, 73, 145, 150, 160, 165<br /><br />ROOT __Item{7}ᐸ49ᐳ[50]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item50,PgSelectSingle51 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalStatus<br />Deps: 51, 10, 69, 72, 140, 145, 154, 159<br />ᐳRelationalTopic<br />ᐳRelationalStatus<br /><br />1: <br />ᐳ: 52, 59, 60<br />2: PgSelect[53], PgSelect[62]<br />ᐳ: 57, 58, 61, 64, 65, 66"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalStatus<br />Deps: 51, 10, 69, 73, 145, 150, 160, 165<br />ᐳRelationalTopic<br />ᐳRelationalStatus<br /><br />1: <br />ᐳ: 52, 59, 60<br />2: PgSelect[53], PgSelect[62]<br />ᐳ: 57, 58, 61, 64, 65, 66"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression52,PgSelect53,First57,PgSelectSingle58,PgClassExpression59,PgClassExpression60,PgClassExpression61,PgSelect62,First64,PgSelectSingle65,PgClassExpression66 bucket8
     Bucket0 --> Bucket1 & Bucket3 & Bucket6

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-pgreserved.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-pgreserved.mermaid
@@ -11,52 +11,52 @@ graph TD
     %% plan dependencies
     PgSelect18[["PgSelect[18∈0] ➊<br />ᐸreservedᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ'2 Unlimited'ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ'2 Unlimited'ᐳ"}}:::plan
     Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant120 & Lambda50 & Lambda53 & Lambda72 & Lambda77 --> PgSelect18
+    Access54{{"Access[54∈0] ➊<br />ᐸ53.0ᐳ"}}:::plan
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant125 & Lambda50 & Access54 & Lambda74 & Lambda79 --> PgSelect18
     PgSelect26[["PgSelect[26∈0] ➊<br />ᐸreservedᐳ"]]:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ'1973'ᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant121 & Lambda50 & Lambda53 & Lambda86 & Lambda91 --> PgSelect26
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ'1973'ᐳ"}}:::plan
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant126 & Lambda50 & Access54 & Lambda89 & Lambda94 --> PgSelect26
     PgSelect34[["PgSelect[34∈0] ➊<br />ᐸreservedᐳ"]]:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant122 & Lambda50 & Lambda53 & Lambda100 & Lambda105 --> PgSelect34
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant127 & Lambda50 & Access54 & Lambda104 & Lambda109 --> PgSelect34
     PgSelect42[["PgSelect[42∈0] ➊<br />ᐸreservedᐳ"]]:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ'No Limit'ᐳ"}}:::plan
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ'No Limit'ᐳ"}}:::plan
     Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant123 & Lambda50 & Lambda53 & Lambda114 & Lambda119 --> PgSelect42
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant128 & Lambda50 & Access54 & Lambda119 & Lambda124 --> PgSelect42
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸreservedᐳ"]]:::plan
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda50 & Lambda53 & Lambda58 & Lambda63 --> PgSelect7
-    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
-    Lambda50 & Constant54 & Constant55 & Constant56 --> Object57
-    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda50 & Constant68 & Constant69 & Constant56 --> Object71
-    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda50 & Constant82 & Constant83 & Constant56 --> Object85
-    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda50 & Constant96 & Constant97 & Constant56 --> Object99
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda50 & Constant110 & Constant111 & Constant56 --> Object113
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda50 & Access54 & Lambda59 & Lambda64 --> PgSelect7
+    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
+    Lambda50 & Constant55 & Constant56 & Constant57 --> Object58
+    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda50 & Constant70 & Constant71 & Constant57 --> Object73
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda50 & Constant85 & Constant86 & Constant57 --> Object88
+    Object103{{"Object[103∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda50 & Constant100 & Constant101 & Constant57 --> Object103
+    Object118{{"Object[118∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda50 & Constant115 & Constant116 & Constant57 --> Object118
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -79,25 +79,27 @@ graph TD
     PgSelect42 --> First44
     PgSelectSingle45{{"PgSelectSingle[45∈0] ➊<br />ᐸreservedᐳ"}}:::plan
     First44 --> PgSelectSingle45
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant124 --> Lambda50
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant125 --> Lambda53
-    Object57 --> Lambda58
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant126 --> Lambda63
-    Object71 --> Lambda72
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant127 --> Lambda77
-    Object85 --> Lambda86
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant128 --> Lambda91
-    Object99 --> Lambda100
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant129 --> Lambda105
-    Object113 --> Lambda114
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant130 --> Lambda119
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant129 --> Lambda50
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant130 --> Lambda53
+    Lambda53 --> Access54
+    Object58 --> Lambda59
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant131 --> Lambda64
+    Object73 --> Lambda74
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant132 --> Lambda79
+    Object88 --> Lambda89
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant133 --> Lambda94
+    Object103 --> Lambda104
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant134 --> Lambda109
+    Object118 --> Lambda119
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant135 --> Lambda124
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
@@ -137,9 +139,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/js-reserved-pgreserved"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 54, 55, 56, 68, 69, 82, 83, 96, 97, 110, 111, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 10, 50, 53, 57, 58, 63, 71, 72, 77, 85, 86, 91, 99, 100, 105, 113, 114, 119<br />2: 7, 18, 26, 34, 42<br />ᐳ: 20, 21, 28, 29, 36, 37, 44, 45"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 55, 56, 57, 70, 71, 85, 86, 100, 101, 115, 116, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 10, 50, 53, 54, 58, 59, 64, 73, 74, 79, 88, 89, 94, 103, 104, 109, 118, 119, 124<br />2: 7, 18, 26, 34, 42<br />ᐳ: 20, 21, 28, 29, 36, 37, 44, 45"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect18,First20,PgSelectSingle21,PgSelect26,First28,PgSelectSingle29,PgSelect34,First36,PgSelectSingle37,PgSelect42,First44,PgSelectSingle45,Lambda50,Lambda53,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant68,Constant69,Object71,Lambda72,Lambda77,Constant82,Constant83,Object85,Lambda86,Lambda91,Constant96,Constant97,Object99,Lambda100,Lambda105,Constant110,Constant111,Object113,Lambda114,Lambda119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect18,First20,PgSelectSingle21,PgSelect26,First28,PgSelectSingle29,PgSelect34,First36,PgSelectSingle37,PgSelect42,First44,PgSelectSingle45,Lambda50,Lambda53,Access54,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant70,Constant71,Object73,Lambda74,Lambda79,Constant85,Constant86,Object88,Lambda89,Lambda94,Constant100,Constant101,Object103,Lambda104,Lambda109,Constant115,Constant116,Object118,Lambda119,Lambda124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133,Constant134,Constant135 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgClassExpression16 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-proto.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-proto.mermaid
@@ -11,26 +11,30 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸprojectᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ'DynaTAC'ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸ'DynaTAC'ᐳ"}}:::plan
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant78 & Lambda36 & Lambda39 & Lambda44 & Lambda49 --> PgSelect7
+    Access40{{"Access[40∈0] ➊<br />ᐸ39.0ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant81 & Lambda36 & Access40 & Lambda45 & Lambda50 --> PgSelect7
     PgSelect16[["PgSelect[16∈0] ➊<br />ᐸprojectᐳ"]]:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant79 & Lambda36 & Lambda39 & Lambda58 & Lambda63 --> PgSelect16
-    Object43{{"Object[43∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸsql.identifier(”project”)ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸRecordCodec(project)ᐳ"}}:::plan
-    Lambda36 & Constant40 & Constant41 & Constant42 --> Object43
-    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”project”)ᐳ"}}:::plan
-    Lambda36 & Constant54 & Constant55 & Constant42 --> Object57
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant82 & Lambda36 & Access40 & Lambda60 & Lambda65 --> PgSelect16
+    Object44{{"Object[44∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”project”)ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(project)ᐳ"}}:::plan
+    Lambda36 & Constant41 & Constant42 & Constant43 --> Object44
+    Object59{{"Object[59∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”project”)ᐳ"}}:::plan
+    Lambda36 & Constant56 & Constant57 & Constant43 --> Object59
+    Object74{{"Object[74∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”project”)ᐳ"}}:::plan
+    Lambda36 & Constant71 & Constant72 & Constant43 --> Object74
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -45,21 +49,25 @@ graph TD
     PgSelect16 --> First18
     PgSelectSingle19{{"PgSelectSingle[19∈0] ➊<br />ᐸprojectᐳ"}}:::plan
     First18 --> PgSelectSingle19
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant80 --> Lambda36
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant81 --> Lambda39
-    Object43 --> Lambda44
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”projecᐳ"}}:::plan
-    Constant82 --> Lambda49
-    Object57 --> Lambda58
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”projecᐳ"}}:::plan
-    Constant83 --> Lambda63
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant83 --> Lambda36
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant84 --> Lambda39
+    Lambda39 --> Access40
+    Object44 --> Lambda45
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”projecᐳ"}}:::plan
+    Constant85 --> Lambda50
+    Object59 --> Lambda60
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”projecᐳ"}}:::plan
+    Constant86 --> Lambda65
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object74 --> Lambda75
+    Lambda80{{"Lambda[80∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant87 --> Lambda80
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection27{{"Connection[27∈0] ➊<br />ᐸ25ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”project”)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__project__.”brand”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__project__.”id”ᐳ"}}:::plan
@@ -69,13 +77,7 @@ graph TD
     PgClassExpression21{{"PgClassExpression[21∈2] ➊<br />ᐸ__project__.”__proto__”ᐳ"}}:::plan
     PgSelectSingle19 --> PgClassExpression21
     PgSelect28[["PgSelect[28∈3] ➊<br />ᐸprojectᐳ"]]:::plan
-    Lambda72{{"Lambda[72∈3] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈3] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection27 & Lambda36 & Lambda39 & Lambda72 & Lambda77 --> PgSelect28
-    Object71{{"Object[71∈3] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda36 & Constant68 & Constant69 & Constant42 --> Object71
-    Object71 --> Lambda72
-    Constant84 --> Lambda77
+    Object10 & Connection27 & Lambda36 & Access40 & Lambda75 & Lambda80 --> PgSelect28
     __Item29[/"__Item[29∈4]<br />ᐸ28ᐳ"\]:::itemplan
     PgSelect28 ==> __Item29
     PgSelectSingle30{{"PgSelectSingle[30∈4]<br />ᐸprojectᐳ"}}:::plan
@@ -90,18 +92,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/js-reserved-proto"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 27, 40, 41, 42, 54, 55, 68, 69, 78, 79, 80, 81, 82, 83, 84, 10, 36, 39, 43, 44, 49, 57, 58, 63<br />2: PgSelect[7], PgSelect[16]<br />ᐳ: 11, 12, 18, 19"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 27, 41, 42, 43, 56, 57, 71, 72, 81, 82, 83, 84, 85, 86, 87, 10, 36, 39, 40, 44, 45, 50, 59, 60, 65, 74, 75, 80<br />2: PgSelect[7], PgSelect[16]<br />ᐳ: 11, 12, 18, 19"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgSelect16,First18,PgSelectSingle19,Connection27,Lambda36,Lambda39,Constant40,Constant41,Constant42,Object43,Lambda44,Lambda49,Constant54,Constant55,Object57,Lambda58,Lambda63,Constant68,Constant69,Constant78,Constant79,Constant80,Constant81,Constant82,Constant83,Constant84 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgSelect16,First18,PgSelectSingle19,Connection27,Lambda36,Lambda39,Access40,Constant41,Constant42,Constant43,Object44,Lambda45,Lambda50,Constant56,Constant57,Object59,Lambda60,Lambda65,Constant71,Constant72,Object74,Lambda75,Lambda80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86,Constant87 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸprojectᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgClassExpression14 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 19<br /><br />ROOT PgSelectSingleᐸprojectᐳ[19]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression20,PgClassExpression21 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 10, 27, 36, 39, 68, 69, 42, 84<br /><br />ROOT Connectionᐸ25ᐳ[27]<br />1: <br />ᐳ: Object[71], Lambda[77], Lambda[72]<br />2: PgSelect[28]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 10, 27, 36, 40, 75, 80<br /><br />ROOT Connectionᐸ25ᐳ[27]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect28,Object71,Lambda72,Lambda77 bucket3
+    class Bucket3,PgSelect28 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item29,PgSelectSingle30 bucket4

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-table-names.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-table-names.mermaid
@@ -11,132 +11,132 @@ graph TD
     %% plan dependencies
     PgSelect17[["PgSelect[17∈0] ➊<br />ᐸconstructorᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸ'Copper Wire'ᐳ"}}:::plan
+    Constant319{{"Constant[319∈0] ➊<br />ᐸ'Copper Wire'ᐳ"}}:::plan
     Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda131{{"Lambda[131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant305 & Lambda109 & Lambda112 & Lambda131 & Lambda136 --> PgSelect17
+    Access113{{"Access[113∈0] ➊<br />ᐸ112.0ᐳ"}}:::plan
+    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant319 & Lambda109 & Access113 & Lambda133 & Lambda138 --> PgSelect17
     PgSelect24[["PgSelect[24∈0] ➊<br />ᐸconstructorᐳ"]]:::plan
-    Constant306{{"Constant[306∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant306 & Lambda109 & Lambda112 & Lambda145 & Lambda150 --> PgSelect24
+    Constant320{{"Constant[320∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda148{{"Lambda[148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda153{{"Lambda[153∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant320 & Lambda109 & Access113 & Lambda148 & Lambda153 --> PgSelect24
     PgSelect31[["PgSelect[31∈0] ➊<br />ᐸconstructorᐳ"]]:::plan
-    Constant307{{"Constant[307∈0] ➊<br />ᐸ'Iron Mine'ᐳ"}}:::plan
-    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda164{{"Lambda[164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant307 & Lambda109 & Lambda112 & Lambda159 & Lambda164 --> PgSelect31
+    Constant321{{"Constant[321∈0] ➊<br />ᐸ'Iron Mine'ᐳ"}}:::plan
+    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant321 & Lambda109 & Access113 & Lambda163 & Lambda168 --> PgSelect31
     PgSelect45[["PgSelect[45∈0] ➊<br />ᐸyieldᐳ"]]:::plan
-    Constant308{{"Constant[308∈0] ➊<br />ᐸ'UK'ᐳ"}}:::plan
-    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant308 & Lambda109 & Lambda112 & Lambda187 & Lambda192 --> PgSelect45
+    Constant322{{"Constant[322∈0] ➊<br />ᐸ'UK'ᐳ"}}:::plan
+    Lambda193{{"Lambda[193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant322 & Lambda109 & Access113 & Lambda193 & Lambda198 --> PgSelect45
     PgSelect52[["PgSelect[52∈0] ➊<br />ᐸyieldᐳ"]]:::plan
-    Lambda201{{"Lambda[201∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant306 & Lambda109 & Lambda112 & Lambda201 & Lambda206 --> PgSelect52
+    Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant320 & Lambda109 & Access113 & Lambda208 & Lambda213 --> PgSelect52
     PgSelect66[["PgSelect[66∈0] ➊<br />ᐸ__proto__ᐳ"]]:::plan
-    Constant309{{"Constant[309∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda229{{"Lambda[229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda234{{"Lambda[234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant309 & Lambda109 & Lambda112 & Lambda229 & Lambda234 --> PgSelect66
-    PgSelect73[["PgSelect[73∈0] ➊<br />ᐸ__proto__ᐳ"]]:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸ'VCS'ᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda238{{"Lambda[238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda243{{"Lambda[243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda248{{"Lambda[248∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant310 & Lambda109 & Lambda112 & Lambda243 & Lambda248 --> PgSelect73
+    Object10 & Constant323 & Lambda109 & Access113 & Lambda238 & Lambda243 --> PgSelect66
+    PgSelect73[["PgSelect[73∈0] ➊<br />ᐸ__proto__ᐳ"]]:::plan
+    Constant324{{"Constant[324∈0] ➊<br />ᐸ'VCS'ᐳ"}}:::plan
+    Lambda253{{"Lambda[253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant324 & Lambda109 & Access113 & Lambda253 & Lambda258 --> PgSelect73
     PgSelect87[["PgSelect[87∈0] ➊<br />ᐸnullᐳ"]]:::plan
-    Constant311{{"Constant[311∈0] ➊<br />ᐸ'10 am'ᐳ"}}:::plan
-    Lambda271{{"Lambda[271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant311 & Lambda109 & Lambda112 & Lambda271 & Lambda276 --> PgSelect87
+    Constant325{{"Constant[325∈0] ➊<br />ᐸ'10 am'ᐳ"}}:::plan
+    Lambda283{{"Lambda[283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda288{{"Lambda[288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant325 & Lambda109 & Access113 & Lambda283 & Lambda288 --> PgSelect87
     PgSelect94[["PgSelect[94∈0] ➊<br />ᐸnullᐳ"]]:::plan
-    Constant312{{"Constant[312∈0] ➊<br />ᐸ'flat'ᐳ"}}:::plan
-    Lambda285{{"Lambda[285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant312 & Lambda109 & Lambda112 & Lambda285 & Lambda290 --> PgSelect94
+    Constant326{{"Constant[326∈0] ➊<br />ᐸ'flat'ᐳ"}}:::plan
+    Lambda298{{"Lambda[298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda303{{"Lambda[303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant326 & Lambda109 & Access113 & Lambda298 & Lambda303 --> PgSelect94
     PgSelect101[["PgSelect[101∈0] ➊<br />ᐸnullᐳ"]]:::plan
-    Constant313{{"Constant[313∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant313 & Lambda109 & Lambda112 & Lambda299 & Lambda304 --> PgSelect101
+    Constant327{{"Constant[327∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Lambda313{{"Lambda[313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda318{{"Lambda[318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant327 & Lambda109 & Access113 & Lambda313 & Lambda318 --> PgSelect101
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸconstructorᐳ"]]:::plan
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda109 & Lambda112 & Lambda117 & Lambda122 --> PgSelect7
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda109 & Access113 & Lambda118 & Lambda123 --> PgSelect7
     PgSelect37[["PgSelect[37∈0] ➊<br />ᐸyieldᐳ"]]:::plan
-    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda109 & Lambda112 & Lambda173 & Lambda178 --> PgSelect37
+    Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda109 & Access113 & Lambda178 & Lambda183 --> PgSelect37
     PgSelect58[["PgSelect[58∈0] ➊<br />ᐸ__proto__ᐳ"]]:::plan
-    Lambda215{{"Lambda[215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda109 & Lambda112 & Lambda215 & Lambda220 --> PgSelect58
+    Lambda223{{"Lambda[223∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda228{{"Lambda[228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda109 & Access113 & Lambda223 & Lambda228 --> PgSelect58
     PgSelect79[["PgSelect[79∈0] ➊<br />ᐸnullᐳ"]]:::plan
-    Lambda257{{"Lambda[257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda262{{"Lambda[262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda109 & Lambda112 & Lambda257 & Lambda262 --> PgSelect79
-    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸRecordCodec(constructor)ᐳ"}}:::plan
-    Lambda109 & Constant113 & Constant114 & Constant115 --> Object116
-    Object130{{"Object[130∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
-    Lambda109 & Constant127 & Constant128 & Constant115 --> Object130
-    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
-    Lambda109 & Constant141 & Constant142 & Constant115 --> Object144
-    Object158{{"Object[158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
-    Lambda109 & Constant155 & Constant156 & Constant115 --> Object158
-    Object172{{"Object[172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant169{{"Constant[169∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸsql.identifier(”yield”)ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸRecordCodec(yield)ᐳ"}}:::plan
-    Lambda109 & Constant169 & Constant170 & Constant171 --> Object172
-    Object186{{"Object[186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸsql.identifier(”yield”)ᐳ"}}:::plan
-    Lambda109 & Constant183 & Constant184 & Constant171 --> Object186
-    Object200{{"Object[200∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant198{{"Constant[198∈0] ➊<br />ᐸsql.identifier(”yield”)ᐳ"}}:::plan
-    Lambda109 & Constant197 & Constant198 & Constant171 --> Object200
-    Object214{{"Object[214∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant211{{"Constant[211∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸsql.identifier(”proto”)ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸRecordCodec(__proto__)ᐳ"}}:::plan
-    Lambda109 & Constant211 & Constant212 & Constant213 --> Object214
-    Object228{{"Object[228∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant225{{"Constant[225∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸsql.identifier(”proto”)ᐳ"}}:::plan
-    Lambda109 & Constant225 & Constant226 & Constant213 --> Object228
-    Object242{{"Object[242∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant239{{"Constant[239∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸsql.identifier(”proto”)ᐳ"}}:::plan
-    Lambda109 & Constant239 & Constant240 & Constant213 --> Object242
-    Object256{{"Object[256∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant253{{"Constant[253∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant254{{"Constant[254∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
-    Constant255{{"Constant[255∈0] ➊<br />ᐸRecordCodec(null)ᐳ"}}:::plan
-    Lambda109 & Constant253 & Constant254 & Constant255 --> Object256
-    Object270{{"Object[270∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant267{{"Constant[267∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant268{{"Constant[268∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
-    Lambda109 & Constant267 & Constant268 & Constant255 --> Object270
-    Object284{{"Object[284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant281{{"Constant[281∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant282{{"Constant[282∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
-    Lambda109 & Constant281 & Constant282 & Constant255 --> Object284
-    Object298{{"Object[298∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant295{{"Constant[295∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant296{{"Constant[296∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
-    Lambda109 & Constant295 & Constant296 & Constant255 --> Object298
+    Lambda268{{"Lambda[268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda273{{"Lambda[273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda109 & Access113 & Lambda268 & Lambda273 --> PgSelect79
+    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸRecordCodec(constructor)ᐳ"}}:::plan
+    Lambda109 & Constant114 & Constant115 & Constant116 --> Object117
+    Object132{{"Object[132∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
+    Lambda109 & Constant129 & Constant130 & Constant116 --> Object132
+    Object147{{"Object[147∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
+    Lambda109 & Constant144 & Constant145 & Constant116 --> Object147
+    Object162{{"Object[162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸsql.identifier(”constructor”)ᐳ"}}:::plan
+    Lambda109 & Constant159 & Constant160 & Constant116 --> Object162
+    Object177{{"Object[177∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant175{{"Constant[175∈0] ➊<br />ᐸsql.identifier(”yield”)ᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸRecordCodec(yield)ᐳ"}}:::plan
+    Lambda109 & Constant174 & Constant175 & Constant176 --> Object177
+    Object192{{"Object[192∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸsql.identifier(”yield”)ᐳ"}}:::plan
+    Lambda109 & Constant189 & Constant190 & Constant176 --> Object192
+    Object207{{"Object[207∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant205{{"Constant[205∈0] ➊<br />ᐸsql.identifier(”yield”)ᐳ"}}:::plan
+    Lambda109 & Constant204 & Constant205 & Constant176 --> Object207
+    Object222{{"Object[222∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸsql.identifier(”proto”)ᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸRecordCodec(__proto__)ᐳ"}}:::plan
+    Lambda109 & Constant219 & Constant220 & Constant221 --> Object222
+    Object237{{"Object[237∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant235{{"Constant[235∈0] ➊<br />ᐸsql.identifier(”proto”)ᐳ"}}:::plan
+    Lambda109 & Constant234 & Constant235 & Constant221 --> Object237
+    Object252{{"Object[252∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant249{{"Constant[249∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant250{{"Constant[250∈0] ➊<br />ᐸsql.identifier(”proto”)ᐳ"}}:::plan
+    Lambda109 & Constant249 & Constant250 & Constant221 --> Object252
+    Object267{{"Object[267∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant264{{"Constant[264∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant265{{"Constant[265∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
+    Constant266{{"Constant[266∈0] ➊<br />ᐸRecordCodec(null)ᐳ"}}:::plan
+    Lambda109 & Constant264 & Constant265 & Constant266 --> Object267
+    Object282{{"Object[282∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant279{{"Constant[279∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant280{{"Constant[280∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
+    Lambda109 & Constant279 & Constant280 & Constant266 --> Object282
+    Object297{{"Object[297∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant294{{"Constant[294∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant295{{"Constant[295∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
+    Lambda109 & Constant294 & Constant295 & Constant266 --> Object297
+    Object312{{"Object[312∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant309{{"Constant[309∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant310{{"Constant[310∈0] ➊<br />ᐸsql.identifier(”null”)ᐳ"}}:::plan
+    Lambda109 & Constant309 & Constant310 & Constant266 --> Object312
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -183,52 +183,54 @@ graph TD
     PgSelect101 --> First103
     PgSelectSingle104{{"PgSelectSingle[104∈0] ➊<br />ᐸnullᐳ"}}:::plan
     First103 --> PgSelectSingle104
-    Constant314{{"Constant[314∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant314 --> Lambda109
-    Constant315{{"Constant[315∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant315 --> Lambda112
-    Object116 --> Lambda117
-    Constant316{{"Constant[316∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant316 --> Lambda122
-    Object130 --> Lambda131
-    Constant317{{"Constant[317∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”constrᐳ"}}:::plan
-    Constant317 --> Lambda136
-    Object144 --> Lambda145
-    Constant318{{"Constant[318∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”constrᐳ"}}:::plan
-    Constant318 --> Lambda150
-    Object158 --> Lambda159
-    Constant319{{"Constant[319∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”constrᐳ"}}:::plan
-    Constant319 --> Lambda164
-    Object172 --> Lambda173
-    Constant320{{"Constant[320∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant320 --> Lambda178
-    Object186 --> Lambda187
-    Constant321{{"Constant[321∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”yield”ᐳ"}}:::plan
-    Constant321 --> Lambda192
-    Object200 --> Lambda201
-    Constant322{{"Constant[322∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”yield”ᐳ"}}:::plan
-    Constant322 --> Lambda206
-    Object214 --> Lambda215
-    Constant323{{"Constant[323∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant323 --> Lambda220
-    Object228 --> Lambda229
-    Constant324{{"Constant[324∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”proto”ᐳ"}}:::plan
-    Constant324 --> Lambda234
-    Object242 --> Lambda243
-    Constant325{{"Constant[325∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”proto”ᐳ"}}:::plan
-    Constant325 --> Lambda248
-    Object256 --> Lambda257
-    Constant326{{"Constant[326∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant326 --> Lambda262
-    Object270 --> Lambda271
-    Constant327{{"Constant[327∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
-    Constant327 --> Lambda276
-    Object284 --> Lambda285
-    Constant328{{"Constant[328∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
-    Constant328 --> Lambda290
-    Object298 --> Lambda299
-    Constant329{{"Constant[329∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
-    Constant329 --> Lambda304
+    Constant328{{"Constant[328∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant328 --> Lambda109
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant329{{"Constant[329∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant329 --> Lambda112
+    Lambda112 --> Access113
+    Object117 --> Lambda118
+    Constant330{{"Constant[330∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant330 --> Lambda123
+    Object132 --> Lambda133
+    Constant331{{"Constant[331∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”constrᐳ"}}:::plan
+    Constant331 --> Lambda138
+    Object147 --> Lambda148
+    Constant332{{"Constant[332∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”constrᐳ"}}:::plan
+    Constant332 --> Lambda153
+    Object162 --> Lambda163
+    Constant333{{"Constant[333∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”constrᐳ"}}:::plan
+    Constant333 --> Lambda168
+    Object177 --> Lambda178
+    Constant334{{"Constant[334∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant334 --> Lambda183
+    Object192 --> Lambda193
+    Constant335{{"Constant[335∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”yield”ᐳ"}}:::plan
+    Constant335 --> Lambda198
+    Object207 --> Lambda208
+    Constant336{{"Constant[336∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”yield”ᐳ"}}:::plan
+    Constant336 --> Lambda213
+    Object222 --> Lambda223
+    Constant337{{"Constant[337∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant337 --> Lambda228
+    Object237 --> Lambda238
+    Constant338{{"Constant[338∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”proto”ᐳ"}}:::plan
+    Constant338 --> Lambda243
+    Object252 --> Lambda253
+    Constant339{{"Constant[339∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”proto”ᐳ"}}:::plan
+    Constant339 --> Lambda258
+    Object267 --> Lambda268
+    Constant340{{"Constant[340∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant340 --> Lambda273
+    Object282 --> Lambda283
+    Constant341{{"Constant[341∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
+    Constant341 --> Lambda288
+    Object297 --> Lambda298
+    Constant342{{"Constant[342∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
+    Constant342 --> Lambda303
+    Object312 --> Lambda313
+    Constant343{{"Constant[343∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null”)ᐳ"}}:::plan
+    Constant343 --> Lambda318
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
@@ -314,9 +316,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/js-reserved-table-names"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 113, 114, 115, 127, 128, 141, 142, 155, 156, 169, 170, 171, 183, 184, 197, 198, 211, 212, 213, 225, 226, 239, 240, 253, 254, 255, 267, 268, 281, 282, 295, 296, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 10, 109, 112, 116, 117, 122, 130, 131, 136, 144, 145, 150, 158, 159, 164, 172, 173, 178, 186, 187, 192, 200, 201, 206, 214, 215, 220, 228, 229, 234, 242, 243, 248, 256, 257, 262, 270, 271, 276, 284, 285, 290, 298, 299, 304<br />2: 7, 17, 24, 31, 37, 45, 52, 58, 66, 73, 79, 87, 94, 101<br />ᐳ: 19, 20, 26, 27, 33, 34, 47, 48, 54, 55, 68, 69, 75, 76, 89, 90, 96, 97, 103, 104"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 114, 115, 116, 129, 130, 144, 145, 159, 160, 174, 175, 176, 189, 190, 204, 205, 219, 220, 221, 234, 235, 249, 250, 264, 265, 266, 279, 280, 294, 295, 309, 310, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 10, 109, 112, 113, 117, 118, 123, 132, 133, 138, 147, 148, 153, 162, 163, 168, 177, 178, 183, 192, 193, 198, 207, 208, 213, 222, 223, 228, 237, 238, 243, 252, 253, 258, 267, 268, 273, 282, 283, 288, 297, 298, 303, 312, 313, 318<br />2: 7, 17, 24, 31, 37, 45, 52, 58, 66, 73, 79, 87, 94, 101<br />ᐳ: 19, 20, 26, 27, 33, 34, 47, 48, 54, 55, 68, 69, 75, 76, 89, 90, 96, 97, 103, 104"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect17,First19,PgSelectSingle20,PgSelect24,First26,PgSelectSingle27,PgSelect31,First33,PgSelectSingle34,PgSelect37,PgSelect45,First47,PgSelectSingle48,PgSelect52,First54,PgSelectSingle55,PgSelect58,PgSelect66,First68,PgSelectSingle69,PgSelect73,First75,PgSelectSingle76,PgSelect79,PgSelect87,First89,PgSelectSingle90,PgSelect94,First96,PgSelectSingle97,PgSelect101,First103,PgSelectSingle104,Lambda109,Lambda112,Constant113,Constant114,Constant115,Object116,Lambda117,Lambda122,Constant127,Constant128,Object130,Lambda131,Lambda136,Constant141,Constant142,Object144,Lambda145,Lambda150,Constant155,Constant156,Object158,Lambda159,Lambda164,Constant169,Constant170,Constant171,Object172,Lambda173,Lambda178,Constant183,Constant184,Object186,Lambda187,Lambda192,Constant197,Constant198,Object200,Lambda201,Lambda206,Constant211,Constant212,Constant213,Object214,Lambda215,Lambda220,Constant225,Constant226,Object228,Lambda229,Lambda234,Constant239,Constant240,Object242,Lambda243,Lambda248,Constant253,Constant254,Constant255,Object256,Lambda257,Lambda262,Constant267,Constant268,Object270,Lambda271,Lambda276,Constant281,Constant282,Object284,Lambda285,Lambda290,Constant295,Constant296,Object298,Lambda299,Lambda304,Constant305,Constant306,Constant307,Constant308,Constant309,Constant310,Constant311,Constant312,Constant313,Constant314,Constant315,Constant316,Constant317,Constant318,Constant319,Constant320,Constant321,Constant322,Constant323,Constant324,Constant325,Constant326,Constant327,Constant328,Constant329 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect17,First19,PgSelectSingle20,PgSelect24,First26,PgSelectSingle27,PgSelect31,First33,PgSelectSingle34,PgSelect37,PgSelect45,First47,PgSelectSingle48,PgSelect52,First54,PgSelectSingle55,PgSelect58,PgSelect66,First68,PgSelectSingle69,PgSelect73,First75,PgSelectSingle76,PgSelect79,PgSelect87,First89,PgSelectSingle90,PgSelect94,First96,PgSelectSingle97,PgSelect101,First103,PgSelectSingle104,Lambda109,Lambda112,Access113,Constant114,Constant115,Constant116,Object117,Lambda118,Lambda123,Constant129,Constant130,Object132,Lambda133,Lambda138,Constant144,Constant145,Object147,Lambda148,Lambda153,Constant159,Constant160,Object162,Lambda163,Lambda168,Constant174,Constant175,Constant176,Object177,Lambda178,Lambda183,Constant189,Constant190,Object192,Lambda193,Lambda198,Constant204,Constant205,Object207,Lambda208,Lambda213,Constant219,Constant220,Constant221,Object222,Lambda223,Lambda228,Constant234,Constant235,Object237,Lambda238,Lambda243,Constant249,Constant250,Object252,Lambda253,Lambda258,Constant264,Constant265,Constant266,Object267,Lambda268,Lambda273,Constant279,Constant280,Object282,Lambda283,Lambda288,Constant294,Constant295,Object297,Lambda298,Lambda303,Constant309,Constant310,Object312,Lambda313,Lambda318,Constant319,Constant320,Constant321,Constant322,Constant323,Constant324,Constant325,Constant326,Constant327,Constant328,Constant329,Constant330,Constant331,Constant332,Constant333,Constant334,Constant335,Constant336,Constant337,Constant338,Constant339,Constant340,Constant341,Constant342,Constant343 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression15 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/json-overflow-nested.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/json-overflow-nested.mermaid
@@ -9,165 +9,167 @@ graph TD
 
 
     %% plan dependencies
-    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant375 --> Connection14
+    Object350{{"Object[350∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda342{{"Lambda[342∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant480{{"Constant[480∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant480 --> Lambda342
+    Constant347{{"Constant[347∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant348{{"Constant[348∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant349{{"Constant[349∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda342 & Constant347 & Constant348 & Constant349 --> Object350
+    Object370{{"Object[370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant367{{"Constant[367∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant369{{"Constant[369∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda342 & Constant367 & Constant368 & Constant369 --> Object370
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access11 & Access12 --> Object13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access11
+    __Value2 --> Access12
+    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant377{{"Constant[377∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant377 --> Connection14
+    Connection26{{"Connection[26∈0] ➊<br />ᐸ22ᐳ"}}:::plan
+    Constant377 --> Connection26
+    Constant482{{"Constant[482∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant482 --> Lambda342
+    Lambda345{{"Lambda[345∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant483{{"Constant[483∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant483 --> Lambda345
+    Access346{{"Access[346∈0] ➊<br />ᐸ345.0ᐳ"}}:::plan
+    Lambda345 --> Access346
+    Lambda351{{"Lambda[351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object350 --> Lambda351
+    Lambda356{{"Lambda[356∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant480 --> Lambda356
+    Lambda371{{"Lambda[371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object370 --> Lambda371
+    Lambda376{{"Lambda[376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant481 --> Lambda376
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant340{{"Constant[340∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant343{{"Constant[343∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant348{{"Constant[348∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant366{{"Constant[366∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant376{{"Constant[376∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant377{{"Constant[377∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸ7ᐳ"}}:::plan
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant385{{"Constant[385∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸ13ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ14ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸ15ᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸ16ᐳ"}}:::plan
-    Constant391{{"Constant[391∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant392{{"Constant[392∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Constant393{{"Constant[393∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸ21ᐳ"}}:::plan
-    Constant396{{"Constant[396∈0] ➊<br />ᐸ22ᐳ"}}:::plan
-    Constant397{{"Constant[397∈0] ➊<br />ᐸ23ᐳ"}}:::plan
-    Constant398{{"Constant[398∈0] ➊<br />ᐸ24ᐳ"}}:::plan
-    Constant399{{"Constant[399∈0] ➊<br />ᐸ25ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ26ᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸ27ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ28ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸ29ᐳ"}}:::plan
-    Constant404{{"Constant[404∈0] ➊<br />ᐸ30ᐳ"}}:::plan
-    Constant405{{"Constant[405∈0] ➊<br />ᐸ31ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ32ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸ33ᐳ"}}:::plan
-    Constant408{{"Constant[408∈0] ➊<br />ᐸ34ᐳ"}}:::plan
-    Constant409{{"Constant[409∈0] ➊<br />ᐸ35ᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ36ᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸ37ᐳ"}}:::plan
-    Constant412{{"Constant[412∈0] ➊<br />ᐸ38ᐳ"}}:::plan
-    Constant413{{"Constant[413∈0] ➊<br />ᐸ39ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ40ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸ41ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ42ᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸ43ᐳ"}}:::plan
-    Constant418{{"Constant[418∈0] ➊<br />ᐸ44ᐳ"}}:::plan
-    Constant419{{"Constant[419∈0] ➊<br />ᐸ45ᐳ"}}:::plan
-    Constant420{{"Constant[420∈0] ➊<br />ᐸ46ᐳ"}}:::plan
-    Constant421{{"Constant[421∈0] ➊<br />ᐸ47ᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸ48ᐳ"}}:::plan
-    Constant423{{"Constant[423∈0] ➊<br />ᐸ49ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ50ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ51ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ52ᐳ"}}:::plan
-    Constant427{{"Constant[427∈0] ➊<br />ᐸ53ᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ54ᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸ55ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ56ᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸ57ᐳ"}}:::plan
-    Constant432{{"Constant[432∈0] ➊<br />ᐸ58ᐳ"}}:::plan
-    Constant433{{"Constant[433∈0] ➊<br />ᐸ59ᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ60ᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ61ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ62ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸ63ᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ64ᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ65ᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸ66ᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ67ᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ68ᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸ69ᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ70ᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸ71ᐳ"}}:::plan
-    Constant446{{"Constant[446∈0] ➊<br />ᐸ72ᐳ"}}:::plan
-    Constant447{{"Constant[447∈0] ➊<br />ᐸ73ᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ74ᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ75ᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸ76ᐳ"}}:::plan
-    Constant451{{"Constant[451∈0] ➊<br />ᐸ77ᐳ"}}:::plan
-    Constant452{{"Constant[452∈0] ➊<br />ᐸ78ᐳ"}}:::plan
-    Constant453{{"Constant[453∈0] ➊<br />ᐸ79ᐳ"}}:::plan
-    Constant454{{"Constant[454∈0] ➊<br />ᐸ80ᐳ"}}:::plan
-    Constant455{{"Constant[455∈0] ➊<br />ᐸ81ᐳ"}}:::plan
-    Constant456{{"Constant[456∈0] ➊<br />ᐸ82ᐳ"}}:::plan
-    Constant457{{"Constant[457∈0] ➊<br />ᐸ83ᐳ"}}:::plan
-    Constant458{{"Constant[458∈0] ➊<br />ᐸ84ᐳ"}}:::plan
-    Constant459{{"Constant[459∈0] ➊<br />ᐸ85ᐳ"}}:::plan
-    Constant460{{"Constant[460∈0] ➊<br />ᐸ86ᐳ"}}:::plan
-    Constant461{{"Constant[461∈0] ➊<br />ᐸ87ᐳ"}}:::plan
-    Constant462{{"Constant[462∈0] ➊<br />ᐸ88ᐳ"}}:::plan
-    Constant463{{"Constant[463∈0] ➊<br />ᐸ89ᐳ"}}:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸ90ᐳ"}}:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸ91ᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸ92ᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸ93ᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸ94ᐳ"}}:::plan
-    Constant469{{"Constant[469∈0] ➊<br />ᐸ95ᐳ"}}:::plan
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ96ᐳ"}}:::plan
-    Constant471{{"Constant[471∈0] ➊<br />ᐸ97ᐳ"}}:::plan
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ98ᐳ"}}:::plan
-    Constant473{{"Constant[473∈0] ➊<br />ᐸ99ᐳ"}}:::plan
-    Constant474{{"Constant[474∈0] ➊<br />ᐸ100ᐳ"}}:::plan
-    Constant475{{"Constant[475∈0] ➊<br />ᐸ101ᐳ"}}:::plan
-    Constant476{{"Constant[476∈0] ➊<br />ᐸ102ᐳ"}}:::plan
-    Constant477{{"Constant[477∈0] ➊<br />ᐸ103ᐳ"}}:::plan
-    Constant478{{"Constant[478∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant479{{"Constant[479∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant378{{"Constant[378∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant379{{"Constant[379∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant380{{"Constant[380∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant381{{"Constant[381∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant382{{"Constant[382∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    Constant384{{"Constant[384∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Constant385{{"Constant[385∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Constant388{{"Constant[388∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸ13ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ14ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸ16ᐳ"}}:::plan
+    Constant393{{"Constant[393∈0] ➊<br />ᐸ17ᐳ"}}:::plan
+    Constant394{{"Constant[394∈0] ➊<br />ᐸ18ᐳ"}}:::plan
+    Constant395{{"Constant[395∈0] ➊<br />ᐸ19ᐳ"}}:::plan
+    Constant396{{"Constant[396∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ21ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ22ᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸ23ᐳ"}}:::plan
+    Constant400{{"Constant[400∈0] ➊<br />ᐸ24ᐳ"}}:::plan
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ25ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸ26ᐳ"}}:::plan
+    Constant403{{"Constant[403∈0] ➊<br />ᐸ27ᐳ"}}:::plan
+    Constant404{{"Constant[404∈0] ➊<br />ᐸ28ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ29ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸ30ᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸ31ᐳ"}}:::plan
+    Constant408{{"Constant[408∈0] ➊<br />ᐸ32ᐳ"}}:::plan
+    Constant409{{"Constant[409∈0] ➊<br />ᐸ33ᐳ"}}:::plan
+    Constant410{{"Constant[410∈0] ➊<br />ᐸ34ᐳ"}}:::plan
+    Constant411{{"Constant[411∈0] ➊<br />ᐸ35ᐳ"}}:::plan
+    Constant412{{"Constant[412∈0] ➊<br />ᐸ36ᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸ37ᐳ"}}:::plan
+    Constant414{{"Constant[414∈0] ➊<br />ᐸ38ᐳ"}}:::plan
+    Constant415{{"Constant[415∈0] ➊<br />ᐸ39ᐳ"}}:::plan
+    Constant416{{"Constant[416∈0] ➊<br />ᐸ40ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ41ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸ42ᐳ"}}:::plan
+    Constant419{{"Constant[419∈0] ➊<br />ᐸ43ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ44ᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸ45ᐳ"}}:::plan
+    Constant422{{"Constant[422∈0] ➊<br />ᐸ46ᐳ"}}:::plan
+    Constant423{{"Constant[423∈0] ➊<br />ᐸ47ᐳ"}}:::plan
+    Constant424{{"Constant[424∈0] ➊<br />ᐸ48ᐳ"}}:::plan
+    Constant425{{"Constant[425∈0] ➊<br />ᐸ49ᐳ"}}:::plan
+    Constant426{{"Constant[426∈0] ➊<br />ᐸ50ᐳ"}}:::plan
+    Constant427{{"Constant[427∈0] ➊<br />ᐸ51ᐳ"}}:::plan
+    Constant428{{"Constant[428∈0] ➊<br />ᐸ52ᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸ53ᐳ"}}:::plan
+    Constant430{{"Constant[430∈0] ➊<br />ᐸ54ᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ55ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ56ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸ57ᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸ58ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ59ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸ60ᐳ"}}:::plan
+    Constant437{{"Constant[437∈0] ➊<br />ᐸ61ᐳ"}}:::plan
+    Constant438{{"Constant[438∈0] ➊<br />ᐸ62ᐳ"}}:::plan
+    Constant439{{"Constant[439∈0] ➊<br />ᐸ63ᐳ"}}:::plan
+    Constant440{{"Constant[440∈0] ➊<br />ᐸ64ᐳ"}}:::plan
+    Constant441{{"Constant[441∈0] ➊<br />ᐸ65ᐳ"}}:::plan
+    Constant442{{"Constant[442∈0] ➊<br />ᐸ66ᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸ67ᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸ68ᐳ"}}:::plan
+    Constant445{{"Constant[445∈0] ➊<br />ᐸ69ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ70ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ71ᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸ72ᐳ"}}:::plan
+    Constant449{{"Constant[449∈0] ➊<br />ᐸ73ᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ74ᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸ75ᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸ76ᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸ77ᐳ"}}:::plan
+    Constant454{{"Constant[454∈0] ➊<br />ᐸ78ᐳ"}}:::plan
+    Constant455{{"Constant[455∈0] ➊<br />ᐸ79ᐳ"}}:::plan
+    Constant456{{"Constant[456∈0] ➊<br />ᐸ80ᐳ"}}:::plan
+    Constant457{{"Constant[457∈0] ➊<br />ᐸ81ᐳ"}}:::plan
+    Constant458{{"Constant[458∈0] ➊<br />ᐸ82ᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸ83ᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸ84ᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸ85ᐳ"}}:::plan
+    Constant462{{"Constant[462∈0] ➊<br />ᐸ86ᐳ"}}:::plan
+    Constant463{{"Constant[463∈0] ➊<br />ᐸ87ᐳ"}}:::plan
+    Constant464{{"Constant[464∈0] ➊<br />ᐸ88ᐳ"}}:::plan
+    Constant465{{"Constant[465∈0] ➊<br />ᐸ89ᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸ90ᐳ"}}:::plan
+    Constant467{{"Constant[467∈0] ➊<br />ᐸ91ᐳ"}}:::plan
+    Constant468{{"Constant[468∈0] ➊<br />ᐸ92ᐳ"}}:::plan
+    Constant469{{"Constant[469∈0] ➊<br />ᐸ93ᐳ"}}:::plan
+    Constant470{{"Constant[470∈0] ➊<br />ᐸ94ᐳ"}}:::plan
+    Constant471{{"Constant[471∈0] ➊<br />ᐸ95ᐳ"}}:::plan
+    Constant472{{"Constant[472∈0] ➊<br />ᐸ96ᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ97ᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸ98ᐳ"}}:::plan
+    Constant475{{"Constant[475∈0] ➊<br />ᐸ99ᐳ"}}:::plan
+    Constant476{{"Constant[476∈0] ➊<br />ᐸ100ᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ101ᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸ102ᐳ"}}:::plan
+    Constant479{{"Constant[479∈0] ➊<br />ᐸ103ᐳ"}}:::plan
     PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda345{{"Lambda[345∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda350{{"Lambda[350∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda355{{"Lambda[355∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda369{{"Lambda[369∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda374{{"Lambda[374∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant375 & Constant375 & Constant376 & Constant377 & Constant378 & Constant379 & Constant380 & Constant381 & Constant382 & Constant383 & Constant384 & Constant385 & Constant386 & Constant387 & Constant388 & Constant389 & Constant390 & Constant391 & Constant392 & Constant393 & Constant394 & Constant395 & Constant396 & Constant397 & Constant398 & Constant399 & Constant400 & Constant401 & Constant402 & Constant403 & Constant404 & Constant405 & Constant406 & Constant407 & Constant408 & Constant409 & Constant410 & Constant411 & Constant412 & Constant413 & Constant414 & Constant415 & Constant416 & Constant417 & Constant418 & Constant419 & Constant420 & Constant421 & Constant422 & Constant423 & Constant424 & Constant425 & Constant426 & Constant427 & Constant428 & Constant429 & Constant430 & Constant431 & Constant432 & Constant433 & Constant434 & Constant435 & Constant436 & Constant437 & Constant438 & Constant439 & Constant440 & Constant441 & Constant442 & Constant443 & Constant444 & Constant445 & Constant446 & Constant447 & Constant448 & Constant449 & Constant450 & Constant451 & Constant452 & Constant453 & Constant454 & Constant455 & Constant456 & Constant457 & Constant458 & Constant459 & Constant460 & Constant461 & Constant462 & Constant463 & Constant464 & Constant465 & Constant466 & Constant467 & Constant468 & Constant469 & Constant470 & Constant471 & Constant472 & Constant473 & Constant474 & Constant475 & Constant476 & Constant477 & Lambda345 & Lambda350 & Lambda355 & Lambda342 & Lambda345 & Lambda369 & Lambda374 --> PgSelect15
-    Object349{{"Object[349∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda342 & Constant346 & Constant347 & Constant348 --> Object349
-    Object368{{"Object[368∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda342 & Constant365 & Constant366 & Constant367 --> Object368
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access11 & Access12 --> Object13
-    __Value2 --> Access11
-    __Value2 --> Access12
-    Connection26{{"Connection[26∈1] ➊<br />ᐸ22ᐳ"}}:::plan
-    Constant375 --> Connection26
-    Constant481 --> Lambda345
-    Object349 --> Lambda350
-    Constant478 --> Lambda355
-    Object368 --> Lambda369
-    Constant479 --> Lambda374
+    Object13 & Connection14 & Constant377 & Constant377 & Constant378 & Constant379 & Constant380 & Constant381 & Constant382 & Constant383 & Constant384 & Constant385 & Constant386 & Constant387 & Constant388 & Constant389 & Constant390 & Constant391 & Constant392 & Constant393 & Constant394 & Constant395 & Constant396 & Constant397 & Constant398 & Constant399 & Constant400 & Constant401 & Constant402 & Constant403 & Constant404 & Constant405 & Constant406 & Constant407 & Constant408 & Constant409 & Constant410 & Constant411 & Constant412 & Constant413 & Constant414 & Constant415 & Constant416 & Constant417 & Constant418 & Constant419 & Constant420 & Constant421 & Constant422 & Constant423 & Constant424 & Constant425 & Constant426 & Constant427 & Constant428 & Constant429 & Constant430 & Constant431 & Constant432 & Constant433 & Constant434 & Constant435 & Constant436 & Constant437 & Constant438 & Constant439 & Constant440 & Constant441 & Constant442 & Constant443 & Constant444 & Constant445 & Constant446 & Constant447 & Constant448 & Constant449 & Constant450 & Constant451 & Constant452 & Constant453 & Constant454 & Constant455 & Constant456 & Constant457 & Constant458 & Constant459 & Constant460 & Constant461 & Constant462 & Constant463 & Constant464 & Constant465 & Constant466 & Constant467 & Constant468 & Constant469 & Constant470 & Constant471 & Constant472 & Constant473 & Constant474 & Constant475 & Constant476 & Constant477 & Constant478 & Constant479 & Access346 & Lambda351 & Lambda356 & Lambda342 & Access346 & Lambda371 & Lambda376 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpersonᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
-    Object359{{"Object[359∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access357{{"Access[357∈3]<br />ᐸ16.0ᐳ"}}:::plan
-    Access357 & Constant375 & Constant340 & Lambda342 & Constant343 --> Object359
+    Object360{{"Object[360∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access358{{"Access[358∈3]<br />ᐸ16.0ᐳ"}}:::plan
+    Access358 & Constant377 & Constant340 & Lambda342 & Constant343 --> Object360
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression18
-    __Item16 --> Access357
-    Lambda360{{"Lambda[360∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object359 --> Lambda360
-    __Item28[/"__Item[28∈4]<br />ᐸ360ᐳ"\]:::itemplan
-    Lambda360 ==> __Item28
+    __Item16 --> Access358
+    Lambda361{{"Lambda[361∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object360 --> Lambda361
+    __Item28[/"__Item[28∈4]<br />ᐸ361ᐳ"\]:::itemplan
+    Lambda361 ==> __Item28
     PgSelectSingle29{{"PgSelectSingle[29∈4]<br />ᐸpostᐳ"}}:::plan
     __Item28 --> PgSelectSingle29
     PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -384,17 +386,17 @@ graph TD
     subgraph "Buckets for queries/v4/json-overflow-nested"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection14,Constant340,Lambda342,Constant343,Constant346,Constant347,Constant348,Constant365,Constant366,Constant367,Constant375,Constant376,Constant377,Constant378,Constant379,Constant380,Constant381,Constant382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397,Constant398,Constant399,Constant400,Constant401,Constant402,Constant403,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422,Constant423,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450,Constant451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 342, 481, 346, 347, 348, 478, 365, 366, 367, 479, 340, 343<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 26, 345, 349, 355, 368, 374, 13, 350, 369<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Connection26,Constant340,Lambda342,Constant343,Lambda345,Access346,Constant347,Constant348,Constant349,Object350,Lambda351,Lambda356,Constant367,Constant368,Constant369,Object370,Lambda371,Lambda376,Constant377,Constant378,Constant379,Constant380,Constant381,Constant382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397,Constant398,Constant399,Constant400,Constant401,Constant402,Constant403,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422,Constant423,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450,Constant451,Constant452,Constant453,Constant454,Constant455,Constant456,Constant457,Constant458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 346, 351, 356, 342, 371, 376, 340, 343, 26<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect15,Connection26,Lambda345,Object349,Lambda350,Lambda355,Object368,Lambda369,Lambda374 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 375, 340, 342, 343, 26<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 377, 340, 342, 343, 26<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 16, 375, 340, 342, 343, 26<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[17]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 16, 377, 340, 342, 343, 26<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[17]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression18,Access357,Object359,Lambda360 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ360ᐳ[28]"):::bucket
+    class Bucket3,PgClassExpression18,Access358,Object360,Lambda361 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ361ᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item28,PgSelectSingle29 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 29<br /><br />ROOT PgSelectSingle{4}ᐸpostᐳ[29]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/json-overflow.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/json-overflow.mermaid
@@ -9,137 +9,139 @@ graph TD
 
 
     %% plan dependencies
-    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant344 --> Connection14
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant334{{"Constant[334∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant335{{"Constant[335∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant336{{"Constant[336∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant345{{"Constant[345∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant346{{"Constant[346∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant347{{"Constant[347∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant348{{"Constant[348∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Constant349{{"Constant[349∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Constant350{{"Constant[350∈0] ➊<br />ᐸ7ᐳ"}}:::plan
-    Constant351{{"Constant[351∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant352{{"Constant[352∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant353{{"Constant[353∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant354{{"Constant[354∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Constant355{{"Constant[355∈0] ➊<br />ᐸ12ᐳ"}}:::plan
-    Constant356{{"Constant[356∈0] ➊<br />ᐸ13ᐳ"}}:::plan
-    Constant357{{"Constant[357∈0] ➊<br />ᐸ14ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ15ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸ16ᐳ"}}:::plan
-    Constant360{{"Constant[360∈0] ➊<br />ᐸ17ᐳ"}}:::plan
-    Constant361{{"Constant[361∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Constant362{{"Constant[362∈0] ➊<br />ᐸ19ᐳ"}}:::plan
-    Constant363{{"Constant[363∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant364{{"Constant[364∈0] ➊<br />ᐸ21ᐳ"}}:::plan
-    Constant365{{"Constant[365∈0] ➊<br />ᐸ22ᐳ"}}:::plan
-    Constant366{{"Constant[366∈0] ➊<br />ᐸ23ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸ24ᐳ"}}:::plan
-    Constant368{{"Constant[368∈0] ➊<br />ᐸ25ᐳ"}}:::plan
-    Constant369{{"Constant[369∈0] ➊<br />ᐸ26ᐳ"}}:::plan
-    Constant370{{"Constant[370∈0] ➊<br />ᐸ27ᐳ"}}:::plan
-    Constant371{{"Constant[371∈0] ➊<br />ᐸ28ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸ29ᐳ"}}:::plan
-    Constant373{{"Constant[373∈0] ➊<br />ᐸ30ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸ31ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸ32ᐳ"}}:::plan
-    Constant376{{"Constant[376∈0] ➊<br />ᐸ33ᐳ"}}:::plan
-    Constant377{{"Constant[377∈0] ➊<br />ᐸ34ᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸ35ᐳ"}}:::plan
-    Constant379{{"Constant[379∈0] ➊<br />ᐸ36ᐳ"}}:::plan
-    Constant380{{"Constant[380∈0] ➊<br />ᐸ37ᐳ"}}:::plan
-    Constant381{{"Constant[381∈0] ➊<br />ᐸ38ᐳ"}}:::plan
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ39ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ40ᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸ41ᐳ"}}:::plan
-    Constant385{{"Constant[385∈0] ➊<br />ᐸ42ᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ43ᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸ44ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ45ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸ46ᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸ47ᐳ"}}:::plan
-    Constant391{{"Constant[391∈0] ➊<br />ᐸ48ᐳ"}}:::plan
-    Constant392{{"Constant[392∈0] ➊<br />ᐸ49ᐳ"}}:::plan
-    Constant393{{"Constant[393∈0] ➊<br />ᐸ50ᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸ51ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸ52ᐳ"}}:::plan
-    Constant396{{"Constant[396∈0] ➊<br />ᐸ53ᐳ"}}:::plan
-    Constant397{{"Constant[397∈0] ➊<br />ᐸ54ᐳ"}}:::plan
-    Constant398{{"Constant[398∈0] ➊<br />ᐸ55ᐳ"}}:::plan
-    Constant399{{"Constant[399∈0] ➊<br />ᐸ56ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ57ᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸ58ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ59ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸ60ᐳ"}}:::plan
-    Constant404{{"Constant[404∈0] ➊<br />ᐸ61ᐳ"}}:::plan
-    Constant405{{"Constant[405∈0] ➊<br />ᐸ62ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ63ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸ64ᐳ"}}:::plan
-    Constant408{{"Constant[408∈0] ➊<br />ᐸ65ᐳ"}}:::plan
-    Constant409{{"Constant[409∈0] ➊<br />ᐸ66ᐳ"}}:::plan
-    Constant410{{"Constant[410∈0] ➊<br />ᐸ67ᐳ"}}:::plan
-    Constant411{{"Constant[411∈0] ➊<br />ᐸ68ᐳ"}}:::plan
-    Constant412{{"Constant[412∈0] ➊<br />ᐸ69ᐳ"}}:::plan
-    Constant413{{"Constant[413∈0] ➊<br />ᐸ70ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ71ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸ72ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸ73ᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸ74ᐳ"}}:::plan
-    Constant418{{"Constant[418∈0] ➊<br />ᐸ75ᐳ"}}:::plan
-    Constant419{{"Constant[419∈0] ➊<br />ᐸ76ᐳ"}}:::plan
-    Constant420{{"Constant[420∈0] ➊<br />ᐸ77ᐳ"}}:::plan
-    Constant421{{"Constant[421∈0] ➊<br />ᐸ78ᐳ"}}:::plan
-    Constant422{{"Constant[422∈0] ➊<br />ᐸ79ᐳ"}}:::plan
-    Constant423{{"Constant[423∈0] ➊<br />ᐸ80ᐳ"}}:::plan
-    Constant424{{"Constant[424∈0] ➊<br />ᐸ81ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ82ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸ83ᐳ"}}:::plan
-    Constant427{{"Constant[427∈0] ➊<br />ᐸ84ᐳ"}}:::plan
-    Constant428{{"Constant[428∈0] ➊<br />ᐸ85ᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸ86ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸ87ᐳ"}}:::plan
-    Constant431{{"Constant[431∈0] ➊<br />ᐸ88ᐳ"}}:::plan
-    Constant432{{"Constant[432∈0] ➊<br />ᐸ89ᐳ"}}:::plan
-    Constant433{{"Constant[433∈0] ➊<br />ᐸ90ᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸ91ᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ92ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸ93ᐳ"}}:::plan
-    Constant437{{"Constant[437∈0] ➊<br />ᐸ94ᐳ"}}:::plan
-    Constant438{{"Constant[438∈0] ➊<br />ᐸ95ᐳ"}}:::plan
-    Constant439{{"Constant[439∈0] ➊<br />ᐸ96ᐳ"}}:::plan
-    Constant440{{"Constant[440∈0] ➊<br />ᐸ97ᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ98ᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸ99ᐳ"}}:::plan
-    Constant443{{"Constant[443∈0] ➊<br />ᐸ100ᐳ"}}:::plan
-    Constant444{{"Constant[444∈0] ➊<br />ᐸ101ᐳ"}}:::plan
-    Constant445{{"Constant[445∈0] ➊<br />ᐸ102ᐳ"}}:::plan
-    Constant446{{"Constant[446∈0] ➊<br />ᐸ103ᐳ"}}:::plan
-    Constant447{{"Constant[447∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpostᐳ"]]:::plan
-    Object13{{"Object[13∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda330{{"Lambda[330∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda333{{"Lambda[333∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda338{{"Lambda[338∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda343{{"Lambda[343∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant344 & Constant344 & Constant345 & Constant346 & Constant347 & Constant348 & Constant349 & Constant350 & Constant351 & Constant352 & Constant353 & Constant354 & Constant355 & Constant356 & Constant357 & Constant358 & Constant359 & Constant360 & Constant361 & Constant362 & Constant363 & Constant364 & Constant365 & Constant366 & Constant367 & Constant368 & Constant369 & Constant370 & Constant371 & Constant372 & Constant373 & Constant374 & Constant375 & Constant376 & Constant377 & Constant378 & Constant379 & Constant380 & Constant381 & Constant382 & Constant383 & Constant384 & Constant385 & Constant386 & Constant387 & Constant388 & Constant389 & Constant390 & Constant391 & Constant392 & Constant393 & Constant394 & Constant395 & Constant396 & Constant397 & Constant398 & Constant399 & Constant400 & Constant401 & Constant402 & Constant403 & Constant404 & Constant405 & Constant406 & Constant407 & Constant408 & Constant409 & Constant410 & Constant411 & Constant412 & Constant413 & Constant414 & Constant415 & Constant416 & Constant417 & Constant418 & Constant419 & Constant420 & Constant421 & Constant422 & Constant423 & Constant424 & Constant425 & Constant426 & Constant427 & Constant428 & Constant429 & Constant430 & Constant431 & Constant432 & Constant433 & Constant434 & Constant435 & Constant436 & Constant437 & Constant438 & Constant439 & Constant440 & Constant441 & Constant442 & Constant443 & Constant444 & Constant445 & Constant446 & Lambda330 & Lambda333 & Lambda338 & Lambda343 --> PgSelect15
-    Object337{{"Object[337∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda330 & Constant334 & Constant335 & Constant336 --> Object337
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access12{{"Access[12∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object338{{"Object[338∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda330{{"Lambda[330∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant335{{"Constant[335∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant336{{"Constant[336∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant337{{"Constant[337∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda330 & Constant335 & Constant336 & Constant337 --> Object338
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Constant448 --> Lambda330
-    Constant449 --> Lambda333
-    Object337 --> Lambda338
-    Constant447 --> Lambda343
+    Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant345 --> Connection14
+    Constant449{{"Constant[449∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant449 --> Lambda330
+    Lambda333{{"Lambda[333∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant450{{"Constant[450∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant450 --> Lambda333
+    Access334{{"Access[334∈0] ➊<br />ᐸ333.0ᐳ"}}:::plan
+    Lambda333 --> Access334
+    Lambda339{{"Lambda[339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object338 --> Lambda339
+    Lambda344{{"Lambda[344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant448{{"Constant[448∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant448 --> Lambda344
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant347{{"Constant[347∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant348{{"Constant[348∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant349{{"Constant[349∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant350{{"Constant[350∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Constant351{{"Constant[351∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    Constant352{{"Constant[352∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Constant353{{"Constant[353∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Constant354{{"Constant[354∈0] ➊<br />ᐸ10ᐳ"}}:::plan
+    Constant355{{"Constant[355∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Constant356{{"Constant[356∈0] ➊<br />ᐸ12ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸ13ᐳ"}}:::plan
+    Constant358{{"Constant[358∈0] ➊<br />ᐸ14ᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸ16ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸ17ᐳ"}}:::plan
+    Constant362{{"Constant[362∈0] ➊<br />ᐸ18ᐳ"}}:::plan
+    Constant363{{"Constant[363∈0] ➊<br />ᐸ19ᐳ"}}:::plan
+    Constant364{{"Constant[364∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    Constant365{{"Constant[365∈0] ➊<br />ᐸ21ᐳ"}}:::plan
+    Constant366{{"Constant[366∈0] ➊<br />ᐸ22ᐳ"}}:::plan
+    Constant367{{"Constant[367∈0] ➊<br />ᐸ23ᐳ"}}:::plan
+    Constant368{{"Constant[368∈0] ➊<br />ᐸ24ᐳ"}}:::plan
+    Constant369{{"Constant[369∈0] ➊<br />ᐸ25ᐳ"}}:::plan
+    Constant370{{"Constant[370∈0] ➊<br />ᐸ26ᐳ"}}:::plan
+    Constant371{{"Constant[371∈0] ➊<br />ᐸ27ᐳ"}}:::plan
+    Constant372{{"Constant[372∈0] ➊<br />ᐸ28ᐳ"}}:::plan
+    Constant373{{"Constant[373∈0] ➊<br />ᐸ29ᐳ"}}:::plan
+    Constant374{{"Constant[374∈0] ➊<br />ᐸ30ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸ31ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸ32ᐳ"}}:::plan
+    Constant377{{"Constant[377∈0] ➊<br />ᐸ33ᐳ"}}:::plan
+    Constant378{{"Constant[378∈0] ➊<br />ᐸ34ᐳ"}}:::plan
+    Constant379{{"Constant[379∈0] ➊<br />ᐸ35ᐳ"}}:::plan
+    Constant380{{"Constant[380∈0] ➊<br />ᐸ36ᐳ"}}:::plan
+    Constant381{{"Constant[381∈0] ➊<br />ᐸ37ᐳ"}}:::plan
+    Constant382{{"Constant[382∈0] ➊<br />ᐸ38ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸ39ᐳ"}}:::plan
+    Constant384{{"Constant[384∈0] ➊<br />ᐸ40ᐳ"}}:::plan
+    Constant385{{"Constant[385∈0] ➊<br />ᐸ41ᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸ42ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸ43ᐳ"}}:::plan
+    Constant388{{"Constant[388∈0] ➊<br />ᐸ44ᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸ45ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ46ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸ47ᐳ"}}:::plan
+    Constant392{{"Constant[392∈0] ➊<br />ᐸ48ᐳ"}}:::plan
+    Constant393{{"Constant[393∈0] ➊<br />ᐸ49ᐳ"}}:::plan
+    Constant394{{"Constant[394∈0] ➊<br />ᐸ50ᐳ"}}:::plan
+    Constant395{{"Constant[395∈0] ➊<br />ᐸ51ᐳ"}}:::plan
+    Constant396{{"Constant[396∈0] ➊<br />ᐸ52ᐳ"}}:::plan
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ53ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ54ᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸ55ᐳ"}}:::plan
+    Constant400{{"Constant[400∈0] ➊<br />ᐸ56ᐳ"}}:::plan
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ57ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸ58ᐳ"}}:::plan
+    Constant403{{"Constant[403∈0] ➊<br />ᐸ59ᐳ"}}:::plan
+    Constant404{{"Constant[404∈0] ➊<br />ᐸ60ᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ61ᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸ62ᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸ63ᐳ"}}:::plan
+    Constant408{{"Constant[408∈0] ➊<br />ᐸ64ᐳ"}}:::plan
+    Constant409{{"Constant[409∈0] ➊<br />ᐸ65ᐳ"}}:::plan
+    Constant410{{"Constant[410∈0] ➊<br />ᐸ66ᐳ"}}:::plan
+    Constant411{{"Constant[411∈0] ➊<br />ᐸ67ᐳ"}}:::plan
+    Constant412{{"Constant[412∈0] ➊<br />ᐸ68ᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸ69ᐳ"}}:::plan
+    Constant414{{"Constant[414∈0] ➊<br />ᐸ70ᐳ"}}:::plan
+    Constant415{{"Constant[415∈0] ➊<br />ᐸ71ᐳ"}}:::plan
+    Constant416{{"Constant[416∈0] ➊<br />ᐸ72ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ73ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸ74ᐳ"}}:::plan
+    Constant419{{"Constant[419∈0] ➊<br />ᐸ75ᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ76ᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸ77ᐳ"}}:::plan
+    Constant422{{"Constant[422∈0] ➊<br />ᐸ78ᐳ"}}:::plan
+    Constant423{{"Constant[423∈0] ➊<br />ᐸ79ᐳ"}}:::plan
+    Constant424{{"Constant[424∈0] ➊<br />ᐸ80ᐳ"}}:::plan
+    Constant425{{"Constant[425∈0] ➊<br />ᐸ81ᐳ"}}:::plan
+    Constant426{{"Constant[426∈0] ➊<br />ᐸ82ᐳ"}}:::plan
+    Constant427{{"Constant[427∈0] ➊<br />ᐸ83ᐳ"}}:::plan
+    Constant428{{"Constant[428∈0] ➊<br />ᐸ84ᐳ"}}:::plan
+    Constant429{{"Constant[429∈0] ➊<br />ᐸ85ᐳ"}}:::plan
+    Constant430{{"Constant[430∈0] ➊<br />ᐸ86ᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ87ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ88ᐳ"}}:::plan
+    Constant433{{"Constant[433∈0] ➊<br />ᐸ89ᐳ"}}:::plan
+    Constant434{{"Constant[434∈0] ➊<br />ᐸ90ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ91ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸ92ᐳ"}}:::plan
+    Constant437{{"Constant[437∈0] ➊<br />ᐸ93ᐳ"}}:::plan
+    Constant438{{"Constant[438∈0] ➊<br />ᐸ94ᐳ"}}:::plan
+    Constant439{{"Constant[439∈0] ➊<br />ᐸ95ᐳ"}}:::plan
+    Constant440{{"Constant[440∈0] ➊<br />ᐸ96ᐳ"}}:::plan
+    Constant441{{"Constant[441∈0] ➊<br />ᐸ97ᐳ"}}:::plan
+    Constant442{{"Constant[442∈0] ➊<br />ᐸ98ᐳ"}}:::plan
+    Constant443{{"Constant[443∈0] ➊<br />ᐸ99ᐳ"}}:::plan
+    Constant444{{"Constant[444∈0] ➊<br />ᐸ100ᐳ"}}:::plan
+    Constant445{{"Constant[445∈0] ➊<br />ᐸ101ᐳ"}}:::plan
+    Constant446{{"Constant[446∈0] ➊<br />ᐸ102ᐳ"}}:::plan
+    Constant447{{"Constant[447∈0] ➊<br />ᐸ103ᐳ"}}:::plan
+    PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpostᐳ"]]:::plan
+    Object13 & Connection14 & Constant345 & Constant345 & Constant346 & Constant347 & Constant348 & Constant349 & Constant350 & Constant351 & Constant352 & Constant353 & Constant354 & Constant355 & Constant356 & Constant357 & Constant358 & Constant359 & Constant360 & Constant361 & Constant362 & Constant363 & Constant364 & Constant365 & Constant366 & Constant367 & Constant368 & Constant369 & Constant370 & Constant371 & Constant372 & Constant373 & Constant374 & Constant375 & Constant376 & Constant377 & Constant378 & Constant379 & Constant380 & Constant381 & Constant382 & Constant383 & Constant384 & Constant385 & Constant386 & Constant387 & Constant388 & Constant389 & Constant390 & Constant391 & Constant392 & Constant393 & Constant394 & Constant395 & Constant396 & Constant397 & Constant398 & Constant399 & Constant400 & Constant401 & Constant402 & Constant403 & Constant404 & Constant405 & Constant406 & Constant407 & Constant408 & Constant409 & Constant410 & Constant411 & Constant412 & Constant413 & Constant414 & Constant415 & Constant416 & Constant417 & Constant418 & Constant419 & Constant420 & Constant421 & Constant422 & Constant423 & Constant424 & Constant425 & Constant426 & Constant427 & Constant428 & Constant429 & Constant430 & Constant431 & Constant432 & Constant433 & Constant434 & Constant435 & Constant436 & Constant437 & Constant438 & Constant439 & Constant440 & Constant441 & Constant442 & Constant443 & Constant444 & Constant445 & Constant446 & Constant447 & Lambda330 & Access334 & Lambda339 & Lambda344 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpostᐳ"}}:::plan
@@ -358,10 +360,10 @@ graph TD
     subgraph "Buckets for queries/v4/json-overflow"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection14,Constant334,Constant335,Constant336,Constant344,Constant345,Constant346,Constant347,Constant348,Constant349,Constant350,Constant351,Constant352,Constant353,Constant354,Constant355,Constant356,Constant357,Constant358,Constant359,Constant360,Constant361,Constant362,Constant363,Constant364,Constant365,Constant366,Constant367,Constant368,Constant369,Constant370,Constant371,Constant372,Constant373,Constant374,Constant375,Constant376,Constant377,Constant378,Constant379,Constant380,Constant381,Constant382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397,Constant398,Constant399,Constant400,Constant401,Constant402,Constant403,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422,Constant423,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 14, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 448, 449, 334, 335, 336, 447<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 11, 12, 330, 333, 343, 13, 337, 338<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda330,Lambda333,Access334,Constant335,Constant336,Constant337,Object338,Lambda339,Lambda344,Constant345,Constant346,Constant347,Constant348,Constant349,Constant350,Constant351,Constant352,Constant353,Constant354,Constant355,Constant356,Constant357,Constant358,Constant359,Constant360,Constant361,Constant362,Constant363,Constant364,Constant365,Constant366,Constant367,Constant368,Constant369,Constant370,Constant371,Constant372,Constant373,Constant374,Constant375,Constant376,Constant377,Constant378,Constant379,Constant380,Constant381,Constant382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397,Constant398,Constant399,Constant400,Constant401,Constant402,Constant403,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422,Constant423,Constant424,Constant425,Constant426,Constant427,Constant428,Constant429,Constant430,Constant431,Constant432,Constant433,Constant434,Constant435,Constant436,Constant437,Constant438,Constant439,Constant440,Constant441,Constant442,Constant443,Constant444,Constant445,Constant446,Constant447,Constant448,Constant449,Constant450 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 330, 334, 339, 344<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access11,Access12,Object13,PgSelect15,Lambda330,Lambda333,Object337,Lambda338,Lambda343 bucket1
+    class Bucket1,PgSelect15 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/large_bigint.issue491.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/large_bigint.issue491.mermaid
@@ -13,26 +13,30 @@ graph TD
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access24{{"Access[24∈0] ➊<br />ᐸ23.1ᐳ"}}:::plan
     Lambda50{{"Lambda[50∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access54{{"Access[54∈0] ➊<br />ᐸ53.0ᐳ"}}:::plan
+    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect26
-    Access24 & Lambda50 & Lambda53 & Lambda72 & Lambda77 --> PgSelect26
+    Access24 & Lambda50 & Access54 & Lambda74 & Lambda79 --> PgSelect26
     PgSelect39[["PgSelect[39∈0] ➊<br />ᐸlarge_node_idᐳ"]]:::plan
     Access37{{"Access[37∈0] ➊<br />ᐸ36.1ᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect39
-    Access37 & Lambda50 & Lambda53 & Lambda86 & Lambda91 --> PgSelect39
-    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”large_node_id”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(largeNodeId)ᐳ"}}:::plan
-    Lambda50 & Constant68 & Constant69 & Constant56 --> Object71
-    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”large_node_id”)ᐳ"}}:::plan
-    Lambda50 & Constant82 & Constant83 & Constant56 --> Object85
+    Access37 & Lambda50 & Access54 & Lambda89 & Lambda94 --> PgSelect39
+    Object58{{"Object[58∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { codec: Codec(int8), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”large_node_id”)ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸRecordCodec(largeNodeId)ᐳ"}}:::plan
+    Lambda50 & Constant55 & Constant56 & Constant57 --> Object58
+    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”large_node_id”)ᐳ"}}:::plan
+    Lambda50 & Constant70 & Constant71 & Constant57 --> Object73
+    Object88{{"Object[88∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”large_node_id”)ᐳ"}}:::plan
+    Lambda50 & Constant85 & Constant86 & Constant57 --> Object88
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -40,45 +44,43 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     Lambda23{{"Lambda[23∈0] ➊<br />ᐸspecifier_LargeNodeId_base64JSONᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ'WyJsYXJnZV9ub2RlX2lkcyIsOTAwNzE5OTI1NDc0MDk5MF0='ᐳ"}}:::plan
-    Constant92 --> Lambda23
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ'WyJsYXJnZV9ub2RlX2lkcyIsOTAwNzE5OTI1NDc0MDk5MF0='ᐳ"}}:::plan
+    Constant95 --> Lambda23
     Lambda23 --> Access24
     First28{{"First[28∈0] ➊"}}:::plan
     PgSelect26 --> First28
     PgSelectSingle29{{"PgSelectSingle[29∈0] ➊<br />ᐸlarge_node_idᐳ"}}:::plan
     First28 --> PgSelectSingle29
     Lambda36{{"Lambda[36∈0] ➊<br />ᐸspecifier_LargeNodeId_base64JSONᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ'WyJsYXJnZV9ub2RlX2lkcyIsIjIwOTgyODg2NjkyMTg1NzE3NjAiXQ=='ᐳ"}}:::plan
-    Constant93 --> Lambda36
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ'WyJsYXJnZV9ub2RlX2lkcyIsIjIwOTgyODg2NjkyMTg1NzE3NjAiXQ=='ᐳ"}}:::plan
+    Constant96 --> Lambda36
     Lambda36 --> Access37
     First41{{"First[41∈0] ➊"}}:::plan
     PgSelect39 --> First41
     PgSelectSingle42{{"PgSelectSingle[42∈0] ➊<br />ᐸlarge_node_idᐳ"}}:::plan
     First41 --> PgSelectSingle42
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant94 --> Lambda50
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant95 --> Lambda53
-    Object71 --> Lambda72
-    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”large_ᐳ"}}:::plan
-    Constant97 --> Lambda77
-    Object85 --> Lambda86
-    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”large_ᐳ"}}:::plan
-    Constant98 --> Lambda91
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant97 --> Lambda50
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant98 --> Lambda53
+    Lambda53 --> Access54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object58 --> Lambda59
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int8), fragment:ᐳ"}}:::plan
+    Constant99 --> Lambda64
+    Object73 --> Lambda74
+    Constant100{{"Constant[100∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”large_ᐳ"}}:::plan
+    Constant100 --> Lambda79
+    Object88 --> Lambda89
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”large_ᐳ"}}:::plan
+    Constant101 --> Lambda94
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant17{{"Constant[17∈0] ➊<br />ᐸ'large_node_ids'ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[ { codec: Codec(int8), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”large_node_id”)ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int8), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸlarge_node_idᐳ"]]:::plan
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda50 & Lambda53 & Lambda58 & Lambda63 --> PgSelect14
-    Object57{{"Object[57∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda50 & Constant54 & Constant55 & Constant56 --> Object57
-    Object57 --> Lambda58
-    Constant96 --> Lambda63
+    Object12 & Connection13 & Lambda50 & Access54 & Lambda59 & Lambda64 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸlarge_node_idᐳ"}}:::plan
@@ -111,12 +113,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/large_bigint.issue491"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 54, 55, 56, 68, 69, 82, 83, 92, 93, 94, 95, 96, 97, 98, 12, 23, 24, 36, 37, 50, 53, 71, 72, 77, 85, 86, 91<br />2: PgSelect[26], PgSelect[39]<br />ᐳ: 28, 29, 41, 42"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 55, 56, 57, 70, 71, 85, 86, 95, 96, 97, 98, 99, 100, 101, 12, 23, 24, 36, 37, 50, 53, 54, 58, 59, 64, 73, 74, 79, 88, 89, 94<br />2: PgSelect[26], PgSelect[39]<br />ᐳ: 28, 29, 41, 42"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Lambda23,Access24,PgSelect26,First28,PgSelectSingle29,Lambda36,Access37,PgSelect39,First41,PgSelectSingle42,Lambda50,Lambda53,Constant54,Constant55,Constant56,Constant68,Constant69,Object71,Lambda72,Lambda77,Constant82,Constant83,Object85,Lambda86,Lambda91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97,Constant98 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 50, 53, 54, 55, 56, 96, 17<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[57], Lambda[63], Lambda[58]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Lambda23,Access24,PgSelect26,First28,PgSelectSingle29,Lambda36,Access37,PgSelect39,First41,PgSelectSingle42,Lambda50,Lambda53,Access54,Constant55,Constant56,Constant57,Object58,Lambda59,Lambda64,Constant70,Constant71,Object73,Lambda74,Lambda79,Constant85,Constant86,Object88,Lambda89,Lambda94,Constant95,Constant96,Constant97,Constant98,Constant99,Constant100,Constant101 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 50, 54, 59, 64, 17<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object57,Lambda58,Lambda63 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/longAliases.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/longAliases.mermaid
@@ -11,28 +11,28 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸ'sara.smith@email.com'ᐳ"}}:::plan
-    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸ'sara.smith@email.com'ᐳ"}}:::plan
+    Access43{{"Access[43∈0] ➊<br />ᐸ42.0ᐳ"}}:::plan
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda83{{"Lambda[83∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant89 & Lambda42 & Lambda47 & Lambda52 & Lambda42 & Lambda66 & Lambda71 & Lambda39 & Lambda42 & Lambda83 & Lambda88 --> PgSelect7
-    Object46{{"Object[46∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda39 & Constant43 & Constant44 & Constant45 --> Object46
-    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda39 & Constant62 & Constant44 & Constant45 --> Object65
-    Object82{{"Object[82∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda39 & Constant79 & Constant80 & Constant45 --> Object82
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant92 & Access43 & Lambda48 & Lambda53 & Access43 & Lambda68 & Lambda73 & Lambda39 & Access43 & Lambda86 & Lambda91 --> PgSelect7
+    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda39 & Constant44 & Constant45 & Constant46 --> Object47
+    Object67{{"Object[67∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda39 & Constant64 & Constant45 & Constant46 --> Object67
+    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda39 & Constant82 & Constant83 & Constant46 --> Object85
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -43,29 +43,33 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant90 --> Lambda39
-    Constant91{{"Constant[91∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant91 --> Lambda42
-    Object46 --> Lambda47
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant92 --> Lambda52
-    Object65 --> Lambda66
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant93 --> Lambda71
-    Object82 --> Lambda83
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant94 --> Lambda88
+    Constant93{{"Constant[93∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant93 --> Lambda39
+    Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant94 --> Lambda42
+    Lambda42 --> Access43
+    Object47 --> Lambda48
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant95 --> Lambda53
+    Object67 --> Lambda68
+    Constant96{{"Constant[96∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant96 --> Lambda73
+    Object85 --> Lambda86
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant97 --> Lambda91
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant13{{"Constant[13∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
+    Connection24{{"Connection[24∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    Connection32{{"Connection[32∈0] ➊<br />ᐸ30ᐳ"}}:::plan
     Constant37{{"Constant[37∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant40{{"Constant[40∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Object56{{"Object[56∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access54{{"Access[54∈1] ➊<br />ᐸ11.2ᐳ"}}:::plan
-    Access54 & Constant37 & Constant37 & Lambda39 & Constant40 --> Object56
-    Object73{{"Object[73∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access72{{"Access[72∈1] ➊<br />ᐸ11.3ᐳ"}}:::plan
-    Access72 & Constant37 & Constant37 & Lambda39 & Constant40 --> Object73
+    Object57{{"Object[57∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access55{{"Access[55∈1] ➊<br />ᐸ11.2ᐳ"}}:::plan
+    Access55 & Constant37 & Constant37 & Lambda39 & Constant40 --> Object57
+    Object75{{"Object[75∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access74{{"Access[74∈1] ➊<br />ᐸ11.3ᐳ"}}:::plan
+    Access74 & Constant37 & Constant37 & Lambda39 & Constant40 --> Object75
     List15{{"List[15∈1] ➊<br />ᐸ13,14ᐳ"}}:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant13 & PgClassExpression14 --> List15
@@ -75,34 +79,32 @@ graph TD
     PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression17
     First26{{"First[26∈1] ➊"}}:::plan
-    Lambda57{{"Lambda[57∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda57 --> First26
+    Lambda58{{"Lambda[58∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda58 --> First26
     PgSelectSingle27{{"PgSelectSingle[27∈1] ➊<br />ᐸperson_friendsᐳ"}}:::plan
     First26 --> PgSelectSingle27
     PgClassExpression28{{"PgClassExpression[28∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle27 --> PgClassExpression28
     First34{{"First[34∈1] ➊"}}:::plan
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda74 --> First34
+    Lambda76{{"Lambda[76∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda76 --> First34
     PgSelectSingle35{{"PgSelectSingle[35∈1] ➊<br />ᐸperson_friendsᐳ"}}:::plan
     First34 --> PgSelectSingle35
     PgClassExpression36{{"PgClassExpression[36∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
-    First11 --> Access54
-    Object56 --> Lambda57
-    First11 --> Access72
-    Object73 --> Lambda74
-    Connection24{{"Connection[24∈1] ➊<br />ᐸ20ᐳ"}}:::plan
-    Connection32{{"Connection[32∈1] ➊<br />ᐸ30ᐳ"}}:::plan
+    First11 --> Access55
+    Object57 --> Lambda58
+    First11 --> Access74
+    Object75 --> Lambda76
 
     %% define steps
 
     subgraph "Buckets for queries/v4/longAliases"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 37, 40, 43, 44, 45, 62, 79, 80, 89, 90, 91, 92, 93, 94, 10, 39, 42, 46, 47, 52, 65, 66, 71, 82, 83, 88<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 24, 32, 37, 40, 44, 45, 46, 64, 82, 83, 92, 93, 94, 95, 96, 97, 10, 39, 42, 43, 47, 48, 53, 67, 68, 73, 85, 86, 91<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Constant37,Lambda39,Constant40,Lambda42,Constant43,Constant44,Constant45,Object46,Lambda47,Lambda52,Constant62,Object65,Lambda66,Lambda71,Constant79,Constant80,Object82,Lambda83,Lambda88,Constant89,Constant90,Constant91,Constant92,Constant93,Constant94 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 11, 37, 39, 40<br /><br />ROOT PgSelectSingleᐸpersonᐳ[12]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Connection24,Connection32,Constant37,Lambda39,Constant40,Lambda42,Access43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant64,Object67,Lambda68,Lambda73,Constant82,Constant83,Object85,Lambda86,Lambda91,Constant92,Constant93,Constant94,Constant95,Constant96,Constant97 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 11, 37, 39, 40, 24, 32<br /><br />ROOT PgSelectSingleᐸpersonᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression14,List15,Lambda16,PgClassExpression17,Connection24,First26,PgSelectSingle27,PgClassExpression28,Connection32,First34,PgSelectSingle35,PgClassExpression36,Access54,Object56,Lambda57,Access72,Object73,Lambda74 bucket1
+    class Bucket1,PgClassExpression14,List15,Lambda16,PgClassExpression17,First26,PgSelectSingle27,PgClassExpression28,First34,PgSelectSingle35,PgClassExpression36,Access55,Object57,Lambda58,Access74,Object75,Lambda76 bucket1
     Bucket0 --> Bucket1
     end

--- a/postgraphile/postgraphile/__tests__/queries/v4/nested_arrays.select.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/nested_arrays.select.mermaid
@@ -9,6 +9,17 @@ graph TD
 
 
     %% plan dependencies
+    Object42{{"Object[42∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸsql.identifier(”frmcdc_work_hour”)ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0] ➊<br />ᐸDomainCodecᐸworkHourPartsᐳ(workHour)ᐳ"}}:::plan
+    Lambda34 & Constant39 & Constant40 & Constant41 --> Object42
+    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 168ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”t”)ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(t)ᐳ"}}:::plan
+    Lambda34 & Constant54 & Constant55 & Constant56 --> Object57
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,36 +27,27 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant62 --> Lambda34
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant64 --> Lambda34
     Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant63 --> Lambda37
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant65 --> Lambda37
+    Access38{{"Access[38∈0] ➊<br />ᐸ37.0ᐳ"}}:::plan
+    Lambda37 --> Access38
+    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object42 --> Lambda43
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant66 --> Lambda48
+    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object57 --> Lambda58
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant67 --> Lambda63
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant38{{"Constant[38∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant39{{"Constant[39∈0] ➊<br />ᐸsql.identifier(”frmcdc_work_hour”)ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸDomainCodecᐸworkHourPartsᐳ(workHour)ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 168ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”t”)ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(t)ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸtᐳ"]]:::plan
-    Lambda56{{"Lambda[56∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda34 & Lambda37 & Lambda56 & Lambda61 --> PgSelect14
-    Object41{{"Object[41∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda34 & Constant38 & Constant39 & Constant40 --> Object41
-    Object55{{"Object[55∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda34 & Constant52 & Constant53 & Constant54 --> Object55
-    Lambda42{{"Lambda[42∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object41 --> Lambda42
-    Lambda47{{"Lambda[47∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant64 --> Lambda47
-    Object55 --> Lambda56
-    Constant65 --> Lambda61
+    Object12 & Connection13 & Lambda34 & Access38 & Lambda58 & Lambda63 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸtᐳ"}}:::plan
@@ -56,7 +58,7 @@ graph TD
     PgSelectSingle16 --> PgClassExpression18
     PgSelect22[["PgSelect[22∈5]<br />ᐸfrmcdc_workHourᐳ"]]:::plan
     __Item21[/"__Item[21∈5]<br />ᐸ18ᐳ"\]:::itemplan
-    Object12 & __Item21 & Lambda34 & Lambda37 & Lambda42 & Lambda47 --> PgSelect22
+    Object12 & __Item21 & Lambda34 & Access38 & Lambda43 & Lambda48 --> PgSelect22
     PgClassExpression18 ==> __Item21
     __Item26[/"__Item[26∈6]<br />ᐸ22ᐳ"\]:::itemplan
     PgSelect22 ==> __Item26
@@ -76,17 +78,17 @@ graph TD
     subgraph "Buckets for queries/v4/nested_arrays.select"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda34,Lambda37,Constant38,Constant39,Constant40,Constant52,Constant53,Constant54,Constant62,Constant63,Constant64,Constant65 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 34, 37, 38, 39, 40, 64, 52, 53, 54, 65<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 41, 47, 55, 61, 42, 56<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda34,Lambda37,Access38,Constant39,Constant40,Constant41,Object42,Lambda43,Lambda48,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant64,Constant65,Constant66,Constant67 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 34, 38, 58, 63, 43, 48<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object41,Lambda42,Lambda47,Object55,Lambda56,Lambda61 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 34, 37, 42, 47<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 12, 34, 38, 43, 48<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 34, 37, 42, 47<br /><br />ROOT PgSelectSingle{2}ᐸtᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 12, 34, 38, 43, 48<br /><br />ROOT PgSelectSingle{2}ᐸtᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression17,PgClassExpression18 bucket3
-    Bucket5("Bucket 5 (listItem)<br />Deps: 12, 34, 37, 42, 47<br /><br />ROOT __Item{5}ᐸ18ᐳ[21]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 12, 34, 38, 43, 48<br /><br />ROOT __Item{5}ᐸ18ᐳ[21]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item21,PgSelect22 bucket5
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ22ᐳ[26]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/network_types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/network_types.mermaid
@@ -9,6 +9,29 @@ graph TD
 
 
     %% plan dependencies
+    Object151{{"Object[151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸRecordCodec(network)ᐳ"}}:::plan
+    Lambda143 & Constant148 & Constant149 & Constant150 --> Object151
+    Object167{{"Object[167∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda143 & Constant164 & Constant149 & Constant150 --> Object167
+    Object182{{"Object[182∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Lambda143 & Constant179 & Constant180 & Constant150 --> Object182
+    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda143 & Constant194 & Constant180 & Constant150 --> Object197
+    Object212{{"Object[212∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Lambda143 & Constant209 & Constant210 & Constant150 --> Object212
+    Object227{{"Object[227∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda143 & Constant224 & Constant210 & Constant150 --> Object227
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,54 +39,63 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant231{{"Constant[231∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant231 --> Lambda143
+    Constant237{{"Constant[237∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant237 --> Lambda143
     Lambda146{{"Lambda[146∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant232{{"Constant[232∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant232 --> Lambda146
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant233{{"Constant[233∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant233 --> Lambda161
+    Constant238{{"Constant[238∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant238 --> Lambda146
+    Access147{{"Access[147∈0] ➊<br />ᐸ146.0ᐳ"}}:::plan
+    Lambda146 --> Access147
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object151 --> Lambda152
+    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant240 --> Lambda158
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant239 --> Lambda162
+    Access163{{"Access[163∈0] ➊<br />ᐸ162.0ᐳ"}}:::plan
+    Lambda162 --> Access163
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object167 --> Lambda168
+    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant241{{"Constant[241∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant241 --> Lambda173
+    Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object182 --> Lambda183
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant242 --> Lambda188
+    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object197 --> Lambda198
+    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant243 --> Lambda203
+    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object212 --> Lambda213
+    Lambda218{{"Lambda[218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant244 --> Lambda218
+    Lambda228{{"Lambda[228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object227 --> Lambda228
+    Lambda233{{"Lambda[233∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant245{{"Constant[245∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant245 --> Lambda233
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
     Connection59{{"Connection[59∈0] ➊<br />ᐸ57ᐳ"}}:::plan
     Connection103{{"Connection[103∈0] ➊<br />ᐸ101ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸRecordCodec(network)ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant205{{"Constant[205∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸ'192.168.0.0'ᐳ"}}:::plan
-    Constant229{{"Constant[229∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
-    Constant230{{"Constant[230∈0] ➊<br />ᐸ'08:00:2b:01:02:03'ᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant235{{"Constant[235∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
-    Constant236{{"Constant[236∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant237{{"Constant[237∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
-    Constant238{{"Constant[238∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant239{{"Constant[239∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant234{{"Constant[234∈0] ➊<br />ᐸ'192.168.0.0'ᐳ"}}:::plan
+    Constant235{{"Constant[235∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
+    Constant236{{"Constant[236∈0] ➊<br />ᐸ'08:00:2b:01:02:03'ᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda151{{"Lambda[151∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda157{{"Lambda[157∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant228 & Connection15 & Lambda143 & Lambda146 & Lambda151 & Lambda157 --> PgSelect16
+    Object14 & Constant234 & Connection15 & Lambda143 & Access147 & Lambda152 & Lambda158 --> PgSelect16
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda166{{"Lambda[166∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda171{{"Lambda[171∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant228 & Connection15 & Lambda143 & Lambda161 & Lambda166 & Lambda171 --> PgSelect39
+    Object14 & Constant234 & Connection15 & Lambda143 & Access163 & Lambda168 & Lambda173 --> PgSelect39
     Object37{{"Object[37∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access32{{"Access[32∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access32 --> Object37
-    Object150{{"Object[150∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda143 & Constant147 & Constant148 & Constant149 --> Object150
-    Object165{{"Object[165∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda143 & Constant162 & Constant148 & Constant149 --> Object165
     Object33{{"Object[33∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access32 --> Object33
     PgPageInfo17{{"PgPageInfo[17∈1] ➊"}}:::plan
@@ -99,10 +131,6 @@ graph TD
     First40 --> PgSelectSingle41
     PgClassExpression42{{"PgClassExpression[42∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression42
-    Object150 --> Lambda151
-    Constant234 --> Lambda157
-    Object165 --> Lambda166
-    Constant235 --> Lambda171
     __Item44[/"__Item[44∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item44
     PgSelectSingle45{{"PgSelectSingle[45∈2]<br />ᐸnetworkᐳ"}}:::plan
@@ -120,20 +148,12 @@ graph TD
     PgClassExpression52{{"PgClassExpression[52∈3]<br />ᐸ__network__.”macaddr”ᐳ"}}:::plan
     PgSelectSingle45 --> PgClassExpression52
     PgSelect60[["PgSelect[60∈4] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda180{{"Lambda[180∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda185{{"Lambda[185∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant229 & Connection59 & Lambda143 & Lambda146 & Lambda180 & Lambda185 --> PgSelect60
+    Object14 & Constant235 & Connection59 & Lambda143 & Access147 & Lambda183 & Lambda188 --> PgSelect60
     PgSelect83[["PgSelect[83∈4] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda194{{"Lambda[194∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda199{{"Lambda[199∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant229 & Connection59 & Lambda143 & Lambda161 & Lambda194 & Lambda199 --> PgSelect83
+    Object14 & Constant235 & Connection59 & Lambda143 & Access163 & Lambda198 & Lambda203 --> PgSelect83
     Object81{{"Object[81∈4] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access76{{"Access[76∈4] ➊<br />ᐸ60.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access76 --> Object81
-    Object179{{"Object[179∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda143 & Constant176 & Constant177 & Constant149 --> Object179
-    Object193{{"Object[193∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda143 & Constant190 & Constant177 & Constant149 --> Object193
     Object77{{"Object[77∈4] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access76 --> Object77
     PgPageInfo61{{"PgPageInfo[61∈4] ➊"}}:::plan
@@ -169,10 +189,6 @@ graph TD
     First84 --> PgSelectSingle85
     PgClassExpression86{{"PgClassExpression[86∈4] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle85 --> PgClassExpression86
-    Object179 --> Lambda180
-    Constant236 --> Lambda185
-    Object193 --> Lambda194
-    Constant237 --> Lambda199
     __Item88[/"__Item[88∈5]<br />ᐸ60ᐳ"\]:::itemplan
     PgSelect60 ==> __Item88
     PgSelectSingle89{{"PgSelectSingle[89∈5]<br />ᐸnetworkᐳ"}}:::plan
@@ -190,20 +206,12 @@ graph TD
     PgClassExpression96{{"PgClassExpression[96∈6]<br />ᐸ__network__.”macaddr”ᐳ"}}:::plan
     PgSelectSingle89 --> PgClassExpression96
     PgSelect104[["PgSelect[104∈7] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda208{{"Lambda[208∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda213{{"Lambda[213∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant230 & Connection103 & Lambda143 & Lambda146 & Lambda208 & Lambda213 --> PgSelect104
+    Object14 & Constant236 & Connection103 & Lambda143 & Access147 & Lambda213 & Lambda218 --> PgSelect104
     PgSelect127[["PgSelect[127∈7] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda222{{"Lambda[222∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda227{{"Lambda[227∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant230 & Connection103 & Lambda143 & Lambda161 & Lambda222 & Lambda227 --> PgSelect127
+    Object14 & Constant236 & Connection103 & Lambda143 & Access163 & Lambda228 & Lambda233 --> PgSelect127
     Object125{{"Object[125∈7] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access120{{"Access[120∈7] ➊<br />ᐸ104.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access120 --> Object125
-    Object207{{"Object[207∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda143 & Constant204 & Constant205 & Constant149 --> Object207
-    Object221{{"Object[221∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda143 & Constant218 & Constant205 & Constant149 --> Object221
     Object121{{"Object[121∈7] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access120 --> Object121
     PgPageInfo105{{"PgPageInfo[105∈7] ➊"}}:::plan
@@ -239,10 +247,6 @@ graph TD
     First128 --> PgSelectSingle129
     PgClassExpression130{{"PgClassExpression[130∈7] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle129 --> PgClassExpression130
-    Object207 --> Lambda208
-    Constant238 --> Lambda213
-    Object221 --> Lambda222
-    Constant239 --> Lambda227
     __Item132[/"__Item[132∈8]<br />ᐸ104ᐳ"\]:::itemplan
     PgSelect104 ==> __Item132
     PgSelectSingle133{{"PgSelectSingle[133∈8]<br />ᐸnetworkᐳ"}}:::plan
@@ -265,28 +269,28 @@ graph TD
     subgraph "Buckets for queries/v4/network_types"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access12,Access13,Object14,Connection15,Connection59,Connection103,Lambda143,Lambda146,Constant147,Constant148,Constant149,Lambda161,Constant162,Constant176,Constant177,Constant190,Constant204,Constant205,Constant218,Constant228,Constant229,Constant230,Constant231,Constant232,Constant233,Constant234,Constant235,Constant236,Constant237,Constant238,Constant239 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 228, 15, 143, 146, 6, 161, 147, 148, 149, 234, 162, 235<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 17, 150, 157, 165, 171, 151, 166<br />2: PgSelect[16], PgSelect[39]<br />ᐳ: 19, 20, 22, 23, 25, 26, 28, 29, 32, 33, 34, 37, 38, 40, 41, 42, 21, 27"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access12,Access13,Object14,Connection15,Connection59,Connection103,Lambda143,Lambda146,Access147,Constant148,Constant149,Constant150,Object151,Lambda152,Lambda158,Lambda162,Access163,Constant164,Object167,Lambda168,Lambda173,Constant179,Constant180,Object182,Lambda183,Lambda188,Constant194,Object197,Lambda198,Lambda203,Constant209,Constant210,Object212,Lambda213,Lambda218,Constant224,Object227,Lambda228,Lambda233,Constant234,Constant235,Constant236,Constant237,Constant238,Constant239,Constant240,Constant241,Constant242,Constant243,Constant244,Constant245 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 234, 15, 143, 147, 152, 158, 6, 163, 168, 173<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,PgPageInfo17,First19,PgSelectSingle20,PgCursor21,PgClassExpression22,List23,Last25,PgSelectSingle26,PgCursor27,PgClassExpression28,List29,Access32,Object33,Lambda34,Object37,Lambda38,PgSelect39,First40,PgSelectSingle41,PgClassExpression42,Object150,Lambda151,Lambda157,Object165,Lambda166,Lambda171 bucket1
+    class Bucket1,PgSelect16,PgPageInfo17,First19,PgSelectSingle20,PgCursor21,PgClassExpression22,List23,Last25,PgSelectSingle26,PgCursor27,PgClassExpression28,List29,Access32,Object33,Lambda34,Object37,Lambda38,PgSelect39,First40,PgSelectSingle41,PgClassExpression42 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[44]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item44,PgSelectSingle45 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{2}ᐸnetworkᐳ[45]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor46,PgClassExpression47,List48,PgClassExpression50,PgClassExpression51,PgClassExpression52 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 229, 59, 143, 146, 6, 161, 176, 177, 149, 236, 190, 237<br /><br />ROOT Connectionᐸ57ᐳ[59]<br />1: <br />ᐳ: 61, 179, 185, 193, 199, 180, 194<br />2: PgSelect[60], PgSelect[83]<br />ᐳ: 63, 64, 66, 67, 69, 70, 72, 73, 76, 77, 78, 81, 82, 84, 85, 86, 65, 71"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 235, 59, 143, 147, 183, 188, 6, 163, 198, 203<br /><br />ROOT Connectionᐸ57ᐳ[59]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect60,PgPageInfo61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,Access76,Object77,Lambda78,Object81,Lambda82,PgSelect83,First84,PgSelectSingle85,PgClassExpression86,Object179,Lambda180,Lambda185,Object193,Lambda194,Lambda199 bucket4
+    class Bucket4,PgSelect60,PgPageInfo61,First63,PgSelectSingle64,PgCursor65,PgClassExpression66,List67,Last69,PgSelectSingle70,PgCursor71,PgClassExpression72,List73,Access76,Object77,Lambda78,Object81,Lambda82,PgSelect83,First84,PgSelectSingle85,PgClassExpression86 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ60ᐳ[88]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item88,PgSelectSingle89 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 89<br /><br />ROOT PgSelectSingle{5}ᐸnetworkᐳ[89]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgCursor90,PgClassExpression91,List92,PgClassExpression94,PgClassExpression95,PgClassExpression96 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 14, 230, 103, 143, 146, 6, 161, 204, 205, 149, 238, 218, 239<br /><br />ROOT Connectionᐸ101ᐳ[103]<br />1: <br />ᐳ: 105, 207, 213, 221, 227, 208, 222<br />2: PgSelect[104], PgSelect[127]<br />ᐳ: 107, 108, 110, 111, 113, 114, 116, 117, 120, 121, 122, 125, 126, 128, 129, 130, 109, 115"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 14, 236, 103, 143, 147, 213, 218, 6, 163, 228, 233<br /><br />ROOT Connectionᐸ101ᐳ[103]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelect104,PgPageInfo105,First107,PgSelectSingle108,PgCursor109,PgClassExpression110,List111,Last113,PgSelectSingle114,PgCursor115,PgClassExpression116,List117,Access120,Object121,Lambda122,Object125,Lambda126,PgSelect127,First128,PgSelectSingle129,PgClassExpression130,Object207,Lambda208,Lambda213,Object221,Lambda222,Lambda227 bucket7
+    class Bucket7,PgSelect104,PgPageInfo105,First107,PgSelectSingle108,PgCursor109,PgClassExpression110,List111,Last113,PgSelectSingle114,PgCursor115,PgClassExpression116,List117,Access120,Object121,Lambda122,Object125,Lambda126,PgSelect127,First128,PgSelectSingle129,PgClassExpression130 bucket7
     Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ104ᐳ[132]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item132,PgSelectSingle133 bucket8

--- a/postgraphile/postgraphile/__tests__/queries/v4/node.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/node.mermaid
@@ -14,717 +14,725 @@ graph TD
     Access1222{{"Access[1222∈0] ➊<br />ᐸ1221.1ᐳ"}}:::plan
     Access1224{{"Access[1224∈0] ➊<br />ᐸ1221.2ᐳ"}}:::plan
     Lambda1679{{"Lambda[1679∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1682{{"Lambda[1682∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda3353{{"Lambda[3353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3358{{"Lambda[3358∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access1683{{"Access[1683∈0] ➊<br />ᐸ1682.0ᐳ"}}:::plan
+    Lambda3473{{"Lambda[3473∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3478{{"Lambda[3478∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1226
     Access1222 -->|rejectNull| PgSelect1226
-    Access1224 & Lambda1679 & Lambda1682 & Lambda3353 & Lambda3358 --> PgSelect1226
+    Access1224 & Lambda1679 & Access1683 & Lambda3473 & Lambda3478 --> PgSelect1226
     PgSelect1241[["PgSelect[1241∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
     Access1237{{"Access[1237∈0] ➊<br />ᐸ1236.1ᐳ"}}:::plan
     Access1239{{"Access[1239∈0] ➊<br />ᐸ1236.2ᐳ"}}:::plan
-    Lambda3367{{"Lambda[3367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3372{{"Lambda[3372∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3488{{"Lambda[3488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3493{{"Lambda[3493∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1241
     Access1237 -->|rejectNull| PgSelect1241
-    Access1239 & Lambda1679 & Lambda1682 & Lambda3367 & Lambda3372 --> PgSelect1241
+    Access1239 & Lambda1679 & Access1683 & Lambda3488 & Lambda3493 --> PgSelect1241
     PgSelect1256[["PgSelect[1256∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
     Access1252{{"Access[1252∈0] ➊<br />ᐸ1251.1ᐳ"}}:::plan
     Access1254{{"Access[1254∈0] ➊<br />ᐸ1251.2ᐳ"}}:::plan
-    Lambda3381{{"Lambda[3381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3386{{"Lambda[3386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3503{{"Lambda[3503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3508{{"Lambda[3508∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1256
     Access1252 -->|rejectNull| PgSelect1256
-    Access1254 & Lambda1679 & Lambda1682 & Lambda3381 & Lambda3386 --> PgSelect1256
+    Access1254 & Lambda1679 & Access1683 & Lambda3503 & Lambda3508 --> PgSelect1256
     PgSelect1185[["PgSelect[1185∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Access1183{{"Access[1183∈0] ➊<br />ᐸ1182.1ᐳ"}}:::plan
-    Lambda3311{{"Lambda[3311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3316{{"Lambda[3316∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3428{{"Lambda[3428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3433{{"Lambda[3433∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1185
-    Access1183 & Lambda1679 & Lambda1682 & Lambda3311 & Lambda3316 --> PgSelect1185
+    Access1183 & Lambda1679 & Access1683 & Lambda3428 & Lambda3433 --> PgSelect1185
     PgSelect1198[["PgSelect[1198∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Access1196{{"Access[1196∈0] ➊<br />ᐸ1195.1ᐳ"}}:::plan
-    Lambda3325{{"Lambda[3325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3330{{"Lambda[3330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3443{{"Lambda[3443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3448{{"Lambda[3448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1198
-    Access1196 & Lambda1679 & Lambda1682 & Lambda3325 & Lambda3330 --> PgSelect1198
+    Access1196 & Lambda1679 & Access1683 & Lambda3443 & Lambda3448 --> PgSelect1198
     PgSelect1211[["PgSelect[1211∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Access1209{{"Access[1209∈0] ➊<br />ᐸ1208.1ᐳ"}}:::plan
-    Lambda3339{{"Lambda[3339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3344{{"Lambda[3344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3458{{"Lambda[3458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3463{{"Lambda[3463∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1211
-    Access1209 & Lambda1679 & Lambda1682 & Lambda3339 & Lambda3344 --> PgSelect1211
+    Access1209 & Lambda1679 & Access1683 & Lambda3458 & Lambda3463 --> PgSelect1211
     PgSelect1651[["PgSelect[1651∈0] ➊<br />ᐸsimilar_table_1ᐳ"]]:::plan
     Access1649{{"Access[1649∈0] ➊<br />ᐸ1648.1ᐳ"}}:::plan
-    Lambda3927{{"Lambda[3927∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3932{{"Lambda[3932∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4088{{"Lambda[4088∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4093{{"Lambda[4093∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1651
-    Access1649 & Lambda1679 & Lambda1682 & Lambda3927 & Lambda3932 --> PgSelect1651
+    Access1649 & Lambda1679 & Access1683 & Lambda4088 & Lambda4093 --> PgSelect1651
     PgSelect1666[["PgSelect[1666∈0] ➊<br />ᐸsimilar_table_2ᐳ"]]:::plan
     Access1664{{"Access[1664∈0] ➊<br />ᐸ1663.1ᐳ"}}:::plan
-    Lambda3941{{"Lambda[3941∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3946{{"Lambda[3946∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4103{{"Lambda[4103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4108{{"Lambda[4108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect1666
-    Access1664 & Lambda1679 & Lambda1682 & Lambda3941 & Lambda3946 --> PgSelect1666
-    Object1714{{"Object[1714∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1711{{"Constant[1711∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1712{{"Constant[1712∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Constant1713{{"Constant[1713∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
-    Lambda1679 & Constant1711 & Constant1712 & Constant1713 --> Object1714
-    Object1728{{"Object[1728∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1725{{"Constant[1725∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1726{{"Constant[1726∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Constant1727{{"Constant[1727∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
-    Lambda1679 & Constant1725 & Constant1726 & Constant1727 --> Object1728
-    Object1742{{"Object[1742∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1739{{"Constant[1739∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1740{{"Constant[1740∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Constant1741{{"Constant[1741∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
-    Lambda1679 & Constant1739 & Constant1740 & Constant1741 --> Object1742
-    Object1756{{"Object[1756∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1753{{"Constant[1753∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1754{{"Constant[1754∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Constant1755{{"Constant[1755∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
-    Lambda1679 & Constant1753 & Constant1754 & Constant1755 --> Object1756
-    Object1770{{"Object[1770∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1767{{"Constant[1767∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1768{{"Constant[1768∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Constant1769{{"Constant[1769∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
-    Lambda1679 & Constant1767 & Constant1768 & Constant1769 --> Object1770
-    Object1784{{"Object[1784∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1781{{"Constant[1781∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1782{{"Constant[1782∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Constant1783{{"Constant[1783∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
-    Lambda1679 & Constant1781 & Constant1782 & Constant1783 --> Object1784
-    Object1798{{"Object[1798∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1795{{"Constant[1795∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1796{{"Constant[1796∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant1699{{"Constant[1699∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda1679 & Constant1795 & Constant1796 & Constant1699 --> Object1798
-    Object1812{{"Object[1812∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1809{{"Constant[1809∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1810{{"Constant[1810∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1685{{"Constant[1685∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda1679 & Constant1809 & Constant1810 & Constant1685 --> Object1812
-    Object1826{{"Object[1826∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1823{{"Constant[1823∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1824{{"Constant[1824∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant1825{{"Constant[1825∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda1679 & Constant1823 & Constant1824 & Constant1825 --> Object1826
-    Object1840{{"Object[1840∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1837{{"Constant[1837∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1838{{"Constant[1838∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant1839{{"Constant[1839∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Lambda1679 & Constant1837 & Constant1838 & Constant1839 --> Object1840
-    Object1854{{"Object[1854∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1851{{"Constant[1851∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1852{{"Constant[1852∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant1853{{"Constant[1853∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Lambda1679 & Constant1851 & Constant1852 & Constant1853 --> Object1854
-    Object1868{{"Object[1868∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1865{{"Constant[1865∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1866{{"Constant[1866∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant1867{{"Constant[1867∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda1679 & Constant1865 & Constant1866 & Constant1867 --> Object1868
+    Access1664 & Lambda1679 & Access1683 & Lambda4103 & Lambda4108 --> PgSelect1666
+    Object1687{{"Object[1687∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1684{{"Constant[1684∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant1685{{"Constant[1685∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant1686{{"Constant[1686∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda1679 & Constant1684 & Constant1685 & Constant1686 --> Object1687
+    Object1702{{"Object[1702∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1699{{"Constant[1699∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant1700{{"Constant[1700∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant1701{{"Constant[1701∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda1679 & Constant1699 & Constant1700 & Constant1701 --> Object1702
+    Object1717{{"Object[1717∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1714{{"Constant[1714∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1715{{"Constant[1715∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Constant1716{{"Constant[1716∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
+    Lambda1679 & Constant1714 & Constant1715 & Constant1716 --> Object1717
+    Object1732{{"Object[1732∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1729{{"Constant[1729∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1730{{"Constant[1730∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Constant1731{{"Constant[1731∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
+    Lambda1679 & Constant1729 & Constant1730 & Constant1731 --> Object1732
+    Object1747{{"Object[1747∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1744{{"Constant[1744∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1745{{"Constant[1745∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Constant1746{{"Constant[1746∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
+    Lambda1679 & Constant1744 & Constant1745 & Constant1746 --> Object1747
+    Object1762{{"Object[1762∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1759{{"Constant[1759∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1760{{"Constant[1760∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Constant1761{{"Constant[1761∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
+    Lambda1679 & Constant1759 & Constant1760 & Constant1761 --> Object1762
+    Object1777{{"Object[1777∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1774{{"Constant[1774∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1775{{"Constant[1775∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Constant1776{{"Constant[1776∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
+    Lambda1679 & Constant1774 & Constant1775 & Constant1776 --> Object1777
+    Object1792{{"Object[1792∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1789{{"Constant[1789∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1790{{"Constant[1790∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Constant1791{{"Constant[1791∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
+    Lambda1679 & Constant1789 & Constant1790 & Constant1791 --> Object1792
+    Object1807{{"Object[1807∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1804{{"Constant[1804∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1805{{"Constant[1805∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant1804 & Constant1805 & Constant1701 --> Object1807
+    Object1822{{"Object[1822∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1819{{"Constant[1819∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1820{{"Constant[1820∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant1819 & Constant1820 & Constant1686 --> Object1822
+    Object1837{{"Object[1837∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1834{{"Constant[1834∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1835{{"Constant[1835∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant1836{{"Constant[1836∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda1679 & Constant1834 & Constant1835 & Constant1836 --> Object1837
+    Object1852{{"Object[1852∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1849{{"Constant[1849∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1850{{"Constant[1850∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant1851{{"Constant[1851∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda1679 & Constant1849 & Constant1850 & Constant1851 --> Object1852
+    Object1867{{"Object[1867∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1864{{"Constant[1864∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1865{{"Constant[1865∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant1866{{"Constant[1866∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda1679 & Constant1864 & Constant1865 & Constant1866 --> Object1867
     Object1882{{"Object[1882∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1879{{"Constant[1879∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1880{{"Constant[1880∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant1881{{"Constant[1881∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
+    Constant1880{{"Constant[1880∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant1881{{"Constant[1881∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
     Lambda1679 & Constant1879 & Constant1880 & Constant1881 --> Object1882
-    Object1896{{"Object[1896∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1893{{"Constant[1893∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1894{{"Constant[1894∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Constant1895{{"Constant[1895∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
-    Lambda1679 & Constant1893 & Constant1894 & Constant1895 --> Object1896
-    Object1910{{"Object[1910∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1907{{"Constant[1907∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1908{{"Constant[1908∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Constant1909{{"Constant[1909∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
-    Lambda1679 & Constant1907 & Constant1908 & Constant1909 --> Object1910
-    Object1924{{"Object[1924∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1921{{"Constant[1921∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1922{{"Constant[1922∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Constant1923{{"Constant[1923∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
-    Lambda1679 & Constant1921 & Constant1922 & Constant1923 --> Object1924
-    Object1938{{"Object[1938∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1935{{"Constant[1935∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1936{{"Constant[1936∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Constant1937{{"Constant[1937∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
-    Lambda1679 & Constant1935 & Constant1936 & Constant1937 --> Object1938
-    Object1952{{"Object[1952∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1949{{"Constant[1949∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1950{{"Constant[1950∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Constant1951{{"Constant[1951∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
-    Lambda1679 & Constant1949 & Constant1950 & Constant1951 --> Object1952
-    Object1966{{"Object[1966∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1963{{"Constant[1963∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1964{{"Constant[1964∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Constant1965{{"Constant[1965∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
-    Lambda1679 & Constant1963 & Constant1964 & Constant1965 --> Object1966
-    Object1980{{"Object[1980∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1977{{"Constant[1977∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1978{{"Constant[1978∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant1977 & Constant1978 & Constant1713 --> Object1980
-    Object1994{{"Object[1994∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1991{{"Constant[1991∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1992{{"Constant[1992∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant1991 & Constant1992 & Constant1727 --> Object1994
-    Object2008{{"Object[2008∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2005{{"Constant[2005∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2006{{"Constant[2006∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant2005 & Constant2006 & Constant1741 --> Object2008
-    Object2022{{"Object[2022∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2019{{"Constant[2019∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2020{{"Constant[2020∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2019 & Constant2020 & Constant1755 --> Object2022
-    Object2036{{"Object[2036∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2033{{"Constant[2033∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2034{{"Constant[2034∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant2033 & Constant2034 & Constant1769 --> Object2036
-    Object2050{{"Object[2050∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2047{{"Constant[2047∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2048{{"Constant[2048∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant2047 & Constant2048 & Constant1783 --> Object2050
-    Object2064{{"Object[2064∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2061{{"Constant[2061∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2062{{"Constant[2062∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant2061 & Constant2062 & Constant1699 --> Object2064
-    Object2078{{"Object[2078∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2075{{"Constant[2075∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2076{{"Constant[2076∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant2075 & Constant2076 & Constant1685 --> Object2078
+    Object1897{{"Object[1897∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1894{{"Constant[1894∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1895{{"Constant[1895∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Constant1896{{"Constant[1896∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
+    Lambda1679 & Constant1894 & Constant1895 & Constant1896 --> Object1897
+    Object1912{{"Object[1912∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1909{{"Constant[1909∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1910{{"Constant[1910∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Constant1911{{"Constant[1911∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
+    Lambda1679 & Constant1909 & Constant1910 & Constant1911 --> Object1912
+    Object1927{{"Object[1927∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1924{{"Constant[1924∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1925{{"Constant[1925∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Constant1926{{"Constant[1926∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Lambda1679 & Constant1924 & Constant1925 & Constant1926 --> Object1927
+    Object1942{{"Object[1942∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1939{{"Constant[1939∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1940{{"Constant[1940∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Constant1941{{"Constant[1941∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
+    Lambda1679 & Constant1939 & Constant1940 & Constant1941 --> Object1942
+    Object1957{{"Object[1957∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1954{{"Constant[1954∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1955{{"Constant[1955∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Constant1956{{"Constant[1956∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
+    Lambda1679 & Constant1954 & Constant1955 & Constant1956 --> Object1957
+    Object1972{{"Object[1972∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1969{{"Constant[1969∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1970{{"Constant[1970∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Constant1971{{"Constant[1971∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
+    Lambda1679 & Constant1969 & Constant1970 & Constant1971 --> Object1972
+    Object1987{{"Object[1987∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1984{{"Constant[1984∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1985{{"Constant[1985∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Constant1986{{"Constant[1986∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
+    Lambda1679 & Constant1984 & Constant1985 & Constant1986 --> Object1987
+    Object2002{{"Object[2002∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1999{{"Constant[1999∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2000{{"Constant[2000∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant1999 & Constant2000 & Constant1716 --> Object2002
+    Object2017{{"Object[2017∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2014{{"Constant[2014∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2015{{"Constant[2015∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2014 & Constant2015 & Constant1731 --> Object2017
+    Object2032{{"Object[2032∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2029{{"Constant[2029∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2030{{"Constant[2030∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant2029 & Constant2030 & Constant1746 --> Object2032
+    Object2047{{"Object[2047∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2044{{"Constant[2044∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2045{{"Constant[2045∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2044 & Constant2045 & Constant1761 --> Object2047
+    Object2062{{"Object[2062∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2059{{"Constant[2059∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2060{{"Constant[2060∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant2059 & Constant2060 & Constant1776 --> Object2062
+    Object2077{{"Object[2077∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2074{{"Constant[2074∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2075{{"Constant[2075∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant2074 & Constant2075 & Constant1791 --> Object2077
     Object2092{{"Object[2092∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2089{{"Constant[2089∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2090{{"Constant[2090∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant2089 & Constant2090 & Constant1825 --> Object2092
-    Object2106{{"Object[2106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2103{{"Constant[2103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2104{{"Constant[2104∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant2103 & Constant2104 & Constant1839 --> Object2106
-    Object2120{{"Object[2120∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2117{{"Constant[2117∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2118{{"Constant[2118∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant2117 & Constant2118 & Constant1853 --> Object2120
-    Object2134{{"Object[2134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2131{{"Constant[2131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2132{{"Constant[2132∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant2131 & Constant2132 & Constant1867 --> Object2134
-    Object2148{{"Object[2148∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2145{{"Constant[2145∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2146{{"Constant[2146∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2145 & Constant2146 & Constant1881 --> Object2148
-    Object2162{{"Object[2162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2159{{"Constant[2159∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2160{{"Constant[2160∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2159 & Constant2160 & Constant1895 --> Object2162
-    Object2176{{"Object[2176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2173{{"Constant[2173∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2174{{"Constant[2174∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant2173 & Constant2174 & Constant1909 --> Object2176
-    Object2190{{"Object[2190∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2187{{"Constant[2187∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2188{{"Constant[2188∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant2187 & Constant2188 & Constant1923 --> Object2190
-    Object2204{{"Object[2204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2201{{"Constant[2201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2202{{"Constant[2202∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant2201 & Constant2202 & Constant1937 --> Object2204
-    Object2218{{"Object[2218∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2215{{"Constant[2215∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2216{{"Constant[2216∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant2215 & Constant2216 & Constant1951 --> Object2218
-    Object2232{{"Object[2232∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2229{{"Constant[2229∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2230{{"Constant[2230∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant2229 & Constant2230 & Constant1965 --> Object2232
-    Object2246{{"Object[2246∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2243{{"Constant[2243∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2244{{"Constant[2244∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2243 & Constant2244 & Constant1713 --> Object2246
-    Object2260{{"Object[2260∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2257{{"Constant[2257∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2258{{"Constant[2258∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2257 & Constant2258 & Constant1727 --> Object2260
-    Object2274{{"Object[2274∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2271{{"Constant[2271∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2272{{"Constant[2272∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant2271 & Constant2272 & Constant1741 --> Object2274
-    Object2288{{"Object[2288∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2285{{"Constant[2285∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2286{{"Constant[2286∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2285 & Constant2286 & Constant1755 --> Object2288
+    Constant2090{{"Constant[2090∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant2089 & Constant2090 & Constant1701 --> Object2092
+    Object2107{{"Object[2107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2104{{"Constant[2104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2105{{"Constant[2105∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant2104 & Constant2105 & Constant1686 --> Object2107
+    Object2122{{"Object[2122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2119{{"Constant[2119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2120{{"Constant[2120∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant2119 & Constant2120 & Constant1836 --> Object2122
+    Object2137{{"Object[2137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2134{{"Constant[2134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2135{{"Constant[2135∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant2134 & Constant2135 & Constant1851 --> Object2137
+    Object2152{{"Object[2152∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2149{{"Constant[2149∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2150{{"Constant[2150∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant2149 & Constant2150 & Constant1866 --> Object2152
+    Object2167{{"Object[2167∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2164{{"Constant[2164∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2165{{"Constant[2165∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant2164 & Constant2165 & Constant1881 --> Object2167
+    Object2182{{"Object[2182∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2179{{"Constant[2179∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2180{{"Constant[2180∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant2179 & Constant2180 & Constant1896 --> Object2182
+    Object2197{{"Object[2197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2194{{"Constant[2194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2195{{"Constant[2195∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant2194 & Constant2195 & Constant1911 --> Object2197
+    Object2212{{"Object[2212∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2209{{"Constant[2209∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2210{{"Constant[2210∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant2209 & Constant2210 & Constant1926 --> Object2212
+    Object2227{{"Object[2227∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2224{{"Constant[2224∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2225{{"Constant[2225∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant2224 & Constant2225 & Constant1941 --> Object2227
+    Object2242{{"Object[2242∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2239{{"Constant[2239∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2240{{"Constant[2240∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant2239 & Constant2240 & Constant1956 --> Object2242
+    Object2257{{"Object[2257∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2254{{"Constant[2254∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2255{{"Constant[2255∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant2254 & Constant2255 & Constant1971 --> Object2257
+    Object2272{{"Object[2272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2269{{"Constant[2269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2270{{"Constant[2270∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant2269 & Constant2270 & Constant1986 --> Object2272
+    Object2287{{"Object[2287∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2284{{"Constant[2284∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2285{{"Constant[2285∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2284 & Constant2285 & Constant1716 --> Object2287
     Object2302{{"Object[2302∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2299{{"Constant[2299∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2300{{"Constant[2300∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant2299 & Constant2300 & Constant1769 --> Object2302
-    Object2316{{"Object[2316∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2313{{"Constant[2313∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2314{{"Constant[2314∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant2313 & Constant2314 & Constant1783 --> Object2316
-    Object2330{{"Object[2330∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2327{{"Constant[2327∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2328{{"Constant[2328∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant2327 & Constant2328 & Constant1699 --> Object2330
-    Object2344{{"Object[2344∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2341{{"Constant[2341∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2342{{"Constant[2342∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant2341 & Constant2342 & Constant1685 --> Object2344
-    Object2358{{"Object[2358∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2355{{"Constant[2355∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2356{{"Constant[2356∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant2355 & Constant2356 & Constant1825 --> Object2358
-    Object2372{{"Object[2372∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2369{{"Constant[2369∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2370{{"Constant[2370∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant2369 & Constant2370 & Constant1839 --> Object2372
-    Object2386{{"Object[2386∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2383{{"Constant[2383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2384{{"Constant[2384∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant2383 & Constant2384 & Constant1853 --> Object2386
-    Object2400{{"Object[2400∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2397{{"Constant[2397∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2398{{"Constant[2398∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant2397 & Constant2398 & Constant1867 --> Object2400
-    Object2414{{"Object[2414∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2411{{"Constant[2411∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2412{{"Constant[2412∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2411 & Constant2412 & Constant1881 --> Object2414
-    Object2428{{"Object[2428∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2425{{"Constant[2425∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2426{{"Constant[2426∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2425 & Constant2426 & Constant1895 --> Object2428
-    Object2442{{"Object[2442∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2439{{"Constant[2439∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2440{{"Constant[2440∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant2439 & Constant2440 & Constant1909 --> Object2442
-    Object2456{{"Object[2456∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2453{{"Constant[2453∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2454{{"Constant[2454∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant2453 & Constant2454 & Constant1923 --> Object2456
-    Object2470{{"Object[2470∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2467{{"Constant[2467∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2468{{"Constant[2468∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant2467 & Constant2468 & Constant1937 --> Object2470
-    Object2484{{"Object[2484∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2481{{"Constant[2481∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2482{{"Constant[2482∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant2481 & Constant2482 & Constant1951 --> Object2484
-    Object2498{{"Object[2498∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2495{{"Constant[2495∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2496{{"Constant[2496∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant2495 & Constant2496 & Constant1965 --> Object2498
+    Constant2300{{"Constant[2300∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2299 & Constant2300 & Constant1731 --> Object2302
+    Object2317{{"Object[2317∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2314{{"Constant[2314∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2315{{"Constant[2315∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant2314 & Constant2315 & Constant1746 --> Object2317
+    Object2332{{"Object[2332∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2329{{"Constant[2329∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2330{{"Constant[2330∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2329 & Constant2330 & Constant1761 --> Object2332
+    Object2347{{"Object[2347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2344{{"Constant[2344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2345{{"Constant[2345∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant2344 & Constant2345 & Constant1776 --> Object2347
+    Object2362{{"Object[2362∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2359{{"Constant[2359∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2360{{"Constant[2360∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant2359 & Constant2360 & Constant1791 --> Object2362
+    Object2377{{"Object[2377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2374{{"Constant[2374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2375{{"Constant[2375∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant2374 & Constant2375 & Constant1701 --> Object2377
+    Object2392{{"Object[2392∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2389{{"Constant[2389∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2390{{"Constant[2390∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant2389 & Constant2390 & Constant1686 --> Object2392
+    Object2407{{"Object[2407∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2404{{"Constant[2404∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2405{{"Constant[2405∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant2404 & Constant2405 & Constant1836 --> Object2407
+    Object2422{{"Object[2422∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2419{{"Constant[2419∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2420{{"Constant[2420∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant2419 & Constant2420 & Constant1851 --> Object2422
+    Object2437{{"Object[2437∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2434{{"Constant[2434∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2435{{"Constant[2435∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant2434 & Constant2435 & Constant1866 --> Object2437
+    Object2452{{"Object[2452∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2449{{"Constant[2449∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2450{{"Constant[2450∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant2449 & Constant2450 & Constant1881 --> Object2452
+    Object2467{{"Object[2467∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2464{{"Constant[2464∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2465{{"Constant[2465∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant2464 & Constant2465 & Constant1896 --> Object2467
+    Object2482{{"Object[2482∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2479{{"Constant[2479∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2480{{"Constant[2480∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant2479 & Constant2480 & Constant1911 --> Object2482
+    Object2497{{"Object[2497∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2494{{"Constant[2494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2495{{"Constant[2495∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant2494 & Constant2495 & Constant1926 --> Object2497
     Object2512{{"Object[2512∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2509{{"Constant[2509∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2510{{"Constant[2510∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2509 & Constant2510 & Constant1713 --> Object2512
-    Object2526{{"Object[2526∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2523{{"Constant[2523∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2524{{"Constant[2524∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2523 & Constant2524 & Constant1727 --> Object2526
-    Object2540{{"Object[2540∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2537{{"Constant[2537∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2538{{"Constant[2538∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant2537 & Constant2538 & Constant1741 --> Object2540
-    Object2554{{"Object[2554∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2551{{"Constant[2551∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2552{{"Constant[2552∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2551 & Constant2552 & Constant1755 --> Object2554
-    Object2568{{"Object[2568∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2565{{"Constant[2565∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2566{{"Constant[2566∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant2565 & Constant2566 & Constant1769 --> Object2568
-    Object2582{{"Object[2582∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2579{{"Constant[2579∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2580{{"Constant[2580∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant2579 & Constant2580 & Constant1783 --> Object2582
-    Object2596{{"Object[2596∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2593{{"Constant[2593∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2594{{"Constant[2594∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant2593 & Constant2594 & Constant1699 --> Object2596
-    Object2610{{"Object[2610∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2607{{"Constant[2607∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2608{{"Constant[2608∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant2607 & Constant2608 & Constant1685 --> Object2610
-    Object2624{{"Object[2624∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2621{{"Constant[2621∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2622{{"Constant[2622∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant2621 & Constant2622 & Constant1825 --> Object2624
-    Object2638{{"Object[2638∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2635{{"Constant[2635∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2636{{"Constant[2636∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant2635 & Constant2636 & Constant1839 --> Object2638
-    Object2652{{"Object[2652∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2649{{"Constant[2649∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2650{{"Constant[2650∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant2649 & Constant2650 & Constant1853 --> Object2652
-    Object2666{{"Object[2666∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2663{{"Constant[2663∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2664{{"Constant[2664∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant2663 & Constant2664 & Constant1867 --> Object2666
-    Object2680{{"Object[2680∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2677{{"Constant[2677∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2678{{"Constant[2678∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2677 & Constant2678 & Constant1881 --> Object2680
-    Object2694{{"Object[2694∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2691{{"Constant[2691∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2692{{"Constant[2692∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2691 & Constant2692 & Constant1895 --> Object2694
-    Object2708{{"Object[2708∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2705{{"Constant[2705∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2706{{"Constant[2706∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant2705 & Constant2706 & Constant1909 --> Object2708
+    Constant2510{{"Constant[2510∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant2509 & Constant2510 & Constant1941 --> Object2512
+    Object2527{{"Object[2527∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2524{{"Constant[2524∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2525{{"Constant[2525∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant2524 & Constant2525 & Constant1956 --> Object2527
+    Object2542{{"Object[2542∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2539{{"Constant[2539∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2540{{"Constant[2540∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant2539 & Constant2540 & Constant1971 --> Object2542
+    Object2557{{"Object[2557∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2554{{"Constant[2554∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2555{{"Constant[2555∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant2554 & Constant2555 & Constant1986 --> Object2557
+    Object2572{{"Object[2572∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2569{{"Constant[2569∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2570{{"Constant[2570∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2569 & Constant2570 & Constant1716 --> Object2572
+    Object2587{{"Object[2587∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2584{{"Constant[2584∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2585{{"Constant[2585∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2584 & Constant2585 & Constant1731 --> Object2587
+    Object2602{{"Object[2602∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2599{{"Constant[2599∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2600{{"Constant[2600∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant2599 & Constant2600 & Constant1746 --> Object2602
+    Object2617{{"Object[2617∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2614{{"Constant[2614∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2615{{"Constant[2615∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2614 & Constant2615 & Constant1761 --> Object2617
+    Object2632{{"Object[2632∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2629{{"Constant[2629∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2630{{"Constant[2630∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant2629 & Constant2630 & Constant1776 --> Object2632
+    Object2647{{"Object[2647∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2644{{"Constant[2644∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2645{{"Constant[2645∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant2644 & Constant2645 & Constant1791 --> Object2647
+    Object2662{{"Object[2662∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2659{{"Constant[2659∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2660{{"Constant[2660∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant2659 & Constant2660 & Constant1701 --> Object2662
+    Object2677{{"Object[2677∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2674{{"Constant[2674∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2675{{"Constant[2675∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant2674 & Constant2675 & Constant1686 --> Object2677
+    Object2692{{"Object[2692∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2689{{"Constant[2689∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2690{{"Constant[2690∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant2689 & Constant2690 & Constant1836 --> Object2692
+    Object2707{{"Object[2707∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2704{{"Constant[2704∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2705{{"Constant[2705∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant2704 & Constant2705 & Constant1851 --> Object2707
     Object2722{{"Object[2722∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2719{{"Constant[2719∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2720{{"Constant[2720∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant2719 & Constant2720 & Constant1923 --> Object2722
-    Object2736{{"Object[2736∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2733{{"Constant[2733∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2734{{"Constant[2734∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant2733 & Constant2734 & Constant1937 --> Object2736
-    Object2750{{"Object[2750∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2747{{"Constant[2747∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2748{{"Constant[2748∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant2747 & Constant2748 & Constant1951 --> Object2750
-    Object2764{{"Object[2764∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2761{{"Constant[2761∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2762{{"Constant[2762∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant2761 & Constant2762 & Constant1965 --> Object2764
-    Object2778{{"Object[2778∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2775{{"Constant[2775∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2776{{"Constant[2776∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2775 & Constant2776 & Constant1713 --> Object2778
-    Object2792{{"Object[2792∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2789{{"Constant[2789∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2790{{"Constant[2790∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2789 & Constant2790 & Constant1727 --> Object2792
-    Object2806{{"Object[2806∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2803{{"Constant[2803∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2804{{"Constant[2804∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant2803 & Constant2804 & Constant1741 --> Object2806
-    Object2820{{"Object[2820∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2817{{"Constant[2817∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2818{{"Constant[2818∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant2817 & Constant2818 & Constant1755 --> Object2820
-    Object2834{{"Object[2834∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2831{{"Constant[2831∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2832{{"Constant[2832∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant2831 & Constant2832 & Constant1769 --> Object2834
-    Object2848{{"Object[2848∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2845{{"Constant[2845∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2846{{"Constant[2846∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant2845 & Constant2846 & Constant1783 --> Object2848
-    Object2862{{"Object[2862∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2859{{"Constant[2859∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2860{{"Constant[2860∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant2859 & Constant2860 & Constant1699 --> Object2862
-    Object2876{{"Object[2876∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2873{{"Constant[2873∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2874{{"Constant[2874∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant2873 & Constant2874 & Constant1685 --> Object2876
-    Object2890{{"Object[2890∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2887{{"Constant[2887∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2888{{"Constant[2888∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant2887 & Constant2888 & Constant1825 --> Object2890
-    Object2904{{"Object[2904∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2901{{"Constant[2901∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2902{{"Constant[2902∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant2901 & Constant2902 & Constant1839 --> Object2904
-    Object2918{{"Object[2918∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2915{{"Constant[2915∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2916{{"Constant[2916∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant2915 & Constant2916 & Constant1853 --> Object2918
+    Constant2720{{"Constant[2720∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant2719 & Constant2720 & Constant1866 --> Object2722
+    Object2737{{"Object[2737∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2734{{"Constant[2734∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2735{{"Constant[2735∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant2734 & Constant2735 & Constant1881 --> Object2737
+    Object2752{{"Object[2752∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2749{{"Constant[2749∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2750{{"Constant[2750∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant2749 & Constant2750 & Constant1896 --> Object2752
+    Object2767{{"Object[2767∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2764{{"Constant[2764∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2765{{"Constant[2765∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant2764 & Constant2765 & Constant1911 --> Object2767
+    Object2782{{"Object[2782∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2779{{"Constant[2779∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2780{{"Constant[2780∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant2779 & Constant2780 & Constant1926 --> Object2782
+    Object2797{{"Object[2797∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2794{{"Constant[2794∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2795{{"Constant[2795∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant2794 & Constant2795 & Constant1941 --> Object2797
+    Object2812{{"Object[2812∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2809{{"Constant[2809∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2810{{"Constant[2810∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant2809 & Constant2810 & Constant1956 --> Object2812
+    Object2827{{"Object[2827∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2824{{"Constant[2824∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2825{{"Constant[2825∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant2824 & Constant2825 & Constant1971 --> Object2827
+    Object2842{{"Object[2842∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2839{{"Constant[2839∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2840{{"Constant[2840∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant2839 & Constant2840 & Constant1986 --> Object2842
+    Object2857{{"Object[2857∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2854{{"Constant[2854∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2855{{"Constant[2855∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2854 & Constant2855 & Constant1716 --> Object2857
+    Object2872{{"Object[2872∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2869{{"Constant[2869∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2870{{"Constant[2870∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2869 & Constant2870 & Constant1731 --> Object2872
+    Object2887{{"Object[2887∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2884{{"Constant[2884∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2885{{"Constant[2885∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant2884 & Constant2885 & Constant1746 --> Object2887
+    Object2902{{"Object[2902∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2899{{"Constant[2899∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2900{{"Constant[2900∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant2899 & Constant2900 & Constant1761 --> Object2902
+    Object2917{{"Object[2917∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2914{{"Constant[2914∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2915{{"Constant[2915∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant2914 & Constant2915 & Constant1776 --> Object2917
     Object2932{{"Object[2932∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2929{{"Constant[2929∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2930{{"Constant[2930∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant2929 & Constant2930 & Constant1867 --> Object2932
-    Object2946{{"Object[2946∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2943{{"Constant[2943∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2944{{"Constant[2944∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2943 & Constant2944 & Constant1881 --> Object2946
-    Object2960{{"Object[2960∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2957{{"Constant[2957∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2958{{"Constant[2958∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant2957 & Constant2958 & Constant1895 --> Object2960
-    Object2974{{"Object[2974∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2971{{"Constant[2971∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2972{{"Constant[2972∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant2971 & Constant2972 & Constant1909 --> Object2974
-    Object2988{{"Object[2988∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2985{{"Constant[2985∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2986{{"Constant[2986∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant2985 & Constant2986 & Constant1923 --> Object2988
-    Object3002{{"Object[3002∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2999{{"Constant[2999∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3000{{"Constant[3000∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant2999 & Constant3000 & Constant1937 --> Object3002
-    Object3016{{"Object[3016∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3013{{"Constant[3013∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3014{{"Constant[3014∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant3013 & Constant3014 & Constant1951 --> Object3016
-    Object3030{{"Object[3030∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3027{{"Constant[3027∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3028{{"Constant[3028∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant3027 & Constant3028 & Constant1965 --> Object3030
-    Object3044{{"Object[3044∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3041{{"Constant[3041∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3042{{"Constant[3042∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3041 & Constant3042 & Constant1713 --> Object3044
-    Object3058{{"Object[3058∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3055{{"Constant[3055∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3056{{"Constant[3056∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3055 & Constant3056 & Constant1727 --> Object3058
-    Object3072{{"Object[3072∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3069{{"Constant[3069∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3070{{"Constant[3070∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant3069 & Constant3070 & Constant1741 --> Object3072
-    Object3086{{"Object[3086∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3083{{"Constant[3083∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3084{{"Constant[3084∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3083 & Constant3084 & Constant1755 --> Object3086
-    Object3100{{"Object[3100∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3097{{"Constant[3097∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3098{{"Constant[3098∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant3097 & Constant3098 & Constant1769 --> Object3100
-    Object3114{{"Object[3114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3111{{"Constant[3111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3112{{"Constant[3112∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant3111 & Constant3112 & Constant1783 --> Object3114
-    Object3128{{"Object[3128∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3125{{"Constant[3125∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3126{{"Constant[3126∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant3125 & Constant3126 & Constant1699 --> Object3128
+    Constant2930{{"Constant[2930∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant2929 & Constant2930 & Constant1791 --> Object2932
+    Object2947{{"Object[2947∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2944{{"Constant[2944∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2945{{"Constant[2945∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant2944 & Constant2945 & Constant1701 --> Object2947
+    Object2962{{"Object[2962∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2959{{"Constant[2959∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2960{{"Constant[2960∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant2959 & Constant2960 & Constant1686 --> Object2962
+    Object2977{{"Object[2977∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2974{{"Constant[2974∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2975{{"Constant[2975∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant2974 & Constant2975 & Constant1836 --> Object2977
+    Object2992{{"Object[2992∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2989{{"Constant[2989∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2990{{"Constant[2990∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant2989 & Constant2990 & Constant1851 --> Object2992
+    Object3007{{"Object[3007∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3004{{"Constant[3004∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3005{{"Constant[3005∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant3004 & Constant3005 & Constant1866 --> Object3007
+    Object3022{{"Object[3022∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3019{{"Constant[3019∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3020{{"Constant[3020∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant3019 & Constant3020 & Constant1881 --> Object3022
+    Object3037{{"Object[3037∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3034{{"Constant[3034∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3035{{"Constant[3035∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3034 & Constant3035 & Constant1896 --> Object3037
+    Object3052{{"Object[3052∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3049{{"Constant[3049∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3050{{"Constant[3050∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3049 & Constant3050 & Constant1911 --> Object3052
+    Object3067{{"Object[3067∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3064{{"Constant[3064∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3065{{"Constant[3065∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant3064 & Constant3065 & Constant1926 --> Object3067
+    Object3082{{"Object[3082∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3079{{"Constant[3079∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3080{{"Constant[3080∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant3079 & Constant3080 & Constant1941 --> Object3082
+    Object3097{{"Object[3097∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3094{{"Constant[3094∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3095{{"Constant[3095∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant3094 & Constant3095 & Constant1956 --> Object3097
+    Object3112{{"Object[3112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3109{{"Constant[3109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3110{{"Constant[3110∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant3109 & Constant3110 & Constant1971 --> Object3112
+    Object3127{{"Object[3127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3124{{"Constant[3124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3125{{"Constant[3125∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant3124 & Constant3125 & Constant1986 --> Object3127
     Object3142{{"Object[3142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3139{{"Constant[3139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3140{{"Constant[3140∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant3139 & Constant3140 & Constant1685 --> Object3142
-    Object3156{{"Object[3156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3153{{"Constant[3153∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3154{{"Constant[3154∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant3153 & Constant3154 & Constant1825 --> Object3156
-    Object3170{{"Object[3170∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3167{{"Constant[3167∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3168{{"Constant[3168∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant3167 & Constant3168 & Constant1839 --> Object3170
-    Object3184{{"Object[3184∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3181{{"Constant[3181∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3182{{"Constant[3182∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant3181 & Constant3182 & Constant1853 --> Object3184
-    Object3198{{"Object[3198∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3195{{"Constant[3195∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3196{{"Constant[3196∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant3195 & Constant3196 & Constant1867 --> Object3198
-    Object3212{{"Object[3212∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3209{{"Constant[3209∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3210{{"Constant[3210∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant3209 & Constant3210 & Constant1881 --> Object3212
-    Object3226{{"Object[3226∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3223{{"Constant[3223∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3224{{"Constant[3224∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant3223 & Constant3224 & Constant1895 --> Object3226
-    Object3240{{"Object[3240∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3237{{"Constant[3237∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3238{{"Constant[3238∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant3237 & Constant3238 & Constant1909 --> Object3240
-    Object3254{{"Object[3254∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3251{{"Constant[3251∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3252{{"Constant[3252∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant3251 & Constant3252 & Constant1923 --> Object3254
-    Object3268{{"Object[3268∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3265{{"Constant[3265∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3266{{"Constant[3266∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant3265 & Constant3266 & Constant1937 --> Object3268
-    Object3282{{"Object[3282∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3279{{"Constant[3279∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3280{{"Constant[3280∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant3279 & Constant3280 & Constant1951 --> Object3282
-    Object3296{{"Object[3296∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3293{{"Constant[3293∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3294{{"Constant[3294∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant3293 & Constant3294 & Constant1965 --> Object3296
-    Object3310{{"Object[3310∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3307{{"Constant[3307∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3308{{"Constant[3308∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant3307 & Constant3308 & Constant1685 --> Object3310
-    Object3324{{"Object[3324∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3321{{"Constant[3321∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3322{{"Constant[3322∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant3321 & Constant3322 & Constant1685 --> Object3324
-    Object3338{{"Object[3338∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3335{{"Constant[3335∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3336{{"Constant[3336∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant3335 & Constant3336 & Constant1685 --> Object3338
+    Constant3140{{"Constant[3140∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3139 & Constant3140 & Constant1716 --> Object3142
+    Object3157{{"Object[3157∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3154{{"Constant[3154∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3155{{"Constant[3155∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3154 & Constant3155 & Constant1731 --> Object3157
+    Object3172{{"Object[3172∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3169{{"Constant[3169∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3170{{"Constant[3170∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant3169 & Constant3170 & Constant1746 --> Object3172
+    Object3187{{"Object[3187∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3184{{"Constant[3184∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3185{{"Constant[3185∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3184 & Constant3185 & Constant1761 --> Object3187
+    Object3202{{"Object[3202∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3199{{"Constant[3199∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3200{{"Constant[3200∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant3199 & Constant3200 & Constant1776 --> Object3202
+    Object3217{{"Object[3217∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3214{{"Constant[3214∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3215{{"Constant[3215∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant3214 & Constant3215 & Constant1791 --> Object3217
+    Object3232{{"Object[3232∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3229{{"Constant[3229∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3230{{"Constant[3230∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant3229 & Constant3230 & Constant1701 --> Object3232
+    Object3247{{"Object[3247∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3244{{"Constant[3244∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3245{{"Constant[3245∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant3244 & Constant3245 & Constant1686 --> Object3247
+    Object3262{{"Object[3262∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3259{{"Constant[3259∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3260{{"Constant[3260∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant3259 & Constant3260 & Constant1836 --> Object3262
+    Object3277{{"Object[3277∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3274{{"Constant[3274∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3275{{"Constant[3275∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant3274 & Constant3275 & Constant1851 --> Object3277
+    Object3292{{"Object[3292∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3289{{"Constant[3289∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3290{{"Constant[3290∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant3289 & Constant3290 & Constant1866 --> Object3292
+    Object3307{{"Object[3307∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3304{{"Constant[3304∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3305{{"Constant[3305∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant3304 & Constant3305 & Constant1881 --> Object3307
+    Object3322{{"Object[3322∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3319{{"Constant[3319∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3320{{"Constant[3320∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3319 & Constant3320 & Constant1896 --> Object3322
+    Object3337{{"Object[3337∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3334{{"Constant[3334∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3335{{"Constant[3335∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3334 & Constant3335 & Constant1911 --> Object3337
     Object3352{{"Object[3352∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3349{{"Constant[3349∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3350{{"Constant[3350∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant3349 & Constant3350 & Constant1699 --> Object3352
-    Object3366{{"Object[3366∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3363{{"Constant[3363∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3364{{"Constant[3364∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant3363 & Constant3364 & Constant1699 --> Object3366
-    Object3380{{"Object[3380∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3377{{"Constant[3377∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3378{{"Constant[3378∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant3377 & Constant3378 & Constant1699 --> Object3380
-    Object3394{{"Object[3394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3391{{"Constant[3391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3392{{"Constant[3392∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3391 & Constant3392 & Constant1713 --> Object3394
-    Object3408{{"Object[3408∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3405{{"Constant[3405∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3406{{"Constant[3406∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3405 & Constant3406 & Constant1727 --> Object3408
-    Object3422{{"Object[3422∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3419{{"Constant[3419∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3420{{"Constant[3420∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant3419 & Constant3420 & Constant1741 --> Object3422
-    Object3436{{"Object[3436∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3433{{"Constant[3433∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3434{{"Constant[3434∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3433 & Constant3434 & Constant1755 --> Object3436
-    Object3450{{"Object[3450∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3447{{"Constant[3447∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3448{{"Constant[3448∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant3447 & Constant3448 & Constant1769 --> Object3450
-    Object3464{{"Object[3464∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3461{{"Constant[3461∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3462{{"Constant[3462∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant3461 & Constant3462 & Constant1783 --> Object3464
-    Object3478{{"Object[3478∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3475{{"Constant[3475∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3476{{"Constant[3476∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant3475 & Constant3476 & Constant1699 --> Object3478
-    Object3492{{"Object[3492∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3489{{"Constant[3489∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3490{{"Constant[3490∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant3489 & Constant3490 & Constant1685 --> Object3492
-    Object3506{{"Object[3506∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3503{{"Constant[3503∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3504{{"Constant[3504∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant3503 & Constant3504 & Constant1825 --> Object3506
-    Object3520{{"Object[3520∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3517{{"Constant[3517∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3518{{"Constant[3518∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant3517 & Constant3518 & Constant1839 --> Object3520
-    Object3534{{"Object[3534∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3531{{"Constant[3531∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3532{{"Constant[3532∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant3531 & Constant3532 & Constant1853 --> Object3534
-    Object3548{{"Object[3548∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3545{{"Constant[3545∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3546{{"Constant[3546∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant3545 & Constant3546 & Constant1867 --> Object3548
+    Constant3350{{"Constant[3350∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant3349 & Constant3350 & Constant1926 --> Object3352
+    Object3367{{"Object[3367∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3364{{"Constant[3364∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3365{{"Constant[3365∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant3364 & Constant3365 & Constant1941 --> Object3367
+    Object3382{{"Object[3382∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3379{{"Constant[3379∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3380{{"Constant[3380∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant3379 & Constant3380 & Constant1956 --> Object3382
+    Object3397{{"Object[3397∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3394{{"Constant[3394∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3395{{"Constant[3395∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant3394 & Constant3395 & Constant1971 --> Object3397
+    Object3412{{"Object[3412∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3409{{"Constant[3409∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3410{{"Constant[3410∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant3409 & Constant3410 & Constant1986 --> Object3412
+    Object3427{{"Object[3427∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3424{{"Constant[3424∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3425{{"Constant[3425∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant3424 & Constant3425 & Constant1686 --> Object3427
+    Object3442{{"Object[3442∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3439{{"Constant[3439∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3440{{"Constant[3440∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant3439 & Constant3440 & Constant1686 --> Object3442
+    Object3457{{"Object[3457∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3454{{"Constant[3454∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3455{{"Constant[3455∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant3454 & Constant3455 & Constant1686 --> Object3457
+    Object3472{{"Object[3472∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3469{{"Constant[3469∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3470{{"Constant[3470∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant3469 & Constant3470 & Constant1701 --> Object3472
+    Object3487{{"Object[3487∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3484{{"Constant[3484∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3485{{"Constant[3485∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant3484 & Constant3485 & Constant1701 --> Object3487
+    Object3502{{"Object[3502∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3499{{"Constant[3499∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3500{{"Constant[3500∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant3499 & Constant3500 & Constant1701 --> Object3502
+    Object3517{{"Object[3517∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3514{{"Constant[3514∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3515{{"Constant[3515∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3514 & Constant3515 & Constant1716 --> Object3517
+    Object3532{{"Object[3532∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3529{{"Constant[3529∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3530{{"Constant[3530∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3529 & Constant3530 & Constant1731 --> Object3532
+    Object3547{{"Object[3547∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3544{{"Constant[3544∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3545{{"Constant[3545∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant3544 & Constant3545 & Constant1746 --> Object3547
     Object3562{{"Object[3562∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3559{{"Constant[3559∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3560{{"Constant[3560∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant3559 & Constant3560 & Constant1881 --> Object3562
-    Object3576{{"Object[3576∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3573{{"Constant[3573∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3574{{"Constant[3574∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant3573 & Constant3574 & Constant1895 --> Object3576
-    Object3590{{"Object[3590∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3587{{"Constant[3587∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3588{{"Constant[3588∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant3587 & Constant3588 & Constant1909 --> Object3590
-    Object3604{{"Object[3604∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3601{{"Constant[3601∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3602{{"Constant[3602∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant3601 & Constant3602 & Constant1923 --> Object3604
-    Object3618{{"Object[3618∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3615{{"Constant[3615∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3616{{"Constant[3616∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant3615 & Constant3616 & Constant1937 --> Object3618
-    Object3632{{"Object[3632∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3629{{"Constant[3629∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3630{{"Constant[3630∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant3629 & Constant3630 & Constant1951 --> Object3632
-    Object3646{{"Object[3646∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3643{{"Constant[3643∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3644{{"Constant[3644∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant3643 & Constant3644 & Constant1965 --> Object3646
-    Object3660{{"Object[3660∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3657{{"Constant[3657∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3658{{"Constant[3658∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3657 & Constant3658 & Constant1713 --> Object3660
-    Object3674{{"Object[3674∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3671{{"Constant[3671∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3672{{"Constant[3672∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3671 & Constant3672 & Constant1727 --> Object3674
-    Object3688{{"Object[3688∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3685{{"Constant[3685∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3686{{"Constant[3686∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda1679 & Constant3685 & Constant3686 & Constant1741 --> Object3688
-    Object3702{{"Object[3702∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3699{{"Constant[3699∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3700{{"Constant[3700∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda1679 & Constant3699 & Constant3700 & Constant1755 --> Object3702
-    Object3716{{"Object[3716∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3713{{"Constant[3713∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3714{{"Constant[3714∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda1679 & Constant3713 & Constant3714 & Constant1769 --> Object3716
-    Object3730{{"Object[3730∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3727{{"Constant[3727∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3728{{"Constant[3728∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda1679 & Constant3727 & Constant3728 & Constant1783 --> Object3730
-    Object3744{{"Object[3744∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3741{{"Constant[3741∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3742{{"Constant[3742∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda1679 & Constant3741 & Constant3742 & Constant1699 --> Object3744
-    Object3758{{"Object[3758∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3755{{"Constant[3755∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3756{{"Constant[3756∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda1679 & Constant3755 & Constant3756 & Constant1685 --> Object3758
+    Constant3560{{"Constant[3560∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3559 & Constant3560 & Constant1761 --> Object3562
+    Object3577{{"Object[3577∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3574{{"Constant[3574∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3575{{"Constant[3575∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant3574 & Constant3575 & Constant1776 --> Object3577
+    Object3592{{"Object[3592∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3589{{"Constant[3589∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3590{{"Constant[3590∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant3589 & Constant3590 & Constant1791 --> Object3592
+    Object3607{{"Object[3607∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3604{{"Constant[3604∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3605{{"Constant[3605∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant3604 & Constant3605 & Constant1701 --> Object3607
+    Object3622{{"Object[3622∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3619{{"Constant[3619∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3620{{"Constant[3620∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant3619 & Constant3620 & Constant1686 --> Object3622
+    Object3637{{"Object[3637∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3634{{"Constant[3634∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3635{{"Constant[3635∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant3634 & Constant3635 & Constant1836 --> Object3637
+    Object3652{{"Object[3652∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3649{{"Constant[3649∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3650{{"Constant[3650∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant3649 & Constant3650 & Constant1851 --> Object3652
+    Object3667{{"Object[3667∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3664{{"Constant[3664∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3665{{"Constant[3665∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant3664 & Constant3665 & Constant1866 --> Object3667
+    Object3682{{"Object[3682∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3679{{"Constant[3679∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3680{{"Constant[3680∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant3679 & Constant3680 & Constant1881 --> Object3682
+    Object3697{{"Object[3697∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3694{{"Constant[3694∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3695{{"Constant[3695∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3694 & Constant3695 & Constant1896 --> Object3697
+    Object3712{{"Object[3712∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3709{{"Constant[3709∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3710{{"Constant[3710∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3709 & Constant3710 & Constant1911 --> Object3712
+    Object3727{{"Object[3727∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3724{{"Constant[3724∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3725{{"Constant[3725∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant3724 & Constant3725 & Constant1926 --> Object3727
+    Object3742{{"Object[3742∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3739{{"Constant[3739∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3740{{"Constant[3740∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant3739 & Constant3740 & Constant1941 --> Object3742
+    Object3757{{"Object[3757∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3754{{"Constant[3754∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3755{{"Constant[3755∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant3754 & Constant3755 & Constant1956 --> Object3757
     Object3772{{"Object[3772∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3769{{"Constant[3769∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3770{{"Constant[3770∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda1679 & Constant3769 & Constant3770 & Constant1825 --> Object3772
-    Object3786{{"Object[3786∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3783{{"Constant[3783∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3784{{"Constant[3784∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda1679 & Constant3783 & Constant3784 & Constant1839 --> Object3786
-    Object3800{{"Object[3800∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3797{{"Constant[3797∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3798{{"Constant[3798∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda1679 & Constant3797 & Constant3798 & Constant1853 --> Object3800
-    Object3814{{"Object[3814∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3811{{"Constant[3811∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3812{{"Constant[3812∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda1679 & Constant3811 & Constant3812 & Constant1867 --> Object3814
-    Object3828{{"Object[3828∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3825{{"Constant[3825∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3826{{"Constant[3826∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant3825 & Constant3826 & Constant1881 --> Object3828
-    Object3842{{"Object[3842∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3839{{"Constant[3839∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3840{{"Constant[3840∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda1679 & Constant3839 & Constant3840 & Constant1895 --> Object3842
-    Object3856{{"Object[3856∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3853{{"Constant[3853∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3854{{"Constant[3854∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant3853 & Constant3854 & Constant1909 --> Object3856
-    Object3870{{"Object[3870∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3867{{"Constant[3867∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3868{{"Constant[3868∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant3867 & Constant3868 & Constant1923 --> Object3870
-    Object3884{{"Object[3884∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3881{{"Constant[3881∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3882{{"Constant[3882∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda1679 & Constant3881 & Constant3882 & Constant1937 --> Object3884
-    Object3898{{"Object[3898∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3895{{"Constant[3895∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3896{{"Constant[3896∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda1679 & Constant3895 & Constant3896 & Constant1951 --> Object3898
-    Object3912{{"Object[3912∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3909{{"Constant[3909∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3910{{"Constant[3910∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda1679 & Constant3909 & Constant3910 & Constant1965 --> Object3912
-    Object3926{{"Object[3926∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3923{{"Constant[3923∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3924{{"Constant[3924∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda1679 & Constant3923 & Constant3924 & Constant1909 --> Object3926
-    Object3940{{"Object[3940∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3937{{"Constant[3937∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3938{{"Constant[3938∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda1679 & Constant3937 & Constant3938 & Constant1923 --> Object3940
+    Constant3770{{"Constant[3770∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant3769 & Constant3770 & Constant1971 --> Object3772
+    Object3787{{"Object[3787∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3784{{"Constant[3784∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3785{{"Constant[3785∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant3784 & Constant3785 & Constant1986 --> Object3787
+    Object3802{{"Object[3802∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3799{{"Constant[3799∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3800{{"Constant[3800∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3799 & Constant3800 & Constant1716 --> Object3802
+    Object3817{{"Object[3817∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3814{{"Constant[3814∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3815{{"Constant[3815∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3814 & Constant3815 & Constant1731 --> Object3817
+    Object3832{{"Object[3832∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3829{{"Constant[3829∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3830{{"Constant[3830∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda1679 & Constant3829 & Constant3830 & Constant1746 --> Object3832
+    Object3847{{"Object[3847∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3844{{"Constant[3844∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3845{{"Constant[3845∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda1679 & Constant3844 & Constant3845 & Constant1761 --> Object3847
+    Object3862{{"Object[3862∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3859{{"Constant[3859∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3860{{"Constant[3860∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda1679 & Constant3859 & Constant3860 & Constant1776 --> Object3862
+    Object3877{{"Object[3877∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3874{{"Constant[3874∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3875{{"Constant[3875∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda1679 & Constant3874 & Constant3875 & Constant1791 --> Object3877
+    Object3892{{"Object[3892∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3889{{"Constant[3889∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3890{{"Constant[3890∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda1679 & Constant3889 & Constant3890 & Constant1701 --> Object3892
+    Object3907{{"Object[3907∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3904{{"Constant[3904∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3905{{"Constant[3905∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda1679 & Constant3904 & Constant3905 & Constant1686 --> Object3907
+    Object3922{{"Object[3922∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3919{{"Constant[3919∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3920{{"Constant[3920∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda1679 & Constant3919 & Constant3920 & Constant1836 --> Object3922
+    Object3937{{"Object[3937∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3934{{"Constant[3934∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3935{{"Constant[3935∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda1679 & Constant3934 & Constant3935 & Constant1851 --> Object3937
+    Object3952{{"Object[3952∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3949{{"Constant[3949∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3950{{"Constant[3950∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda1679 & Constant3949 & Constant3950 & Constant1866 --> Object3952
+    Object3967{{"Object[3967∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3964{{"Constant[3964∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3965{{"Constant[3965∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda1679 & Constant3964 & Constant3965 & Constant1881 --> Object3967
+    Object3982{{"Object[3982∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3979{{"Constant[3979∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3980{{"Constant[3980∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3979 & Constant3980 & Constant1896 --> Object3982
+    Object3997{{"Object[3997∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3994{{"Constant[3994∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3995{{"Constant[3995∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda1679 & Constant3994 & Constant3995 & Constant1911 --> Object3997
+    Object4012{{"Object[4012∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4009{{"Constant[4009∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4010{{"Constant[4010∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant4009 & Constant4010 & Constant1926 --> Object4012
+    Object4027{{"Object[4027∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4024{{"Constant[4024∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4025{{"Constant[4025∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant4024 & Constant4025 & Constant1941 --> Object4027
+    Object4042{{"Object[4042∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4039{{"Constant[4039∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4040{{"Constant[4040∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda1679 & Constant4039 & Constant4040 & Constant1956 --> Object4042
+    Object4057{{"Object[4057∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4054{{"Constant[4054∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4055{{"Constant[4055∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda1679 & Constant4054 & Constant4055 & Constant1971 --> Object4057
+    Object4072{{"Object[4072∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4069{{"Constant[4069∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4070{{"Constant[4070∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda1679 & Constant4069 & Constant4070 & Constant1986 --> Object4072
+    Object4087{{"Object[4087∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4084{{"Constant[4084∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4085{{"Constant[4085∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda1679 & Constant4084 & Constant4085 & Constant1926 --> Object4087
+    Object4102{{"Object[4102∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4099{{"Constant[4099∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4100{{"Constant[4100∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda1679 & Constant4099 & Constant4100 & Constant1941 --> Object4102
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -734,56 +742,56 @@ graph TD
     Node36{{"Node[36∈0] ➊"}}:::plan
     Lambda37{{"Lambda[37∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda37 --> Node36
-    Constant3949{{"Constant[3949∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwyLDNd'ᐳ"}}:::plan
-    Constant3949 --> Lambda37
+    Constant4111{{"Constant[4111∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwyLDNd'ᐳ"}}:::plan
+    Constant4111 --> Lambda37
     Node227{{"Node[227∈0] ➊"}}:::plan
     Lambda228{{"Lambda[228∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda228 --> Node227
-    Constant3952{{"Constant[3952∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDJd'ᐳ"}}:::plan
-    Constant3952 --> Lambda228
+    Constant4114{{"Constant[4114∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDJd'ᐳ"}}:::plan
+    Constant4114 --> Lambda228
     Node418{{"Node[418∈0] ➊"}}:::plan
     Lambda419{{"Lambda[419∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda419 --> Node418
-    Constant3955{{"Constant[3955∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwxLDJd'ᐳ"}}:::plan
-    Constant3955 --> Lambda419
+    Constant4117{{"Constant[4117∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwxLDJd'ᐳ"}}:::plan
+    Constant4117 --> Lambda419
     Node609{{"Node[609∈0] ➊"}}:::plan
     Lambda610{{"Lambda[610∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda610 --> Node609
-    Constant3958{{"Constant[3958∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDVd'ᐳ"}}:::plan
-    Constant3958 --> Lambda610
+    Constant4120{{"Constant[4120∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDVd'ᐳ"}}:::plan
+    Constant4120 --> Lambda610
     Node800{{"Node[800∈0] ➊"}}:::plan
     Lambda801{{"Lambda[801∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda801 --> Node800
-    Constant3961{{"Constant[3961∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDUwMF0='ᐳ"}}:::plan
-    Constant3961 --> Lambda801
+    Constant4123{{"Constant[4123∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDUwMF0='ᐳ"}}:::plan
+    Constant4123 --> Lambda801
     Node991{{"Node[991∈0] ➊"}}:::plan
     Lambda992{{"Lambda[992∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda992 --> Node991
-    Constant3964{{"Constant[3964∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwxMDAsMjAwXQ=='ᐳ"}}:::plan
-    Constant3964 --> Lambda992
+    Constant4126{{"Constant[4126∈0] ➊<br />ᐸ'WyJjb21wb3VuZF9rZXlzIiwxMDAsMjAwXQ=='ᐳ"}}:::plan
+    Constant4126 --> Lambda992
     Lambda1182{{"Lambda[1182∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant3952 --> Lambda1182
+    Constant4114 --> Lambda1182
     Lambda1182 --> Access1183
     First1187{{"First[1187∈0] ➊"}}:::plan
     PgSelect1185 --> First1187
     PgSelectSingle1188{{"PgSelectSingle[1188∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First1187 --> PgSelectSingle1188
     Lambda1195{{"Lambda[1195∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant3958 --> Lambda1195
+    Constant4120 --> Lambda1195
     Lambda1195 --> Access1196
     First1200{{"First[1200∈0] ➊"}}:::plan
     PgSelect1198 --> First1200
     PgSelectSingle1201{{"PgSelectSingle[1201∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First1200 --> PgSelectSingle1201
     Lambda1208{{"Lambda[1208∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant3961 --> Lambda1208
+    Constant4123 --> Lambda1208
     Lambda1208 --> Access1209
     First1213{{"First[1213∈0] ➊"}}:::plan
     PgSelect1211 --> First1213
     PgSelectSingle1214{{"PgSelectSingle[1214∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First1213 --> PgSelectSingle1214
     Lambda1221{{"Lambda[1221∈0] ➊<br />ᐸspecifier_CompoundKey_base64JSONᐳ"}}:::plan
-    Constant3949 --> Lambda1221
+    Constant4111 --> Lambda1221
     Lambda1221 --> Access1222
     Lambda1221 --> Access1224
     First1228{{"First[1228∈0] ➊"}}:::plan
@@ -791,7 +799,7 @@ graph TD
     PgSelectSingle1229{{"PgSelectSingle[1229∈0] ➊<br />ᐸcompound_keyᐳ"}}:::plan
     First1228 --> PgSelectSingle1229
     Lambda1236{{"Lambda[1236∈0] ➊<br />ᐸspecifier_CompoundKey_base64JSONᐳ"}}:::plan
-    Constant3955 --> Lambda1236
+    Constant4117 --> Lambda1236
     Lambda1236 --> Access1237
     Lambda1236 --> Access1239
     First1243{{"First[1243∈0] ➊"}}:::plan
@@ -799,7 +807,7 @@ graph TD
     PgSelectSingle1244{{"PgSelectSingle[1244∈0] ➊<br />ᐸcompound_keyᐳ"}}:::plan
     First1243 --> PgSelectSingle1244
     Lambda1251{{"Lambda[1251∈0] ➊<br />ᐸspecifier_CompoundKey_base64JSONᐳ"}}:::plan
-    Constant3964 --> Lambda1251
+    Constant4126 --> Lambda1251
     Lambda1251 --> Access1252
     Lambda1251 --> Access1254
     First1258{{"First[1258∈0] ➊"}}:::plan
@@ -809,815 +817,827 @@ graph TD
     Node1266{{"Node[1266∈0] ➊"}}:::plan
     Lambda1267{{"Lambda[1267∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1267 --> Node1266
-    Constant3967{{"Constant[3967∈0] ➊<br />ᐸ'WyJzaW1pbGFyX3RhYmxlXzFTIiwyXQ=='ᐳ"}}:::plan
-    Constant3967 --> Lambda1267
+    Constant4129{{"Constant[4129∈0] ➊<br />ᐸ'WyJzaW1pbGFyX3RhYmxlXzFTIiwyXQ=='ᐳ"}}:::plan
+    Constant4129 --> Lambda1267
     Node1457{{"Node[1457∈0] ➊"}}:::plan
     Lambda1458{{"Lambda[1458∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1458 --> Node1457
-    Constant3970{{"Constant[3970∈0] ➊<br />ᐸ'WyJzaW1pbGFyX3RhYmxlXzJTIiwyXQ=='ᐳ"}}:::plan
-    Constant3970 --> Lambda1458
+    Constant4132{{"Constant[4132∈0] ➊<br />ᐸ'WyJzaW1pbGFyX3RhYmxlXzJTIiwyXQ=='ᐳ"}}:::plan
+    Constant4132 --> Lambda1458
     Lambda1648{{"Lambda[1648∈0] ➊<br />ᐸspecifier_SimilarTable1_base64JSONᐳ"}}:::plan
-    Constant3967 --> Lambda1648
+    Constant4129 --> Lambda1648
     Lambda1648 --> Access1649
     First1653{{"First[1653∈0] ➊"}}:::plan
     PgSelect1651 --> First1653
     PgSelectSingle1654{{"PgSelectSingle[1654∈0] ➊<br />ᐸsimilar_table_1ᐳ"}}:::plan
     First1653 --> PgSelectSingle1654
     Lambda1663{{"Lambda[1663∈0] ➊<br />ᐸspecifier_SimilarTable2_base64JSONᐳ"}}:::plan
-    Constant3970 --> Lambda1663
+    Constant4132 --> Lambda1663
     Lambda1663 --> Access1664
     First1668{{"First[1668∈0] ➊"}}:::plan
     PgSelect1666 --> First1668
     PgSelectSingle1669{{"PgSelectSingle[1669∈0] ➊<br />ᐸsimilar_table_2ᐳ"}}:::plan
     First1668 --> PgSelectSingle1669
-    Constant3971{{"Constant[3971∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant3971 --> Lambda1679
-    Constant3972{{"Constant[3972∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant3972 --> Lambda1682
-    Lambda1715{{"Lambda[1715∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1714 --> Lambda1715
-    Lambda1720{{"Lambda[1720∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3975{{"Constant[3975∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant3975 --> Lambda1720
-    Lambda1729{{"Lambda[1729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1728 --> Lambda1729
-    Lambda1734{{"Lambda[1734∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3976{{"Constant[3976∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant3976 --> Lambda1734
-    Lambda1743{{"Lambda[1743∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1742 --> Lambda1743
+    Constant4133{{"Constant[4133∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant4133 --> Lambda1679
+    Lambda1682{{"Lambda[1682∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant4134{{"Constant[4134∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant4134 --> Lambda1682
+    Lambda1682 --> Access1683
+    Lambda1688{{"Lambda[1688∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1687 --> Lambda1688
+    Lambda1693{{"Lambda[1693∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4135{{"Constant[4135∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant4135 --> Lambda1693
+    Lambda1703{{"Lambda[1703∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1702 --> Lambda1703
+    Lambda1708{{"Lambda[1708∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4136{{"Constant[4136∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant4136 --> Lambda1708
+    Lambda1718{{"Lambda[1718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1717 --> Lambda1718
+    Lambda1723{{"Lambda[1723∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4137{{"Constant[4137∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4137 --> Lambda1723
+    Lambda1733{{"Lambda[1733∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1732 --> Lambda1733
+    Lambda1738{{"Lambda[1738∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4138{{"Constant[4138∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4138 --> Lambda1738
     Lambda1748{{"Lambda[1748∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3977{{"Constant[3977∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant3977 --> Lambda1748
-    Lambda1757{{"Lambda[1757∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1756 --> Lambda1757
-    Lambda1762{{"Lambda[1762∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3978{{"Constant[3978∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant3978 --> Lambda1762
-    Lambda1771{{"Lambda[1771∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1770 --> Lambda1771
-    Lambda1776{{"Lambda[1776∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3979{{"Constant[3979∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant3979 --> Lambda1776
-    Lambda1785{{"Lambda[1785∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1784 --> Lambda1785
-    Lambda1790{{"Lambda[1790∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3980{{"Constant[3980∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant3980 --> Lambda1790
-    Lambda1799{{"Lambda[1799∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1798 --> Lambda1799
-    Lambda1804{{"Lambda[1804∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3981{{"Constant[3981∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant3981 --> Lambda1804
+    Object1747 --> Lambda1748
+    Lambda1753{{"Lambda[1753∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4139{{"Constant[4139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4139 --> Lambda1753
+    Lambda1763{{"Lambda[1763∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1762 --> Lambda1763
+    Lambda1768{{"Lambda[1768∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4140{{"Constant[4140∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4140 --> Lambda1768
+    Lambda1778{{"Lambda[1778∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1777 --> Lambda1778
+    Lambda1783{{"Lambda[1783∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4141{{"Constant[4141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4141 --> Lambda1783
+    Lambda1793{{"Lambda[1793∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1792 --> Lambda1793
+    Lambda1798{{"Lambda[1798∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4142{{"Constant[4142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4142 --> Lambda1798
+    Lambda1808{{"Lambda[1808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1807 --> Lambda1808
     Lambda1813{{"Lambda[1813∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1812 --> Lambda1813
-    Lambda1818{{"Lambda[1818∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3982{{"Constant[3982∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant3982 --> Lambda1818
-    Lambda1827{{"Lambda[1827∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1826 --> Lambda1827
-    Lambda1832{{"Lambda[1832∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3983{{"Constant[3983∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant3983 --> Lambda1832
-    Lambda1841{{"Lambda[1841∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1840 --> Lambda1841
-    Lambda1846{{"Lambda[1846∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3984{{"Constant[3984∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant3984 --> Lambda1846
-    Lambda1855{{"Lambda[1855∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1854 --> Lambda1855
-    Lambda1860{{"Lambda[1860∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3985{{"Constant[3985∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant3985 --> Lambda1860
-    Lambda1869{{"Lambda[1869∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1868 --> Lambda1869
-    Lambda1874{{"Lambda[1874∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3986{{"Constant[3986∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant3986 --> Lambda1874
+    Constant4143{{"Constant[4143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4143 --> Lambda1813
+    Lambda1823{{"Lambda[1823∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1822 --> Lambda1823
+    Lambda1828{{"Lambda[1828∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4144{{"Constant[4144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4144 --> Lambda1828
+    Lambda1838{{"Lambda[1838∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1837 --> Lambda1838
+    Lambda1843{{"Lambda[1843∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4145{{"Constant[4145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4145 --> Lambda1843
+    Lambda1853{{"Lambda[1853∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1852 --> Lambda1853
+    Lambda1858{{"Lambda[1858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4146{{"Constant[4146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4146 --> Lambda1858
+    Lambda1868{{"Lambda[1868∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1867 --> Lambda1868
+    Lambda1873{{"Lambda[1873∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4147{{"Constant[4147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4147 --> Lambda1873
     Lambda1883{{"Lambda[1883∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object1882 --> Lambda1883
     Lambda1888{{"Lambda[1888∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3987{{"Constant[3987∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant3987 --> Lambda1888
-    Lambda1897{{"Lambda[1897∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1896 --> Lambda1897
-    Lambda1902{{"Lambda[1902∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3988{{"Constant[3988∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant3988 --> Lambda1902
-    Lambda1911{{"Lambda[1911∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1910 --> Lambda1911
-    Lambda1916{{"Lambda[1916∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3989{{"Constant[3989∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant3989 --> Lambda1916
-    Lambda1925{{"Lambda[1925∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1924 --> Lambda1925
-    Lambda1930{{"Lambda[1930∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3990{{"Constant[3990∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant3990 --> Lambda1930
-    Lambda1939{{"Lambda[1939∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1938 --> Lambda1939
-    Lambda1944{{"Lambda[1944∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3991{{"Constant[3991∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant3991 --> Lambda1944
-    Lambda1953{{"Lambda[1953∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1952 --> Lambda1953
+    Constant4148{{"Constant[4148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4148 --> Lambda1888
+    Lambda1898{{"Lambda[1898∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1897 --> Lambda1898
+    Lambda1903{{"Lambda[1903∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4149{{"Constant[4149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4149 --> Lambda1903
+    Lambda1913{{"Lambda[1913∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1912 --> Lambda1913
+    Lambda1918{{"Lambda[1918∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4150{{"Constant[4150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4150 --> Lambda1918
+    Lambda1928{{"Lambda[1928∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1927 --> Lambda1928
+    Lambda1933{{"Lambda[1933∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4151{{"Constant[4151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4151 --> Lambda1933
+    Lambda1943{{"Lambda[1943∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1942 --> Lambda1943
+    Lambda1948{{"Lambda[1948∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4152{{"Constant[4152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4152 --> Lambda1948
     Lambda1958{{"Lambda[1958∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3992{{"Constant[3992∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant3992 --> Lambda1958
-    Lambda1967{{"Lambda[1967∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1966 --> Lambda1967
-    Lambda1972{{"Lambda[1972∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3993{{"Constant[3993∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant3993 --> Lambda1972
-    Lambda1981{{"Lambda[1981∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1980 --> Lambda1981
-    Lambda1986{{"Lambda[1986∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3994{{"Constant[3994∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant3994 --> Lambda1986
-    Lambda1995{{"Lambda[1995∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object1994 --> Lambda1995
-    Lambda2000{{"Lambda[2000∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3995{{"Constant[3995∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant3995 --> Lambda2000
-    Lambda2009{{"Lambda[2009∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2008 --> Lambda2009
-    Lambda2014{{"Lambda[2014∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3996{{"Constant[3996∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant3996 --> Lambda2014
+    Object1957 --> Lambda1958
+    Lambda1963{{"Lambda[1963∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4153{{"Constant[4153∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4153 --> Lambda1963
+    Lambda1973{{"Lambda[1973∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1972 --> Lambda1973
+    Lambda1978{{"Lambda[1978∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4154{{"Constant[4154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4154 --> Lambda1978
+    Lambda1988{{"Lambda[1988∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1987 --> Lambda1988
+    Lambda1993{{"Lambda[1993∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4155{{"Constant[4155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4155 --> Lambda1993
+    Lambda2003{{"Lambda[2003∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2002 --> Lambda2003
+    Lambda2008{{"Lambda[2008∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4156{{"Constant[4156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4156 --> Lambda2008
+    Lambda2018{{"Lambda[2018∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2017 --> Lambda2018
     Lambda2023{{"Lambda[2023∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2022 --> Lambda2023
-    Lambda2028{{"Lambda[2028∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3997{{"Constant[3997∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant3997 --> Lambda2028
-    Lambda2037{{"Lambda[2037∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2036 --> Lambda2037
-    Lambda2042{{"Lambda[2042∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3998{{"Constant[3998∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant3998 --> Lambda2042
-    Lambda2051{{"Lambda[2051∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2050 --> Lambda2051
-    Lambda2056{{"Lambda[2056∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant3999{{"Constant[3999∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant3999 --> Lambda2056
-    Lambda2065{{"Lambda[2065∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2064 --> Lambda2065
-    Lambda2070{{"Lambda[2070∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4000{{"Constant[4000∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4000 --> Lambda2070
-    Lambda2079{{"Lambda[2079∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2078 --> Lambda2079
-    Lambda2084{{"Lambda[2084∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4001{{"Constant[4001∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4001 --> Lambda2084
+    Constant4157{{"Constant[4157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4157 --> Lambda2023
+    Lambda2033{{"Lambda[2033∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2032 --> Lambda2033
+    Lambda2038{{"Lambda[2038∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4158{{"Constant[4158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4158 --> Lambda2038
+    Lambda2048{{"Lambda[2048∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2047 --> Lambda2048
+    Lambda2053{{"Lambda[2053∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4159{{"Constant[4159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4159 --> Lambda2053
+    Lambda2063{{"Lambda[2063∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2062 --> Lambda2063
+    Lambda2068{{"Lambda[2068∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4160{{"Constant[4160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4160 --> Lambda2068
+    Lambda2078{{"Lambda[2078∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2077 --> Lambda2078
+    Lambda2083{{"Lambda[2083∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4161{{"Constant[4161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4161 --> Lambda2083
     Lambda2093{{"Lambda[2093∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2092 --> Lambda2093
     Lambda2098{{"Lambda[2098∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4002{{"Constant[4002∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4002 --> Lambda2098
-    Lambda2107{{"Lambda[2107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2106 --> Lambda2107
-    Lambda2112{{"Lambda[2112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4003{{"Constant[4003∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4003 --> Lambda2112
-    Lambda2121{{"Lambda[2121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2120 --> Lambda2121
-    Lambda2126{{"Lambda[2126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4004{{"Constant[4004∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4004 --> Lambda2126
-    Lambda2135{{"Lambda[2135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2134 --> Lambda2135
-    Lambda2140{{"Lambda[2140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4005{{"Constant[4005∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4005 --> Lambda2140
-    Lambda2149{{"Lambda[2149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2148 --> Lambda2149
-    Lambda2154{{"Lambda[2154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4006{{"Constant[4006∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4006 --> Lambda2154
-    Lambda2163{{"Lambda[2163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2162 --> Lambda2163
+    Constant4162{{"Constant[4162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4162 --> Lambda2098
+    Lambda2108{{"Lambda[2108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2107 --> Lambda2108
+    Lambda2113{{"Lambda[2113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4163{{"Constant[4163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4163 --> Lambda2113
+    Lambda2123{{"Lambda[2123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2122 --> Lambda2123
+    Lambda2128{{"Lambda[2128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4164{{"Constant[4164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4164 --> Lambda2128
+    Lambda2138{{"Lambda[2138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2137 --> Lambda2138
+    Lambda2143{{"Lambda[2143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4165{{"Constant[4165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4165 --> Lambda2143
+    Lambda2153{{"Lambda[2153∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2152 --> Lambda2153
+    Lambda2158{{"Lambda[2158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4166{{"Constant[4166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4166 --> Lambda2158
     Lambda2168{{"Lambda[2168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4007{{"Constant[4007∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4007 --> Lambda2168
-    Lambda2177{{"Lambda[2177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2176 --> Lambda2177
-    Lambda2182{{"Lambda[2182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4008{{"Constant[4008∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4008 --> Lambda2182
-    Lambda2191{{"Lambda[2191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2190 --> Lambda2191
-    Lambda2196{{"Lambda[2196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4009{{"Constant[4009∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4009 --> Lambda2196
-    Lambda2205{{"Lambda[2205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2204 --> Lambda2205
-    Lambda2210{{"Lambda[2210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4010{{"Constant[4010∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4010 --> Lambda2210
-    Lambda2219{{"Lambda[2219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2218 --> Lambda2219
-    Lambda2224{{"Lambda[2224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4011{{"Constant[4011∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4011 --> Lambda2224
+    Object2167 --> Lambda2168
+    Lambda2173{{"Lambda[2173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4167{{"Constant[4167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4167 --> Lambda2173
+    Lambda2183{{"Lambda[2183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2182 --> Lambda2183
+    Lambda2188{{"Lambda[2188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4168{{"Constant[4168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4168 --> Lambda2188
+    Lambda2198{{"Lambda[2198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2197 --> Lambda2198
+    Lambda2203{{"Lambda[2203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4169{{"Constant[4169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4169 --> Lambda2203
+    Lambda2213{{"Lambda[2213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2212 --> Lambda2213
+    Lambda2218{{"Lambda[2218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4170{{"Constant[4170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4170 --> Lambda2218
+    Lambda2228{{"Lambda[2228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2227 --> Lambda2228
     Lambda2233{{"Lambda[2233∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2232 --> Lambda2233
-    Lambda2238{{"Lambda[2238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4012{{"Constant[4012∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4012 --> Lambda2238
-    Lambda2247{{"Lambda[2247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2246 --> Lambda2247
-    Lambda2252{{"Lambda[2252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4013{{"Constant[4013∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant4013 --> Lambda2252
-    Lambda2261{{"Lambda[2261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2260 --> Lambda2261
-    Lambda2266{{"Lambda[2266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4014{{"Constant[4014∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant4014 --> Lambda2266
-    Lambda2275{{"Lambda[2275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2274 --> Lambda2275
-    Lambda2280{{"Lambda[2280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4015{{"Constant[4015∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4015 --> Lambda2280
-    Lambda2289{{"Lambda[2289∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2288 --> Lambda2289
-    Lambda2294{{"Lambda[2294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4016{{"Constant[4016∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4016 --> Lambda2294
+    Constant4171{{"Constant[4171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4171 --> Lambda2233
+    Lambda2243{{"Lambda[2243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2242 --> Lambda2243
+    Lambda2248{{"Lambda[2248∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4172{{"Constant[4172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4172 --> Lambda2248
+    Lambda2258{{"Lambda[2258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2257 --> Lambda2258
+    Lambda2263{{"Lambda[2263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4173{{"Constant[4173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4173 --> Lambda2263
+    Lambda2273{{"Lambda[2273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2272 --> Lambda2273
+    Lambda2278{{"Lambda[2278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4174{{"Constant[4174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4174 --> Lambda2278
+    Lambda2288{{"Lambda[2288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2287 --> Lambda2288
+    Lambda2293{{"Lambda[2293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4175{{"Constant[4175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4175 --> Lambda2293
     Lambda2303{{"Lambda[2303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2302 --> Lambda2303
     Lambda2308{{"Lambda[2308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4017{{"Constant[4017∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4017 --> Lambda2308
-    Lambda2317{{"Lambda[2317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2316 --> Lambda2317
-    Lambda2322{{"Lambda[2322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4018{{"Constant[4018∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant4018 --> Lambda2322
-    Lambda2331{{"Lambda[2331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2330 --> Lambda2331
-    Lambda2336{{"Lambda[2336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4019{{"Constant[4019∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4019 --> Lambda2336
-    Lambda2345{{"Lambda[2345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2344 --> Lambda2345
-    Lambda2350{{"Lambda[2350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4020{{"Constant[4020∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4020 --> Lambda2350
-    Lambda2359{{"Lambda[2359∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2358 --> Lambda2359
-    Lambda2364{{"Lambda[2364∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4021{{"Constant[4021∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4021 --> Lambda2364
-    Lambda2373{{"Lambda[2373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2372 --> Lambda2373
+    Constant4176{{"Constant[4176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4176 --> Lambda2308
+    Lambda2318{{"Lambda[2318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2317 --> Lambda2318
+    Lambda2323{{"Lambda[2323∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4177{{"Constant[4177∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4177 --> Lambda2323
+    Lambda2333{{"Lambda[2333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2332 --> Lambda2333
+    Lambda2338{{"Lambda[2338∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4178{{"Constant[4178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4178 --> Lambda2338
+    Lambda2348{{"Lambda[2348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2347 --> Lambda2348
+    Lambda2353{{"Lambda[2353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4179{{"Constant[4179∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4179 --> Lambda2353
+    Lambda2363{{"Lambda[2363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2362 --> Lambda2363
+    Lambda2368{{"Lambda[2368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4180{{"Constant[4180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4180 --> Lambda2368
     Lambda2378{{"Lambda[2378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4022{{"Constant[4022∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4022 --> Lambda2378
-    Lambda2387{{"Lambda[2387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2386 --> Lambda2387
-    Lambda2392{{"Lambda[2392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4023{{"Constant[4023∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4023 --> Lambda2392
-    Lambda2401{{"Lambda[2401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2400 --> Lambda2401
-    Lambda2406{{"Lambda[2406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4024{{"Constant[4024∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4024 --> Lambda2406
-    Lambda2415{{"Lambda[2415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2414 --> Lambda2415
-    Lambda2420{{"Lambda[2420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4025{{"Constant[4025∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4025 --> Lambda2420
-    Lambda2429{{"Lambda[2429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2428 --> Lambda2429
-    Lambda2434{{"Lambda[2434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4026{{"Constant[4026∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4026 --> Lambda2434
+    Object2377 --> Lambda2378
+    Lambda2383{{"Lambda[2383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4181{{"Constant[4181∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4181 --> Lambda2383
+    Lambda2393{{"Lambda[2393∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2392 --> Lambda2393
+    Lambda2398{{"Lambda[2398∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4182{{"Constant[4182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4182 --> Lambda2398
+    Lambda2408{{"Lambda[2408∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2407 --> Lambda2408
+    Lambda2413{{"Lambda[2413∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4183{{"Constant[4183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4183 --> Lambda2413
+    Lambda2423{{"Lambda[2423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2422 --> Lambda2423
+    Lambda2428{{"Lambda[2428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4184{{"Constant[4184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4184 --> Lambda2428
+    Lambda2438{{"Lambda[2438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2437 --> Lambda2438
     Lambda2443{{"Lambda[2443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2442 --> Lambda2443
-    Lambda2448{{"Lambda[2448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4027{{"Constant[4027∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4027 --> Lambda2448
-    Lambda2457{{"Lambda[2457∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2456 --> Lambda2457
-    Lambda2462{{"Lambda[2462∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4028{{"Constant[4028∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4028 --> Lambda2462
-    Lambda2471{{"Lambda[2471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2470 --> Lambda2471
-    Lambda2476{{"Lambda[2476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4029{{"Constant[4029∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4029 --> Lambda2476
-    Lambda2485{{"Lambda[2485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2484 --> Lambda2485
-    Lambda2490{{"Lambda[2490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4030{{"Constant[4030∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4030 --> Lambda2490
-    Lambda2499{{"Lambda[2499∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2498 --> Lambda2499
-    Lambda2504{{"Lambda[2504∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4031{{"Constant[4031∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4031 --> Lambda2504
+    Constant4185{{"Constant[4185∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4185 --> Lambda2443
+    Lambda2453{{"Lambda[2453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2452 --> Lambda2453
+    Lambda2458{{"Lambda[2458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4186{{"Constant[4186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4186 --> Lambda2458
+    Lambda2468{{"Lambda[2468∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2467 --> Lambda2468
+    Lambda2473{{"Lambda[2473∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4187{{"Constant[4187∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4187 --> Lambda2473
+    Lambda2483{{"Lambda[2483∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2482 --> Lambda2483
+    Lambda2488{{"Lambda[2488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4188{{"Constant[4188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4188 --> Lambda2488
+    Lambda2498{{"Lambda[2498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2497 --> Lambda2498
+    Lambda2503{{"Lambda[2503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4189{{"Constant[4189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4189 --> Lambda2503
     Lambda2513{{"Lambda[2513∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2512 --> Lambda2513
     Lambda2518{{"Lambda[2518∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4032{{"Constant[4032∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant4032 --> Lambda2518
-    Lambda2527{{"Lambda[2527∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2526 --> Lambda2527
-    Lambda2532{{"Lambda[2532∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4033{{"Constant[4033∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant4033 --> Lambda2532
-    Lambda2541{{"Lambda[2541∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2540 --> Lambda2541
-    Lambda2546{{"Lambda[2546∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4034{{"Constant[4034∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4034 --> Lambda2546
-    Lambda2555{{"Lambda[2555∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2554 --> Lambda2555
-    Lambda2560{{"Lambda[2560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4035{{"Constant[4035∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4035 --> Lambda2560
-    Lambda2569{{"Lambda[2569∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2568 --> Lambda2569
-    Lambda2574{{"Lambda[2574∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4036{{"Constant[4036∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4036 --> Lambda2574
-    Lambda2583{{"Lambda[2583∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2582 --> Lambda2583
+    Constant4190{{"Constant[4190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4190 --> Lambda2518
+    Lambda2528{{"Lambda[2528∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2527 --> Lambda2528
+    Lambda2533{{"Lambda[2533∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4191{{"Constant[4191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4191 --> Lambda2533
+    Lambda2543{{"Lambda[2543∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2542 --> Lambda2543
+    Lambda2548{{"Lambda[2548∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4192{{"Constant[4192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4192 --> Lambda2548
+    Lambda2558{{"Lambda[2558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2557 --> Lambda2558
+    Lambda2563{{"Lambda[2563∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4193{{"Constant[4193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4193 --> Lambda2563
+    Lambda2573{{"Lambda[2573∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2572 --> Lambda2573
+    Lambda2578{{"Lambda[2578∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4194{{"Constant[4194∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4194 --> Lambda2578
     Lambda2588{{"Lambda[2588∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4037{{"Constant[4037∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant4037 --> Lambda2588
-    Lambda2597{{"Lambda[2597∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2596 --> Lambda2597
-    Lambda2602{{"Lambda[2602∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4038{{"Constant[4038∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4038 --> Lambda2602
-    Lambda2611{{"Lambda[2611∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2610 --> Lambda2611
-    Lambda2616{{"Lambda[2616∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4039{{"Constant[4039∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4039 --> Lambda2616
-    Lambda2625{{"Lambda[2625∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2624 --> Lambda2625
-    Lambda2630{{"Lambda[2630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4040{{"Constant[4040∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4040 --> Lambda2630
-    Lambda2639{{"Lambda[2639∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2638 --> Lambda2639
-    Lambda2644{{"Lambda[2644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4041{{"Constant[4041∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4041 --> Lambda2644
+    Object2587 --> Lambda2588
+    Lambda2593{{"Lambda[2593∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4195{{"Constant[4195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4195 --> Lambda2593
+    Lambda2603{{"Lambda[2603∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2602 --> Lambda2603
+    Lambda2608{{"Lambda[2608∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4196{{"Constant[4196∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4196 --> Lambda2608
+    Lambda2618{{"Lambda[2618∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2617 --> Lambda2618
+    Lambda2623{{"Lambda[2623∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4197{{"Constant[4197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4197 --> Lambda2623
+    Lambda2633{{"Lambda[2633∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2632 --> Lambda2633
+    Lambda2638{{"Lambda[2638∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4198{{"Constant[4198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4198 --> Lambda2638
+    Lambda2648{{"Lambda[2648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2647 --> Lambda2648
     Lambda2653{{"Lambda[2653∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2652 --> Lambda2653
-    Lambda2658{{"Lambda[2658∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4042{{"Constant[4042∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4042 --> Lambda2658
-    Lambda2667{{"Lambda[2667∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2666 --> Lambda2667
-    Lambda2672{{"Lambda[2672∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4043{{"Constant[4043∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4043 --> Lambda2672
-    Lambda2681{{"Lambda[2681∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2680 --> Lambda2681
-    Lambda2686{{"Lambda[2686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4044{{"Constant[4044∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4044 --> Lambda2686
-    Lambda2695{{"Lambda[2695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2694 --> Lambda2695
-    Lambda2700{{"Lambda[2700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4045{{"Constant[4045∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4045 --> Lambda2700
-    Lambda2709{{"Lambda[2709∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2708 --> Lambda2709
-    Lambda2714{{"Lambda[2714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4046{{"Constant[4046∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4046 --> Lambda2714
+    Constant4199{{"Constant[4199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4199 --> Lambda2653
+    Lambda2663{{"Lambda[2663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2662 --> Lambda2663
+    Lambda2668{{"Lambda[2668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4200{{"Constant[4200∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4200 --> Lambda2668
+    Lambda2678{{"Lambda[2678∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2677 --> Lambda2678
+    Lambda2683{{"Lambda[2683∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4201{{"Constant[4201∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4201 --> Lambda2683
+    Lambda2693{{"Lambda[2693∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2692 --> Lambda2693
+    Lambda2698{{"Lambda[2698∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4202{{"Constant[4202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4202 --> Lambda2698
+    Lambda2708{{"Lambda[2708∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2707 --> Lambda2708
+    Lambda2713{{"Lambda[2713∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4203{{"Constant[4203∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4203 --> Lambda2713
     Lambda2723{{"Lambda[2723∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2722 --> Lambda2723
     Lambda2728{{"Lambda[2728∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4047{{"Constant[4047∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4047 --> Lambda2728
-    Lambda2737{{"Lambda[2737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2736 --> Lambda2737
-    Lambda2742{{"Lambda[2742∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4048{{"Constant[4048∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4048 --> Lambda2742
-    Lambda2751{{"Lambda[2751∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2750 --> Lambda2751
-    Lambda2756{{"Lambda[2756∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4049{{"Constant[4049∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4049 --> Lambda2756
-    Lambda2765{{"Lambda[2765∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2764 --> Lambda2765
-    Lambda2770{{"Lambda[2770∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4050{{"Constant[4050∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4050 --> Lambda2770
-    Lambda2779{{"Lambda[2779∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2778 --> Lambda2779
-    Lambda2784{{"Lambda[2784∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4051{{"Constant[4051∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant4051 --> Lambda2784
-    Lambda2793{{"Lambda[2793∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2792 --> Lambda2793
+    Constant4204{{"Constant[4204∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4204 --> Lambda2728
+    Lambda2738{{"Lambda[2738∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2737 --> Lambda2738
+    Lambda2743{{"Lambda[2743∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4205{{"Constant[4205∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4205 --> Lambda2743
+    Lambda2753{{"Lambda[2753∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2752 --> Lambda2753
+    Lambda2758{{"Lambda[2758∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4206{{"Constant[4206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4206 --> Lambda2758
+    Lambda2768{{"Lambda[2768∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2767 --> Lambda2768
+    Lambda2773{{"Lambda[2773∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4207{{"Constant[4207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4207 --> Lambda2773
+    Lambda2783{{"Lambda[2783∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2782 --> Lambda2783
+    Lambda2788{{"Lambda[2788∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4208{{"Constant[4208∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4208 --> Lambda2788
     Lambda2798{{"Lambda[2798∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4052{{"Constant[4052∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant4052 --> Lambda2798
-    Lambda2807{{"Lambda[2807∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2806 --> Lambda2807
-    Lambda2812{{"Lambda[2812∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4053{{"Constant[4053∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4053 --> Lambda2812
-    Lambda2821{{"Lambda[2821∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2820 --> Lambda2821
-    Lambda2826{{"Lambda[2826∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4054{{"Constant[4054∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4054 --> Lambda2826
-    Lambda2835{{"Lambda[2835∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2834 --> Lambda2835
-    Lambda2840{{"Lambda[2840∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4055{{"Constant[4055∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4055 --> Lambda2840
-    Lambda2849{{"Lambda[2849∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2848 --> Lambda2849
-    Lambda2854{{"Lambda[2854∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4056{{"Constant[4056∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant4056 --> Lambda2854
+    Object2797 --> Lambda2798
+    Lambda2803{{"Lambda[2803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4209{{"Constant[4209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4209 --> Lambda2803
+    Lambda2813{{"Lambda[2813∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2812 --> Lambda2813
+    Lambda2818{{"Lambda[2818∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4210{{"Constant[4210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4210 --> Lambda2818
+    Lambda2828{{"Lambda[2828∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2827 --> Lambda2828
+    Lambda2833{{"Lambda[2833∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4211{{"Constant[4211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4211 --> Lambda2833
+    Lambda2843{{"Lambda[2843∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2842 --> Lambda2843
+    Lambda2848{{"Lambda[2848∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4212{{"Constant[4212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4212 --> Lambda2848
+    Lambda2858{{"Lambda[2858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2857 --> Lambda2858
     Lambda2863{{"Lambda[2863∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2862 --> Lambda2863
-    Lambda2868{{"Lambda[2868∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4057{{"Constant[4057∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4057 --> Lambda2868
-    Lambda2877{{"Lambda[2877∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2876 --> Lambda2877
-    Lambda2882{{"Lambda[2882∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4058{{"Constant[4058∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4058 --> Lambda2882
-    Lambda2891{{"Lambda[2891∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2890 --> Lambda2891
-    Lambda2896{{"Lambda[2896∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4059{{"Constant[4059∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4059 --> Lambda2896
-    Lambda2905{{"Lambda[2905∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2904 --> Lambda2905
-    Lambda2910{{"Lambda[2910∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4060{{"Constant[4060∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4060 --> Lambda2910
-    Lambda2919{{"Lambda[2919∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2918 --> Lambda2919
-    Lambda2924{{"Lambda[2924∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4061{{"Constant[4061∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4061 --> Lambda2924
+    Constant4213{{"Constant[4213∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4213 --> Lambda2863
+    Lambda2873{{"Lambda[2873∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2872 --> Lambda2873
+    Lambda2878{{"Lambda[2878∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4214{{"Constant[4214∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4214 --> Lambda2878
+    Lambda2888{{"Lambda[2888∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2887 --> Lambda2888
+    Lambda2893{{"Lambda[2893∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4215{{"Constant[4215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4215 --> Lambda2893
+    Lambda2903{{"Lambda[2903∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2902 --> Lambda2903
+    Lambda2908{{"Lambda[2908∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4216{{"Constant[4216∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4216 --> Lambda2908
+    Lambda2918{{"Lambda[2918∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2917 --> Lambda2918
+    Lambda2923{{"Lambda[2923∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4217{{"Constant[4217∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4217 --> Lambda2923
     Lambda2933{{"Lambda[2933∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2932 --> Lambda2933
     Lambda2938{{"Lambda[2938∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4062{{"Constant[4062∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4062 --> Lambda2938
-    Lambda2947{{"Lambda[2947∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2946 --> Lambda2947
-    Lambda2952{{"Lambda[2952∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4063{{"Constant[4063∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4063 --> Lambda2952
-    Lambda2961{{"Lambda[2961∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2960 --> Lambda2961
-    Lambda2966{{"Lambda[2966∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4064{{"Constant[4064∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4064 --> Lambda2966
-    Lambda2975{{"Lambda[2975∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2974 --> Lambda2975
-    Lambda2980{{"Lambda[2980∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4065{{"Constant[4065∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4065 --> Lambda2980
-    Lambda2989{{"Lambda[2989∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2988 --> Lambda2989
-    Lambda2994{{"Lambda[2994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4066{{"Constant[4066∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4066 --> Lambda2994
-    Lambda3003{{"Lambda[3003∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3002 --> Lambda3003
+    Constant4218{{"Constant[4218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4218 --> Lambda2938
+    Lambda2948{{"Lambda[2948∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2947 --> Lambda2948
+    Lambda2953{{"Lambda[2953∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4219{{"Constant[4219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4219 --> Lambda2953
+    Lambda2963{{"Lambda[2963∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2962 --> Lambda2963
+    Lambda2968{{"Lambda[2968∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4220{{"Constant[4220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4220 --> Lambda2968
+    Lambda2978{{"Lambda[2978∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2977 --> Lambda2978
+    Lambda2983{{"Lambda[2983∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4221{{"Constant[4221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4221 --> Lambda2983
+    Lambda2993{{"Lambda[2993∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2992 --> Lambda2993
+    Lambda2998{{"Lambda[2998∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4222{{"Constant[4222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4222 --> Lambda2998
     Lambda3008{{"Lambda[3008∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4067{{"Constant[4067∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4067 --> Lambda3008
-    Lambda3017{{"Lambda[3017∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3016 --> Lambda3017
-    Lambda3022{{"Lambda[3022∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4068{{"Constant[4068∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4068 --> Lambda3022
-    Lambda3031{{"Lambda[3031∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3030 --> Lambda3031
-    Lambda3036{{"Lambda[3036∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4069{{"Constant[4069∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4069 --> Lambda3036
-    Lambda3045{{"Lambda[3045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3044 --> Lambda3045
-    Lambda3050{{"Lambda[3050∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4070{{"Constant[4070∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant4070 --> Lambda3050
-    Lambda3059{{"Lambda[3059∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3058 --> Lambda3059
-    Lambda3064{{"Lambda[3064∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4071{{"Constant[4071∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant4071 --> Lambda3064
+    Object3007 --> Lambda3008
+    Lambda3013{{"Lambda[3013∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4223{{"Constant[4223∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4223 --> Lambda3013
+    Lambda3023{{"Lambda[3023∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3022 --> Lambda3023
+    Lambda3028{{"Lambda[3028∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4224{{"Constant[4224∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4224 --> Lambda3028
+    Lambda3038{{"Lambda[3038∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3037 --> Lambda3038
+    Lambda3043{{"Lambda[3043∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4225{{"Constant[4225∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4225 --> Lambda3043
+    Lambda3053{{"Lambda[3053∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3052 --> Lambda3053
+    Lambda3058{{"Lambda[3058∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4226{{"Constant[4226∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4226 --> Lambda3058
+    Lambda3068{{"Lambda[3068∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3067 --> Lambda3068
     Lambda3073{{"Lambda[3073∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3072 --> Lambda3073
-    Lambda3078{{"Lambda[3078∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4072{{"Constant[4072∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4072 --> Lambda3078
-    Lambda3087{{"Lambda[3087∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3086 --> Lambda3087
-    Lambda3092{{"Lambda[3092∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4073{{"Constant[4073∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4073 --> Lambda3092
-    Lambda3101{{"Lambda[3101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3100 --> Lambda3101
-    Lambda3106{{"Lambda[3106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4074{{"Constant[4074∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4074 --> Lambda3106
-    Lambda3115{{"Lambda[3115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3114 --> Lambda3115
-    Lambda3120{{"Lambda[3120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4075{{"Constant[4075∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant4075 --> Lambda3120
-    Lambda3129{{"Lambda[3129∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3128 --> Lambda3129
-    Lambda3134{{"Lambda[3134∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4076{{"Constant[4076∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4076 --> Lambda3134
+    Constant4227{{"Constant[4227∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4227 --> Lambda3073
+    Lambda3083{{"Lambda[3083∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3082 --> Lambda3083
+    Lambda3088{{"Lambda[3088∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4228{{"Constant[4228∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4228 --> Lambda3088
+    Lambda3098{{"Lambda[3098∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3097 --> Lambda3098
+    Lambda3103{{"Lambda[3103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4229{{"Constant[4229∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4229 --> Lambda3103
+    Lambda3113{{"Lambda[3113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3112 --> Lambda3113
+    Lambda3118{{"Lambda[3118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4230{{"Constant[4230∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4230 --> Lambda3118
+    Lambda3128{{"Lambda[3128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3127 --> Lambda3128
+    Lambda3133{{"Lambda[3133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4231{{"Constant[4231∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4231 --> Lambda3133
     Lambda3143{{"Lambda[3143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3142 --> Lambda3143
     Lambda3148{{"Lambda[3148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4077{{"Constant[4077∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4077 --> Lambda3148
-    Lambda3157{{"Lambda[3157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3156 --> Lambda3157
-    Lambda3162{{"Lambda[3162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4078{{"Constant[4078∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4078 --> Lambda3162
-    Lambda3171{{"Lambda[3171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3170 --> Lambda3171
-    Lambda3176{{"Lambda[3176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4079{{"Constant[4079∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4079 --> Lambda3176
-    Lambda3185{{"Lambda[3185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3184 --> Lambda3185
-    Lambda3190{{"Lambda[3190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4080{{"Constant[4080∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4080 --> Lambda3190
-    Lambda3199{{"Lambda[3199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3198 --> Lambda3199
-    Lambda3204{{"Lambda[3204∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4081{{"Constant[4081∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4081 --> Lambda3204
-    Lambda3213{{"Lambda[3213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3212 --> Lambda3213
+    Constant4232{{"Constant[4232∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4232 --> Lambda3148
+    Lambda3158{{"Lambda[3158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3157 --> Lambda3158
+    Lambda3163{{"Lambda[3163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4233{{"Constant[4233∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4233 --> Lambda3163
+    Lambda3173{{"Lambda[3173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3172 --> Lambda3173
+    Lambda3178{{"Lambda[3178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4234{{"Constant[4234∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4234 --> Lambda3178
+    Lambda3188{{"Lambda[3188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3187 --> Lambda3188
+    Lambda3193{{"Lambda[3193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4235{{"Constant[4235∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4235 --> Lambda3193
+    Lambda3203{{"Lambda[3203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3202 --> Lambda3203
+    Lambda3208{{"Lambda[3208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4236{{"Constant[4236∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4236 --> Lambda3208
     Lambda3218{{"Lambda[3218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4082{{"Constant[4082∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4082 --> Lambda3218
-    Lambda3227{{"Lambda[3227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3226 --> Lambda3227
-    Lambda3232{{"Lambda[3232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4083{{"Constant[4083∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4083 --> Lambda3232
-    Lambda3241{{"Lambda[3241∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3240 --> Lambda3241
-    Lambda3246{{"Lambda[3246∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4084{{"Constant[4084∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4084 --> Lambda3246
-    Lambda3255{{"Lambda[3255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3254 --> Lambda3255
-    Lambda3260{{"Lambda[3260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4085{{"Constant[4085∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4085 --> Lambda3260
-    Lambda3269{{"Lambda[3269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3268 --> Lambda3269
-    Lambda3274{{"Lambda[3274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4086{{"Constant[4086∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4086 --> Lambda3274
+    Object3217 --> Lambda3218
+    Lambda3223{{"Lambda[3223∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4237{{"Constant[4237∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4237 --> Lambda3223
+    Lambda3233{{"Lambda[3233∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3232 --> Lambda3233
+    Lambda3238{{"Lambda[3238∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4238{{"Constant[4238∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4238 --> Lambda3238
+    Lambda3248{{"Lambda[3248∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3247 --> Lambda3248
+    Lambda3253{{"Lambda[3253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4239{{"Constant[4239∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4239 --> Lambda3253
+    Lambda3263{{"Lambda[3263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3262 --> Lambda3263
+    Lambda3268{{"Lambda[3268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4240{{"Constant[4240∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4240 --> Lambda3268
+    Lambda3278{{"Lambda[3278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3277 --> Lambda3278
     Lambda3283{{"Lambda[3283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3282 --> Lambda3283
-    Lambda3288{{"Lambda[3288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4087{{"Constant[4087∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4087 --> Lambda3288
-    Lambda3297{{"Lambda[3297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3296 --> Lambda3297
-    Lambda3302{{"Lambda[3302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4088{{"Constant[4088∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4088 --> Lambda3302
-    Object3310 --> Lambda3311
-    Constant4089{{"Constant[4089∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4089 --> Lambda3316
-    Object3324 --> Lambda3325
-    Constant4090{{"Constant[4090∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4090 --> Lambda3330
-    Object3338 --> Lambda3339
-    Constant4091{{"Constant[4091∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4091 --> Lambda3344
+    Constant4241{{"Constant[4241∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4241 --> Lambda3283
+    Lambda3293{{"Lambda[3293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3292 --> Lambda3293
+    Lambda3298{{"Lambda[3298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4242{{"Constant[4242∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4242 --> Lambda3298
+    Lambda3308{{"Lambda[3308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3307 --> Lambda3308
+    Lambda3313{{"Lambda[3313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4243{{"Constant[4243∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4243 --> Lambda3313
+    Lambda3323{{"Lambda[3323∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3322 --> Lambda3323
+    Lambda3328{{"Lambda[3328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4244{{"Constant[4244∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4244 --> Lambda3328
+    Lambda3338{{"Lambda[3338∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3337 --> Lambda3338
+    Lambda3343{{"Lambda[3343∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4245{{"Constant[4245∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4245 --> Lambda3343
+    Lambda3353{{"Lambda[3353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3352 --> Lambda3353
-    Constant4092{{"Constant[4092∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4092 --> Lambda3358
-    Object3366 --> Lambda3367
-    Constant4093{{"Constant[4093∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4093 --> Lambda3372
-    Object3380 --> Lambda3381
-    Constant4094{{"Constant[4094∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4094 --> Lambda3386
-    Lambda3395{{"Lambda[3395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3394 --> Lambda3395
-    Lambda3400{{"Lambda[3400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4095{{"Constant[4095∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant4095 --> Lambda3400
-    Lambda3409{{"Lambda[3409∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3408 --> Lambda3409
-    Lambda3414{{"Lambda[3414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4096{{"Constant[4096∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant4096 --> Lambda3414
-    Lambda3423{{"Lambda[3423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3422 --> Lambda3423
-    Lambda3428{{"Lambda[3428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4097{{"Constant[4097∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4097 --> Lambda3428
-    Lambda3437{{"Lambda[3437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3436 --> Lambda3437
-    Lambda3442{{"Lambda[3442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4098{{"Constant[4098∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4098 --> Lambda3442
-    Lambda3451{{"Lambda[3451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3450 --> Lambda3451
-    Lambda3456{{"Lambda[3456∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4099{{"Constant[4099∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4099 --> Lambda3456
-    Lambda3465{{"Lambda[3465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3464 --> Lambda3465
-    Lambda3470{{"Lambda[3470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4100{{"Constant[4100∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant4100 --> Lambda3470
-    Lambda3479{{"Lambda[3479∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3478 --> Lambda3479
-    Lambda3484{{"Lambda[3484∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4101{{"Constant[4101∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4101 --> Lambda3484
-    Lambda3493{{"Lambda[3493∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3492 --> Lambda3493
-    Lambda3498{{"Lambda[3498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4102{{"Constant[4102∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4102 --> Lambda3498
-    Lambda3507{{"Lambda[3507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3506 --> Lambda3507
-    Lambda3512{{"Lambda[3512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4103{{"Constant[4103∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4103 --> Lambda3512
-    Lambda3521{{"Lambda[3521∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3520 --> Lambda3521
-    Lambda3526{{"Lambda[3526∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4104{{"Constant[4104∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4104 --> Lambda3526
-    Lambda3535{{"Lambda[3535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3534 --> Lambda3535
-    Lambda3540{{"Lambda[3540∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4105{{"Constant[4105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4105 --> Lambda3540
-    Lambda3549{{"Lambda[3549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3548 --> Lambda3549
-    Lambda3554{{"Lambda[3554∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4106{{"Constant[4106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4106 --> Lambda3554
+    Lambda3358{{"Lambda[3358∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4246{{"Constant[4246∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4246 --> Lambda3358
+    Lambda3368{{"Lambda[3368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3367 --> Lambda3368
+    Lambda3373{{"Lambda[3373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4247{{"Constant[4247∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4247 --> Lambda3373
+    Lambda3383{{"Lambda[3383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3382 --> Lambda3383
+    Lambda3388{{"Lambda[3388∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4248{{"Constant[4248∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4248 --> Lambda3388
+    Lambda3398{{"Lambda[3398∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3397 --> Lambda3398
+    Lambda3403{{"Lambda[3403∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4249{{"Constant[4249∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4249 --> Lambda3403
+    Lambda3413{{"Lambda[3413∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3412 --> Lambda3413
+    Lambda3418{{"Lambda[3418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4250{{"Constant[4250∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4250 --> Lambda3418
+    Object3427 --> Lambda3428
+    Constant4251{{"Constant[4251∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4251 --> Lambda3433
+    Object3442 --> Lambda3443
+    Constant4252{{"Constant[4252∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4252 --> Lambda3448
+    Object3457 --> Lambda3458
+    Constant4253{{"Constant[4253∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4253 --> Lambda3463
+    Object3472 --> Lambda3473
+    Constant4254{{"Constant[4254∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4254 --> Lambda3478
+    Object3487 --> Lambda3488
+    Constant4255{{"Constant[4255∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4255 --> Lambda3493
+    Object3502 --> Lambda3503
+    Constant4256{{"Constant[4256∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4256 --> Lambda3508
+    Lambda3518{{"Lambda[3518∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3517 --> Lambda3518
+    Lambda3523{{"Lambda[3523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4257{{"Constant[4257∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4257 --> Lambda3523
+    Lambda3533{{"Lambda[3533∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3532 --> Lambda3533
+    Lambda3538{{"Lambda[3538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4258{{"Constant[4258∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4258 --> Lambda3538
+    Lambda3548{{"Lambda[3548∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3547 --> Lambda3548
+    Lambda3553{{"Lambda[3553∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4259{{"Constant[4259∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4259 --> Lambda3553
     Lambda3563{{"Lambda[3563∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3562 --> Lambda3563
     Lambda3568{{"Lambda[3568∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4107{{"Constant[4107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4107 --> Lambda3568
-    Lambda3577{{"Lambda[3577∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3576 --> Lambda3577
-    Lambda3582{{"Lambda[3582∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4108{{"Constant[4108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4108 --> Lambda3582
-    Lambda3591{{"Lambda[3591∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3590 --> Lambda3591
-    Lambda3596{{"Lambda[3596∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4109{{"Constant[4109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4109 --> Lambda3596
-    Lambda3605{{"Lambda[3605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3604 --> Lambda3605
-    Lambda3610{{"Lambda[3610∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4110{{"Constant[4110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4110 --> Lambda3610
-    Lambda3619{{"Lambda[3619∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3618 --> Lambda3619
-    Lambda3624{{"Lambda[3624∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4111{{"Constant[4111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4111 --> Lambda3624
-    Lambda3633{{"Lambda[3633∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3632 --> Lambda3633
+    Constant4260{{"Constant[4260∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4260 --> Lambda3568
+    Lambda3578{{"Lambda[3578∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3577 --> Lambda3578
+    Lambda3583{{"Lambda[3583∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4261{{"Constant[4261∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4261 --> Lambda3583
+    Lambda3593{{"Lambda[3593∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3592 --> Lambda3593
+    Lambda3598{{"Lambda[3598∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4262{{"Constant[4262∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4262 --> Lambda3598
+    Lambda3608{{"Lambda[3608∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3607 --> Lambda3608
+    Lambda3613{{"Lambda[3613∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4263{{"Constant[4263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4263 --> Lambda3613
+    Lambda3623{{"Lambda[3623∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3622 --> Lambda3623
+    Lambda3628{{"Lambda[3628∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4264{{"Constant[4264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4264 --> Lambda3628
     Lambda3638{{"Lambda[3638∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4112{{"Constant[4112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4112 --> Lambda3638
-    Lambda3647{{"Lambda[3647∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3646 --> Lambda3647
-    Lambda3652{{"Lambda[3652∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4113{{"Constant[4113∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4113 --> Lambda3652
-    Lambda3661{{"Lambda[3661∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3660 --> Lambda3661
-    Lambda3666{{"Lambda[3666∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4114{{"Constant[4114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant4114 --> Lambda3666
-    Lambda3675{{"Lambda[3675∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3674 --> Lambda3675
-    Lambda3680{{"Lambda[3680∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4115{{"Constant[4115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant4115 --> Lambda3680
-    Lambda3689{{"Lambda[3689∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3688 --> Lambda3689
-    Lambda3694{{"Lambda[3694∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4116{{"Constant[4116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4116 --> Lambda3694
+    Object3637 --> Lambda3638
+    Lambda3643{{"Lambda[3643∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4265{{"Constant[4265∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4265 --> Lambda3643
+    Lambda3653{{"Lambda[3653∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3652 --> Lambda3653
+    Lambda3658{{"Lambda[3658∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4266{{"Constant[4266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4266 --> Lambda3658
+    Lambda3668{{"Lambda[3668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3667 --> Lambda3668
+    Lambda3673{{"Lambda[3673∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4267{{"Constant[4267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4267 --> Lambda3673
+    Lambda3683{{"Lambda[3683∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3682 --> Lambda3683
+    Lambda3688{{"Lambda[3688∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4268{{"Constant[4268∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4268 --> Lambda3688
+    Lambda3698{{"Lambda[3698∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3697 --> Lambda3698
     Lambda3703{{"Lambda[3703∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3702 --> Lambda3703
-    Lambda3708{{"Lambda[3708∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4117{{"Constant[4117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4117 --> Lambda3708
-    Lambda3717{{"Lambda[3717∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3716 --> Lambda3717
-    Lambda3722{{"Lambda[3722∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4118{{"Constant[4118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant4118 --> Lambda3722
-    Lambda3731{{"Lambda[3731∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3730 --> Lambda3731
-    Lambda3736{{"Lambda[3736∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4119{{"Constant[4119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant4119 --> Lambda3736
-    Lambda3745{{"Lambda[3745∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3744 --> Lambda3745
-    Lambda3750{{"Lambda[3750∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4120{{"Constant[4120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant4120 --> Lambda3750
-    Lambda3759{{"Lambda[3759∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3758 --> Lambda3759
-    Lambda3764{{"Lambda[3764∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4121{{"Constant[4121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4121 --> Lambda3764
+    Constant4269{{"Constant[4269∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4269 --> Lambda3703
+    Lambda3713{{"Lambda[3713∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3712 --> Lambda3713
+    Lambda3718{{"Lambda[3718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4270{{"Constant[4270∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4270 --> Lambda3718
+    Lambda3728{{"Lambda[3728∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3727 --> Lambda3728
+    Lambda3733{{"Lambda[3733∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4271{{"Constant[4271∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4271 --> Lambda3733
+    Lambda3743{{"Lambda[3743∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3742 --> Lambda3743
+    Lambda3748{{"Lambda[3748∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4272{{"Constant[4272∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4272 --> Lambda3748
+    Lambda3758{{"Lambda[3758∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3757 --> Lambda3758
+    Lambda3763{{"Lambda[3763∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4273{{"Constant[4273∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4273 --> Lambda3763
     Lambda3773{{"Lambda[3773∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3772 --> Lambda3773
     Lambda3778{{"Lambda[3778∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4122{{"Constant[4122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant4122 --> Lambda3778
-    Lambda3787{{"Lambda[3787∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3786 --> Lambda3787
-    Lambda3792{{"Lambda[3792∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4123{{"Constant[4123∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant4123 --> Lambda3792
-    Lambda3801{{"Lambda[3801∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3800 --> Lambda3801
-    Lambda3806{{"Lambda[3806∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4124{{"Constant[4124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant4124 --> Lambda3806
-    Lambda3815{{"Lambda[3815∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3814 --> Lambda3815
-    Lambda3820{{"Lambda[3820∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4125{{"Constant[4125∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant4125 --> Lambda3820
-    Lambda3829{{"Lambda[3829∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3828 --> Lambda3829
-    Lambda3834{{"Lambda[3834∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4126{{"Constant[4126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant4126 --> Lambda3834
-    Lambda3843{{"Lambda[3843∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3842 --> Lambda3843
+    Constant4274{{"Constant[4274∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4274 --> Lambda3778
+    Lambda3788{{"Lambda[3788∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3787 --> Lambda3788
+    Lambda3793{{"Lambda[3793∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4275{{"Constant[4275∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4275 --> Lambda3793
+    Lambda3803{{"Lambda[3803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3802 --> Lambda3803
+    Lambda3808{{"Lambda[3808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4276{{"Constant[4276∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant4276 --> Lambda3808
+    Lambda3818{{"Lambda[3818∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3817 --> Lambda3818
+    Lambda3823{{"Lambda[3823∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4277{{"Constant[4277∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant4277 --> Lambda3823
+    Lambda3833{{"Lambda[3833∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3832 --> Lambda3833
+    Lambda3838{{"Lambda[3838∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4278{{"Constant[4278∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4278 --> Lambda3838
     Lambda3848{{"Lambda[3848∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4127{{"Constant[4127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant4127 --> Lambda3848
-    Lambda3857{{"Lambda[3857∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3856 --> Lambda3857
-    Lambda3862{{"Lambda[3862∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4128{{"Constant[4128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4128 --> Lambda3862
-    Lambda3871{{"Lambda[3871∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3870 --> Lambda3871
-    Lambda3876{{"Lambda[3876∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4129{{"Constant[4129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4129 --> Lambda3876
-    Lambda3885{{"Lambda[3885∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3884 --> Lambda3885
-    Lambda3890{{"Lambda[3890∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4130{{"Constant[4130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant4130 --> Lambda3890
-    Lambda3899{{"Lambda[3899∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3898 --> Lambda3899
-    Lambda3904{{"Lambda[3904∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4131{{"Constant[4131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant4131 --> Lambda3904
+    Object3847 --> Lambda3848
+    Lambda3853{{"Lambda[3853∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4279{{"Constant[4279∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4279 --> Lambda3853
+    Lambda3863{{"Lambda[3863∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3862 --> Lambda3863
+    Lambda3868{{"Lambda[3868∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4280{{"Constant[4280∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant4280 --> Lambda3868
+    Lambda3878{{"Lambda[3878∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3877 --> Lambda3878
+    Lambda3883{{"Lambda[3883∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4281{{"Constant[4281∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant4281 --> Lambda3883
+    Lambda3893{{"Lambda[3893∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3892 --> Lambda3893
+    Lambda3898{{"Lambda[3898∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4282{{"Constant[4282∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant4282 --> Lambda3898
+    Lambda3908{{"Lambda[3908∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3907 --> Lambda3908
     Lambda3913{{"Lambda[3913∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3912 --> Lambda3913
-    Lambda3918{{"Lambda[3918∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant4132{{"Constant[4132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant4132 --> Lambda3918
-    Object3926 --> Lambda3927
-    Constant4133{{"Constant[4133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4133 --> Lambda3932
-    Object3940 --> Lambda3941
-    Constant4134{{"Constant[4134∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant4134 --> Lambda3946
+    Constant4283{{"Constant[4283∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4283 --> Lambda3913
+    Lambda3923{{"Lambda[3923∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3922 --> Lambda3923
+    Lambda3928{{"Lambda[3928∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4284{{"Constant[4284∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4284 --> Lambda3928
+    Lambda3938{{"Lambda[3938∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3937 --> Lambda3938
+    Lambda3943{{"Lambda[3943∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4285{{"Constant[4285∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant4285 --> Lambda3943
+    Lambda3953{{"Lambda[3953∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3952 --> Lambda3953
+    Lambda3958{{"Lambda[3958∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4286{{"Constant[4286∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant4286 --> Lambda3958
+    Lambda3968{{"Lambda[3968∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3967 --> Lambda3968
+    Lambda3973{{"Lambda[3973∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4287{{"Constant[4287∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant4287 --> Lambda3973
+    Lambda3983{{"Lambda[3983∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3982 --> Lambda3983
+    Lambda3988{{"Lambda[3988∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4288{{"Constant[4288∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant4288 --> Lambda3988
+    Lambda3998{{"Lambda[3998∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3997 --> Lambda3998
+    Lambda4003{{"Lambda[4003∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4289{{"Constant[4289∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant4289 --> Lambda4003
+    Lambda4013{{"Lambda[4013∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4012 --> Lambda4013
+    Lambda4018{{"Lambda[4018∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4290{{"Constant[4290∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4290 --> Lambda4018
+    Lambda4028{{"Lambda[4028∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4027 --> Lambda4028
+    Lambda4033{{"Lambda[4033∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4291{{"Constant[4291∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4291 --> Lambda4033
+    Lambda4043{{"Lambda[4043∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4042 --> Lambda4043
+    Lambda4048{{"Lambda[4048∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4292{{"Constant[4292∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant4292 --> Lambda4048
+    Lambda4058{{"Lambda[4058∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4057 --> Lambda4058
+    Lambda4063{{"Lambda[4063∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4293{{"Constant[4293∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant4293 --> Lambda4063
+    Lambda4073{{"Lambda[4073∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4072 --> Lambda4073
+    Lambda4078{{"Lambda[4078∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant4294{{"Constant[4294∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant4294 --> Lambda4078
+    Object4087 --> Lambda4088
+    Constant4295{{"Constant[4295∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4295 --> Lambda4093
+    Object4102 --> Lambda4103
+    Constant4296{{"Constant[4296∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant4296 --> Lambda4108
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant17{{"Constant[17∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
@@ -1641,20 +1661,8 @@ graph TD
     Constant204{{"Constant[204∈0] ➊<br />ᐸ'null_test_records'ᐳ"}}:::plan
     Constant213{{"Constant[213∈0] ➊<br />ᐸ'issue756S'ᐳ"}}:::plan
     Constant222{{"Constant[222∈0] ➊<br />ᐸ'lists'ᐳ"}}:::plan
-    Constant1683{{"Constant[1683∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant1684{{"Constant[1684∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant1697{{"Constant[1697∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant1698{{"Constant[1698∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant3973{{"Constant[3973∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant3974{{"Constant[3974∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda1687{{"Lambda[1687∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1692{{"Lambda[1692∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda1679 & Lambda1682 & Lambda1687 & Lambda1692 --> PgSelect14
-    Object1686{{"Object[1686∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1679 & Constant1683 & Constant1684 & Constant1685 --> Object1686
-    Object1686 --> Lambda1687
-    Constant3973 --> Lambda1692
+    Object12 & Connection13 & Lambda1679 & Access1683 & Lambda1688 & Lambda1693 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -1668,13 +1676,7 @@ graph TD
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression21
     PgSelect27[["PgSelect[27∈4] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Lambda1701{{"Lambda[1701∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1706{{"Lambda[1706∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection26 & Lambda1679 & Lambda1682 & Lambda1701 & Lambda1706 --> PgSelect27
-    Object1700{{"Object[1700∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1679 & Constant1697 & Constant1698 & Constant1699 --> Object1700
-    Object1700 --> Lambda1701
-    Constant3974 --> Lambda1706
+    Object12 & Connection26 & Lambda1679 & Access1683 & Lambda1703 & Lambda1708 --> PgSelect27
     __Item28[/"__Item[28∈5]<br />ᐸ27ᐳ"\]:::itemplan
     PgSelect27 ==> __Item28
     PgSelectSingle29{{"PgSelectSingle[29∈5]<br />ᐸcompound_keyᐳ"}}:::plan
@@ -1688,65 +1690,65 @@ graph TD
     Lambda34{{"Lambda[34∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List33 --> Lambda34
     PgSelect102[["PgSelect[102∈7] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3947{{"Access[3947∈7] ➊<br />ᐸ37.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3948{{"Access[3948∈7] ➊<br />ᐸ37.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4109{{"Access[4109∈7] ➊<br />ᐸ37.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4110{{"Access[4110∈7] ➊<br />ᐸ37.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect102
-    Access3947 -->|rejectNull| PgSelect102
-    Access3948 & Lambda1679 & Lambda1682 & Lambda1799 & Lambda1804 --> PgSelect102
+    Access4109 -->|rejectNull| PgSelect102
+    Access4110 & Lambda1679 & Access1683 & Lambda1808 & Lambda1813 --> PgSelect102
     PgSelect44[["PgSelect[44∈7] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect44
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1715 & Lambda1720 --> PgSelect44
+    Access4109 & Lambda1679 & Access1683 & Lambda1718 & Lambda1723 --> PgSelect44
     PgSelect55[["PgSelect[55∈7] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect55
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1729 & Lambda1734 --> PgSelect55
+    Access4109 & Lambda1679 & Access1683 & Lambda1733 & Lambda1738 --> PgSelect55
     PgSelect64[["PgSelect[64∈7] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect64
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1743 & Lambda1748 --> PgSelect64
+    Access4109 & Lambda1679 & Access1683 & Lambda1748 & Lambda1753 --> PgSelect64
     PgSelect73[["PgSelect[73∈7] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect73
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1757 & Lambda1762 --> PgSelect73
+    Access4109 & Lambda1679 & Access1683 & Lambda1763 & Lambda1768 --> PgSelect73
     PgSelect82[["PgSelect[82∈7] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect82
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1771 & Lambda1776 --> PgSelect82
+    Access4109 & Lambda1679 & Access1683 & Lambda1778 & Lambda1783 --> PgSelect82
     PgSelect91[["PgSelect[91∈7] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect91
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1785 & Lambda1790 --> PgSelect91
+    Access4109 & Lambda1679 & Access1683 & Lambda1793 & Lambda1798 --> PgSelect91
     PgSelect112[["PgSelect[112∈7] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect112
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1813 & Lambda1818 --> PgSelect112
+    Access4109 & Lambda1679 & Access1683 & Lambda1823 & Lambda1828 --> PgSelect112
     PgSelect122[["PgSelect[122∈7] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect122
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1827 & Lambda1832 --> PgSelect122
+    Access4109 & Lambda1679 & Access1683 & Lambda1838 & Lambda1843 --> PgSelect122
     PgSelect131[["PgSelect[131∈7] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect131
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1841 & Lambda1846 --> PgSelect131
+    Access4109 & Lambda1679 & Access1683 & Lambda1853 & Lambda1858 --> PgSelect131
     PgSelect140[["PgSelect[140∈7] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect140
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1855 & Lambda1860 --> PgSelect140
+    Access4109 & Lambda1679 & Access1683 & Lambda1868 & Lambda1873 --> PgSelect140
     PgSelect149[["PgSelect[149∈7] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect149
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1869 & Lambda1874 --> PgSelect149
+    Access4109 & Lambda1679 & Access1683 & Lambda1883 & Lambda1888 --> PgSelect149
     PgSelect158[["PgSelect[158∈7] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect158
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1883 & Lambda1888 --> PgSelect158
+    Access4109 & Lambda1679 & Access1683 & Lambda1898 & Lambda1903 --> PgSelect158
     PgSelect167[["PgSelect[167∈7] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect167
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1897 & Lambda1902 --> PgSelect167
+    Access4109 & Lambda1679 & Access1683 & Lambda1913 & Lambda1918 --> PgSelect167
     PgSelect176[["PgSelect[176∈7] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect176
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1911 & Lambda1916 --> PgSelect176
+    Access4109 & Lambda1679 & Access1683 & Lambda1928 & Lambda1933 --> PgSelect176
     PgSelect188[["PgSelect[188∈7] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect188
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1925 & Lambda1930 --> PgSelect188
+    Access4109 & Lambda1679 & Access1683 & Lambda1943 & Lambda1948 --> PgSelect188
     PgSelect200[["PgSelect[200∈7] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect200
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1939 & Lambda1944 --> PgSelect200
+    Access4109 & Lambda1679 & Access1683 & Lambda1958 & Lambda1963 --> PgSelect200
     PgSelect209[["PgSelect[209∈7] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect209
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1953 & Lambda1958 --> PgSelect209
+    Access4109 & Lambda1679 & Access1683 & Lambda1973 & Lambda1978 --> PgSelect209
     PgSelect218[["PgSelect[218∈7] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect218
-    Access3947 & Lambda1679 & Lambda1682 & Lambda1967 & Lambda1972 --> PgSelect218
+    Access4109 & Lambda1679 & Access1683 & Lambda1988 & Lambda1993 --> PgSelect218
     List109{{"List[109∈7] ➊<br />ᐸ30,107,108ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression107{{"PgClassExpression[107∈7] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression108{{"PgClassExpression[108∈7] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -1955,68 +1957,68 @@ graph TD
     PgSelectSingle221 --> PgClassExpression223
     Lambda225{{"Lambda[225∈7] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List224 --> Lambda225
-    Lambda37 --> Access3947
-    Lambda37 --> Access3948
+    Lambda37 --> Access4109
+    Lambda37 --> Access4110
     PgSelect293[["PgSelect[293∈8] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3950{{"Access[3950∈8] ➊<br />ᐸ228.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3951{{"Access[3951∈8] ➊<br />ᐸ228.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4112{{"Access[4112∈8] ➊<br />ᐸ228.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4113{{"Access[4113∈8] ➊<br />ᐸ228.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect293
-    Access3950 -->|rejectNull| PgSelect293
-    Access3951 & Lambda1679 & Lambda1682 & Lambda2065 & Lambda2070 --> PgSelect293
+    Access4112 -->|rejectNull| PgSelect293
+    Access4113 & Lambda1679 & Access1683 & Lambda2093 & Lambda2098 --> PgSelect293
     PgSelect235[["PgSelect[235∈8] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect235
-    Access3950 & Lambda1679 & Lambda1682 & Lambda1981 & Lambda1986 --> PgSelect235
+    Access4112 & Lambda1679 & Access1683 & Lambda2003 & Lambda2008 --> PgSelect235
     PgSelect246[["PgSelect[246∈8] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect246
-    Access3950 & Lambda1679 & Lambda1682 & Lambda1995 & Lambda2000 --> PgSelect246
+    Access4112 & Lambda1679 & Access1683 & Lambda2018 & Lambda2023 --> PgSelect246
     PgSelect255[["PgSelect[255∈8] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect255
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2009 & Lambda2014 --> PgSelect255
+    Access4112 & Lambda1679 & Access1683 & Lambda2033 & Lambda2038 --> PgSelect255
     PgSelect264[["PgSelect[264∈8] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect264
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2023 & Lambda2028 --> PgSelect264
+    Access4112 & Lambda1679 & Access1683 & Lambda2048 & Lambda2053 --> PgSelect264
     PgSelect273[["PgSelect[273∈8] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect273
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2037 & Lambda2042 --> PgSelect273
+    Access4112 & Lambda1679 & Access1683 & Lambda2063 & Lambda2068 --> PgSelect273
     PgSelect282[["PgSelect[282∈8] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect282
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2051 & Lambda2056 --> PgSelect282
+    Access4112 & Lambda1679 & Access1683 & Lambda2078 & Lambda2083 --> PgSelect282
     PgSelect303[["PgSelect[303∈8] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect303
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2079 & Lambda2084 --> PgSelect303
+    Access4112 & Lambda1679 & Access1683 & Lambda2108 & Lambda2113 --> PgSelect303
     PgSelect313[["PgSelect[313∈8] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect313
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2093 & Lambda2098 --> PgSelect313
+    Access4112 & Lambda1679 & Access1683 & Lambda2123 & Lambda2128 --> PgSelect313
     PgSelect322[["PgSelect[322∈8] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect322
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2107 & Lambda2112 --> PgSelect322
+    Access4112 & Lambda1679 & Access1683 & Lambda2138 & Lambda2143 --> PgSelect322
     PgSelect331[["PgSelect[331∈8] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect331
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2121 & Lambda2126 --> PgSelect331
+    Access4112 & Lambda1679 & Access1683 & Lambda2153 & Lambda2158 --> PgSelect331
     PgSelect340[["PgSelect[340∈8] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect340
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2135 & Lambda2140 --> PgSelect340
+    Access4112 & Lambda1679 & Access1683 & Lambda2168 & Lambda2173 --> PgSelect340
     PgSelect349[["PgSelect[349∈8] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect349
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2149 & Lambda2154 --> PgSelect349
+    Access4112 & Lambda1679 & Access1683 & Lambda2183 & Lambda2188 --> PgSelect349
     PgSelect358[["PgSelect[358∈8] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect358
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2163 & Lambda2168 --> PgSelect358
+    Access4112 & Lambda1679 & Access1683 & Lambda2198 & Lambda2203 --> PgSelect358
     PgSelect367[["PgSelect[367∈8] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect367
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2177 & Lambda2182 --> PgSelect367
+    Access4112 & Lambda1679 & Access1683 & Lambda2213 & Lambda2218 --> PgSelect367
     PgSelect379[["PgSelect[379∈8] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect379
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2191 & Lambda2196 --> PgSelect379
+    Access4112 & Lambda1679 & Access1683 & Lambda2228 & Lambda2233 --> PgSelect379
     PgSelect391[["PgSelect[391∈8] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect391
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2205 & Lambda2210 --> PgSelect391
+    Access4112 & Lambda1679 & Access1683 & Lambda2243 & Lambda2248 --> PgSelect391
     PgSelect400[["PgSelect[400∈8] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect400
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2219 & Lambda2224 --> PgSelect400
+    Access4112 & Lambda1679 & Access1683 & Lambda2258 & Lambda2263 --> PgSelect400
     PgSelect409[["PgSelect[409∈8] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect409
-    Access3950 & Lambda1679 & Lambda1682 & Lambda2233 & Lambda2238 --> PgSelect409
+    Access4112 & Lambda1679 & Access1683 & Lambda2273 & Lambda2278 --> PgSelect409
     List300{{"List[300∈8] ➊<br />ᐸ30,298,299ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression298{{"PgClassExpression[298∈8] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression299{{"PgClassExpression[299∈8] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -2225,68 +2227,68 @@ graph TD
     PgSelectSingle412 --> PgClassExpression414
     Lambda416{{"Lambda[416∈8] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List415 --> Lambda416
-    Lambda228 --> Access3950
-    Lambda228 --> Access3951
+    Lambda228 --> Access4112
+    Lambda228 --> Access4113
     PgSelect484[["PgSelect[484∈9] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3953{{"Access[3953∈9] ➊<br />ᐸ419.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3954{{"Access[3954∈9] ➊<br />ᐸ419.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4115{{"Access[4115∈9] ➊<br />ᐸ419.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4116{{"Access[4116∈9] ➊<br />ᐸ419.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect484
-    Access3953 -->|rejectNull| PgSelect484
-    Access3954 & Lambda1679 & Lambda1682 & Lambda2331 & Lambda2336 --> PgSelect484
+    Access4115 -->|rejectNull| PgSelect484
+    Access4116 & Lambda1679 & Access1683 & Lambda2378 & Lambda2383 --> PgSelect484
     PgSelect426[["PgSelect[426∈9] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect426
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2247 & Lambda2252 --> PgSelect426
+    Access4115 & Lambda1679 & Access1683 & Lambda2288 & Lambda2293 --> PgSelect426
     PgSelect437[["PgSelect[437∈9] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect437
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2261 & Lambda2266 --> PgSelect437
+    Access4115 & Lambda1679 & Access1683 & Lambda2303 & Lambda2308 --> PgSelect437
     PgSelect446[["PgSelect[446∈9] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect446
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2275 & Lambda2280 --> PgSelect446
+    Access4115 & Lambda1679 & Access1683 & Lambda2318 & Lambda2323 --> PgSelect446
     PgSelect455[["PgSelect[455∈9] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect455
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2289 & Lambda2294 --> PgSelect455
+    Access4115 & Lambda1679 & Access1683 & Lambda2333 & Lambda2338 --> PgSelect455
     PgSelect464[["PgSelect[464∈9] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect464
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2303 & Lambda2308 --> PgSelect464
+    Access4115 & Lambda1679 & Access1683 & Lambda2348 & Lambda2353 --> PgSelect464
     PgSelect473[["PgSelect[473∈9] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect473
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2317 & Lambda2322 --> PgSelect473
+    Access4115 & Lambda1679 & Access1683 & Lambda2363 & Lambda2368 --> PgSelect473
     PgSelect494[["PgSelect[494∈9] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect494
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2345 & Lambda2350 --> PgSelect494
+    Access4115 & Lambda1679 & Access1683 & Lambda2393 & Lambda2398 --> PgSelect494
     PgSelect504[["PgSelect[504∈9] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect504
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2359 & Lambda2364 --> PgSelect504
+    Access4115 & Lambda1679 & Access1683 & Lambda2408 & Lambda2413 --> PgSelect504
     PgSelect513[["PgSelect[513∈9] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect513
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2373 & Lambda2378 --> PgSelect513
+    Access4115 & Lambda1679 & Access1683 & Lambda2423 & Lambda2428 --> PgSelect513
     PgSelect522[["PgSelect[522∈9] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect522
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2387 & Lambda2392 --> PgSelect522
+    Access4115 & Lambda1679 & Access1683 & Lambda2438 & Lambda2443 --> PgSelect522
     PgSelect531[["PgSelect[531∈9] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect531
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2401 & Lambda2406 --> PgSelect531
+    Access4115 & Lambda1679 & Access1683 & Lambda2453 & Lambda2458 --> PgSelect531
     PgSelect540[["PgSelect[540∈9] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect540
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2415 & Lambda2420 --> PgSelect540
+    Access4115 & Lambda1679 & Access1683 & Lambda2468 & Lambda2473 --> PgSelect540
     PgSelect549[["PgSelect[549∈9] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect549
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2429 & Lambda2434 --> PgSelect549
+    Access4115 & Lambda1679 & Access1683 & Lambda2483 & Lambda2488 --> PgSelect549
     PgSelect558[["PgSelect[558∈9] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect558
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2443 & Lambda2448 --> PgSelect558
+    Access4115 & Lambda1679 & Access1683 & Lambda2498 & Lambda2503 --> PgSelect558
     PgSelect570[["PgSelect[570∈9] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect570
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2457 & Lambda2462 --> PgSelect570
+    Access4115 & Lambda1679 & Access1683 & Lambda2513 & Lambda2518 --> PgSelect570
     PgSelect582[["PgSelect[582∈9] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect582
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2471 & Lambda2476 --> PgSelect582
+    Access4115 & Lambda1679 & Access1683 & Lambda2528 & Lambda2533 --> PgSelect582
     PgSelect591[["PgSelect[591∈9] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect591
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2485 & Lambda2490 --> PgSelect591
+    Access4115 & Lambda1679 & Access1683 & Lambda2543 & Lambda2548 --> PgSelect591
     PgSelect600[["PgSelect[600∈9] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect600
-    Access3953 & Lambda1679 & Lambda1682 & Lambda2499 & Lambda2504 --> PgSelect600
+    Access4115 & Lambda1679 & Access1683 & Lambda2558 & Lambda2563 --> PgSelect600
     List491{{"List[491∈9] ➊<br />ᐸ30,489,490ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression489{{"PgClassExpression[489∈9] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression490{{"PgClassExpression[490∈9] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -2495,68 +2497,68 @@ graph TD
     PgSelectSingle603 --> PgClassExpression605
     Lambda607{{"Lambda[607∈9] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List606 --> Lambda607
-    Lambda419 --> Access3953
-    Lambda419 --> Access3954
+    Lambda419 --> Access4115
+    Lambda419 --> Access4116
     PgSelect675[["PgSelect[675∈10] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3956{{"Access[3956∈10] ➊<br />ᐸ610.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3957{{"Access[3957∈10] ➊<br />ᐸ610.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4118{{"Access[4118∈10] ➊<br />ᐸ610.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4119{{"Access[4119∈10] ➊<br />ᐸ610.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect675
-    Access3956 -->|rejectNull| PgSelect675
-    Access3957 & Lambda1679 & Lambda1682 & Lambda2597 & Lambda2602 --> PgSelect675
+    Access4118 -->|rejectNull| PgSelect675
+    Access4119 & Lambda1679 & Access1683 & Lambda2663 & Lambda2668 --> PgSelect675
     PgSelect617[["PgSelect[617∈10] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect617
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2513 & Lambda2518 --> PgSelect617
+    Access4118 & Lambda1679 & Access1683 & Lambda2573 & Lambda2578 --> PgSelect617
     PgSelect628[["PgSelect[628∈10] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect628
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2527 & Lambda2532 --> PgSelect628
+    Access4118 & Lambda1679 & Access1683 & Lambda2588 & Lambda2593 --> PgSelect628
     PgSelect637[["PgSelect[637∈10] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect637
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2541 & Lambda2546 --> PgSelect637
+    Access4118 & Lambda1679 & Access1683 & Lambda2603 & Lambda2608 --> PgSelect637
     PgSelect646[["PgSelect[646∈10] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect646
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2555 & Lambda2560 --> PgSelect646
+    Access4118 & Lambda1679 & Access1683 & Lambda2618 & Lambda2623 --> PgSelect646
     PgSelect655[["PgSelect[655∈10] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect655
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2569 & Lambda2574 --> PgSelect655
+    Access4118 & Lambda1679 & Access1683 & Lambda2633 & Lambda2638 --> PgSelect655
     PgSelect664[["PgSelect[664∈10] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect664
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2583 & Lambda2588 --> PgSelect664
+    Access4118 & Lambda1679 & Access1683 & Lambda2648 & Lambda2653 --> PgSelect664
     PgSelect685[["PgSelect[685∈10] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect685
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2611 & Lambda2616 --> PgSelect685
+    Access4118 & Lambda1679 & Access1683 & Lambda2678 & Lambda2683 --> PgSelect685
     PgSelect695[["PgSelect[695∈10] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect695
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2625 & Lambda2630 --> PgSelect695
+    Access4118 & Lambda1679 & Access1683 & Lambda2693 & Lambda2698 --> PgSelect695
     PgSelect704[["PgSelect[704∈10] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect704
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2639 & Lambda2644 --> PgSelect704
+    Access4118 & Lambda1679 & Access1683 & Lambda2708 & Lambda2713 --> PgSelect704
     PgSelect713[["PgSelect[713∈10] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect713
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2653 & Lambda2658 --> PgSelect713
+    Access4118 & Lambda1679 & Access1683 & Lambda2723 & Lambda2728 --> PgSelect713
     PgSelect722[["PgSelect[722∈10] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect722
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2667 & Lambda2672 --> PgSelect722
+    Access4118 & Lambda1679 & Access1683 & Lambda2738 & Lambda2743 --> PgSelect722
     PgSelect731[["PgSelect[731∈10] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect731
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2681 & Lambda2686 --> PgSelect731
+    Access4118 & Lambda1679 & Access1683 & Lambda2753 & Lambda2758 --> PgSelect731
     PgSelect740[["PgSelect[740∈10] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect740
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2695 & Lambda2700 --> PgSelect740
+    Access4118 & Lambda1679 & Access1683 & Lambda2768 & Lambda2773 --> PgSelect740
     PgSelect749[["PgSelect[749∈10] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect749
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2709 & Lambda2714 --> PgSelect749
+    Access4118 & Lambda1679 & Access1683 & Lambda2783 & Lambda2788 --> PgSelect749
     PgSelect761[["PgSelect[761∈10] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect761
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2723 & Lambda2728 --> PgSelect761
+    Access4118 & Lambda1679 & Access1683 & Lambda2798 & Lambda2803 --> PgSelect761
     PgSelect773[["PgSelect[773∈10] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect773
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2737 & Lambda2742 --> PgSelect773
+    Access4118 & Lambda1679 & Access1683 & Lambda2813 & Lambda2818 --> PgSelect773
     PgSelect782[["PgSelect[782∈10] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect782
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2751 & Lambda2756 --> PgSelect782
+    Access4118 & Lambda1679 & Access1683 & Lambda2828 & Lambda2833 --> PgSelect782
     PgSelect791[["PgSelect[791∈10] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect791
-    Access3956 & Lambda1679 & Lambda1682 & Lambda2765 & Lambda2770 --> PgSelect791
+    Access4118 & Lambda1679 & Access1683 & Lambda2843 & Lambda2848 --> PgSelect791
     List682{{"List[682∈10] ➊<br />ᐸ30,680,681ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression680{{"PgClassExpression[680∈10] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression681{{"PgClassExpression[681∈10] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -2765,68 +2767,68 @@ graph TD
     PgSelectSingle794 --> PgClassExpression796
     Lambda798{{"Lambda[798∈10] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List797 --> Lambda798
-    Lambda610 --> Access3956
-    Lambda610 --> Access3957
+    Lambda610 --> Access4118
+    Lambda610 --> Access4119
     PgSelect866[["PgSelect[866∈11] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3959{{"Access[3959∈11] ➊<br />ᐸ801.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3960{{"Access[3960∈11] ➊<br />ᐸ801.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4121{{"Access[4121∈11] ➊<br />ᐸ801.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4122{{"Access[4122∈11] ➊<br />ᐸ801.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect866
-    Access3959 -->|rejectNull| PgSelect866
-    Access3960 & Lambda1679 & Lambda1682 & Lambda2863 & Lambda2868 --> PgSelect866
+    Access4121 -->|rejectNull| PgSelect866
+    Access4122 & Lambda1679 & Access1683 & Lambda2948 & Lambda2953 --> PgSelect866
     PgSelect808[["PgSelect[808∈11] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect808
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2779 & Lambda2784 --> PgSelect808
+    Access4121 & Lambda1679 & Access1683 & Lambda2858 & Lambda2863 --> PgSelect808
     PgSelect819[["PgSelect[819∈11] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect819
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2793 & Lambda2798 --> PgSelect819
+    Access4121 & Lambda1679 & Access1683 & Lambda2873 & Lambda2878 --> PgSelect819
     PgSelect828[["PgSelect[828∈11] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect828
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2807 & Lambda2812 --> PgSelect828
+    Access4121 & Lambda1679 & Access1683 & Lambda2888 & Lambda2893 --> PgSelect828
     PgSelect837[["PgSelect[837∈11] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect837
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2821 & Lambda2826 --> PgSelect837
+    Access4121 & Lambda1679 & Access1683 & Lambda2903 & Lambda2908 --> PgSelect837
     PgSelect846[["PgSelect[846∈11] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect846
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2835 & Lambda2840 --> PgSelect846
+    Access4121 & Lambda1679 & Access1683 & Lambda2918 & Lambda2923 --> PgSelect846
     PgSelect855[["PgSelect[855∈11] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect855
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2849 & Lambda2854 --> PgSelect855
+    Access4121 & Lambda1679 & Access1683 & Lambda2933 & Lambda2938 --> PgSelect855
     PgSelect876[["PgSelect[876∈11] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect876
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2877 & Lambda2882 --> PgSelect876
+    Access4121 & Lambda1679 & Access1683 & Lambda2963 & Lambda2968 --> PgSelect876
     PgSelect886[["PgSelect[886∈11] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect886
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2891 & Lambda2896 --> PgSelect886
+    Access4121 & Lambda1679 & Access1683 & Lambda2978 & Lambda2983 --> PgSelect886
     PgSelect895[["PgSelect[895∈11] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect895
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2905 & Lambda2910 --> PgSelect895
+    Access4121 & Lambda1679 & Access1683 & Lambda2993 & Lambda2998 --> PgSelect895
     PgSelect904[["PgSelect[904∈11] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect904
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2919 & Lambda2924 --> PgSelect904
+    Access4121 & Lambda1679 & Access1683 & Lambda3008 & Lambda3013 --> PgSelect904
     PgSelect913[["PgSelect[913∈11] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect913
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2933 & Lambda2938 --> PgSelect913
+    Access4121 & Lambda1679 & Access1683 & Lambda3023 & Lambda3028 --> PgSelect913
     PgSelect922[["PgSelect[922∈11] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect922
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2947 & Lambda2952 --> PgSelect922
+    Access4121 & Lambda1679 & Access1683 & Lambda3038 & Lambda3043 --> PgSelect922
     PgSelect931[["PgSelect[931∈11] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect931
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2961 & Lambda2966 --> PgSelect931
+    Access4121 & Lambda1679 & Access1683 & Lambda3053 & Lambda3058 --> PgSelect931
     PgSelect940[["PgSelect[940∈11] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect940
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2975 & Lambda2980 --> PgSelect940
+    Access4121 & Lambda1679 & Access1683 & Lambda3068 & Lambda3073 --> PgSelect940
     PgSelect952[["PgSelect[952∈11] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect952
-    Access3959 & Lambda1679 & Lambda1682 & Lambda2989 & Lambda2994 --> PgSelect952
+    Access4121 & Lambda1679 & Access1683 & Lambda3083 & Lambda3088 --> PgSelect952
     PgSelect964[["PgSelect[964∈11] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect964
-    Access3959 & Lambda1679 & Lambda1682 & Lambda3003 & Lambda3008 --> PgSelect964
+    Access4121 & Lambda1679 & Access1683 & Lambda3098 & Lambda3103 --> PgSelect964
     PgSelect973[["PgSelect[973∈11] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect973
-    Access3959 & Lambda1679 & Lambda1682 & Lambda3017 & Lambda3022 --> PgSelect973
+    Access4121 & Lambda1679 & Access1683 & Lambda3113 & Lambda3118 --> PgSelect973
     PgSelect982[["PgSelect[982∈11] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect982
-    Access3959 & Lambda1679 & Lambda1682 & Lambda3031 & Lambda3036 --> PgSelect982
+    Access4121 & Lambda1679 & Access1683 & Lambda3128 & Lambda3133 --> PgSelect982
     List873{{"List[873∈11] ➊<br />ᐸ30,871,872ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression871{{"PgClassExpression[871∈11] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression872{{"PgClassExpression[872∈11] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3035,68 +3037,68 @@ graph TD
     PgSelectSingle985 --> PgClassExpression987
     Lambda989{{"Lambda[989∈11] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List988 --> Lambda989
-    Lambda801 --> Access3959
-    Lambda801 --> Access3960
+    Lambda801 --> Access4121
+    Lambda801 --> Access4122
     PgSelect1057[["PgSelect[1057∈12] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3962{{"Access[3962∈12] ➊<br />ᐸ992.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3963{{"Access[3963∈12] ➊<br />ᐸ992.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4124{{"Access[4124∈12] ➊<br />ᐸ992.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4125{{"Access[4125∈12] ➊<br />ᐸ992.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1057
-    Access3962 -->|rejectNull| PgSelect1057
-    Access3963 & Lambda1679 & Lambda1682 & Lambda3129 & Lambda3134 --> PgSelect1057
+    Access4124 -->|rejectNull| PgSelect1057
+    Access4125 & Lambda1679 & Access1683 & Lambda3233 & Lambda3238 --> PgSelect1057
     PgSelect999[["PgSelect[999∈12] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect999
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3045 & Lambda3050 --> PgSelect999
+    Access4124 & Lambda1679 & Access1683 & Lambda3143 & Lambda3148 --> PgSelect999
     PgSelect1010[["PgSelect[1010∈12] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect1010
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3059 & Lambda3064 --> PgSelect1010
+    Access4124 & Lambda1679 & Access1683 & Lambda3158 & Lambda3163 --> PgSelect1010
     PgSelect1019[["PgSelect[1019∈12] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect1019
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3073 & Lambda3078 --> PgSelect1019
+    Access4124 & Lambda1679 & Access1683 & Lambda3173 & Lambda3178 --> PgSelect1019
     PgSelect1028[["PgSelect[1028∈12] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1028
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3087 & Lambda3092 --> PgSelect1028
+    Access4124 & Lambda1679 & Access1683 & Lambda3188 & Lambda3193 --> PgSelect1028
     PgSelect1037[["PgSelect[1037∈12] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1037
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3101 & Lambda3106 --> PgSelect1037
+    Access4124 & Lambda1679 & Access1683 & Lambda3203 & Lambda3208 --> PgSelect1037
     PgSelect1046[["PgSelect[1046∈12] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect1046
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3115 & Lambda3120 --> PgSelect1046
+    Access4124 & Lambda1679 & Access1683 & Lambda3218 & Lambda3223 --> PgSelect1046
     PgSelect1067[["PgSelect[1067∈12] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect1067
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3143 & Lambda3148 --> PgSelect1067
+    Access4124 & Lambda1679 & Access1683 & Lambda3248 & Lambda3253 --> PgSelect1067
     PgSelect1077[["PgSelect[1077∈12] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect1077
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3157 & Lambda3162 --> PgSelect1077
+    Access4124 & Lambda1679 & Access1683 & Lambda3263 & Lambda3268 --> PgSelect1077
     PgSelect1086[["PgSelect[1086∈12] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect1086
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3171 & Lambda3176 --> PgSelect1086
+    Access4124 & Lambda1679 & Access1683 & Lambda3278 & Lambda3283 --> PgSelect1086
     PgSelect1095[["PgSelect[1095∈12] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect1095
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3185 & Lambda3190 --> PgSelect1095
+    Access4124 & Lambda1679 & Access1683 & Lambda3293 & Lambda3298 --> PgSelect1095
     PgSelect1104[["PgSelect[1104∈12] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect1104
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3199 & Lambda3204 --> PgSelect1104
+    Access4124 & Lambda1679 & Access1683 & Lambda3308 & Lambda3313 --> PgSelect1104
     PgSelect1113[["PgSelect[1113∈12] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1113
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3213 & Lambda3218 --> PgSelect1113
+    Access4124 & Lambda1679 & Access1683 & Lambda3323 & Lambda3328 --> PgSelect1113
     PgSelect1122[["PgSelect[1122∈12] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1122
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3227 & Lambda3232 --> PgSelect1122
+    Access4124 & Lambda1679 & Access1683 & Lambda3338 & Lambda3343 --> PgSelect1122
     PgSelect1131[["PgSelect[1131∈12] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect1131
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3241 & Lambda3246 --> PgSelect1131
+    Access4124 & Lambda1679 & Access1683 & Lambda3353 & Lambda3358 --> PgSelect1131
     PgSelect1143[["PgSelect[1143∈12] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect1143
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3255 & Lambda3260 --> PgSelect1143
+    Access4124 & Lambda1679 & Access1683 & Lambda3368 & Lambda3373 --> PgSelect1143
     PgSelect1155[["PgSelect[1155∈12] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1155
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3269 & Lambda3274 --> PgSelect1155
+    Access4124 & Lambda1679 & Access1683 & Lambda3383 & Lambda3388 --> PgSelect1155
     PgSelect1164[["PgSelect[1164∈12] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect1164
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3283 & Lambda3288 --> PgSelect1164
+    Access4124 & Lambda1679 & Access1683 & Lambda3398 & Lambda3403 --> PgSelect1164
     PgSelect1173[["PgSelect[1173∈12] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect1173
-    Access3962 & Lambda1679 & Lambda1682 & Lambda3297 & Lambda3302 --> PgSelect1173
+    Access4124 & Lambda1679 & Access1683 & Lambda3413 & Lambda3418 --> PgSelect1173
     List1064{{"List[1064∈12] ➊<br />ᐸ30,1062,1063ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1062{{"PgClassExpression[1062∈12] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1063{{"PgClassExpression[1063∈12] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3305,8 +3307,8 @@ graph TD
     PgSelectSingle1176 --> PgClassExpression1178
     Lambda1180{{"Lambda[1180∈12] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1179 --> Lambda1180
-    Lambda992 --> Access3962
-    Lambda992 --> Access3963
+    Lambda992 --> Access4124
+    Lambda992 --> Access4125
     List1191{{"List[1191∈13] ➊<br />ᐸ17,1190ᐳ"}}:::plan
     PgClassExpression1190{{"PgClassExpression[1190∈13] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant17 & PgClassExpression1190 --> List1191
@@ -3356,65 +3358,65 @@ graph TD
     Lambda1264{{"Lambda[1264∈18] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1263 --> Lambda1264
     PgSelect1332[["PgSelect[1332∈19] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3965{{"Access[3965∈19] ➊<br />ᐸ1267.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3966{{"Access[3966∈19] ➊<br />ᐸ1267.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4127{{"Access[4127∈19] ➊<br />ᐸ1267.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4128{{"Access[4128∈19] ➊<br />ᐸ1267.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1332
-    Access3965 -->|rejectNull| PgSelect1332
-    Access3966 & Lambda1679 & Lambda1682 & Lambda3479 & Lambda3484 --> PgSelect1332
+    Access4127 -->|rejectNull| PgSelect1332
+    Access4128 & Lambda1679 & Access1683 & Lambda3608 & Lambda3613 --> PgSelect1332
     PgSelect1274[["PgSelect[1274∈19] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect1274
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3395 & Lambda3400 --> PgSelect1274
+    Access4127 & Lambda1679 & Access1683 & Lambda3518 & Lambda3523 --> PgSelect1274
     PgSelect1285[["PgSelect[1285∈19] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect1285
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3409 & Lambda3414 --> PgSelect1285
+    Access4127 & Lambda1679 & Access1683 & Lambda3533 & Lambda3538 --> PgSelect1285
     PgSelect1294[["PgSelect[1294∈19] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect1294
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3423 & Lambda3428 --> PgSelect1294
+    Access4127 & Lambda1679 & Access1683 & Lambda3548 & Lambda3553 --> PgSelect1294
     PgSelect1303[["PgSelect[1303∈19] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1303
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3437 & Lambda3442 --> PgSelect1303
+    Access4127 & Lambda1679 & Access1683 & Lambda3563 & Lambda3568 --> PgSelect1303
     PgSelect1312[["PgSelect[1312∈19] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1312
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3451 & Lambda3456 --> PgSelect1312
+    Access4127 & Lambda1679 & Access1683 & Lambda3578 & Lambda3583 --> PgSelect1312
     PgSelect1321[["PgSelect[1321∈19] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect1321
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3465 & Lambda3470 --> PgSelect1321
+    Access4127 & Lambda1679 & Access1683 & Lambda3593 & Lambda3598 --> PgSelect1321
     PgSelect1342[["PgSelect[1342∈19] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect1342
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3493 & Lambda3498 --> PgSelect1342
+    Access4127 & Lambda1679 & Access1683 & Lambda3623 & Lambda3628 --> PgSelect1342
     PgSelect1352[["PgSelect[1352∈19] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect1352
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3507 & Lambda3512 --> PgSelect1352
+    Access4127 & Lambda1679 & Access1683 & Lambda3638 & Lambda3643 --> PgSelect1352
     PgSelect1361[["PgSelect[1361∈19] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect1361
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3521 & Lambda3526 --> PgSelect1361
+    Access4127 & Lambda1679 & Access1683 & Lambda3653 & Lambda3658 --> PgSelect1361
     PgSelect1370[["PgSelect[1370∈19] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect1370
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3535 & Lambda3540 --> PgSelect1370
+    Access4127 & Lambda1679 & Access1683 & Lambda3668 & Lambda3673 --> PgSelect1370
     PgSelect1379[["PgSelect[1379∈19] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect1379
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3549 & Lambda3554 --> PgSelect1379
+    Access4127 & Lambda1679 & Access1683 & Lambda3683 & Lambda3688 --> PgSelect1379
     PgSelect1388[["PgSelect[1388∈19] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1388
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3563 & Lambda3568 --> PgSelect1388
+    Access4127 & Lambda1679 & Access1683 & Lambda3698 & Lambda3703 --> PgSelect1388
     PgSelect1397[["PgSelect[1397∈19] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1397
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3577 & Lambda3582 --> PgSelect1397
+    Access4127 & Lambda1679 & Access1683 & Lambda3713 & Lambda3718 --> PgSelect1397
     PgSelect1406[["PgSelect[1406∈19] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect1406
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3591 & Lambda3596 --> PgSelect1406
+    Access4127 & Lambda1679 & Access1683 & Lambda3728 & Lambda3733 --> PgSelect1406
     PgSelect1418[["PgSelect[1418∈19] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect1418
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3605 & Lambda3610 --> PgSelect1418
+    Access4127 & Lambda1679 & Access1683 & Lambda3743 & Lambda3748 --> PgSelect1418
     PgSelect1430[["PgSelect[1430∈19] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1430
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3619 & Lambda3624 --> PgSelect1430
+    Access4127 & Lambda1679 & Access1683 & Lambda3758 & Lambda3763 --> PgSelect1430
     PgSelect1439[["PgSelect[1439∈19] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect1439
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3633 & Lambda3638 --> PgSelect1439
+    Access4127 & Lambda1679 & Access1683 & Lambda3773 & Lambda3778 --> PgSelect1439
     PgSelect1448[["PgSelect[1448∈19] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect1448
-    Access3965 & Lambda1679 & Lambda1682 & Lambda3647 & Lambda3652 --> PgSelect1448
+    Access4127 & Lambda1679 & Access1683 & Lambda3788 & Lambda3793 --> PgSelect1448
     List1339{{"List[1339∈19] ➊<br />ᐸ30,1337,1338ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1337{{"PgClassExpression[1337∈19] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1338{{"PgClassExpression[1338∈19] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3623,68 +3625,68 @@ graph TD
     PgSelectSingle1451 --> PgClassExpression1453
     Lambda1455{{"Lambda[1455∈19] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1454 --> Lambda1455
-    Lambda1267 --> Access3965
-    Lambda1267 --> Access3966
+    Lambda1267 --> Access4127
+    Lambda1267 --> Access4128
     PgSelect1523[["PgSelect[1523∈20] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3968{{"Access[3968∈20] ➊<br />ᐸ1458.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access3969{{"Access[3969∈20] ➊<br />ᐸ1458.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access4130{{"Access[4130∈20] ➊<br />ᐸ1458.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access4131{{"Access[4131∈20] ➊<br />ᐸ1458.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1523
-    Access3968 -->|rejectNull| PgSelect1523
-    Access3969 & Lambda1679 & Lambda1682 & Lambda3745 & Lambda3750 --> PgSelect1523
+    Access4130 -->|rejectNull| PgSelect1523
+    Access4131 & Lambda1679 & Access1683 & Lambda3893 & Lambda3898 --> PgSelect1523
     PgSelect1465[["PgSelect[1465∈20] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect1465
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3661 & Lambda3666 --> PgSelect1465
+    Access4130 & Lambda1679 & Access1683 & Lambda3803 & Lambda3808 --> PgSelect1465
     PgSelect1476[["PgSelect[1476∈20] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect1476
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3675 & Lambda3680 --> PgSelect1476
+    Access4130 & Lambda1679 & Access1683 & Lambda3818 & Lambda3823 --> PgSelect1476
     PgSelect1485[["PgSelect[1485∈20] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect1485
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3689 & Lambda3694 --> PgSelect1485
+    Access4130 & Lambda1679 & Access1683 & Lambda3833 & Lambda3838 --> PgSelect1485
     PgSelect1494[["PgSelect[1494∈20] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1494
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3703 & Lambda3708 --> PgSelect1494
+    Access4130 & Lambda1679 & Access1683 & Lambda3848 & Lambda3853 --> PgSelect1494
     PgSelect1503[["PgSelect[1503∈20] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1503
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3717 & Lambda3722 --> PgSelect1503
+    Access4130 & Lambda1679 & Access1683 & Lambda3863 & Lambda3868 --> PgSelect1503
     PgSelect1512[["PgSelect[1512∈20] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect1512
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3731 & Lambda3736 --> PgSelect1512
+    Access4130 & Lambda1679 & Access1683 & Lambda3878 & Lambda3883 --> PgSelect1512
     PgSelect1533[["PgSelect[1533∈20] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect1533
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3759 & Lambda3764 --> PgSelect1533
+    Access4130 & Lambda1679 & Access1683 & Lambda3908 & Lambda3913 --> PgSelect1533
     PgSelect1543[["PgSelect[1543∈20] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect1543
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3773 & Lambda3778 --> PgSelect1543
+    Access4130 & Lambda1679 & Access1683 & Lambda3923 & Lambda3928 --> PgSelect1543
     PgSelect1552[["PgSelect[1552∈20] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object12 -->|rejectNull| PgSelect1552
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3787 & Lambda3792 --> PgSelect1552
+    Access4130 & Lambda1679 & Access1683 & Lambda3938 & Lambda3943 --> PgSelect1552
     PgSelect1561[["PgSelect[1561∈20] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect1561
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3801 & Lambda3806 --> PgSelect1561
+    Access4130 & Lambda1679 & Access1683 & Lambda3953 & Lambda3958 --> PgSelect1561
     PgSelect1570[["PgSelect[1570∈20] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect1570
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3815 & Lambda3820 --> PgSelect1570
+    Access4130 & Lambda1679 & Access1683 & Lambda3968 & Lambda3973 --> PgSelect1570
     PgSelect1579[["PgSelect[1579∈20] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1579
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3829 & Lambda3834 --> PgSelect1579
+    Access4130 & Lambda1679 & Access1683 & Lambda3983 & Lambda3988 --> PgSelect1579
     PgSelect1588[["PgSelect[1588∈20] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1588
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3843 & Lambda3848 --> PgSelect1588
+    Access4130 & Lambda1679 & Access1683 & Lambda3998 & Lambda4003 --> PgSelect1588
     PgSelect1597[["PgSelect[1597∈20] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect1597
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3857 & Lambda3862 --> PgSelect1597
+    Access4130 & Lambda1679 & Access1683 & Lambda4013 & Lambda4018 --> PgSelect1597
     PgSelect1609[["PgSelect[1609∈20] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect1609
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3871 & Lambda3876 --> PgSelect1609
+    Access4130 & Lambda1679 & Access1683 & Lambda4028 & Lambda4033 --> PgSelect1609
     PgSelect1621[["PgSelect[1621∈20] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1621
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3885 & Lambda3890 --> PgSelect1621
+    Access4130 & Lambda1679 & Access1683 & Lambda4043 & Lambda4048 --> PgSelect1621
     PgSelect1630[["PgSelect[1630∈20] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect1630
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3899 & Lambda3904 --> PgSelect1630
+    Access4130 & Lambda1679 & Access1683 & Lambda4058 & Lambda4063 --> PgSelect1630
     PgSelect1639[["PgSelect[1639∈20] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect1639
-    Access3968 & Lambda1679 & Lambda1682 & Lambda3913 & Lambda3918 --> PgSelect1639
+    Access4130 & Lambda1679 & Access1683 & Lambda4073 & Lambda4078 --> PgSelect1639
     List1530{{"List[1530∈20] ➊<br />ᐸ30,1528,1529ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1528{{"PgClassExpression[1528∈20] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1529{{"PgClassExpression[1529∈20] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3893,8 +3895,8 @@ graph TD
     PgSelectSingle1642 --> PgClassExpression1644
     Lambda1646{{"Lambda[1646∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1645 --> Lambda1646
-    Lambda1458 --> Access3968
-    Lambda1458 --> Access3969
+    Lambda1458 --> Access4130
+    Lambda1458 --> Access4131
     List1657{{"List[1657∈21] ➊<br />ᐸ180,1656ᐳ"}}:::plan
     PgClassExpression1656{{"PgClassExpression[1656∈21] ➊<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant180 & PgClassExpression1656 --> List1657
@@ -3923,45 +3925,45 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/node"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 26, 30, 39, 50, 59, 68, 77, 86, 95, 126, 135, 144, 153, 162, 171, 180, 192, 204, 213, 222, 1683, 1684, 1685, 1697, 1698, 1699, 1711, 1712, 1713, 1725, 1726, 1727, 1739, 1740, 1741, 1753, 1754, 1755, 1767, 1768, 1769, 1781, 1782, 1783, 1795, 1796, 1809, 1810, 1823, 1824, 1825, 1837, 1838, 1839, 1851, 1852, 1853, 1865, 1866, 1867, 1879, 1880, 1881, 1893, 1894, 1895, 1907, 1908, 1909, 1921, 1922, 1923, 1935, 1936, 1937, 1949, 1950, 1951, 1963, 1964, 1965, 1977, 1978, 1991, 1992, 2005, 2006, 2019, 2020, 2033, 2034, 2047, 2048, 2061, 2062, 2075, 2076, 2089, 2090, 2103, 2104, 2117, 2118, 2131, 2132, 2145, 2146, 2159, 2160, 2173, 2174, 2187, 2188, 2201, 2202, 2215, 2216, 2229, 2230, 2243, 2244, 2257, 2258, 2271, 2272, 2285, 2286, 2299, 2300, 2313, 2314, 2327, 2328, 2341, 2342, 2355, 2356, 2369, 2370, 2383, 2384, 2397, 2398, 2411, 2412, 2425, 2426, 2439, 2440, 2453, 2454, 2467, 2468, 2481, 2482, 2495, 2496, 2509, 2510, 2523, 2524, 2537, 2538, 2551, 2552, 2565, 2566, 2579, 2580, 2593, 2594, 2607, 2608, 2621, 2622, 2635, 2636, 2649, 2650, 2663, 2664, 2677, 2678, 2691, 2692, 2705, 2706, 2719, 2720, 2733, 2734, 2747, 2748, 2761, 2762, 2775, 2776, 2789, 2790, 2803, 2804, 2817, 2818, 2831, 2832, 2845, 2846, 2859, 2860, 2873, 2874, 2887, 2888, 2901, 2902, 2915, 2916, 2929, 2930, 2943, 2944, 2957, 2958, 2971, 2972, 2985, 2986, 2999, 3000, 3013, 3014, 3027, 3028, 3041, 3042, 3055, 3056, 3069, 3070, 3083, 3084, 3097, 3098, 3111, 3112, 3125, 3126, 3139, 3140, 3153, 3154, 3167, 3168, 3181, 3182, 3195, 3196, 3209, 3210, 3223, 3224, 3237, 3238, 3251, 3252, 3265, 3266, 3279, 3280, 3293, 3294, 3307, 3308, 3321, 3322, 3335, 3336, 3349, 3350, 3363, 3364, 3377, 3378, 3391, 3392, 3405, 3406, 3419, 3420, 3433, 3434, 3447, 3448, 3461, 3462, 3475, 3476, 3489, 3490, 3503, 3504, 3517, 3518, 3531, 3532, 3545, 3546, 3559, 3560, 3573, 3574, 3587, 3588, 3601, 3602, 3615, 3616, 3629, 3630, 3643, 3644, 3657, 3658, 3671, 3672, 3685, 3686, 3699, 3700, 3713, 3714, 3727, 3728, 3741, 3742, 3755, 3756, 3769, 3770, 3783, 3784, 3797, 3798, 3811, 3812, 3825, 3826, 3839, 3840, 3853, 3854, 3867, 3868, 3881, 3882, 3895, 3896, 3909, 3910, 3923, 3924, 3937, 3938, 3949, 3952, 3955, 3958, 3961, 3964, 3967, 3970, 3971, 3972, 3973, 3974, 3975, 3976, 3977, 3978, 3979, 3980, 3981, 3982, 3983, 3984, 3985, 3986, 3987, 3988, 3989, 3990, 3991, 3992, 3993, 3994, 3995, 3996, 3997, 3998, 3999, 4000, 4001, 4002, 4003, 4004, 4005, 4006, 4007, 4008, 4009, 4010, 4011, 4012, 4013, 4014, 4015, 4016, 4017, 4018, 4019, 4020, 4021, 4022, 4023, 4024, 4025, 4026, 4027, 4028, 4029, 4030, 4031, 4032, 4033, 4034, 4035, 4036, 4037, 4038, 4039, 4040, 4041, 4042, 4043, 4044, 4045, 4046, 4047, 4048, 4049, 4050, 4051, 4052, 4053, 4054, 4055, 4056, 4057, 4058, 4059, 4060, 4061, 4062, 4063, 4064, 4065, 4066, 4067, 4068, 4069, 4070, 4071, 4072, 4073, 4074, 4075, 4076, 4077, 4078, 4079, 4080, 4081, 4082, 4083, 4084, 4085, 4086, 4087, 4088, 4089, 4090, 4091, 4092, 4093, 4094, 4095, 4096, 4097, 4098, 4099, 4100, 4101, 4102, 4103, 4104, 4105, 4106, 4107, 4108, 4109, 4110, 4111, 4112, 4113, 4114, 4115, 4116, 4117, 4118, 4119, 4120, 4121, 4122, 4123, 4124, 4125, 4126, 4127, 4128, 4129, 4130, 4131, 4132, 4133, 4134, 12, 37, 228, 419, 610, 801, 992, 1182, 1183, 1195, 1196, 1208, 1209, 1221, 1222, 1224, 1236, 1237, 1239, 1251, 1252, 1254, 1267, 1458, 1648, 1649, 1663, 1664, 1679, 1682, 1714, 1715, 1720, 1728, 1729, 1734, 1742, 1743, 1748, 1756, 1757, 1762, 1770, 1771, 1776, 1784, 1785, 1790, 1798, 1799, 1804, 1812, 1813, 1818, 1826, 1827, 1832, 1840, 1841, 1846, 1854, 1855, 1860, 1868, 1869, 1874, 1882, 1883, 1888, 1896, 1897, 1902, 1910, 1911, 1916, 1924, 1925, 1930, 1938, 1939, 1944, 1952, 1953, 1958, 1966, 1967, 1972, 1980, 1981, 1986, 1994, 1995, 2000, 2008, 2009, 2014, 2022, 2023, 2028, 2036, 2037, 2042, 2050, 2051, 2056, 2064, 2065, 2070, 2078, 2079, 2084, 2092, 2093, 2098, 2106, 2107, 2112, 2120, 2121, 2126, 2134, 2135, 2140, 2148, 2149, 2154, 2162, 2163, 2168, 2176, 2177, 2182, 2190, 2191, 2196, 2204, 2205, 2210, 2218, 2219, 2224, 2232, 2233, 2238, 2246, 2247, 2252, 2260, 2261, 2266, 2274, 2275, 2280, 2288, 2289, 2294, 2302, 2303, 2308, 2316, 2317, 2322, 2330, 2331, 2336, 2344, 2345, 2350, 2358, 2359, 2364, 2372, 2373, 2378, 2386, 2387, 2392, 2400, 2401, 2406, 2414, 2415, 2420, 2428, 2429, 2434, 2442, 2443, 2448, 2456, 2457, 2462, 2470, 2471, 2476, 2484, 2485, 2490, 2498, 2499, 2504, 2512, 2513, 2518, 2526, 2527, 2532, 2540, 2541, 2546, 2554, 2555, 2560, 2568, 2569, 2574, 2582, 2583, 2588, 2596, 2597, 2602, 2610, 2611, 2616, 2624, 2625, 2630, 2638, 2639, 2644, 2652, 2653, 2658, 2666, 2667, 2672, 2680, 2681, 2686, 2694, 2695, 2700, 2708, 2709, 2714, 2722, 2723, 2728, 2736, 2737, 2742, 2750, 2751, 2756, 2764, 2765, 2770, 2778, 2779, 2784, 2792, 2793, 2798, 2806, 2807, 2812, 2820, 2821, 2826, 2834, 2835, 2840, 2848, 2849, 2854, 2862, 2863, 2868, 2876, 2877, 2882, 2890, 2891, 2896, 2904, 2905, 2910, 2918, 2919, 2924, 2932, 2933, 2938, 2946, 2947, 2952, 2960, 2961, 2966, 2974, 2975, 2980, 2988, 2989, 2994, 3002, 3003, 3008, 3016, 3017, 3022, 3030, 3031, 3036, 3044, 3045, 3050, 3058, 3059, 3064, 3072, 3073, 3078, 3086, 3087, 3092, 3100, 3101, 3106, 3114, 3115, 3120, 3128, 3129, 3134, 3142, 3143, 3148, 3156, 3157, 3162, 3170, 3171, 3176, 3184, 3185, 3190, 3198, 3199, 3204, 3212, 3213, 3218, 3226, 3227, 3232, 3240, 3241, 3246, 3254, 3255, 3260, 3268, 3269, 3274, 3282, 3283, 3288, 3296, 3297, 3302, 3310, 3311, 3316, 3324, 3325, 3330, 3338, 3339, 3344, 3352, 3353, 3358, 3366, 3367, 3372, 3380, 3381, 3386, 3394, 3395, 3400, 3408, 3409, 3414, 3422, 3423, 3428, 3436, 3437, 3442, 3450, 3451, 3456, 3464, 3465, 3470, 3478, 3479, 3484, 3492, 3493, 3498, 3506, 3507, 3512, 3520, 3521, 3526, 3534, 3535, 3540, 3548, 3549, 3554, 3562, 3563, 3568, 3576, 3577, 3582, 3590, 3591, 3596, 3604, 3605, 3610, 3618, 3619, 3624, 3632, 3633, 3638, 3646, 3647, 3652, 3660, 3661, 3666, 3674, 3675, 3680, 3688, 3689, 3694, 3702, 3703, 3708, 3716, 3717, 3722, 3730, 3731, 3736, 3744, 3745, 3750, 3758, 3759, 3764, 3772, 3773, 3778, 3786, 3787, 3792, 3800, 3801, 3806, 3814, 3815, 3820, 3828, 3829, 3834, 3842, 3843, 3848, 3856, 3857, 3862, 3870, 3871, 3876, 3884, 3885, 3890, 3898, 3899, 3904, 3912, 3913, 3918, 3926, 3927, 3932, 3940, 3941, 3946, 36, 227, 418, 609, 800, 991, 1266, 1457<br />2: 1185, 1198, 1211, 1226, 1241, 1256, 1651, 1666<br />ᐳ: 1187, 1188, 1200, 1201, 1213, 1214, 1228, 1229, 1243, 1244, 1258, 1259, 1653, 1654, 1668, 1669"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 26, 30, 39, 50, 59, 68, 77, 86, 95, 126, 135, 144, 153, 162, 171, 180, 192, 204, 213, 222, 1684, 1685, 1686, 1699, 1700, 1701, 1714, 1715, 1716, 1729, 1730, 1731, 1744, 1745, 1746, 1759, 1760, 1761, 1774, 1775, 1776, 1789, 1790, 1791, 1804, 1805, 1819, 1820, 1834, 1835, 1836, 1849, 1850, 1851, 1864, 1865, 1866, 1879, 1880, 1881, 1894, 1895, 1896, 1909, 1910, 1911, 1924, 1925, 1926, 1939, 1940, 1941, 1954, 1955, 1956, 1969, 1970, 1971, 1984, 1985, 1986, 1999, 2000, 2014, 2015, 2029, 2030, 2044, 2045, 2059, 2060, 2074, 2075, 2089, 2090, 2104, 2105, 2119, 2120, 2134, 2135, 2149, 2150, 2164, 2165, 2179, 2180, 2194, 2195, 2209, 2210, 2224, 2225, 2239, 2240, 2254, 2255, 2269, 2270, 2284, 2285, 2299, 2300, 2314, 2315, 2329, 2330, 2344, 2345, 2359, 2360, 2374, 2375, 2389, 2390, 2404, 2405, 2419, 2420, 2434, 2435, 2449, 2450, 2464, 2465, 2479, 2480, 2494, 2495, 2509, 2510, 2524, 2525, 2539, 2540, 2554, 2555, 2569, 2570, 2584, 2585, 2599, 2600, 2614, 2615, 2629, 2630, 2644, 2645, 2659, 2660, 2674, 2675, 2689, 2690, 2704, 2705, 2719, 2720, 2734, 2735, 2749, 2750, 2764, 2765, 2779, 2780, 2794, 2795, 2809, 2810, 2824, 2825, 2839, 2840, 2854, 2855, 2869, 2870, 2884, 2885, 2899, 2900, 2914, 2915, 2929, 2930, 2944, 2945, 2959, 2960, 2974, 2975, 2989, 2990, 3004, 3005, 3019, 3020, 3034, 3035, 3049, 3050, 3064, 3065, 3079, 3080, 3094, 3095, 3109, 3110, 3124, 3125, 3139, 3140, 3154, 3155, 3169, 3170, 3184, 3185, 3199, 3200, 3214, 3215, 3229, 3230, 3244, 3245, 3259, 3260, 3274, 3275, 3289, 3290, 3304, 3305, 3319, 3320, 3334, 3335, 3349, 3350, 3364, 3365, 3379, 3380, 3394, 3395, 3409, 3410, 3424, 3425, 3439, 3440, 3454, 3455, 3469, 3470, 3484, 3485, 3499, 3500, 3514, 3515, 3529, 3530, 3544, 3545, 3559, 3560, 3574, 3575, 3589, 3590, 3604, 3605, 3619, 3620, 3634, 3635, 3649, 3650, 3664, 3665, 3679, 3680, 3694, 3695, 3709, 3710, 3724, 3725, 3739, 3740, 3754, 3755, 3769, 3770, 3784, 3785, 3799, 3800, 3814, 3815, 3829, 3830, 3844, 3845, 3859, 3860, 3874, 3875, 3889, 3890, 3904, 3905, 3919, 3920, 3934, 3935, 3949, 3950, 3964, 3965, 3979, 3980, 3994, 3995, 4009, 4010, 4024, 4025, 4039, 4040, 4054, 4055, 4069, 4070, 4084, 4085, 4099, 4100, 4111, 4114, 4117, 4120, 4123, 4126, 4129, 4132, 4133, 4134, 4135, 4136, 4137, 4138, 4139, 4140, 4141, 4142, 4143, 4144, 4145, 4146, 4147, 4148, 4149, 4150, 4151, 4152, 4153, 4154, 4155, 4156, 4157, 4158, 4159, 4160, 4161, 4162, 4163, 4164, 4165, 4166, 4167, 4168, 4169, 4170, 4171, 4172, 4173, 4174, 4175, 4176, 4177, 4178, 4179, 4180, 4181, 4182, 4183, 4184, 4185, 4186, 4187, 4188, 4189, 4190, 4191, 4192, 4193, 4194, 4195, 4196, 4197, 4198, 4199, 4200, 4201, 4202, 4203, 4204, 4205, 4206, 4207, 4208, 4209, 4210, 4211, 4212, 4213, 4214, 4215, 4216, 4217, 4218, 4219, 4220, 4221, 4222, 4223, 4224, 4225, 4226, 4227, 4228, 4229, 4230, 4231, 4232, 4233, 4234, 4235, 4236, 4237, 4238, 4239, 4240, 4241, 4242, 4243, 4244, 4245, 4246, 4247, 4248, 4249, 4250, 4251, 4252, 4253, 4254, 4255, 4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273, 4274, 4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291, 4292, 4293, 4294, 4295, 4296, 12, 37, 228, 419, 610, 801, 992, 1182, 1183, 1195, 1196, 1208, 1209, 1221, 1222, 1224, 1236, 1237, 1239, 1251, 1252, 1254, 1267, 1458, 1648, 1649, 1663, 1664, 1679, 1682, 1683, 1687, 1688, 1693, 1702, 1703, 1708, 1717, 1718, 1723, 1732, 1733, 1738, 1747, 1748, 1753, 1762, 1763, 1768, 1777, 1778, 1783, 1792, 1793, 1798, 1807, 1808, 1813, 1822, 1823, 1828, 1837, 1838, 1843, 1852, 1853, 1858, 1867, 1868, 1873, 1882, 1883, 1888, 1897, 1898, 1903, 1912, 1913, 1918, 1927, 1928, 1933, 1942, 1943, 1948, 1957, 1958, 1963, 1972, 1973, 1978, 1987, 1988, 1993, 2002, 2003, 2008, 2017, 2018, 2023, 2032, 2033, 2038, 2047, 2048, 2053, 2062, 2063, 2068, 2077, 2078, 2083, 2092, 2093, 2098, 2107, 2108, 2113, 2122, 2123, 2128, 2137, 2138, 2143, 2152, 2153, 2158, 2167, 2168, 2173, 2182, 2183, 2188, 2197, 2198, 2203, 2212, 2213, 2218, 2227, 2228, 2233, 2242, 2243, 2248, 2257, 2258, 2263, 2272, 2273, 2278, 2287, 2288, 2293, 2302, 2303, 2308, 2317, 2318, 2323, 2332, 2333, 2338, 2347, 2348, 2353, 2362, 2363, 2368, 2377, 2378, 2383, 2392, 2393, 2398, 2407, 2408, 2413, 2422, 2423, 2428, 2437, 2438, 2443, 2452, 2453, 2458, 2467, 2468, 2473, 2482, 2483, 2488, 2497, 2498, 2503, 2512, 2513, 2518, 2527, 2528, 2533, 2542, 2543, 2548, 2557, 2558, 2563, 2572, 2573, 2578, 2587, 2588, 2593, 2602, 2603, 2608, 2617, 2618, 2623, 2632, 2633, 2638, 2647, 2648, 2653, 2662, 2663, 2668, 2677, 2678, 2683, 2692, 2693, 2698, 2707, 2708, 2713, 2722, 2723, 2728, 2737, 2738, 2743, 2752, 2753, 2758, 2767, 2768, 2773, 2782, 2783, 2788, 2797, 2798, 2803, 2812, 2813, 2818, 2827, 2828, 2833, 2842, 2843, 2848, 2857, 2858, 2863, 2872, 2873, 2878, 2887, 2888, 2893, 2902, 2903, 2908, 2917, 2918, 2923, 2932, 2933, 2938, 2947, 2948, 2953, 2962, 2963, 2968, 2977, 2978, 2983, 2992, 2993, 2998, 3007, 3008, 3013, 3022, 3023, 3028, 3037, 3038, 3043, 3052, 3053, 3058, 3067, 3068, 3073, 3082, 3083, 3088, 3097, 3098, 3103, 3112, 3113, 3118, 3127, 3128, 3133, 3142, 3143, 3148, 3157, 3158, 3163, 3172, 3173, 3178, 3187, 3188, 3193, 3202, 3203, 3208, 3217, 3218, 3223, 3232, 3233, 3238, 3247, 3248, 3253, 3262, 3263, 3268, 3277, 3278, 3283, 3292, 3293, 3298, 3307, 3308, 3313, 3322, 3323, 3328, 3337, 3338, 3343, 3352, 3353, 3358, 3367, 3368, 3373, 3382, 3383, 3388, 3397, 3398, 3403, 3412, 3413, 3418, 3427, 3428, 3433, 3442, 3443, 3448, 3457, 3458, 3463, 3472, 3473, 3478, 3487, 3488, 3493, 3502, 3503, 3508, 3517, 3518, 3523, 3532, 3533, 3538, 3547, 3548, 3553, 3562, 3563, 3568, 3577, 3578, 3583, 3592, 3593, 3598, 3607, 3608, 3613, 3622, 3623, 3628, 3637, 3638, 3643, 3652, 3653, 3658, 3667, 3668, 3673, 3682, 3683, 3688, 3697, 3698, 3703, 3712, 3713, 3718, 3727, 3728, 3733, 3742, 3743, 3748, 3757, 3758, 3763, 3772, 3773, 3778, 3787, 3788, 3793, 3802, 3803, 3808, 3817, 3818, 3823, 3832, 3833, 3838, 3847, 3848, 3853, 3862, 3863, 3868, 3877, 3878, 3883, 3892, 3893, 3898, 3907, 3908, 3913, 3922, 3923, 3928, 3937, 3938, 3943, 3952, 3953, 3958, 3967, 3968, 3973, 3982, 3983, 3988, 3997, 3998, 4003, 4012, 4013, 4018, 4027, 4028, 4033, 4042, 4043, 4048, 4057, 4058, 4063, 4072, 4073, 4078, 4087, 4088, 4093, 4102, 4103, 4108, 36, 227, 418, 609, 800, 991, 1266, 1457<br />2: 1185, 1198, 1211, 1226, 1241, 1256, 1651, 1666<br />ᐳ: 1187, 1188, 1200, 1201, 1213, 1214, 1228, 1229, 1243, 1244, 1258, 1259, 1653, 1654, 1668, 1669"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Connection26,Constant30,Node36,Lambda37,Constant39,Constant50,Constant59,Constant68,Constant77,Constant86,Constant95,Constant126,Constant135,Constant144,Constant153,Constant162,Constant171,Constant180,Constant192,Constant204,Constant213,Constant222,Node227,Lambda228,Node418,Lambda419,Node609,Lambda610,Node800,Lambda801,Node991,Lambda992,Lambda1182,Access1183,PgSelect1185,First1187,PgSelectSingle1188,Lambda1195,Access1196,PgSelect1198,First1200,PgSelectSingle1201,Lambda1208,Access1209,PgSelect1211,First1213,PgSelectSingle1214,Lambda1221,Access1222,Access1224,PgSelect1226,First1228,PgSelectSingle1229,Lambda1236,Access1237,Access1239,PgSelect1241,First1243,PgSelectSingle1244,Lambda1251,Access1252,Access1254,PgSelect1256,First1258,PgSelectSingle1259,Node1266,Lambda1267,Node1457,Lambda1458,Lambda1648,Access1649,PgSelect1651,First1653,PgSelectSingle1654,Lambda1663,Access1664,PgSelect1666,First1668,PgSelectSingle1669,Lambda1679,Lambda1682,Constant1683,Constant1684,Constant1685,Constant1697,Constant1698,Constant1699,Constant1711,Constant1712,Constant1713,Object1714,Lambda1715,Lambda1720,Constant1725,Constant1726,Constant1727,Object1728,Lambda1729,Lambda1734,Constant1739,Constant1740,Constant1741,Object1742,Lambda1743,Lambda1748,Constant1753,Constant1754,Constant1755,Object1756,Lambda1757,Lambda1762,Constant1767,Constant1768,Constant1769,Object1770,Lambda1771,Lambda1776,Constant1781,Constant1782,Constant1783,Object1784,Lambda1785,Lambda1790,Constant1795,Constant1796,Object1798,Lambda1799,Lambda1804,Constant1809,Constant1810,Object1812,Lambda1813,Lambda1818,Constant1823,Constant1824,Constant1825,Object1826,Lambda1827,Lambda1832,Constant1837,Constant1838,Constant1839,Object1840,Lambda1841,Lambda1846,Constant1851,Constant1852,Constant1853,Object1854,Lambda1855,Lambda1860,Constant1865,Constant1866,Constant1867,Object1868,Lambda1869,Lambda1874,Constant1879,Constant1880,Constant1881,Object1882,Lambda1883,Lambda1888,Constant1893,Constant1894,Constant1895,Object1896,Lambda1897,Lambda1902,Constant1907,Constant1908,Constant1909,Object1910,Lambda1911,Lambda1916,Constant1921,Constant1922,Constant1923,Object1924,Lambda1925,Lambda1930,Constant1935,Constant1936,Constant1937,Object1938,Lambda1939,Lambda1944,Constant1949,Constant1950,Constant1951,Object1952,Lambda1953,Lambda1958,Constant1963,Constant1964,Constant1965,Object1966,Lambda1967,Lambda1972,Constant1977,Constant1978,Object1980,Lambda1981,Lambda1986,Constant1991,Constant1992,Object1994,Lambda1995,Lambda2000,Constant2005,Constant2006,Object2008,Lambda2009,Lambda2014,Constant2019,Constant2020,Object2022,Lambda2023,Lambda2028,Constant2033,Constant2034,Object2036,Lambda2037,Lambda2042,Constant2047,Constant2048,Object2050,Lambda2051,Lambda2056,Constant2061,Constant2062,Object2064,Lambda2065,Lambda2070,Constant2075,Constant2076,Object2078,Lambda2079,Lambda2084,Constant2089,Constant2090,Object2092,Lambda2093,Lambda2098,Constant2103,Constant2104,Object2106,Lambda2107,Lambda2112,Constant2117,Constant2118,Object2120,Lambda2121,Lambda2126,Constant2131,Constant2132,Object2134,Lambda2135,Lambda2140,Constant2145,Constant2146,Object2148,Lambda2149,Lambda2154,Constant2159,Constant2160,Object2162,Lambda2163,Lambda2168,Constant2173,Constant2174,Object2176,Lambda2177,Lambda2182,Constant2187,Constant2188,Object2190,Lambda2191,Lambda2196,Constant2201,Constant2202,Object2204,Lambda2205,Lambda2210,Constant2215,Constant2216,Object2218,Lambda2219,Lambda2224,Constant2229,Constant2230,Object2232,Lambda2233,Lambda2238,Constant2243,Constant2244,Object2246,Lambda2247,Lambda2252,Constant2257,Constant2258,Object2260,Lambda2261,Lambda2266,Constant2271,Constant2272,Object2274,Lambda2275,Lambda2280,Constant2285,Constant2286,Object2288,Lambda2289,Lambda2294,Constant2299,Constant2300,Object2302,Lambda2303,Lambda2308,Constant2313,Constant2314,Object2316,Lambda2317,Lambda2322,Constant2327,Constant2328,Object2330,Lambda2331,Lambda2336,Constant2341,Constant2342,Object2344,Lambda2345,Lambda2350,Constant2355,Constant2356,Object2358,Lambda2359,Lambda2364,Constant2369,Constant2370,Object2372,Lambda2373,Lambda2378,Constant2383,Constant2384,Object2386,Lambda2387,Lambda2392,Constant2397,Constant2398,Object2400,Lambda2401,Lambda2406,Constant2411,Constant2412,Object2414,Lambda2415,Lambda2420,Constant2425,Constant2426,Object2428,Lambda2429,Lambda2434,Constant2439,Constant2440,Object2442,Lambda2443,Lambda2448,Constant2453,Constant2454,Object2456,Lambda2457,Lambda2462,Constant2467,Constant2468,Object2470,Lambda2471,Lambda2476,Constant2481,Constant2482,Object2484,Lambda2485,Lambda2490,Constant2495,Constant2496,Object2498,Lambda2499,Lambda2504,Constant2509,Constant2510,Object2512,Lambda2513,Lambda2518,Constant2523,Constant2524,Object2526,Lambda2527,Lambda2532,Constant2537,Constant2538,Object2540,Lambda2541,Lambda2546,Constant2551,Constant2552,Object2554,Lambda2555,Lambda2560,Constant2565,Constant2566,Object2568,Lambda2569,Lambda2574,Constant2579,Constant2580,Object2582,Lambda2583,Lambda2588,Constant2593,Constant2594,Object2596,Lambda2597,Lambda2602,Constant2607,Constant2608,Object2610,Lambda2611,Lambda2616,Constant2621,Constant2622,Object2624,Lambda2625,Lambda2630,Constant2635,Constant2636,Object2638,Lambda2639,Lambda2644,Constant2649,Constant2650,Object2652,Lambda2653,Lambda2658,Constant2663,Constant2664,Object2666,Lambda2667,Lambda2672,Constant2677,Constant2678,Object2680,Lambda2681,Lambda2686,Constant2691,Constant2692,Object2694,Lambda2695,Lambda2700,Constant2705,Constant2706,Object2708,Lambda2709,Lambda2714,Constant2719,Constant2720,Object2722,Lambda2723,Lambda2728,Constant2733,Constant2734,Object2736,Lambda2737,Lambda2742,Constant2747,Constant2748,Object2750,Lambda2751,Lambda2756,Constant2761,Constant2762,Object2764,Lambda2765,Lambda2770,Constant2775,Constant2776,Object2778,Lambda2779,Lambda2784,Constant2789,Constant2790,Object2792,Lambda2793,Lambda2798,Constant2803,Constant2804,Object2806,Lambda2807,Lambda2812,Constant2817,Constant2818,Object2820,Lambda2821,Lambda2826,Constant2831,Constant2832,Object2834,Lambda2835,Lambda2840,Constant2845,Constant2846,Object2848,Lambda2849,Lambda2854,Constant2859,Constant2860,Object2862,Lambda2863,Lambda2868,Constant2873,Constant2874,Object2876,Lambda2877,Lambda2882,Constant2887,Constant2888,Object2890,Lambda2891,Lambda2896,Constant2901,Constant2902,Object2904,Lambda2905,Lambda2910,Constant2915,Constant2916,Object2918,Lambda2919,Lambda2924,Constant2929,Constant2930,Object2932,Lambda2933,Lambda2938,Constant2943,Constant2944,Object2946,Lambda2947,Lambda2952,Constant2957,Constant2958,Object2960,Lambda2961,Lambda2966,Constant2971,Constant2972,Object2974,Lambda2975,Lambda2980,Constant2985,Constant2986,Object2988,Lambda2989,Lambda2994,Constant2999,Constant3000,Object3002,Lambda3003,Lambda3008,Constant3013,Constant3014,Object3016,Lambda3017,Lambda3022,Constant3027,Constant3028,Object3030,Lambda3031,Lambda3036,Constant3041,Constant3042,Object3044,Lambda3045,Lambda3050,Constant3055,Constant3056,Object3058,Lambda3059,Lambda3064,Constant3069,Constant3070,Object3072,Lambda3073,Lambda3078,Constant3083,Constant3084,Object3086,Lambda3087,Lambda3092,Constant3097,Constant3098,Object3100,Lambda3101,Lambda3106,Constant3111,Constant3112,Object3114,Lambda3115,Lambda3120,Constant3125,Constant3126,Object3128,Lambda3129,Lambda3134,Constant3139,Constant3140,Object3142,Lambda3143,Lambda3148,Constant3153,Constant3154,Object3156,Lambda3157,Lambda3162,Constant3167,Constant3168,Object3170,Lambda3171,Lambda3176,Constant3181,Constant3182,Object3184,Lambda3185,Lambda3190,Constant3195,Constant3196,Object3198,Lambda3199,Lambda3204,Constant3209,Constant3210,Object3212,Lambda3213,Lambda3218,Constant3223,Constant3224,Object3226,Lambda3227,Lambda3232,Constant3237,Constant3238,Object3240,Lambda3241,Lambda3246,Constant3251,Constant3252,Object3254,Lambda3255,Lambda3260,Constant3265,Constant3266,Object3268,Lambda3269,Lambda3274,Constant3279,Constant3280,Object3282,Lambda3283,Lambda3288,Constant3293,Constant3294,Object3296,Lambda3297,Lambda3302,Constant3307,Constant3308,Object3310,Lambda3311,Lambda3316,Constant3321,Constant3322,Object3324,Lambda3325,Lambda3330,Constant3335,Constant3336,Object3338,Lambda3339,Lambda3344,Constant3349,Constant3350,Object3352,Lambda3353,Lambda3358,Constant3363,Constant3364,Object3366,Lambda3367,Lambda3372,Constant3377,Constant3378,Object3380,Lambda3381,Lambda3386,Constant3391,Constant3392,Object3394,Lambda3395,Lambda3400,Constant3405,Constant3406,Object3408,Lambda3409,Lambda3414,Constant3419,Constant3420,Object3422,Lambda3423,Lambda3428,Constant3433,Constant3434,Object3436,Lambda3437,Lambda3442,Constant3447,Constant3448,Object3450,Lambda3451,Lambda3456,Constant3461,Constant3462,Object3464,Lambda3465,Lambda3470,Constant3475,Constant3476,Object3478,Lambda3479,Lambda3484,Constant3489,Constant3490,Object3492,Lambda3493,Lambda3498,Constant3503,Constant3504,Object3506,Lambda3507,Lambda3512,Constant3517,Constant3518,Object3520,Lambda3521,Lambda3526,Constant3531,Constant3532,Object3534,Lambda3535,Lambda3540,Constant3545,Constant3546,Object3548,Lambda3549,Lambda3554,Constant3559,Constant3560,Object3562,Lambda3563,Lambda3568,Constant3573,Constant3574,Object3576,Lambda3577,Lambda3582,Constant3587,Constant3588,Object3590,Lambda3591,Lambda3596,Constant3601,Constant3602,Object3604,Lambda3605,Lambda3610,Constant3615,Constant3616,Object3618,Lambda3619,Lambda3624,Constant3629,Constant3630,Object3632,Lambda3633,Lambda3638,Constant3643,Constant3644,Object3646,Lambda3647,Lambda3652,Constant3657,Constant3658,Object3660,Lambda3661,Lambda3666,Constant3671,Constant3672,Object3674,Lambda3675,Lambda3680,Constant3685,Constant3686,Object3688,Lambda3689,Lambda3694,Constant3699,Constant3700,Object3702,Lambda3703,Lambda3708,Constant3713,Constant3714,Object3716,Lambda3717,Lambda3722,Constant3727,Constant3728,Object3730,Lambda3731,Lambda3736,Constant3741,Constant3742,Object3744,Lambda3745,Lambda3750,Constant3755,Constant3756,Object3758,Lambda3759,Lambda3764,Constant3769,Constant3770,Object3772,Lambda3773,Lambda3778,Constant3783,Constant3784,Object3786,Lambda3787,Lambda3792,Constant3797,Constant3798,Object3800,Lambda3801,Lambda3806,Constant3811,Constant3812,Object3814,Lambda3815,Lambda3820,Constant3825,Constant3826,Object3828,Lambda3829,Lambda3834,Constant3839,Constant3840,Object3842,Lambda3843,Lambda3848,Constant3853,Constant3854,Object3856,Lambda3857,Lambda3862,Constant3867,Constant3868,Object3870,Lambda3871,Lambda3876,Constant3881,Constant3882,Object3884,Lambda3885,Lambda3890,Constant3895,Constant3896,Object3898,Lambda3899,Lambda3904,Constant3909,Constant3910,Object3912,Lambda3913,Lambda3918,Constant3923,Constant3924,Object3926,Lambda3927,Lambda3932,Constant3937,Constant3938,Object3940,Lambda3941,Lambda3946,Constant3949,Constant3952,Constant3955,Constant3958,Constant3961,Constant3964,Constant3967,Constant3970,Constant3971,Constant3972,Constant3973,Constant3974,Constant3975,Constant3976,Constant3977,Constant3978,Constant3979,Constant3980,Constant3981,Constant3982,Constant3983,Constant3984,Constant3985,Constant3986,Constant3987,Constant3988,Constant3989,Constant3990,Constant3991,Constant3992,Constant3993,Constant3994,Constant3995,Constant3996,Constant3997,Constant3998,Constant3999,Constant4000,Constant4001,Constant4002,Constant4003,Constant4004,Constant4005,Constant4006,Constant4007,Constant4008,Constant4009,Constant4010,Constant4011,Constant4012,Constant4013,Constant4014,Constant4015,Constant4016,Constant4017,Constant4018,Constant4019,Constant4020,Constant4021,Constant4022,Constant4023,Constant4024,Constant4025,Constant4026,Constant4027,Constant4028,Constant4029,Constant4030,Constant4031,Constant4032,Constant4033,Constant4034,Constant4035,Constant4036,Constant4037,Constant4038,Constant4039,Constant4040,Constant4041,Constant4042,Constant4043,Constant4044,Constant4045,Constant4046,Constant4047,Constant4048,Constant4049,Constant4050,Constant4051,Constant4052,Constant4053,Constant4054,Constant4055,Constant4056,Constant4057,Constant4058,Constant4059,Constant4060,Constant4061,Constant4062,Constant4063,Constant4064,Constant4065,Constant4066,Constant4067,Constant4068,Constant4069,Constant4070,Constant4071,Constant4072,Constant4073,Constant4074,Constant4075,Constant4076,Constant4077,Constant4078,Constant4079,Constant4080,Constant4081,Constant4082,Constant4083,Constant4084,Constant4085,Constant4086,Constant4087,Constant4088,Constant4089,Constant4090,Constant4091,Constant4092,Constant4093,Constant4094,Constant4095,Constant4096,Constant4097,Constant4098,Constant4099,Constant4100,Constant4101,Constant4102,Constant4103,Constant4104,Constant4105,Constant4106,Constant4107,Constant4108,Constant4109,Constant4110,Constant4111,Constant4112,Constant4113,Constant4114,Constant4115,Constant4116,Constant4117,Constant4118,Constant4119,Constant4120,Constant4121,Constant4122,Constant4123,Constant4124,Constant4125,Constant4126,Constant4127,Constant4128,Constant4129,Constant4130,Constant4131,Constant4132,Constant4133,Constant4134 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 1679, 1682, 1683, 1684, 1685, 3973, 17<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 1686, 1692, 1687<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Connection26,Constant30,Node36,Lambda37,Constant39,Constant50,Constant59,Constant68,Constant77,Constant86,Constant95,Constant126,Constant135,Constant144,Constant153,Constant162,Constant171,Constant180,Constant192,Constant204,Constant213,Constant222,Node227,Lambda228,Node418,Lambda419,Node609,Lambda610,Node800,Lambda801,Node991,Lambda992,Lambda1182,Access1183,PgSelect1185,First1187,PgSelectSingle1188,Lambda1195,Access1196,PgSelect1198,First1200,PgSelectSingle1201,Lambda1208,Access1209,PgSelect1211,First1213,PgSelectSingle1214,Lambda1221,Access1222,Access1224,PgSelect1226,First1228,PgSelectSingle1229,Lambda1236,Access1237,Access1239,PgSelect1241,First1243,PgSelectSingle1244,Lambda1251,Access1252,Access1254,PgSelect1256,First1258,PgSelectSingle1259,Node1266,Lambda1267,Node1457,Lambda1458,Lambda1648,Access1649,PgSelect1651,First1653,PgSelectSingle1654,Lambda1663,Access1664,PgSelect1666,First1668,PgSelectSingle1669,Lambda1679,Lambda1682,Access1683,Constant1684,Constant1685,Constant1686,Object1687,Lambda1688,Lambda1693,Constant1699,Constant1700,Constant1701,Object1702,Lambda1703,Lambda1708,Constant1714,Constant1715,Constant1716,Object1717,Lambda1718,Lambda1723,Constant1729,Constant1730,Constant1731,Object1732,Lambda1733,Lambda1738,Constant1744,Constant1745,Constant1746,Object1747,Lambda1748,Lambda1753,Constant1759,Constant1760,Constant1761,Object1762,Lambda1763,Lambda1768,Constant1774,Constant1775,Constant1776,Object1777,Lambda1778,Lambda1783,Constant1789,Constant1790,Constant1791,Object1792,Lambda1793,Lambda1798,Constant1804,Constant1805,Object1807,Lambda1808,Lambda1813,Constant1819,Constant1820,Object1822,Lambda1823,Lambda1828,Constant1834,Constant1835,Constant1836,Object1837,Lambda1838,Lambda1843,Constant1849,Constant1850,Constant1851,Object1852,Lambda1853,Lambda1858,Constant1864,Constant1865,Constant1866,Object1867,Lambda1868,Lambda1873,Constant1879,Constant1880,Constant1881,Object1882,Lambda1883,Lambda1888,Constant1894,Constant1895,Constant1896,Object1897,Lambda1898,Lambda1903,Constant1909,Constant1910,Constant1911,Object1912,Lambda1913,Lambda1918,Constant1924,Constant1925,Constant1926,Object1927,Lambda1928,Lambda1933,Constant1939,Constant1940,Constant1941,Object1942,Lambda1943,Lambda1948,Constant1954,Constant1955,Constant1956,Object1957,Lambda1958,Lambda1963,Constant1969,Constant1970,Constant1971,Object1972,Lambda1973,Lambda1978,Constant1984,Constant1985,Constant1986,Object1987,Lambda1988,Lambda1993,Constant1999,Constant2000,Object2002,Lambda2003,Lambda2008,Constant2014,Constant2015,Object2017,Lambda2018,Lambda2023,Constant2029,Constant2030,Object2032,Lambda2033,Lambda2038,Constant2044,Constant2045,Object2047,Lambda2048,Lambda2053,Constant2059,Constant2060,Object2062,Lambda2063,Lambda2068,Constant2074,Constant2075,Object2077,Lambda2078,Lambda2083,Constant2089,Constant2090,Object2092,Lambda2093,Lambda2098,Constant2104,Constant2105,Object2107,Lambda2108,Lambda2113,Constant2119,Constant2120,Object2122,Lambda2123,Lambda2128,Constant2134,Constant2135,Object2137,Lambda2138,Lambda2143,Constant2149,Constant2150,Object2152,Lambda2153,Lambda2158,Constant2164,Constant2165,Object2167,Lambda2168,Lambda2173,Constant2179,Constant2180,Object2182,Lambda2183,Lambda2188,Constant2194,Constant2195,Object2197,Lambda2198,Lambda2203,Constant2209,Constant2210,Object2212,Lambda2213,Lambda2218,Constant2224,Constant2225,Object2227,Lambda2228,Lambda2233,Constant2239,Constant2240,Object2242,Lambda2243,Lambda2248,Constant2254,Constant2255,Object2257,Lambda2258,Lambda2263,Constant2269,Constant2270,Object2272,Lambda2273,Lambda2278,Constant2284,Constant2285,Object2287,Lambda2288,Lambda2293,Constant2299,Constant2300,Object2302,Lambda2303,Lambda2308,Constant2314,Constant2315,Object2317,Lambda2318,Lambda2323,Constant2329,Constant2330,Object2332,Lambda2333,Lambda2338,Constant2344,Constant2345,Object2347,Lambda2348,Lambda2353,Constant2359,Constant2360,Object2362,Lambda2363,Lambda2368,Constant2374,Constant2375,Object2377,Lambda2378,Lambda2383,Constant2389,Constant2390,Object2392,Lambda2393,Lambda2398,Constant2404,Constant2405,Object2407,Lambda2408,Lambda2413,Constant2419,Constant2420,Object2422,Lambda2423,Lambda2428,Constant2434,Constant2435,Object2437,Lambda2438,Lambda2443,Constant2449,Constant2450,Object2452,Lambda2453,Lambda2458,Constant2464,Constant2465,Object2467,Lambda2468,Lambda2473,Constant2479,Constant2480,Object2482,Lambda2483,Lambda2488,Constant2494,Constant2495,Object2497,Lambda2498,Lambda2503,Constant2509,Constant2510,Object2512,Lambda2513,Lambda2518,Constant2524,Constant2525,Object2527,Lambda2528,Lambda2533,Constant2539,Constant2540,Object2542,Lambda2543,Lambda2548,Constant2554,Constant2555,Object2557,Lambda2558,Lambda2563,Constant2569,Constant2570,Object2572,Lambda2573,Lambda2578,Constant2584,Constant2585,Object2587,Lambda2588,Lambda2593,Constant2599,Constant2600,Object2602,Lambda2603,Lambda2608,Constant2614,Constant2615,Object2617,Lambda2618,Lambda2623,Constant2629,Constant2630,Object2632,Lambda2633,Lambda2638,Constant2644,Constant2645,Object2647,Lambda2648,Lambda2653,Constant2659,Constant2660,Object2662,Lambda2663,Lambda2668,Constant2674,Constant2675,Object2677,Lambda2678,Lambda2683,Constant2689,Constant2690,Object2692,Lambda2693,Lambda2698,Constant2704,Constant2705,Object2707,Lambda2708,Lambda2713,Constant2719,Constant2720,Object2722,Lambda2723,Lambda2728,Constant2734,Constant2735,Object2737,Lambda2738,Lambda2743,Constant2749,Constant2750,Object2752,Lambda2753,Lambda2758,Constant2764,Constant2765,Object2767,Lambda2768,Lambda2773,Constant2779,Constant2780,Object2782,Lambda2783,Lambda2788,Constant2794,Constant2795,Object2797,Lambda2798,Lambda2803,Constant2809,Constant2810,Object2812,Lambda2813,Lambda2818,Constant2824,Constant2825,Object2827,Lambda2828,Lambda2833,Constant2839,Constant2840,Object2842,Lambda2843,Lambda2848,Constant2854,Constant2855,Object2857,Lambda2858,Lambda2863,Constant2869,Constant2870,Object2872,Lambda2873,Lambda2878,Constant2884,Constant2885,Object2887,Lambda2888,Lambda2893,Constant2899,Constant2900,Object2902,Lambda2903,Lambda2908,Constant2914,Constant2915,Object2917,Lambda2918,Lambda2923,Constant2929,Constant2930,Object2932,Lambda2933,Lambda2938,Constant2944,Constant2945,Object2947,Lambda2948,Lambda2953,Constant2959,Constant2960,Object2962,Lambda2963,Lambda2968,Constant2974,Constant2975,Object2977,Lambda2978,Lambda2983,Constant2989,Constant2990,Object2992,Lambda2993,Lambda2998,Constant3004,Constant3005,Object3007,Lambda3008,Lambda3013,Constant3019,Constant3020,Object3022,Lambda3023,Lambda3028,Constant3034,Constant3035,Object3037,Lambda3038,Lambda3043,Constant3049,Constant3050,Object3052,Lambda3053,Lambda3058,Constant3064,Constant3065,Object3067,Lambda3068,Lambda3073,Constant3079,Constant3080,Object3082,Lambda3083,Lambda3088,Constant3094,Constant3095,Object3097,Lambda3098,Lambda3103,Constant3109,Constant3110,Object3112,Lambda3113,Lambda3118,Constant3124,Constant3125,Object3127,Lambda3128,Lambda3133,Constant3139,Constant3140,Object3142,Lambda3143,Lambda3148,Constant3154,Constant3155,Object3157,Lambda3158,Lambda3163,Constant3169,Constant3170,Object3172,Lambda3173,Lambda3178,Constant3184,Constant3185,Object3187,Lambda3188,Lambda3193,Constant3199,Constant3200,Object3202,Lambda3203,Lambda3208,Constant3214,Constant3215,Object3217,Lambda3218,Lambda3223,Constant3229,Constant3230,Object3232,Lambda3233,Lambda3238,Constant3244,Constant3245,Object3247,Lambda3248,Lambda3253,Constant3259,Constant3260,Object3262,Lambda3263,Lambda3268,Constant3274,Constant3275,Object3277,Lambda3278,Lambda3283,Constant3289,Constant3290,Object3292,Lambda3293,Lambda3298,Constant3304,Constant3305,Object3307,Lambda3308,Lambda3313,Constant3319,Constant3320,Object3322,Lambda3323,Lambda3328,Constant3334,Constant3335,Object3337,Lambda3338,Lambda3343,Constant3349,Constant3350,Object3352,Lambda3353,Lambda3358,Constant3364,Constant3365,Object3367,Lambda3368,Lambda3373,Constant3379,Constant3380,Object3382,Lambda3383,Lambda3388,Constant3394,Constant3395,Object3397,Lambda3398,Lambda3403,Constant3409,Constant3410,Object3412,Lambda3413,Lambda3418,Constant3424,Constant3425,Object3427,Lambda3428,Lambda3433,Constant3439,Constant3440,Object3442,Lambda3443,Lambda3448,Constant3454,Constant3455,Object3457,Lambda3458,Lambda3463,Constant3469,Constant3470,Object3472,Lambda3473,Lambda3478,Constant3484,Constant3485,Object3487,Lambda3488,Lambda3493,Constant3499,Constant3500,Object3502,Lambda3503,Lambda3508,Constant3514,Constant3515,Object3517,Lambda3518,Lambda3523,Constant3529,Constant3530,Object3532,Lambda3533,Lambda3538,Constant3544,Constant3545,Object3547,Lambda3548,Lambda3553,Constant3559,Constant3560,Object3562,Lambda3563,Lambda3568,Constant3574,Constant3575,Object3577,Lambda3578,Lambda3583,Constant3589,Constant3590,Object3592,Lambda3593,Lambda3598,Constant3604,Constant3605,Object3607,Lambda3608,Lambda3613,Constant3619,Constant3620,Object3622,Lambda3623,Lambda3628,Constant3634,Constant3635,Object3637,Lambda3638,Lambda3643,Constant3649,Constant3650,Object3652,Lambda3653,Lambda3658,Constant3664,Constant3665,Object3667,Lambda3668,Lambda3673,Constant3679,Constant3680,Object3682,Lambda3683,Lambda3688,Constant3694,Constant3695,Object3697,Lambda3698,Lambda3703,Constant3709,Constant3710,Object3712,Lambda3713,Lambda3718,Constant3724,Constant3725,Object3727,Lambda3728,Lambda3733,Constant3739,Constant3740,Object3742,Lambda3743,Lambda3748,Constant3754,Constant3755,Object3757,Lambda3758,Lambda3763,Constant3769,Constant3770,Object3772,Lambda3773,Lambda3778,Constant3784,Constant3785,Object3787,Lambda3788,Lambda3793,Constant3799,Constant3800,Object3802,Lambda3803,Lambda3808,Constant3814,Constant3815,Object3817,Lambda3818,Lambda3823,Constant3829,Constant3830,Object3832,Lambda3833,Lambda3838,Constant3844,Constant3845,Object3847,Lambda3848,Lambda3853,Constant3859,Constant3860,Object3862,Lambda3863,Lambda3868,Constant3874,Constant3875,Object3877,Lambda3878,Lambda3883,Constant3889,Constant3890,Object3892,Lambda3893,Lambda3898,Constant3904,Constant3905,Object3907,Lambda3908,Lambda3913,Constant3919,Constant3920,Object3922,Lambda3923,Lambda3928,Constant3934,Constant3935,Object3937,Lambda3938,Lambda3943,Constant3949,Constant3950,Object3952,Lambda3953,Lambda3958,Constant3964,Constant3965,Object3967,Lambda3968,Lambda3973,Constant3979,Constant3980,Object3982,Lambda3983,Lambda3988,Constant3994,Constant3995,Object3997,Lambda3998,Lambda4003,Constant4009,Constant4010,Object4012,Lambda4013,Lambda4018,Constant4024,Constant4025,Object4027,Lambda4028,Lambda4033,Constant4039,Constant4040,Object4042,Lambda4043,Lambda4048,Constant4054,Constant4055,Object4057,Lambda4058,Lambda4063,Constant4069,Constant4070,Object4072,Lambda4073,Lambda4078,Constant4084,Constant4085,Object4087,Lambda4088,Lambda4093,Constant4099,Constant4100,Object4102,Lambda4103,Lambda4108,Constant4111,Constant4114,Constant4117,Constant4120,Constant4123,Constant4126,Constant4129,Constant4132,Constant4133,Constant4134,Constant4135,Constant4136,Constant4137,Constant4138,Constant4139,Constant4140,Constant4141,Constant4142,Constant4143,Constant4144,Constant4145,Constant4146,Constant4147,Constant4148,Constant4149,Constant4150,Constant4151,Constant4152,Constant4153,Constant4154,Constant4155,Constant4156,Constant4157,Constant4158,Constant4159,Constant4160,Constant4161,Constant4162,Constant4163,Constant4164,Constant4165,Constant4166,Constant4167,Constant4168,Constant4169,Constant4170,Constant4171,Constant4172,Constant4173,Constant4174,Constant4175,Constant4176,Constant4177,Constant4178,Constant4179,Constant4180,Constant4181,Constant4182,Constant4183,Constant4184,Constant4185,Constant4186,Constant4187,Constant4188,Constant4189,Constant4190,Constant4191,Constant4192,Constant4193,Constant4194,Constant4195,Constant4196,Constant4197,Constant4198,Constant4199,Constant4200,Constant4201,Constant4202,Constant4203,Constant4204,Constant4205,Constant4206,Constant4207,Constant4208,Constant4209,Constant4210,Constant4211,Constant4212,Constant4213,Constant4214,Constant4215,Constant4216,Constant4217,Constant4218,Constant4219,Constant4220,Constant4221,Constant4222,Constant4223,Constant4224,Constant4225,Constant4226,Constant4227,Constant4228,Constant4229,Constant4230,Constant4231,Constant4232,Constant4233,Constant4234,Constant4235,Constant4236,Constant4237,Constant4238,Constant4239,Constant4240,Constant4241,Constant4242,Constant4243,Constant4244,Constant4245,Constant4246,Constant4247,Constant4248,Constant4249,Constant4250,Constant4251,Constant4252,Constant4253,Constant4254,Constant4255,Constant4256,Constant4257,Constant4258,Constant4259,Constant4260,Constant4261,Constant4262,Constant4263,Constant4264,Constant4265,Constant4266,Constant4267,Constant4268,Constant4269,Constant4270,Constant4271,Constant4272,Constant4273,Constant4274,Constant4275,Constant4276,Constant4277,Constant4278,Constant4279,Constant4280,Constant4281,Constant4282,Constant4283,Constant4284,Constant4285,Constant4286,Constant4287,Constant4288,Constant4289,Constant4290,Constant4291,Constant4292,Constant4293,Constant4294,Constant4295,Constant4296 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 1679, 1683, 1688, 1693, 17<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object1686,Lambda1687,Lambda1692 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 17<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,List19,Lambda20,PgClassExpression21 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 26, 1679, 1682, 1697, 1698, 1699, 3974, 30<br /><br />ROOT Connectionᐸ24ᐳ[26]<br />1: <br />ᐳ: 1700, 1706, 1701<br />2: PgSelect[27]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 26, 1679, 1683, 1703, 1708, 30<br /><br />ROOT Connectionᐸ24ᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect27,Object1700,Lambda1701,Lambda1706 bucket4
+    class Bucket4,PgSelect27 bucket4
     Bucket5("Bucket 5 (listItem)<br />Deps: 30<br /><br />ROOT __Item{5}ᐸ27ᐳ[28]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item28,PgSelectSingle29 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 29, 30<br /><br />ROOT PgSelectSingle{5}ᐸcompound_keyᐳ[29]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression31,PgClassExpression32,List33,Lambda34 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 1715, 1720, 50, 1729, 1734, 59, 1743, 1748, 68, 1757, 1762, 77, 1771, 1776, 86, 1785, 1790, 95, 1799, 1804, 30, 1813, 1818, 17, 1827, 1832, 126, 1841, 1846, 135, 1855, 1860, 144, 1869, 1874, 153, 1883, 1888, 162, 1897, 1902, 171, 1911, 1916, 180, 1925, 1930, 192, 1939, 1944, 204, 1953, 1958, 213, 1967, 1972, 222, 37, 36, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[40], Access[3947], Access[3948]<br />2: 44, 55, 64, 73, 82, 91, 102, 112, 122, 131, 140, 149, 158, 167, 176, 188, 200, 209, 218<br />ᐳ: 48, 49, 51, 52, 53, 57, 58, 60, 61, 62, 66, 67, 69, 70, 71, 75, 76, 78, 79, 80, 84, 85, 87, 88, 89, 93, 94, 96, 97, 98, 104, 105, 107, 108, 109, 110, 114, 115, 117, 118, 119, 120, 124, 125, 127, 128, 129, 133, 134, 136, 137, 138, 142, 143, 145, 146, 147, 151, 152, 154, 155, 156, 160, 161, 163, 164, 165, 169, 170, 172, 173, 174, 178, 179, 181, 182, 183, 184, 185, 186, 190, 191, 193, 194, 195, 196, 197, 198, 202, 203, 205, 206, 207, 211, 212, 214, 215, 216, 220, 221, 223, 224, 225"):::bucket
+    Bucket7("Bucket 7 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 1718, 1723, 50, 1733, 1738, 59, 1748, 1753, 68, 1763, 1768, 77, 1778, 1783, 86, 1793, 1798, 95, 1808, 1813, 30, 1823, 1828, 17, 1838, 1843, 126, 1853, 1858, 135, 1868, 1873, 144, 1883, 1888, 153, 1898, 1903, 162, 1913, 1918, 171, 1928, 1933, 180, 1943, 1948, 192, 1958, 1963, 204, 1973, 1978, 213, 1988, 1993, 222, 37, 36, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[40], Access[4109], Access[4110]<br />2: 44, 55, 64, 73, 82, 91, 102, 112, 122, 131, 140, 149, 158, 167, 176, 188, 200, 209, 218<br />ᐳ: 48, 49, 51, 52, 53, 57, 58, 60, 61, 62, 66, 67, 69, 70, 71, 75, 76, 78, 79, 80, 84, 85, 87, 88, 89, 93, 94, 96, 97, 98, 104, 105, 107, 108, 109, 110, 114, 115, 117, 118, 119, 120, 124, 125, 127, 128, 129, 133, 134, 136, 137, 138, 142, 143, 145, 146, 147, 151, 152, 154, 155, 156, 160, 161, 163, 164, 165, 169, 170, 172, 173, 174, 178, 179, 181, 182, 183, 184, 185, 186, 190, 191, 193, 194, 195, 196, 197, 198, 202, 203, 205, 206, 207, 211, 212, 214, 215, 216, 220, 221, 223, 224, 225"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Lambda40,PgSelect44,First48,PgSelectSingle49,PgClassExpression51,List52,Lambda53,PgSelect55,First57,PgSelectSingle58,PgClassExpression60,List61,Lambda62,PgSelect64,First66,PgSelectSingle67,PgClassExpression69,List70,Lambda71,PgSelect73,First75,PgSelectSingle76,PgClassExpression78,List79,Lambda80,PgSelect82,First84,PgSelectSingle85,PgClassExpression87,List88,Lambda89,PgSelect91,First93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgSelect102,First104,PgSelectSingle105,PgClassExpression107,PgClassExpression108,List109,Lambda110,PgSelect112,First114,PgSelectSingle115,PgClassExpression117,List118,Lambda119,PgClassExpression120,PgSelect122,First124,PgSelectSingle125,PgClassExpression127,List128,Lambda129,PgSelect131,First133,PgSelectSingle134,PgClassExpression136,List137,Lambda138,PgSelect140,First142,PgSelectSingle143,PgClassExpression145,List146,Lambda147,PgSelect149,First151,PgSelectSingle152,PgClassExpression154,List155,Lambda156,PgSelect158,First160,PgSelectSingle161,PgClassExpression163,List164,Lambda165,PgSelect167,First169,PgSelectSingle170,PgClassExpression172,List173,Lambda174,PgSelect176,First178,PgSelectSingle179,PgClassExpression181,List182,Lambda183,PgClassExpression184,PgClassExpression185,PgClassExpression186,PgSelect188,First190,PgSelectSingle191,PgClassExpression193,List194,Lambda195,PgClassExpression196,PgClassExpression197,PgClassExpression198,PgSelect200,First202,PgSelectSingle203,PgClassExpression205,List206,Lambda207,PgSelect209,First211,PgSelectSingle212,PgClassExpression214,List215,Lambda216,PgSelect218,First220,PgSelectSingle221,PgClassExpression223,List224,Lambda225,Access3947,Access3948 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 1981, 1986, 50, 1995, 2000, 59, 2009, 2014, 68, 2023, 2028, 77, 2037, 2042, 86, 2051, 2056, 95, 2065, 2070, 30, 2079, 2084, 17, 2093, 2098, 126, 2107, 2112, 135, 2121, 2126, 144, 2135, 2140, 153, 2149, 2154, 162, 2163, 2168, 171, 2177, 2182, 180, 2191, 2196, 192, 2205, 2210, 204, 2219, 2224, 213, 2233, 2238, 222, 228, 227, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[231], Access[3950], Access[3951]<br />2: 235, 246, 255, 264, 273, 282, 293, 303, 313, 322, 331, 340, 349, 358, 367, 379, 391, 400, 409<br />ᐳ: 239, 240, 242, 243, 244, 248, 249, 251, 252, 253, 257, 258, 260, 261, 262, 266, 267, 269, 270, 271, 275, 276, 278, 279, 280, 284, 285, 287, 288, 289, 295, 296, 298, 299, 300, 301, 305, 306, 308, 309, 310, 311, 315, 316, 318, 319, 320, 324, 325, 327, 328, 329, 333, 334, 336, 337, 338, 342, 343, 345, 346, 347, 351, 352, 354, 355, 356, 360, 361, 363, 364, 365, 369, 370, 372, 373, 374, 375, 376, 377, 381, 382, 384, 385, 386, 387, 388, 389, 393, 394, 396, 397, 398, 402, 403, 405, 406, 407, 411, 412, 414, 415, 416"):::bucket
+    class Bucket7,Lambda40,PgSelect44,First48,PgSelectSingle49,PgClassExpression51,List52,Lambda53,PgSelect55,First57,PgSelectSingle58,PgClassExpression60,List61,Lambda62,PgSelect64,First66,PgSelectSingle67,PgClassExpression69,List70,Lambda71,PgSelect73,First75,PgSelectSingle76,PgClassExpression78,List79,Lambda80,PgSelect82,First84,PgSelectSingle85,PgClassExpression87,List88,Lambda89,PgSelect91,First93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgSelect102,First104,PgSelectSingle105,PgClassExpression107,PgClassExpression108,List109,Lambda110,PgSelect112,First114,PgSelectSingle115,PgClassExpression117,List118,Lambda119,PgClassExpression120,PgSelect122,First124,PgSelectSingle125,PgClassExpression127,List128,Lambda129,PgSelect131,First133,PgSelectSingle134,PgClassExpression136,List137,Lambda138,PgSelect140,First142,PgSelectSingle143,PgClassExpression145,List146,Lambda147,PgSelect149,First151,PgSelectSingle152,PgClassExpression154,List155,Lambda156,PgSelect158,First160,PgSelectSingle161,PgClassExpression163,List164,Lambda165,PgSelect167,First169,PgSelectSingle170,PgClassExpression172,List173,Lambda174,PgSelect176,First178,PgSelectSingle179,PgClassExpression181,List182,Lambda183,PgClassExpression184,PgClassExpression185,PgClassExpression186,PgSelect188,First190,PgSelectSingle191,PgClassExpression193,List194,Lambda195,PgClassExpression196,PgClassExpression197,PgClassExpression198,PgSelect200,First202,PgSelectSingle203,PgClassExpression205,List206,Lambda207,PgSelect209,First211,PgSelectSingle212,PgClassExpression214,List215,Lambda216,PgSelect218,First220,PgSelectSingle221,PgClassExpression223,List224,Lambda225,Access4109,Access4110 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 2003, 2008, 50, 2018, 2023, 59, 2033, 2038, 68, 2048, 2053, 77, 2063, 2068, 86, 2078, 2083, 95, 2093, 2098, 30, 2108, 2113, 17, 2123, 2128, 126, 2138, 2143, 135, 2153, 2158, 144, 2168, 2173, 153, 2183, 2188, 162, 2198, 2203, 171, 2213, 2218, 180, 2228, 2233, 192, 2243, 2248, 204, 2258, 2263, 213, 2273, 2278, 222, 228, 227, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[231], Access[4112], Access[4113]<br />2: 235, 246, 255, 264, 273, 282, 293, 303, 313, 322, 331, 340, 349, 358, 367, 379, 391, 400, 409<br />ᐳ: 239, 240, 242, 243, 244, 248, 249, 251, 252, 253, 257, 258, 260, 261, 262, 266, 267, 269, 270, 271, 275, 276, 278, 279, 280, 284, 285, 287, 288, 289, 295, 296, 298, 299, 300, 301, 305, 306, 308, 309, 310, 311, 315, 316, 318, 319, 320, 324, 325, 327, 328, 329, 333, 334, 336, 337, 338, 342, 343, 345, 346, 347, 351, 352, 354, 355, 356, 360, 361, 363, 364, 365, 369, 370, 372, 373, 374, 375, 376, 377, 381, 382, 384, 385, 386, 387, 388, 389, 393, 394, 396, 397, 398, 402, 403, 405, 406, 407, 411, 412, 414, 415, 416"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,Lambda231,PgSelect235,First239,PgSelectSingle240,PgClassExpression242,List243,Lambda244,PgSelect246,First248,PgSelectSingle249,PgClassExpression251,List252,Lambda253,PgSelect255,First257,PgSelectSingle258,PgClassExpression260,List261,Lambda262,PgSelect264,First266,PgSelectSingle267,PgClassExpression269,List270,Lambda271,PgSelect273,First275,PgSelectSingle276,PgClassExpression278,List279,Lambda280,PgSelect282,First284,PgSelectSingle285,PgClassExpression287,List288,Lambda289,PgSelect293,First295,PgSelectSingle296,PgClassExpression298,PgClassExpression299,List300,Lambda301,PgSelect303,First305,PgSelectSingle306,PgClassExpression308,List309,Lambda310,PgClassExpression311,PgSelect313,First315,PgSelectSingle316,PgClassExpression318,List319,Lambda320,PgSelect322,First324,PgSelectSingle325,PgClassExpression327,List328,Lambda329,PgSelect331,First333,PgSelectSingle334,PgClassExpression336,List337,Lambda338,PgSelect340,First342,PgSelectSingle343,PgClassExpression345,List346,Lambda347,PgSelect349,First351,PgSelectSingle352,PgClassExpression354,List355,Lambda356,PgSelect358,First360,PgSelectSingle361,PgClassExpression363,List364,Lambda365,PgSelect367,First369,PgSelectSingle370,PgClassExpression372,List373,Lambda374,PgClassExpression375,PgClassExpression376,PgClassExpression377,PgSelect379,First381,PgSelectSingle382,PgClassExpression384,List385,Lambda386,PgClassExpression387,PgClassExpression388,PgClassExpression389,PgSelect391,First393,PgSelectSingle394,PgClassExpression396,List397,Lambda398,PgSelect400,First402,PgSelectSingle403,PgClassExpression405,List406,Lambda407,PgSelect409,First411,PgSelectSingle412,PgClassExpression414,List415,Lambda416,Access3950,Access3951 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 2247, 2252, 50, 2261, 2266, 59, 2275, 2280, 68, 2289, 2294, 77, 2303, 2308, 86, 2317, 2322, 95, 2331, 2336, 30, 2345, 2350, 17, 2359, 2364, 126, 2373, 2378, 135, 2387, 2392, 144, 2401, 2406, 153, 2415, 2420, 162, 2429, 2434, 171, 2443, 2448, 180, 2457, 2462, 192, 2471, 2476, 204, 2485, 2490, 213, 2499, 2504, 222, 419, 418, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[422], Access[3953], Access[3954]<br />2: 426, 437, 446, 455, 464, 473, 484, 494, 504, 513, 522, 531, 540, 549, 558, 570, 582, 591, 600<br />ᐳ: 430, 431, 433, 434, 435, 439, 440, 442, 443, 444, 448, 449, 451, 452, 453, 457, 458, 460, 461, 462, 466, 467, 469, 470, 471, 475, 476, 478, 479, 480, 486, 487, 489, 490, 491, 492, 496, 497, 499, 500, 501, 502, 506, 507, 509, 510, 511, 515, 516, 518, 519, 520, 524, 525, 527, 528, 529, 533, 534, 536, 537, 538, 542, 543, 545, 546, 547, 551, 552, 554, 555, 556, 560, 561, 563, 564, 565, 566, 567, 568, 572, 573, 575, 576, 577, 578, 579, 580, 584, 585, 587, 588, 589, 593, 594, 596, 597, 598, 602, 603, 605, 606, 607"):::bucket
+    class Bucket8,Lambda231,PgSelect235,First239,PgSelectSingle240,PgClassExpression242,List243,Lambda244,PgSelect246,First248,PgSelectSingle249,PgClassExpression251,List252,Lambda253,PgSelect255,First257,PgSelectSingle258,PgClassExpression260,List261,Lambda262,PgSelect264,First266,PgSelectSingle267,PgClassExpression269,List270,Lambda271,PgSelect273,First275,PgSelectSingle276,PgClassExpression278,List279,Lambda280,PgSelect282,First284,PgSelectSingle285,PgClassExpression287,List288,Lambda289,PgSelect293,First295,PgSelectSingle296,PgClassExpression298,PgClassExpression299,List300,Lambda301,PgSelect303,First305,PgSelectSingle306,PgClassExpression308,List309,Lambda310,PgClassExpression311,PgSelect313,First315,PgSelectSingle316,PgClassExpression318,List319,Lambda320,PgSelect322,First324,PgSelectSingle325,PgClassExpression327,List328,Lambda329,PgSelect331,First333,PgSelectSingle334,PgClassExpression336,List337,Lambda338,PgSelect340,First342,PgSelectSingle343,PgClassExpression345,List346,Lambda347,PgSelect349,First351,PgSelectSingle352,PgClassExpression354,List355,Lambda356,PgSelect358,First360,PgSelectSingle361,PgClassExpression363,List364,Lambda365,PgSelect367,First369,PgSelectSingle370,PgClassExpression372,List373,Lambda374,PgClassExpression375,PgClassExpression376,PgClassExpression377,PgSelect379,First381,PgSelectSingle382,PgClassExpression384,List385,Lambda386,PgClassExpression387,PgClassExpression388,PgClassExpression389,PgSelect391,First393,PgSelectSingle394,PgClassExpression396,List397,Lambda398,PgSelect400,First402,PgSelectSingle403,PgClassExpression405,List406,Lambda407,PgSelect409,First411,PgSelectSingle412,PgClassExpression414,List415,Lambda416,Access4112,Access4113 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 2288, 2293, 50, 2303, 2308, 59, 2318, 2323, 68, 2333, 2338, 77, 2348, 2353, 86, 2363, 2368, 95, 2378, 2383, 30, 2393, 2398, 17, 2408, 2413, 126, 2423, 2428, 135, 2438, 2443, 144, 2453, 2458, 153, 2468, 2473, 162, 2483, 2488, 171, 2498, 2503, 180, 2513, 2518, 192, 2528, 2533, 204, 2543, 2548, 213, 2558, 2563, 222, 419, 418, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[422], Access[4115], Access[4116]<br />2: 426, 437, 446, 455, 464, 473, 484, 494, 504, 513, 522, 531, 540, 549, 558, 570, 582, 591, 600<br />ᐳ: 430, 431, 433, 434, 435, 439, 440, 442, 443, 444, 448, 449, 451, 452, 453, 457, 458, 460, 461, 462, 466, 467, 469, 470, 471, 475, 476, 478, 479, 480, 486, 487, 489, 490, 491, 492, 496, 497, 499, 500, 501, 502, 506, 507, 509, 510, 511, 515, 516, 518, 519, 520, 524, 525, 527, 528, 529, 533, 534, 536, 537, 538, 542, 543, 545, 546, 547, 551, 552, 554, 555, 556, 560, 561, 563, 564, 565, 566, 567, 568, 572, 573, 575, 576, 577, 578, 579, 580, 584, 585, 587, 588, 589, 593, 594, 596, 597, 598, 602, 603, 605, 606, 607"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Lambda422,PgSelect426,First430,PgSelectSingle431,PgClassExpression433,List434,Lambda435,PgSelect437,First439,PgSelectSingle440,PgClassExpression442,List443,Lambda444,PgSelect446,First448,PgSelectSingle449,PgClassExpression451,List452,Lambda453,PgSelect455,First457,PgSelectSingle458,PgClassExpression460,List461,Lambda462,PgSelect464,First466,PgSelectSingle467,PgClassExpression469,List470,Lambda471,PgSelect473,First475,PgSelectSingle476,PgClassExpression478,List479,Lambda480,PgSelect484,First486,PgSelectSingle487,PgClassExpression489,PgClassExpression490,List491,Lambda492,PgSelect494,First496,PgSelectSingle497,PgClassExpression499,List500,Lambda501,PgClassExpression502,PgSelect504,First506,PgSelectSingle507,PgClassExpression509,List510,Lambda511,PgSelect513,First515,PgSelectSingle516,PgClassExpression518,List519,Lambda520,PgSelect522,First524,PgSelectSingle525,PgClassExpression527,List528,Lambda529,PgSelect531,First533,PgSelectSingle534,PgClassExpression536,List537,Lambda538,PgSelect540,First542,PgSelectSingle543,PgClassExpression545,List546,Lambda547,PgSelect549,First551,PgSelectSingle552,PgClassExpression554,List555,Lambda556,PgSelect558,First560,PgSelectSingle561,PgClassExpression563,List564,Lambda565,PgClassExpression566,PgClassExpression567,PgClassExpression568,PgSelect570,First572,PgSelectSingle573,PgClassExpression575,List576,Lambda577,PgClassExpression578,PgClassExpression579,PgClassExpression580,PgSelect582,First584,PgSelectSingle585,PgClassExpression587,List588,Lambda589,PgSelect591,First593,PgSelectSingle594,PgClassExpression596,List597,Lambda598,PgSelect600,First602,PgSelectSingle603,PgClassExpression605,List606,Lambda607,Access3953,Access3954 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 2513, 2518, 50, 2527, 2532, 59, 2541, 2546, 68, 2555, 2560, 77, 2569, 2574, 86, 2583, 2588, 95, 2597, 2602, 30, 2611, 2616, 17, 2625, 2630, 126, 2639, 2644, 135, 2653, 2658, 144, 2667, 2672, 153, 2681, 2686, 162, 2695, 2700, 171, 2709, 2714, 180, 2723, 2728, 192, 2737, 2742, 204, 2751, 2756, 213, 2765, 2770, 222, 610, 609, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[613], Access[3956], Access[3957]<br />2: 617, 628, 637, 646, 655, 664, 675, 685, 695, 704, 713, 722, 731, 740, 749, 761, 773, 782, 791<br />ᐳ: 621, 622, 624, 625, 626, 630, 631, 633, 634, 635, 639, 640, 642, 643, 644, 648, 649, 651, 652, 653, 657, 658, 660, 661, 662, 666, 667, 669, 670, 671, 677, 678, 680, 681, 682, 683, 687, 688, 690, 691, 692, 693, 697, 698, 700, 701, 702, 706, 707, 709, 710, 711, 715, 716, 718, 719, 720, 724, 725, 727, 728, 729, 733, 734, 736, 737, 738, 742, 743, 745, 746, 747, 751, 752, 754, 755, 756, 757, 758, 759, 763, 764, 766, 767, 768, 769, 770, 771, 775, 776, 778, 779, 780, 784, 785, 787, 788, 789, 793, 794, 796, 797, 798"):::bucket
+    class Bucket9,Lambda422,PgSelect426,First430,PgSelectSingle431,PgClassExpression433,List434,Lambda435,PgSelect437,First439,PgSelectSingle440,PgClassExpression442,List443,Lambda444,PgSelect446,First448,PgSelectSingle449,PgClassExpression451,List452,Lambda453,PgSelect455,First457,PgSelectSingle458,PgClassExpression460,List461,Lambda462,PgSelect464,First466,PgSelectSingle467,PgClassExpression469,List470,Lambda471,PgSelect473,First475,PgSelectSingle476,PgClassExpression478,List479,Lambda480,PgSelect484,First486,PgSelectSingle487,PgClassExpression489,PgClassExpression490,List491,Lambda492,PgSelect494,First496,PgSelectSingle497,PgClassExpression499,List500,Lambda501,PgClassExpression502,PgSelect504,First506,PgSelectSingle507,PgClassExpression509,List510,Lambda511,PgSelect513,First515,PgSelectSingle516,PgClassExpression518,List519,Lambda520,PgSelect522,First524,PgSelectSingle525,PgClassExpression527,List528,Lambda529,PgSelect531,First533,PgSelectSingle534,PgClassExpression536,List537,Lambda538,PgSelect540,First542,PgSelectSingle543,PgClassExpression545,List546,Lambda547,PgSelect549,First551,PgSelectSingle552,PgClassExpression554,List555,Lambda556,PgSelect558,First560,PgSelectSingle561,PgClassExpression563,List564,Lambda565,PgClassExpression566,PgClassExpression567,PgClassExpression568,PgSelect570,First572,PgSelectSingle573,PgClassExpression575,List576,Lambda577,PgClassExpression578,PgClassExpression579,PgClassExpression580,PgSelect582,First584,PgSelectSingle585,PgClassExpression587,List588,Lambda589,PgSelect591,First593,PgSelectSingle594,PgClassExpression596,List597,Lambda598,PgSelect600,First602,PgSelectSingle603,PgClassExpression605,List606,Lambda607,Access4115,Access4116 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 2573, 2578, 50, 2588, 2593, 59, 2603, 2608, 68, 2618, 2623, 77, 2633, 2638, 86, 2648, 2653, 95, 2663, 2668, 30, 2678, 2683, 17, 2693, 2698, 126, 2708, 2713, 135, 2723, 2728, 144, 2738, 2743, 153, 2753, 2758, 162, 2768, 2773, 171, 2783, 2788, 180, 2798, 2803, 192, 2813, 2818, 204, 2828, 2833, 213, 2843, 2848, 222, 610, 609, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[613], Access[4118], Access[4119]<br />2: 617, 628, 637, 646, 655, 664, 675, 685, 695, 704, 713, 722, 731, 740, 749, 761, 773, 782, 791<br />ᐳ: 621, 622, 624, 625, 626, 630, 631, 633, 634, 635, 639, 640, 642, 643, 644, 648, 649, 651, 652, 653, 657, 658, 660, 661, 662, 666, 667, 669, 670, 671, 677, 678, 680, 681, 682, 683, 687, 688, 690, 691, 692, 693, 697, 698, 700, 701, 702, 706, 707, 709, 710, 711, 715, 716, 718, 719, 720, 724, 725, 727, 728, 729, 733, 734, 736, 737, 738, 742, 743, 745, 746, 747, 751, 752, 754, 755, 756, 757, 758, 759, 763, 764, 766, 767, 768, 769, 770, 771, 775, 776, 778, 779, 780, 784, 785, 787, 788, 789, 793, 794, 796, 797, 798"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,Lambda613,PgSelect617,First621,PgSelectSingle622,PgClassExpression624,List625,Lambda626,PgSelect628,First630,PgSelectSingle631,PgClassExpression633,List634,Lambda635,PgSelect637,First639,PgSelectSingle640,PgClassExpression642,List643,Lambda644,PgSelect646,First648,PgSelectSingle649,PgClassExpression651,List652,Lambda653,PgSelect655,First657,PgSelectSingle658,PgClassExpression660,List661,Lambda662,PgSelect664,First666,PgSelectSingle667,PgClassExpression669,List670,Lambda671,PgSelect675,First677,PgSelectSingle678,PgClassExpression680,PgClassExpression681,List682,Lambda683,PgSelect685,First687,PgSelectSingle688,PgClassExpression690,List691,Lambda692,PgClassExpression693,PgSelect695,First697,PgSelectSingle698,PgClassExpression700,List701,Lambda702,PgSelect704,First706,PgSelectSingle707,PgClassExpression709,List710,Lambda711,PgSelect713,First715,PgSelectSingle716,PgClassExpression718,List719,Lambda720,PgSelect722,First724,PgSelectSingle725,PgClassExpression727,List728,Lambda729,PgSelect731,First733,PgSelectSingle734,PgClassExpression736,List737,Lambda738,PgSelect740,First742,PgSelectSingle743,PgClassExpression745,List746,Lambda747,PgSelect749,First751,PgSelectSingle752,PgClassExpression754,List755,Lambda756,PgClassExpression757,PgClassExpression758,PgClassExpression759,PgSelect761,First763,PgSelectSingle764,PgClassExpression766,List767,Lambda768,PgClassExpression769,PgClassExpression770,PgClassExpression771,PgSelect773,First775,PgSelectSingle776,PgClassExpression778,List779,Lambda780,PgSelect782,First784,PgSelectSingle785,PgClassExpression787,List788,Lambda789,PgSelect791,First793,PgSelectSingle794,PgClassExpression796,List797,Lambda798,Access3956,Access3957 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 2779, 2784, 50, 2793, 2798, 59, 2807, 2812, 68, 2821, 2826, 77, 2835, 2840, 86, 2849, 2854, 95, 2863, 2868, 30, 2877, 2882, 17, 2891, 2896, 126, 2905, 2910, 135, 2919, 2924, 144, 2933, 2938, 153, 2947, 2952, 162, 2961, 2966, 171, 2975, 2980, 180, 2989, 2994, 192, 3003, 3008, 204, 3017, 3022, 213, 3031, 3036, 222, 801, 800, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[804], Access[3959], Access[3960]<br />2: 808, 819, 828, 837, 846, 855, 866, 876, 886, 895, 904, 913, 922, 931, 940, 952, 964, 973, 982<br />ᐳ: 812, 813, 815, 816, 817, 821, 822, 824, 825, 826, 830, 831, 833, 834, 835, 839, 840, 842, 843, 844, 848, 849, 851, 852, 853, 857, 858, 860, 861, 862, 868, 869, 871, 872, 873, 874, 878, 879, 881, 882, 883, 884, 888, 889, 891, 892, 893, 897, 898, 900, 901, 902, 906, 907, 909, 910, 911, 915, 916, 918, 919, 920, 924, 925, 927, 928, 929, 933, 934, 936, 937, 938, 942, 943, 945, 946, 947, 948, 949, 950, 954, 955, 957, 958, 959, 960, 961, 962, 966, 967, 969, 970, 971, 975, 976, 978, 979, 980, 984, 985, 987, 988, 989"):::bucket
+    class Bucket10,Lambda613,PgSelect617,First621,PgSelectSingle622,PgClassExpression624,List625,Lambda626,PgSelect628,First630,PgSelectSingle631,PgClassExpression633,List634,Lambda635,PgSelect637,First639,PgSelectSingle640,PgClassExpression642,List643,Lambda644,PgSelect646,First648,PgSelectSingle649,PgClassExpression651,List652,Lambda653,PgSelect655,First657,PgSelectSingle658,PgClassExpression660,List661,Lambda662,PgSelect664,First666,PgSelectSingle667,PgClassExpression669,List670,Lambda671,PgSelect675,First677,PgSelectSingle678,PgClassExpression680,PgClassExpression681,List682,Lambda683,PgSelect685,First687,PgSelectSingle688,PgClassExpression690,List691,Lambda692,PgClassExpression693,PgSelect695,First697,PgSelectSingle698,PgClassExpression700,List701,Lambda702,PgSelect704,First706,PgSelectSingle707,PgClassExpression709,List710,Lambda711,PgSelect713,First715,PgSelectSingle716,PgClassExpression718,List719,Lambda720,PgSelect722,First724,PgSelectSingle725,PgClassExpression727,List728,Lambda729,PgSelect731,First733,PgSelectSingle734,PgClassExpression736,List737,Lambda738,PgSelect740,First742,PgSelectSingle743,PgClassExpression745,List746,Lambda747,PgSelect749,First751,PgSelectSingle752,PgClassExpression754,List755,Lambda756,PgClassExpression757,PgClassExpression758,PgClassExpression759,PgSelect761,First763,PgSelectSingle764,PgClassExpression766,List767,Lambda768,PgClassExpression769,PgClassExpression770,PgClassExpression771,PgSelect773,First775,PgSelectSingle776,PgClassExpression778,List779,Lambda780,PgSelect782,First784,PgSelectSingle785,PgClassExpression787,List788,Lambda789,PgSelect791,First793,PgSelectSingle794,PgClassExpression796,List797,Lambda798,Access4118,Access4119 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 2858, 2863, 50, 2873, 2878, 59, 2888, 2893, 68, 2903, 2908, 77, 2918, 2923, 86, 2933, 2938, 95, 2948, 2953, 30, 2963, 2968, 17, 2978, 2983, 126, 2993, 2998, 135, 3008, 3013, 144, 3023, 3028, 153, 3038, 3043, 162, 3053, 3058, 171, 3068, 3073, 180, 3083, 3088, 192, 3098, 3103, 204, 3113, 3118, 213, 3128, 3133, 222, 801, 800, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[804], Access[4121], Access[4122]<br />2: 808, 819, 828, 837, 846, 855, 866, 876, 886, 895, 904, 913, 922, 931, 940, 952, 964, 973, 982<br />ᐳ: 812, 813, 815, 816, 817, 821, 822, 824, 825, 826, 830, 831, 833, 834, 835, 839, 840, 842, 843, 844, 848, 849, 851, 852, 853, 857, 858, 860, 861, 862, 868, 869, 871, 872, 873, 874, 878, 879, 881, 882, 883, 884, 888, 889, 891, 892, 893, 897, 898, 900, 901, 902, 906, 907, 909, 910, 911, 915, 916, 918, 919, 920, 924, 925, 927, 928, 929, 933, 934, 936, 937, 938, 942, 943, 945, 946, 947, 948, 949, 950, 954, 955, 957, 958, 959, 960, 961, 962, 966, 967, 969, 970, 971, 975, 976, 978, 979, 980, 984, 985, 987, 988, 989"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,Lambda804,PgSelect808,First812,PgSelectSingle813,PgClassExpression815,List816,Lambda817,PgSelect819,First821,PgSelectSingle822,PgClassExpression824,List825,Lambda826,PgSelect828,First830,PgSelectSingle831,PgClassExpression833,List834,Lambda835,PgSelect837,First839,PgSelectSingle840,PgClassExpression842,List843,Lambda844,PgSelect846,First848,PgSelectSingle849,PgClassExpression851,List852,Lambda853,PgSelect855,First857,PgSelectSingle858,PgClassExpression860,List861,Lambda862,PgSelect866,First868,PgSelectSingle869,PgClassExpression871,PgClassExpression872,List873,Lambda874,PgSelect876,First878,PgSelectSingle879,PgClassExpression881,List882,Lambda883,PgClassExpression884,PgSelect886,First888,PgSelectSingle889,PgClassExpression891,List892,Lambda893,PgSelect895,First897,PgSelectSingle898,PgClassExpression900,List901,Lambda902,PgSelect904,First906,PgSelectSingle907,PgClassExpression909,List910,Lambda911,PgSelect913,First915,PgSelectSingle916,PgClassExpression918,List919,Lambda920,PgSelect922,First924,PgSelectSingle925,PgClassExpression927,List928,Lambda929,PgSelect931,First933,PgSelectSingle934,PgClassExpression936,List937,Lambda938,PgSelect940,First942,PgSelectSingle943,PgClassExpression945,List946,Lambda947,PgClassExpression948,PgClassExpression949,PgClassExpression950,PgSelect952,First954,PgSelectSingle955,PgClassExpression957,List958,Lambda959,PgClassExpression960,PgClassExpression961,PgClassExpression962,PgSelect964,First966,PgSelectSingle967,PgClassExpression969,List970,Lambda971,PgSelect973,First975,PgSelectSingle976,PgClassExpression978,List979,Lambda980,PgSelect982,First984,PgSelectSingle985,PgClassExpression987,List988,Lambda989,Access3959,Access3960 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 3045, 3050, 50, 3059, 3064, 59, 3073, 3078, 68, 3087, 3092, 77, 3101, 3106, 86, 3115, 3120, 95, 3129, 3134, 30, 3143, 3148, 17, 3157, 3162, 126, 3171, 3176, 135, 3185, 3190, 144, 3199, 3204, 153, 3213, 3218, 162, 3227, 3232, 171, 3241, 3246, 180, 3255, 3260, 192, 3269, 3274, 204, 3283, 3288, 213, 3297, 3302, 222, 992, 991, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[995], Access[3962], Access[3963]<br />2: 999, 1010, 1019, 1028, 1037, 1046, 1057, 1067, 1077, 1086, 1095, 1104, 1113, 1122, 1131, 1143, 1155, 1164, 1173<br />ᐳ: 1003, 1004, 1006, 1007, 1008, 1012, 1013, 1015, 1016, 1017, 1021, 1022, 1024, 1025, 1026, 1030, 1031, 1033, 1034, 1035, 1039, 1040, 1042, 1043, 1044, 1048, 1049, 1051, 1052, 1053, 1059, 1060, 1062, 1063, 1064, 1065, 1069, 1070, 1072, 1073, 1074, 1075, 1079, 1080, 1082, 1083, 1084, 1088, 1089, 1091, 1092, 1093, 1097, 1098, 1100, 1101, 1102, 1106, 1107, 1109, 1110, 1111, 1115, 1116, 1118, 1119, 1120, 1124, 1125, 1127, 1128, 1129, 1133, 1134, 1136, 1137, 1138, 1139, 1140, 1141, 1145, 1146, 1148, 1149, 1150, 1151, 1152, 1153, 1157, 1158, 1160, 1161, 1162, 1166, 1167, 1169, 1170, 1171, 1175, 1176, 1178, 1179, 1180"):::bucket
+    class Bucket11,Lambda804,PgSelect808,First812,PgSelectSingle813,PgClassExpression815,List816,Lambda817,PgSelect819,First821,PgSelectSingle822,PgClassExpression824,List825,Lambda826,PgSelect828,First830,PgSelectSingle831,PgClassExpression833,List834,Lambda835,PgSelect837,First839,PgSelectSingle840,PgClassExpression842,List843,Lambda844,PgSelect846,First848,PgSelectSingle849,PgClassExpression851,List852,Lambda853,PgSelect855,First857,PgSelectSingle858,PgClassExpression860,List861,Lambda862,PgSelect866,First868,PgSelectSingle869,PgClassExpression871,PgClassExpression872,List873,Lambda874,PgSelect876,First878,PgSelectSingle879,PgClassExpression881,List882,Lambda883,PgClassExpression884,PgSelect886,First888,PgSelectSingle889,PgClassExpression891,List892,Lambda893,PgSelect895,First897,PgSelectSingle898,PgClassExpression900,List901,Lambda902,PgSelect904,First906,PgSelectSingle907,PgClassExpression909,List910,Lambda911,PgSelect913,First915,PgSelectSingle916,PgClassExpression918,List919,Lambda920,PgSelect922,First924,PgSelectSingle925,PgClassExpression927,List928,Lambda929,PgSelect931,First933,PgSelectSingle934,PgClassExpression936,List937,Lambda938,PgSelect940,First942,PgSelectSingle943,PgClassExpression945,List946,Lambda947,PgClassExpression948,PgClassExpression949,PgClassExpression950,PgSelect952,First954,PgSelectSingle955,PgClassExpression957,List958,Lambda959,PgClassExpression960,PgClassExpression961,PgClassExpression962,PgSelect964,First966,PgSelectSingle967,PgClassExpression969,List970,Lambda971,PgSelect973,First975,PgSelectSingle976,PgClassExpression978,List979,Lambda980,PgSelect982,First984,PgSelectSingle985,PgClassExpression987,List988,Lambda989,Access4121,Access4122 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 3143, 3148, 50, 3158, 3163, 59, 3173, 3178, 68, 3188, 3193, 77, 3203, 3208, 86, 3218, 3223, 95, 3233, 3238, 30, 3248, 3253, 17, 3263, 3268, 126, 3278, 3283, 135, 3293, 3298, 144, 3308, 3313, 153, 3323, 3328, 162, 3338, 3343, 171, 3353, 3358, 180, 3368, 3373, 192, 3383, 3388, 204, 3398, 3403, 213, 3413, 3418, 222, 992, 991, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Lambda[995], Access[4124], Access[4125]<br />2: 999, 1010, 1019, 1028, 1037, 1046, 1057, 1067, 1077, 1086, 1095, 1104, 1113, 1122, 1131, 1143, 1155, 1164, 1173<br />ᐳ: 1003, 1004, 1006, 1007, 1008, 1012, 1013, 1015, 1016, 1017, 1021, 1022, 1024, 1025, 1026, 1030, 1031, 1033, 1034, 1035, 1039, 1040, 1042, 1043, 1044, 1048, 1049, 1051, 1052, 1053, 1059, 1060, 1062, 1063, 1064, 1065, 1069, 1070, 1072, 1073, 1074, 1075, 1079, 1080, 1082, 1083, 1084, 1088, 1089, 1091, 1092, 1093, 1097, 1098, 1100, 1101, 1102, 1106, 1107, 1109, 1110, 1111, 1115, 1116, 1118, 1119, 1120, 1124, 1125, 1127, 1128, 1129, 1133, 1134, 1136, 1137, 1138, 1139, 1140, 1141, 1145, 1146, 1148, 1149, 1150, 1151, 1152, 1153, 1157, 1158, 1160, 1161, 1162, 1166, 1167, 1169, 1170, 1171, 1175, 1176, 1178, 1179, 1180"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,Lambda995,PgSelect999,First1003,PgSelectSingle1004,PgClassExpression1006,List1007,Lambda1008,PgSelect1010,First1012,PgSelectSingle1013,PgClassExpression1015,List1016,Lambda1017,PgSelect1019,First1021,PgSelectSingle1022,PgClassExpression1024,List1025,Lambda1026,PgSelect1028,First1030,PgSelectSingle1031,PgClassExpression1033,List1034,Lambda1035,PgSelect1037,First1039,PgSelectSingle1040,PgClassExpression1042,List1043,Lambda1044,PgSelect1046,First1048,PgSelectSingle1049,PgClassExpression1051,List1052,Lambda1053,PgSelect1057,First1059,PgSelectSingle1060,PgClassExpression1062,PgClassExpression1063,List1064,Lambda1065,PgSelect1067,First1069,PgSelectSingle1070,PgClassExpression1072,List1073,Lambda1074,PgClassExpression1075,PgSelect1077,First1079,PgSelectSingle1080,PgClassExpression1082,List1083,Lambda1084,PgSelect1086,First1088,PgSelectSingle1089,PgClassExpression1091,List1092,Lambda1093,PgSelect1095,First1097,PgSelectSingle1098,PgClassExpression1100,List1101,Lambda1102,PgSelect1104,First1106,PgSelectSingle1107,PgClassExpression1109,List1110,Lambda1111,PgSelect1113,First1115,PgSelectSingle1116,PgClassExpression1118,List1119,Lambda1120,PgSelect1122,First1124,PgSelectSingle1125,PgClassExpression1127,List1128,Lambda1129,PgSelect1131,First1133,PgSelectSingle1134,PgClassExpression1136,List1137,Lambda1138,PgClassExpression1139,PgClassExpression1140,PgClassExpression1141,PgSelect1143,First1145,PgSelectSingle1146,PgClassExpression1148,List1149,Lambda1150,PgClassExpression1151,PgClassExpression1152,PgClassExpression1153,PgSelect1155,First1157,PgSelectSingle1158,PgClassExpression1160,List1161,Lambda1162,PgSelect1164,First1166,PgSelectSingle1167,PgClassExpression1169,List1170,Lambda1171,PgSelect1173,First1175,PgSelectSingle1176,PgClassExpression1178,List1179,Lambda1180,Access3962,Access3963 bucket12
+    class Bucket12,Lambda995,PgSelect999,First1003,PgSelectSingle1004,PgClassExpression1006,List1007,Lambda1008,PgSelect1010,First1012,PgSelectSingle1013,PgClassExpression1015,List1016,Lambda1017,PgSelect1019,First1021,PgSelectSingle1022,PgClassExpression1024,List1025,Lambda1026,PgSelect1028,First1030,PgSelectSingle1031,PgClassExpression1033,List1034,Lambda1035,PgSelect1037,First1039,PgSelectSingle1040,PgClassExpression1042,List1043,Lambda1044,PgSelect1046,First1048,PgSelectSingle1049,PgClassExpression1051,List1052,Lambda1053,PgSelect1057,First1059,PgSelectSingle1060,PgClassExpression1062,PgClassExpression1063,List1064,Lambda1065,PgSelect1067,First1069,PgSelectSingle1070,PgClassExpression1072,List1073,Lambda1074,PgClassExpression1075,PgSelect1077,First1079,PgSelectSingle1080,PgClassExpression1082,List1083,Lambda1084,PgSelect1086,First1088,PgSelectSingle1089,PgClassExpression1091,List1092,Lambda1093,PgSelect1095,First1097,PgSelectSingle1098,PgClassExpression1100,List1101,Lambda1102,PgSelect1104,First1106,PgSelectSingle1107,PgClassExpression1109,List1110,Lambda1111,PgSelect1113,First1115,PgSelectSingle1116,PgClassExpression1118,List1119,Lambda1120,PgSelect1122,First1124,PgSelectSingle1125,PgClassExpression1127,List1128,Lambda1129,PgSelect1131,First1133,PgSelectSingle1134,PgClassExpression1136,List1137,Lambda1138,PgClassExpression1139,PgClassExpression1140,PgClassExpression1141,PgSelect1143,First1145,PgSelectSingle1146,PgClassExpression1148,List1149,Lambda1150,PgClassExpression1151,PgClassExpression1152,PgClassExpression1153,PgSelect1155,First1157,PgSelectSingle1158,PgClassExpression1160,List1161,Lambda1162,PgSelect1164,First1166,PgSelectSingle1167,PgClassExpression1169,List1170,Lambda1171,PgSelect1173,First1175,PgSelectSingle1176,PgClassExpression1178,List1179,Lambda1180,Access4124,Access4125 bucket12
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 1188, 17<br /><br />ROOT PgSelectSingleᐸpersonᐳ[1188]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression1190,List1191,Lambda1192,PgClassExpression1193 bucket13
@@ -3980,12 +3982,12 @@ graph TD
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 1259, 30<br /><br />ROOT PgSelectSingleᐸcompound_keyᐳ[1259]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,PgClassExpression1261,PgClassExpression1262,List1263,Lambda1264 bucket18
-    Bucket19("Bucket 19 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 3395, 3400, 50, 3409, 3414, 59, 3423, 3428, 68, 3437, 3442, 77, 3451, 3456, 86, 3465, 3470, 95, 3479, 3484, 30, 3493, 3498, 17, 3507, 3512, 126, 3521, 3526, 135, 3535, 3540, 144, 3549, 3554, 153, 3563, 3568, 162, 3577, 3582, 171, 3591, 3596, 180, 3605, 3610, 192, 3619, 3624, 204, 3633, 3638, 213, 3647, 3652, 222, 1267, 1266, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1270, 3965, 3966<br />2: 1274, 1285, 1294, 1303, 1312, 1321, 1332, 1342, 1352, 1361, 1370, 1379, 1388, 1397, 1406, 1418, 1430, 1439, 1448<br />ᐳ: 1278, 1279, 1281, 1282, 1283, 1287, 1288, 1290, 1291, 1292, 1296, 1297, 1299, 1300, 1301, 1305, 1306, 1308, 1309, 1310, 1314, 1315, 1317, 1318, 1319, 1323, 1324, 1326, 1327, 1328, 1334, 1335, 1337, 1338, 1339, 1340, 1344, 1345, 1347, 1348, 1349, 1350, 1354, 1355, 1357, 1358, 1359, 1363, 1364, 1366, 1367, 1368, 1372, 1373, 1375, 1376, 1377, 1381, 1382, 1384, 1385, 1386, 1390, 1391, 1393, 1394, 1395, 1399, 1400, 1402, 1403, 1404, 1408, 1409, 1411, 1412, 1413, 1414, 1415, 1416, 1420, 1421, 1423, 1424, 1425, 1426, 1427, 1428, 1432, 1433, 1435, 1436, 1437, 1441, 1442, 1444, 1445, 1446, 1450, 1451, 1453, 1454, 1455"):::bucket
+    Bucket19("Bucket 19 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 3518, 3523, 50, 3533, 3538, 59, 3548, 3553, 68, 3563, 3568, 77, 3578, 3583, 86, 3593, 3598, 95, 3608, 3613, 30, 3623, 3628, 17, 3638, 3643, 126, 3653, 3658, 135, 3668, 3673, 144, 3683, 3688, 153, 3698, 3703, 162, 3713, 3718, 171, 3728, 3733, 180, 3743, 3748, 192, 3758, 3763, 204, 3773, 3778, 213, 3788, 3793, 222, 1267, 1266, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1270, 4127, 4128<br />2: 1274, 1285, 1294, 1303, 1312, 1321, 1332, 1342, 1352, 1361, 1370, 1379, 1388, 1397, 1406, 1418, 1430, 1439, 1448<br />ᐳ: 1278, 1279, 1281, 1282, 1283, 1287, 1288, 1290, 1291, 1292, 1296, 1297, 1299, 1300, 1301, 1305, 1306, 1308, 1309, 1310, 1314, 1315, 1317, 1318, 1319, 1323, 1324, 1326, 1327, 1328, 1334, 1335, 1337, 1338, 1339, 1340, 1344, 1345, 1347, 1348, 1349, 1350, 1354, 1355, 1357, 1358, 1359, 1363, 1364, 1366, 1367, 1368, 1372, 1373, 1375, 1376, 1377, 1381, 1382, 1384, 1385, 1386, 1390, 1391, 1393, 1394, 1395, 1399, 1400, 1402, 1403, 1404, 1408, 1409, 1411, 1412, 1413, 1414, 1415, 1416, 1420, 1421, 1423, 1424, 1425, 1426, 1427, 1428, 1432, 1433, 1435, 1436, 1437, 1441, 1442, 1444, 1445, 1446, 1450, 1451, 1453, 1454, 1455"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,Lambda1270,PgSelect1274,First1278,PgSelectSingle1279,PgClassExpression1281,List1282,Lambda1283,PgSelect1285,First1287,PgSelectSingle1288,PgClassExpression1290,List1291,Lambda1292,PgSelect1294,First1296,PgSelectSingle1297,PgClassExpression1299,List1300,Lambda1301,PgSelect1303,First1305,PgSelectSingle1306,PgClassExpression1308,List1309,Lambda1310,PgSelect1312,First1314,PgSelectSingle1315,PgClassExpression1317,List1318,Lambda1319,PgSelect1321,First1323,PgSelectSingle1324,PgClassExpression1326,List1327,Lambda1328,PgSelect1332,First1334,PgSelectSingle1335,PgClassExpression1337,PgClassExpression1338,List1339,Lambda1340,PgSelect1342,First1344,PgSelectSingle1345,PgClassExpression1347,List1348,Lambda1349,PgClassExpression1350,PgSelect1352,First1354,PgSelectSingle1355,PgClassExpression1357,List1358,Lambda1359,PgSelect1361,First1363,PgSelectSingle1364,PgClassExpression1366,List1367,Lambda1368,PgSelect1370,First1372,PgSelectSingle1373,PgClassExpression1375,List1376,Lambda1377,PgSelect1379,First1381,PgSelectSingle1382,PgClassExpression1384,List1385,Lambda1386,PgSelect1388,First1390,PgSelectSingle1391,PgClassExpression1393,List1394,Lambda1395,PgSelect1397,First1399,PgSelectSingle1400,PgClassExpression1402,List1403,Lambda1404,PgSelect1406,First1408,PgSelectSingle1409,PgClassExpression1411,List1412,Lambda1413,PgClassExpression1414,PgClassExpression1415,PgClassExpression1416,PgSelect1418,First1420,PgSelectSingle1421,PgClassExpression1423,List1424,Lambda1425,PgClassExpression1426,PgClassExpression1427,PgClassExpression1428,PgSelect1430,First1432,PgSelectSingle1433,PgClassExpression1435,List1436,Lambda1437,PgSelect1439,First1441,PgSelectSingle1442,PgClassExpression1444,List1445,Lambda1446,PgSelect1448,First1450,PgSelectSingle1451,PgClassExpression1453,List1454,Lambda1455,Access3965,Access3966 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1682, 3661, 3666, 50, 3675, 3680, 59, 3689, 3694, 68, 3703, 3708, 77, 3717, 3722, 86, 3731, 3736, 95, 3745, 3750, 30, 3759, 3764, 17, 3773, 3778, 126, 3787, 3792, 135, 3801, 3806, 144, 3815, 3820, 153, 3829, 3834, 162, 3843, 3848, 171, 3857, 3862, 180, 3871, 3876, 192, 3885, 3890, 204, 3899, 3904, 213, 3913, 3918, 222, 1458, 1457, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1461, 3968, 3969<br />2: 1465, 1476, 1485, 1494, 1503, 1512, 1523, 1533, 1543, 1552, 1561, 1570, 1579, 1588, 1597, 1609, 1621, 1630, 1639<br />ᐳ: 1469, 1470, 1472, 1473, 1474, 1478, 1479, 1481, 1482, 1483, 1487, 1488, 1490, 1491, 1492, 1496, 1497, 1499, 1500, 1501, 1505, 1506, 1508, 1509, 1510, 1514, 1515, 1517, 1518, 1519, 1525, 1526, 1528, 1529, 1530, 1531, 1535, 1536, 1538, 1539, 1540, 1541, 1545, 1546, 1548, 1549, 1550, 1554, 1555, 1557, 1558, 1559, 1563, 1564, 1566, 1567, 1568, 1572, 1573, 1575, 1576, 1577, 1581, 1582, 1584, 1585, 1586, 1590, 1591, 1593, 1594, 1595, 1599, 1600, 1602, 1603, 1604, 1605, 1606, 1607, 1611, 1612, 1614, 1615, 1616, 1617, 1618, 1619, 1623, 1624, 1626, 1627, 1628, 1632, 1633, 1635, 1636, 1637, 1641, 1642, 1644, 1645, 1646"):::bucket
+    class Bucket19,Lambda1270,PgSelect1274,First1278,PgSelectSingle1279,PgClassExpression1281,List1282,Lambda1283,PgSelect1285,First1287,PgSelectSingle1288,PgClassExpression1290,List1291,Lambda1292,PgSelect1294,First1296,PgSelectSingle1297,PgClassExpression1299,List1300,Lambda1301,PgSelect1303,First1305,PgSelectSingle1306,PgClassExpression1308,List1309,Lambda1310,PgSelect1312,First1314,PgSelectSingle1315,PgClassExpression1317,List1318,Lambda1319,PgSelect1321,First1323,PgSelectSingle1324,PgClassExpression1326,List1327,Lambda1328,PgSelect1332,First1334,PgSelectSingle1335,PgClassExpression1337,PgClassExpression1338,List1339,Lambda1340,PgSelect1342,First1344,PgSelectSingle1345,PgClassExpression1347,List1348,Lambda1349,PgClassExpression1350,PgSelect1352,First1354,PgSelectSingle1355,PgClassExpression1357,List1358,Lambda1359,PgSelect1361,First1363,PgSelectSingle1364,PgClassExpression1366,List1367,Lambda1368,PgSelect1370,First1372,PgSelectSingle1373,PgClassExpression1375,List1376,Lambda1377,PgSelect1379,First1381,PgSelectSingle1382,PgClassExpression1384,List1385,Lambda1386,PgSelect1388,First1390,PgSelectSingle1391,PgClassExpression1393,List1394,Lambda1395,PgSelect1397,First1399,PgSelectSingle1400,PgClassExpression1402,List1403,Lambda1404,PgSelect1406,First1408,PgSelectSingle1409,PgClassExpression1411,List1412,Lambda1413,PgClassExpression1414,PgClassExpression1415,PgClassExpression1416,PgSelect1418,First1420,PgSelectSingle1421,PgClassExpression1423,List1424,Lambda1425,PgClassExpression1426,PgClassExpression1427,PgClassExpression1428,PgSelect1430,First1432,PgSelectSingle1433,PgClassExpression1435,List1436,Lambda1437,PgSelect1439,First1441,PgSelectSingle1442,PgClassExpression1444,List1445,Lambda1446,PgSelect1448,First1450,PgSelectSingle1451,PgClassExpression1453,List1454,Lambda1455,Access4127,Access4128 bucket19
+    Bucket20("Bucket 20 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 39, 12, 1679, 1683, 3803, 3808, 50, 3818, 3823, 59, 3833, 3838, 68, 3848, 3853, 77, 3863, 3868, 86, 3878, 3883, 95, 3893, 3898, 30, 3908, 3913, 17, 3923, 3928, 126, 3938, 3943, 135, 3953, 3958, 144, 3968, 3973, 153, 3983, 3988, 162, 3998, 4003, 171, 4013, 4018, 180, 4028, 4033, 192, 4043, 4048, 204, 4058, 4063, 213, 4073, 4078, 222, 1458, 1457, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1461, 4130, 4131<br />2: 1465, 1476, 1485, 1494, 1503, 1512, 1523, 1533, 1543, 1552, 1561, 1570, 1579, 1588, 1597, 1609, 1621, 1630, 1639<br />ᐳ: 1469, 1470, 1472, 1473, 1474, 1478, 1479, 1481, 1482, 1483, 1487, 1488, 1490, 1491, 1492, 1496, 1497, 1499, 1500, 1501, 1505, 1506, 1508, 1509, 1510, 1514, 1515, 1517, 1518, 1519, 1525, 1526, 1528, 1529, 1530, 1531, 1535, 1536, 1538, 1539, 1540, 1541, 1545, 1546, 1548, 1549, 1550, 1554, 1555, 1557, 1558, 1559, 1563, 1564, 1566, 1567, 1568, 1572, 1573, 1575, 1576, 1577, 1581, 1582, 1584, 1585, 1586, 1590, 1591, 1593, 1594, 1595, 1599, 1600, 1602, 1603, 1604, 1605, 1606, 1607, 1611, 1612, 1614, 1615, 1616, 1617, 1618, 1619, 1623, 1624, 1626, 1627, 1628, 1632, 1633, 1635, 1636, 1637, 1641, 1642, 1644, 1645, 1646"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,Lambda1461,PgSelect1465,First1469,PgSelectSingle1470,PgClassExpression1472,List1473,Lambda1474,PgSelect1476,First1478,PgSelectSingle1479,PgClassExpression1481,List1482,Lambda1483,PgSelect1485,First1487,PgSelectSingle1488,PgClassExpression1490,List1491,Lambda1492,PgSelect1494,First1496,PgSelectSingle1497,PgClassExpression1499,List1500,Lambda1501,PgSelect1503,First1505,PgSelectSingle1506,PgClassExpression1508,List1509,Lambda1510,PgSelect1512,First1514,PgSelectSingle1515,PgClassExpression1517,List1518,Lambda1519,PgSelect1523,First1525,PgSelectSingle1526,PgClassExpression1528,PgClassExpression1529,List1530,Lambda1531,PgSelect1533,First1535,PgSelectSingle1536,PgClassExpression1538,List1539,Lambda1540,PgClassExpression1541,PgSelect1543,First1545,PgSelectSingle1546,PgClassExpression1548,List1549,Lambda1550,PgSelect1552,First1554,PgSelectSingle1555,PgClassExpression1557,List1558,Lambda1559,PgSelect1561,First1563,PgSelectSingle1564,PgClassExpression1566,List1567,Lambda1568,PgSelect1570,First1572,PgSelectSingle1573,PgClassExpression1575,List1576,Lambda1577,PgSelect1579,First1581,PgSelectSingle1582,PgClassExpression1584,List1585,Lambda1586,PgSelect1588,First1590,PgSelectSingle1591,PgClassExpression1593,List1594,Lambda1595,PgSelect1597,First1599,PgSelectSingle1600,PgClassExpression1602,List1603,Lambda1604,PgClassExpression1605,PgClassExpression1606,PgClassExpression1607,PgSelect1609,First1611,PgSelectSingle1612,PgClassExpression1614,List1615,Lambda1616,PgClassExpression1617,PgClassExpression1618,PgClassExpression1619,PgSelect1621,First1623,PgSelectSingle1624,PgClassExpression1626,List1627,Lambda1628,PgSelect1630,First1632,PgSelectSingle1633,PgClassExpression1635,List1636,Lambda1637,PgSelect1639,First1641,PgSelectSingle1642,PgClassExpression1644,List1645,Lambda1646,Access3968,Access3969 bucket20
+    class Bucket20,Lambda1461,PgSelect1465,First1469,PgSelectSingle1470,PgClassExpression1472,List1473,Lambda1474,PgSelect1476,First1478,PgSelectSingle1479,PgClassExpression1481,List1482,Lambda1483,PgSelect1485,First1487,PgSelectSingle1488,PgClassExpression1490,List1491,Lambda1492,PgSelect1494,First1496,PgSelectSingle1497,PgClassExpression1499,List1500,Lambda1501,PgSelect1503,First1505,PgSelectSingle1506,PgClassExpression1508,List1509,Lambda1510,PgSelect1512,First1514,PgSelectSingle1515,PgClassExpression1517,List1518,Lambda1519,PgSelect1523,First1525,PgSelectSingle1526,PgClassExpression1528,PgClassExpression1529,List1530,Lambda1531,PgSelect1533,First1535,PgSelectSingle1536,PgClassExpression1538,List1539,Lambda1540,PgClassExpression1541,PgSelect1543,First1545,PgSelectSingle1546,PgClassExpression1548,List1549,Lambda1550,PgSelect1552,First1554,PgSelectSingle1555,PgClassExpression1557,List1558,Lambda1559,PgSelect1561,First1563,PgSelectSingle1564,PgClassExpression1566,List1567,Lambda1568,PgSelect1570,First1572,PgSelectSingle1573,PgClassExpression1575,List1576,Lambda1577,PgSelect1579,First1581,PgSelectSingle1582,PgClassExpression1584,List1585,Lambda1586,PgSelect1588,First1590,PgSelectSingle1591,PgClassExpression1593,List1594,Lambda1595,PgSelect1597,First1599,PgSelectSingle1600,PgClassExpression1602,List1603,Lambda1604,PgClassExpression1605,PgClassExpression1606,PgClassExpression1607,PgSelect1609,First1611,PgSelectSingle1612,PgClassExpression1614,List1615,Lambda1616,PgClassExpression1617,PgClassExpression1618,PgClassExpression1619,PgSelect1621,First1623,PgSelectSingle1624,PgClassExpression1626,List1627,Lambda1628,PgSelect1630,First1632,PgSelectSingle1633,PgClassExpression1635,List1636,Lambda1637,PgSelect1639,First1641,PgSelectSingle1642,PgClassExpression1644,List1645,Lambda1646,Access4130,Access4131 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 1654, 180<br /><br />ROOT PgSelectSingleᐸsimilar_table_1ᐳ[1654]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression1656,List1657,Lambda1658,PgClassExpression1659,PgClassExpression1660,PgClassExpression1661 bucket21

--- a/postgraphile/postgraphile/__tests__/queries/v4/nodeId-earlyExit.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/nodeId-earlyExit.mermaid
@@ -13,26 +13,35 @@ graph TD
     Object18{{"Object[18∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access30{{"Access[30∈0] ➊<br />ᐸ29.1ᐳ"}}:::plan
     Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access67{{"Access[67∈0] ➊<br />ᐸ66.0ᐳ"}}:::plan
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object18 -->|rejectNull| PgSelect32
-    Access30 & Lambda63 & Lambda66 & Lambda85 & Lambda90 --> PgSelect32
+    Access30 & Lambda63 & Access67 & Lambda87 & Lambda92 --> PgSelect32
     PgSelect56[["PgSelect[56∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Access54{{"Access[54∈0] ➊<br />ᐸ53.1ᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object18 -->|rejectNull| PgSelect56
-    Access54 & Lambda63 & Lambda66 & Lambda113 & Lambda118 --> PgSelect56
-    Object84{{"Object[84∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda63 & Constant81 & Constant82 & Constant69 --> Object84
-    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda63 & Constant109 & Constant110 & Constant69 --> Object112
+    Access54 & Lambda63 & Access67 & Lambda117 & Lambda122 --> PgSelect56
+    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda63 & Constant68 & Constant69 & Constant70 --> Object71
+    Object86{{"Object[86∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda63 & Constant83 & Constant84 & Constant70 --> Object86
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda63 & Constant98 & Constant99 & Constant100 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda63 & Constant113 & Constant114 & Constant70 --> Object116
     Access16{{"Access[16∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access16 & Access17 --> Object18
@@ -40,53 +49,52 @@ graph TD
     __Value2 --> Access16
     __Value2 --> Access17
     Lambda29{{"Lambda[29∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDZd'ᐳ"}}:::plan
-    Constant120 --> Lambda29
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDZd'ᐳ"}}:::plan
+    Constant124 --> Lambda29
     Lambda29 --> Access30
     First34{{"First[34∈0] ➊"}}:::plan
     PgSelect32 --> First34
     PgSelectSingle35{{"PgSelectSingle[35∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First34 --> PgSelectSingle35
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ'WyJwb3N0cyIsM10='ᐳ"}}:::plan
-    Constant122 --> Lambda53
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ'WyJwb3N0cyIsM10='ᐳ"}}:::plan
+    Constant126 --> Lambda53
     Lambda53 --> Access54
     First58{{"First[58∈0] ➊"}}:::plan
     PgSelect56 --> First58
     PgSelectSingle59{{"PgSelectSingle[59∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First58 --> PgSelectSingle59
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant123 --> Lambda63
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant124 --> Lambda66
-    Object84 --> Lambda85
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant126 --> Lambda90
-    Object112 --> Lambda113
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant128 --> Lambda118
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant127 --> Lambda63
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant128 --> Lambda66
+    Lambda66 --> Access67
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object71 --> Lambda72
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant129 --> Lambda77
+    Object86 --> Lambda87
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant130 --> Lambda92
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object101 --> Lambda102
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant131 --> Lambda107
+    Object116 --> Lambda117
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant132 --> Lambda122
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection19{{"Connection[19∈0] ➊<br />ᐸ15ᐳ"}}:::plan
     Constant23{{"Constant[23∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
     Connection43{{"Connection[43∈0] ➊<br />ᐸ41ᐳ"}}:::plan
     Constant47{{"Constant[47∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ'Twenty Seventwo'ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ'Is that a cooking show?'ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ'Twenty Seventwo'ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ'Is that a cooking show?'ᐳ"}}:::plan
     PgSelect20[["PgSelect[20∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda71{{"Lambda[71∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda76{{"Lambda[76∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object18 & Constant119 & Connection19 & Lambda63 & Lambda66 & Lambda71 & Lambda76 --> PgSelect20
-    Object70{{"Object[70∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda63 & Constant67 & Constant68 & Constant69 --> Object70
-    Object70 --> Lambda71
-    Constant125 --> Lambda76
+    Object18 & Constant123 & Connection19 & Lambda63 & Access67 & Lambda72 & Lambda77 --> PgSelect20
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -102,13 +110,7 @@ graph TD
     PgClassExpression36{{"PgClassExpression[36∈4] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgSelect44[["PgSelect[44∈5] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda99{{"Lambda[99∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈5] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object18 & Constant121 & Connection43 & Lambda63 & Lambda66 & Lambda99 & Lambda104 --> PgSelect44
-    Object98{{"Object[98∈5] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda63 & Constant95 & Constant96 & Constant97 --> Object98
-    Object98 --> Lambda99
-    Constant127 --> Lambda104
+    Object18 & Constant125 & Connection43 & Lambda63 & Access67 & Lambda102 & Lambda107 --> PgSelect44
     __Item45[/"__Item[45∈6]<br />ᐸ44ᐳ"\]:::itemplan
     PgSelect44 ==> __Item45
     PgSelectSingle46{{"PgSelectSingle[46∈6]<br />ᐸpostᐳ"}}:::plan
@@ -127,12 +129,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/nodeId-earlyExit"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 19, 23, 43, 47, 67, 68, 69, 81, 82, 95, 96, 97, 109, 110, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 18, 29, 30, 53, 54, 63, 66, 84, 85, 90, 112, 113, 118<br />2: PgSelect[32], PgSelect[56]<br />ᐳ: 34, 35, 58, 59"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 16, 17, 19, 23, 43, 47, 68, 69, 70, 83, 84, 98, 99, 100, 113, 114, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 18, 29, 30, 53, 54, 63, 66, 67, 71, 72, 77, 86, 87, 92, 101, 102, 107, 116, 117, 122<br />2: PgSelect[32], PgSelect[56]<br />ᐳ: 34, 35, 58, 59"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access16,Access17,Object18,Connection19,Constant23,Lambda29,Access30,PgSelect32,First34,PgSelectSingle35,Connection43,Constant47,Lambda53,Access54,PgSelect56,First58,PgSelectSingle59,Lambda63,Lambda66,Constant67,Constant68,Constant69,Constant81,Constant82,Object84,Lambda85,Lambda90,Constant95,Constant96,Constant97,Constant109,Constant110,Object112,Lambda113,Lambda118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 119, 19, 63, 66, 67, 68, 69, 125, 23<br /><br />ROOT Connectionᐸ15ᐳ[19]<br />1: <br />ᐳ: Object[70], Lambda[76], Lambda[71]<br />2: PgSelect[20]"):::bucket
+    class Bucket0,__Value2,__Value4,Access16,Access17,Object18,Connection19,Constant23,Lambda29,Access30,PgSelect32,First34,PgSelectSingle35,Connection43,Constant47,Lambda53,Access54,PgSelect56,First58,PgSelectSingle59,Lambda63,Lambda66,Access67,Constant68,Constant69,Constant70,Object71,Lambda72,Lambda77,Constant83,Constant84,Object86,Lambda87,Lambda92,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 123, 19, 63, 67, 72, 77, 23<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Object70,Lambda71,Lambda76 bucket1
+    class Bucket1,PgSelect20 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 23<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
@@ -142,9 +144,9 @@ graph TD
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 35<br /><br />ROOT PgSelectSingleᐸpersonᐳ[35]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression36 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 18, 121, 43, 63, 66, 95, 96, 97, 127, 47<br /><br />ROOT Connectionᐸ41ᐳ[43]<br />1: <br />ᐳ: Object[98], Lambda[104], Lambda[99]<br />2: PgSelect[44]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 18, 125, 43, 63, 67, 102, 107, 47<br /><br />ROOT Connectionᐸ41ᐳ[43]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgSelect44,Object98,Lambda99,Lambda104 bucket5
+    class Bucket5,PgSelect44 bucket5
     Bucket6("Bucket 6 (listItem)<br />Deps: 47<br /><br />ROOT __Item{6}ᐸ44ᐳ[45]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item45,PgSelectSingle46 bucket6

--- a/postgraphile/postgraphile/__tests__/queries/v4/nonexistant-record-from-function.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/nonexistant-record-from-function.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸtable_queryᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant31{{"Constant[31∈0] ➊<br />ᐸ13373475ᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ13373475ᐳ"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant31 & Lambda17 & Lambda20 & Lambda25 & Lambda30 --> PgSelect7
-    Object24{{"Object[24∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant21{{"Constant[21∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant22{{"Constant[22∈0] ➊<br />ᐸsql.identifier(”table_query”)ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda17 & Constant21 & Constant22 & Constant23 --> Object24
+    Access21{{"Access[21∈0] ➊<br />ᐸ20.0ᐳ"}}:::plan
+    Lambda26{{"Lambda[26∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant32 & Lambda17 & Access21 & Lambda26 & Lambda31 --> PgSelect7
+    Object25{{"Object[25∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant22{{"Constant[22∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant23{{"Constant[23∈0] ➊<br />ᐸsql.identifier(”table_query”)ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda17 & Constant22 & Constant23 & Constant24 --> Object25
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸtable_queryᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant32 --> Lambda17
     Constant33{{"Constant[33∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant33 --> Lambda20
-    Object24 --> Lambda25
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant34 --> Lambda30
+    Constant33 --> Lambda17
+    Lambda20{{"Lambda[20∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant34 --> Lambda20
+    Lambda20 --> Access21
+    Object25 --> Lambda26
+    Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant35 --> Lambda31
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__table_query__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -48,9 +50,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/nonexistant-record-from-function"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 22, 23, 31, 32, 33, 34, 10, 17, 20, 24, 25, 30<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 22, 23, 24, 32, 33, 34, 35, 10, 17, 20, 21, 25, 26, 31<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda17,Lambda20,Constant21,Constant22,Constant23,Object24,Lambda25,Lambda30,Constant31,Constant32,Constant33,Constant34 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda17,Lambda20,Access21,Constant22,Constant23,Constant24,Object25,Lambda26,Lambda31,Constant32,Constant33,Constant34,Constant35 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸtable_queryᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgClassExpression14 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/numeric.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/numeric.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrange_testᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ934ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ934ᐳ"}}:::plan
     Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda30{{"Lambda[30∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda35{{"Lambda[35∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant36 & Lambda22 & Lambda25 & Lambda30 & Lambda35 --> PgSelect7
-    Object29{{"Object[29∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant26{{"Constant[26∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant27{{"Constant[27∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
-    Constant28{{"Constant[28∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
-    Lambda22 & Constant26 & Constant27 & Constant28 --> Object29
+    Access26{{"Access[26∈0] ➊<br />ᐸ25.0ᐳ"}}:::plan
+    Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda36{{"Lambda[36∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant37 & Lambda22 & Access26 & Lambda31 & Lambda36 --> PgSelect7
+    Object30{{"Object[30∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant27{{"Constant[27∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant28{{"Constant[28∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
+    Constant29{{"Constant[29∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
+    Lambda22 & Constant27 & Constant28 & Constant29 --> Object30
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrange_testᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant37 --> Lambda22
     Constant38{{"Constant[38∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant38 --> Lambda25
-    Object29 --> Lambda30
-    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
-    Constant39 --> Lambda35
+    Constant38 --> Lambda22
+    Lambda25{{"Lambda[25∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant39{{"Constant[39∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant39 --> Lambda25
+    Lambda25 --> Access26
+    Object30 --> Lambda31
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
+    Constant40 --> Lambda36
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__range_test__.”num”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -50,9 +52,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/numeric"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 26, 27, 28, 36, 37, 38, 39, 10, 22, 25, 29, 30, 35<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 27, 28, 29, 37, 38, 39, 40, 10, 22, 25, 26, 30, 31, 36<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda22,Lambda25,Constant26,Constant27,Constant28,Object29,Lambda30,Lambda35,Constant36,Constant37,Constant38,Constant39 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda22,Lambda25,Access26,Constant27,Constant28,Constant29,Object30,Lambda31,Lambda36,Constant37,Constant38,Constant39,Constant40 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/one-to-one-backward.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/one-to-one-backward.mermaid
@@ -9,73 +9,75 @@ graph TD
 
 
     %% plan dependencies
+    Object75{{"Object[75∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda67 & Constant72 & Constant73 & Constant74 --> Object75
+    Object92{{"Object[92∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant90{{"Constant[90∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda67 & Constant89 & Constant90 & Constant91 --> Object92
+    Object109{{"Object[109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant107{{"Constant[107∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda67 & Constant106 & Constant107 & Constant74 --> Object109
+    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda67 & Constant123 & Constant124 & Constant125 --> Object126
+    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda67 & Constant140 & Constant141 & Constant74 --> Object143
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access10
+    __Value2 --> Access11
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant150 --> Lambda67
+    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant151 --> Lambda70
+    Access71{{"Access[71∈0] ➊<br />ᐸ70.0ᐳ"}}:::plan
+    Lambda70 --> Access71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object75 --> Lambda76
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant152 --> Lambda81
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object92 --> Lambda93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant153 --> Lambda98
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object109 --> Lambda110
+    Lambda115{{"Lambda[115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant154 --> Lambda115
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object126 --> Lambda127
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant155 --> Lambda132
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object143 --> Lambda144
+    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant156 --> Lambda149
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant30{{"Constant[30∈0] ➊<br />ᐸ'left_arms'ᐳ"}}:::plan
     Constant50{{"Constant[50∈0] ➊<br />ᐸ'person_secrets'ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant145{{"Constant[145∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda80{{"Lambda[80∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda123{{"Lambda[123∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda128{{"Lambda[128∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda139{{"Lambda[139∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda144{{"Lambda[144∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda70 & Lambda75 & Lambda80 & Lambda70 & Lambda91 & Lambda96 & Lambda107 & Lambda112 & Lambda70 & Lambda123 & Lambda128 & Lambda67 & Lambda70 & Lambda139 & Lambda144 --> PgSelect14
-    Object74{{"Object[74∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda67 & Constant71 & Constant72 & Constant73 --> Object74
-    Object90{{"Object[90∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda67 & Constant87 & Constant88 & Constant89 --> Object90
-    Object106{{"Object[106∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda67 & Constant103 & Constant104 & Constant73 --> Object106
-    Object122{{"Object[122∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda67 & Constant119 & Constant120 & Constant121 --> Object122
-    Object138{{"Object[138∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda67 & Constant135 & Constant136 & Constant73 --> Object138
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access10 & Access11 --> Object12
-    __Value2 --> Access10
-    __Value2 --> Access11
-    Constant145 --> Lambda67
-    Constant146 --> Lambda70
-    Object74 --> Lambda75
-    Constant147 --> Lambda80
-    Object90 --> Lambda91
-    Constant148 --> Lambda96
-    Object106 --> Lambda107
-    Constant149 --> Lambda112
-    Object122 --> Lambda123
-    Constant150 --> Lambda128
-    Object138 --> Lambda139
-    Constant151 --> Lambda144
+    Object12 & Connection13 & Access71 & Lambda76 & Lambda81 & Access71 & Lambda93 & Lambda98 & Lambda110 & Lambda115 & Access71 & Lambda127 & Lambda132 & Lambda67 & Access71 & Lambda144 & Lambda149 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpersonᐳ"}}:::plan
@@ -93,9 +95,9 @@ graph TD
     PgSelectSingle29{{"PgSelectSingle[29∈3]<br />ᐸleft_armᐳ"}}:::plan
     PgSelectSingle16 --> PgSelectSingle29
     PgSelectSingle49{{"PgSelectSingle[49∈3]<br />ᐸperson_secretᐳ"}}:::plan
-    RemapKeys129{{"RemapKeys[129∈3]<br />ᐸ16:{”0”:6,”1”:7,”2”:8,”3”:9,”4”:10}ᐳ"}}:::plan
-    RemapKeys129 --> PgSelectSingle49
-    PgSelectSingle16 --> RemapKeys129
+    RemapKeys133{{"RemapKeys[133∈3]<br />ᐸ16:{”0”:6,”1”:7,”2”:8,”3”:9,”4”:10}ᐳ"}}:::plan
+    RemapKeys133 --> PgSelectSingle49
+    PgSelectSingle16 --> RemapKeys133
     List32{{"List[32∈4]<br />ᐸ30,31ᐳ"}}:::plan
     PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant30 & PgClassExpression31 --> List32
@@ -105,11 +107,11 @@ graph TD
     PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression34
     PgSelectSingle40{{"PgSelectSingle[40∈4]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys81{{"RemapKeys[81∈4]<br />ᐸ29:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
-    RemapKeys81 --> PgSelectSingle40
+    RemapKeys82{{"RemapKeys[82∈4]<br />ᐸ29:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
+    RemapKeys82 --> PgSelectSingle40
     PgClassExpression45{{"PgClassExpression[45∈4]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression45
-    PgSelectSingle29 --> RemapKeys81
+    PgSelectSingle29 --> RemapKeys82
     PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
@@ -138,19 +140,19 @@ graph TD
     subgraph "Buckets for queries/v4/one-to-one-backward"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant30,Constant50,Constant71,Constant72,Constant73,Constant87,Constant88,Constant89,Constant103,Constant104,Constant119,Constant120,Constant121,Constant135,Constant136,Constant145,Constant146,Constant147,Constant148,Constant149,Constant150,Constant151 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 145, 146, 71, 72, 73, 147, 87, 88, 89, 148, 103, 104, 149, 119, 120, 121, 150, 135, 136, 151, 30, 50<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 67, 70, 80, 96, 112, 128, 144, 12, 74, 75, 90, 91, 106, 107, 122, 123, 138, 139<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant30,Constant50,Lambda67,Lambda70,Access71,Constant72,Constant73,Constant74,Object75,Lambda76,Lambda81,Constant89,Constant90,Constant91,Object92,Lambda93,Lambda98,Constant106,Constant107,Object109,Lambda110,Lambda115,Constant123,Constant124,Constant125,Object126,Lambda127,Lambda132,Constant140,Constant141,Object143,Lambda144,Lambda149,Constant150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 71, 76, 81, 93, 98, 110, 115, 127, 132, 67, 144, 149, 30, 50<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda67,Lambda70,Object74,Lambda75,Lambda80,Object90,Lambda91,Lambda96,Object106,Lambda107,Lambda112,Object122,Lambda123,Lambda128,Object138,Lambda139,Lambda144 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 30, 50<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 30, 50<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression21,PgClassExpression23,PgSelectSingle29,PgSelectSingle49,RemapKeys129 bucket3
+    class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression21,PgClassExpression23,PgSelectSingle29,PgSelectSingle49,RemapKeys133 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 29, 30<br /><br />ROOT PgSelectSingle{3}ᐸleft_armᐳ[29]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression31,List32,Lambda33,PgClassExpression34,PgSelectSingle40,PgClassExpression45,RemapKeys81 bucket4
+    class Bucket4,PgClassExpression31,List32,Lambda33,PgClassExpression34,PgSelectSingle40,PgClassExpression45,RemapKeys82 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 40<br /><br />ROOT PgSelectSingle{4}ᐸpersonᐳ[40]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression41,PgClassExpression42,PgClassExpression44 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/orderByNullsLast.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/orderByNullsLast.mermaid
@@ -9,6 +9,16 @@ graph TD
 
 
     %% plan dependencies
+    Object45{{"Object[45∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant42{{"Constant[42∈0] ➊<br />ᐸ[ { attribute: 'col2', direction: 'ASC', nulls: 'LAST' }, { ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Lambda37 & Constant42 & Constant43 & Constant44 --> Object45
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { attribute: 'col2', direction: 'DESC', nulls: 'LAST' }, {ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda37 & Constant57 & Constant58 & Constant44 --> Object60
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,31 +26,29 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda37{{"Lambda[37∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant65 --> Lambda37
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant67 --> Lambda37
     Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant66 --> Lambda40
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant68 --> Lambda40
+    Access41{{"Access[41∈0] ➊<br />ᐸ40.0ᐳ"}}:::plan
+    Lambda40 --> Access41
+    Lambda46{{"Lambda[46∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object45 --> Lambda46
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col2', direction:ᐳ"}}:::plan
+    Constant69 --> Lambda51
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object60 --> Lambda61
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col2', direction:ᐳ"}}:::plan
+    Constant70 --> Lambda66
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant17{{"Constant[17∈0] ➊<br />ᐸ'similar_table_1S'ᐳ"}}:::plan
     Connection26{{"Connection[26∈0] ➊<br />ᐸ24ᐳ"}}:::plan
-    Constant41{{"Constant[41∈0] ➊<br />ᐸ[ { attribute: 'col2', direction: 'ASC', nulls: 'LAST' }, { ᐳ"}}:::plan
-    Constant42{{"Constant[42∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸ[ { attribute: 'col2', direction: 'DESC', nulls: 'LAST' }, {ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col2', direction:ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col2', direction:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸsimilar_table_1ᐳ"]]:::plan
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda50{{"Lambda[50∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda37 & Lambda40 & Lambda45 & Lambda50 --> PgSelect14
-    Object44{{"Object[44∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant41 & Constant42 & Constant43 --> Object44
-    Object44 --> Lambda45
-    Constant67 --> Lambda50
+    Object12 & Connection13 & Lambda37 & Access41 & Lambda46 & Lambda51 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸsimilar_table_1ᐳ"}}:::plan
@@ -54,13 +62,7 @@ graph TD
     PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__similar_...1__.”col2”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression21
     PgSelect27[["PgSelect[27∈4] ➊<br />ᐸsimilar_table_1ᐳ"]]:::plan
-    Lambda59{{"Lambda[59∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection26 & Lambda37 & Lambda40 & Lambda59 & Lambda64 --> PgSelect27
-    Object58{{"Object[58∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda37 & Constant55 & Constant56 & Constant43 --> Object58
-    Object58 --> Lambda59
-    Constant68 --> Lambda64
+    Object12 & Connection26 & Lambda37 & Access41 & Lambda61 & Lambda66 --> PgSelect27
     __Item28[/"__Item[28∈5]<br />ᐸ27ᐳ"\]:::itemplan
     PgSelect27 ==> __Item28
     PgSelectSingle29{{"PgSelectSingle[29∈5]<br />ᐸsimilar_table_1ᐳ"}}:::plan
@@ -79,19 +81,19 @@ graph TD
     subgraph "Buckets for queries/v4/orderByNullsLast"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Connection26,Lambda37,Lambda40,Constant41,Constant42,Constant43,Constant55,Constant56,Constant65,Constant66,Constant67,Constant68 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 37, 40, 41, 42, 43, 67, 17<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[44], Lambda[50], Lambda[45]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Connection26,Lambda37,Lambda40,Access41,Constant42,Constant43,Constant44,Object45,Lambda46,Lambda51,Constant57,Constant58,Object60,Lambda61,Lambda66,Constant67,Constant68,Constant69,Constant70 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 37, 41, 46, 51, 17<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object44,Lambda45,Lambda50 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 17<br /><br />ROOT PgSelectSingle{2}ᐸsimilar_table_1ᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,List19,Lambda20,PgClassExpression21 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 26, 37, 40, 55, 56, 43, 68, 17<br /><br />ROOT Connectionᐸ24ᐳ[26]<br />1: <br />ᐳ: Object[58], Lambda[64], Lambda[59]<br />2: PgSelect[27]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 26, 37, 41, 61, 66, 17<br /><br />ROOT Connectionᐸ24ᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect27,Object58,Lambda59,Lambda64 bucket4
+    class Bucket4,PgSelect27 bucket4
     Bucket5("Bucket 5 (listItem)<br />Deps: 17<br /><br />ROOT __Item{5}ᐸ27ᐳ[28]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item28,PgSelectSingle29 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/partitions.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/partitions.mermaid
@@ -9,51 +9,66 @@ graph TD
 
 
     %% plan dependencies
+    Object72{{"Object[72∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
+    Lambda64 & Constant69 & Constant70 & Constant71 --> Object72
+    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ[ { codec: Codec(timestamptz), fragment: { n: [Array], f: 0,ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”measurements”)ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(measurements)ᐳ"}}:::plan
+    Lambda64 & Constant87 & Constant88 & Constant89 --> Object90
+    Object105{{"Object[105∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda64 & Constant102 & Constant88 & Constant89 --> Object105
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access10
+    __Value2 --> Access11
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant112 --> Lambda64
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant113 --> Lambda67
+    Access68{{"Access[68∈0] ➊<br />ᐸ67.0ᐳ"}}:::plan
+    Lambda67 --> Access68
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object72 --> Lambda73
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
+    Constant115 --> Lambda78
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant114 --> Lambda85
+    Access86{{"Access[86∈0] ➊<br />ᐸ85.0ᐳ"}}:::plan
+    Lambda85 --> Access86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object90 --> Lambda91
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(timestamptz), frᐳ"}}:::plan
+    Constant116 --> Lambda96
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object105 --> Lambda106
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant117{{"Constant[117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”measurᐳ"}}:::plan
+    Constant117 --> Lambda111
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”users”)ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸRecordCodec(users)ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ[ { codec: Codec(timestamptz), fragment: { n: [Array], f: 0,ᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸsql.identifier(”measurements”)ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸRecordCodec(measurements)ᐳ"}}:::plan
-    Constant99{{"Constant[99∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”users”ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(timestamptz), frᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”measurᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸmeasurements+1ᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda67{{"Lambda[67∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda67 & Lambda72 & Lambda77 & Lambda64 & Lambda84 & Lambda89 & Lambda94 --> PgSelect14
+    Object12 & Connection13 & Access68 & Lambda73 & Lambda78 & Lambda64 & Access86 & Lambda91 & Lambda96 --> PgSelect14
     PgSelect33[["PgSelect[33∈1] ➊<br />ᐸmeasurements(aggregate)ᐳ"]]:::plan
-    Lambda103{{"Lambda[103∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda108{{"Lambda[108∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda64 & Lambda67 & Lambda103 & Lambda108 --> PgSelect33
+    Object12 & Connection13 & Lambda64 & Access68 & Lambda106 & Lambda111 --> PgSelect33
     Object60{{"Object[60∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access55{{"Access[55∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access55 --> Object60
-    Object71{{"Object[71∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant68 & Constant69 & Constant70 --> Object71
-    Object88{{"Object[88∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant85 & Constant86 & Constant87 --> Object88
-    Object102{{"Object[102∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant99 & Constant86 & Constant87 --> Object102
     Object56{{"Object[56∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access55 --> Object56
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access10 & Access11 --> Object12
     List45{{"List[45∈1] ➊<br />ᐸ43,44ᐳ"}}:::plan
     PgClassExpression43{{"PgClassExpression[43∈1] ➊<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
     PgClassExpression44{{"PgClassExpression[44∈1] ➊<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
@@ -62,8 +77,6 @@ graph TD
     PgClassExpression50{{"PgClassExpression[50∈1] ➊<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
     PgClassExpression51{{"PgClassExpression[51∈1] ➊<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
     PgClassExpression50 & PgClassExpression51 --> List52
-    __Value2 --> Access10
-    __Value2 --> Access11
     First34{{"First[34∈1] ➊"}}:::plan
     PgSelect33 --> First34
     PgSelectSingle35{{"PgSelectSingle[35∈1] ➊<br />ᐸmeasurementsᐳ"}}:::plan
@@ -93,15 +106,6 @@ graph TD
     Object56 --> Lambda57
     Lambda61{{"Lambda[61∈1] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object60 --> Lambda61
-    Constant109 --> Lambda64
-    Constant110 --> Lambda67
-    Object71 --> Lambda72
-    Constant112 --> Lambda77
-    Constant111 --> Lambda84
-    Object88 --> Lambda89
-    Constant113 --> Lambda94
-    Object102 --> Lambda103
-    Constant114 --> Lambda108
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸmeasurementsᐳ"}}:::plan
@@ -117,9 +121,9 @@ graph TD
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__measurem...__.”value”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression23
     PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸusersᐳ"}}:::plan
-    RemapKeys78{{"RemapKeys[78∈3]<br />ᐸ16:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys78 --> PgSelectSingle30
-    PgSelectSingle16 --> RemapKeys78
+    RemapKeys79{{"RemapKeys[79∈3]<br />ᐸ16:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys79 --> PgSelectSingle30
+    PgSelectSingle16 --> RemapKeys79
     PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__users__.”id”ᐳ"}}:::plan
     PgSelectSingle30 --> PgClassExpression31
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__users__.”name”ᐳ"}}:::plan
@@ -130,16 +134,16 @@ graph TD
     subgraph "Buckets for queries/v4/partitions"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection13,Constant68,Constant69,Constant70,Constant85,Constant86,Constant87,Constant99,Constant109,Constant110,Constant111,Constant112,Constant113,Constant114 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 6, 109, 110, 68, 69, 70, 112, 111, 85, 86, 87, 113, 99, 114<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 38, 64, 67, 77, 84, 94, 108, 12, 71, 72, 88, 89, 102, 103<br />2: PgSelect[14], PgSelect[33]<br />ᐳ: 34, 35, 36, 40, 41, 43, 44, 45, 47, 48, 50, 51, 52, 55, 56, 57, 60, 61, 42, 49"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Lambda64,Lambda67,Access68,Constant69,Constant70,Constant71,Object72,Lambda73,Lambda78,Lambda85,Access86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant102,Object105,Lambda106,Lambda111,Constant112,Constant113,Constant114,Constant115,Constant116,Constant117 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 68, 73, 78, 64, 86, 91, 96, 106, 111, 6<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,PgSelect33,First34,PgSelectSingle35,PgClassExpression36,PgPageInfo38,First40,PgSelectSingle41,PgCursor42,PgClassExpression43,PgClassExpression44,List45,Last47,PgSelectSingle48,PgCursor49,PgClassExpression50,PgClassExpression51,List52,Access55,Object56,Lambda57,Object60,Lambda61,Lambda64,Lambda67,Object71,Lambda72,Lambda77,Lambda84,Object88,Lambda89,Lambda94,Object102,Lambda103,Lambda108 bucket1
+    class Bucket1,PgSelect14,PgSelect33,First34,PgSelectSingle35,PgClassExpression36,PgPageInfo38,First40,PgSelectSingle41,PgCursor42,PgClassExpression43,PgClassExpression44,List45,Last47,PgSelectSingle48,PgCursor49,PgClassExpression50,PgClassExpression51,List52,Access55,Object56,Lambda57,Object60,Lambda61 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸmeasurementsᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor17,PgClassExpression18,PgClassExpression19,List20,PgClassExpression23,PgSelectSingle30,RemapKeys78 bucket3
+    class Bucket3,PgCursor17,PgClassExpression18,PgClassExpression19,List20,PgClassExpression23,PgSelectSingle30,RemapKeys79 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 30<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[30]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression31,PgClassExpression32 bucket4

--- a/postgraphile/postgraphile/__tests__/queries/v4/pg11.network_types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/pg11.network_types.mermaid
@@ -9,6 +9,36 @@ graph TD
 
 
     %% plan dependencies
+    Object199{{"Object[199∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant196{{"Constant[196∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant197{{"Constant[197∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸRecordCodec(network)ᐳ"}}:::plan
+    Lambda191 & Constant196 & Constant197 & Constant198 --> Object199
+    Object215{{"Object[215∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant212{{"Constant[212∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda191 & Constant212 & Constant197 & Constant198 --> Object215
+    Object230{{"Object[230∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Lambda191 & Constant227 & Constant228 & Constant198 --> Object230
+    Object245{{"Object[245∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant242{{"Constant[242∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda191 & Constant242 & Constant228 & Constant198 --> Object245
+    Object260{{"Object[260∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant257{{"Constant[257∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant258{{"Constant[258∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Lambda191 & Constant257 & Constant258 & Constant198 --> Object260
+    Object275{{"Object[275∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant272{{"Constant[272∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda191 & Constant272 & Constant258 & Constant198 --> Object275
+    Object290{{"Object[290∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant287{{"Constant[287∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant288{{"Constant[288∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
+    Lambda191 & Constant287 & Constant288 & Constant198 --> Object290
+    Object305{{"Object[305∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant302{{"Constant[302∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda191 & Constant302 & Constant288 & Constant198 --> Object305
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,61 +46,75 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access12
     __Value2 --> Access13
-    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant308{{"Constant[308∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant308 --> Lambda191
+    Constant316{{"Constant[316∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant316 --> Lambda191
     Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant309{{"Constant[309∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant309 --> Lambda194
-    Lambda209{{"Lambda[209∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant310{{"Constant[310∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant310 --> Lambda209
+    Constant317{{"Constant[317∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant317 --> Lambda194
+    Access195{{"Access[195∈0] ➊<br />ᐸ194.0ᐳ"}}:::plan
+    Lambda194 --> Access195
+    Lambda200{{"Lambda[200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object199 --> Lambda200
+    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant319{{"Constant[319∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant319 --> Lambda206
+    Lambda210{{"Lambda[210∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant318{{"Constant[318∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant318 --> Lambda210
+    Access211{{"Access[211∈0] ➊<br />ᐸ210.0ᐳ"}}:::plan
+    Lambda210 --> Access211
+    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object215 --> Lambda216
+    Lambda221{{"Lambda[221∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant320{{"Constant[320∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant320 --> Lambda221
+    Lambda231{{"Lambda[231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object230 --> Lambda231
+    Lambda236{{"Lambda[236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant321{{"Constant[321∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant321 --> Lambda236
+    Lambda246{{"Lambda[246∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object245 --> Lambda246
+    Lambda251{{"Lambda[251∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant322{{"Constant[322∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant322 --> Lambda251
+    Lambda261{{"Lambda[261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object260 --> Lambda261
+    Lambda266{{"Lambda[266∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant323 --> Lambda266
+    Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object275 --> Lambda276
+    Lambda281{{"Lambda[281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant324{{"Constant[324∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant324 --> Lambda281
+    Lambda291{{"Lambda[291∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object290 --> Lambda291
+    Lambda296{{"Lambda[296∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant325{{"Constant[325∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant325 --> Lambda296
+    Lambda306{{"Lambda[306∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object305 --> Lambda306
+    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant326{{"Constant[326∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant326 --> Lambda311
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection15{{"Connection[15∈0] ➊<br />ᐸ11ᐳ"}}:::plan
     Connection60{{"Connection[60∈0] ➊<br />ᐸ58ᐳ"}}:::plan
     Connection105{{"Connection[105∈0] ➊<br />ᐸ103ᐳ"}}:::plan
     Connection150{{"Connection[150∈0] ➊<br />ᐸ148ᐳ"}}:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸRecordCodec(network)ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant224{{"Constant[224∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant225{{"Constant[225∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant238{{"Constant[238∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant252{{"Constant[252∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant253{{"Constant[253∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant266{{"Constant[266∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant280{{"Constant[280∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant281{{"Constant[281∈0] ➊<br />ᐸsql.identifier(”network”)ᐳ"}}:::plan
-    Constant294{{"Constant[294∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸ'192.168.0.0'ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
-    Constant306{{"Constant[306∈0] ➊<br />ᐸ'08:00:2b:01:02:03'ᐳ"}}:::plan
-    Constant307{{"Constant[307∈0] ➊<br />ᐸ'08:00:2b:01:02:03:04:05'ᐳ"}}:::plan
-    Constant311{{"Constant[311∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant312{{"Constant[312∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
-    Constant313{{"Constant[313∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant314{{"Constant[314∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
-    Constant315{{"Constant[315∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
-    Constant317{{"Constant[317∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant318{{"Constant[318∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”networᐳ"}}:::plan
+    Constant312{{"Constant[312∈0] ➊<br />ᐸ'192.168.0.0'ᐳ"}}:::plan
+    Constant313{{"Constant[313∈0] ➊<br />ᐸ'192.168.0.0/16'ᐳ"}}:::plan
+    Constant314{{"Constant[314∈0] ➊<br />ᐸ'08:00:2b:01:02:03'ᐳ"}}:::plan
+    Constant315{{"Constant[315∈0] ➊<br />ᐸ'08:00:2b:01:02:03:04:05'ᐳ"}}:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda199{{"Lambda[199∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda205{{"Lambda[205∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant304 & Connection15 & Lambda191 & Lambda194 & Lambda199 & Lambda205 --> PgSelect16
+    Object14 & Constant312 & Connection15 & Lambda191 & Access195 & Lambda200 & Lambda206 --> PgSelect16
     PgSelect39[["PgSelect[39∈1] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda214{{"Lambda[214∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda219{{"Lambda[219∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant304 & Connection15 & Lambda191 & Lambda209 & Lambda214 & Lambda219 --> PgSelect39
+    Object14 & Constant312 & Connection15 & Lambda191 & Access211 & Lambda216 & Lambda221 --> PgSelect39
     Object37{{"Object[37∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access32{{"Access[32∈1] ➊<br />ᐸ16.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access32 --> Object37
-    Object198{{"Object[198∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant195 & Constant196 & Constant197 --> Object198
-    Object213{{"Object[213∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant210 & Constant196 & Constant197 --> Object213
     Object33{{"Object[33∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access32 --> Object33
     PgPageInfo17{{"PgPageInfo[17∈1] ➊"}}:::plan
@@ -106,10 +150,6 @@ graph TD
     First40 --> PgSelectSingle41
     PgClassExpression42{{"PgClassExpression[42∈1] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression42
-    Object198 --> Lambda199
-    Constant311 --> Lambda205
-    Object213 --> Lambda214
-    Constant312 --> Lambda219
     __Item44[/"__Item[44∈2]<br />ᐸ16ᐳ"\]:::itemplan
     PgSelect16 ==> __Item44
     PgSelectSingle45{{"PgSelectSingle[45∈2]<br />ᐸnetworkᐳ"}}:::plan
@@ -129,20 +169,12 @@ graph TD
     PgClassExpression53{{"PgClassExpression[53∈3]<br />ᐸ__network__.”macaddr8”ᐳ"}}:::plan
     PgSelectSingle45 --> PgClassExpression53
     PgSelect61[["PgSelect[61∈4] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda228{{"Lambda[228∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda233{{"Lambda[233∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant305 & Connection60 & Lambda191 & Lambda194 & Lambda228 & Lambda233 --> PgSelect61
+    Object14 & Constant313 & Connection60 & Lambda191 & Access195 & Lambda231 & Lambda236 --> PgSelect61
     PgSelect84[["PgSelect[84∈4] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda242{{"Lambda[242∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda247{{"Lambda[247∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant305 & Connection60 & Lambda191 & Lambda209 & Lambda242 & Lambda247 --> PgSelect84
+    Object14 & Constant313 & Connection60 & Lambda191 & Access211 & Lambda246 & Lambda251 --> PgSelect84
     Object82{{"Object[82∈4] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access77{{"Access[77∈4] ➊<br />ᐸ61.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access77 --> Object82
-    Object227{{"Object[227∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant224 & Constant225 & Constant197 --> Object227
-    Object241{{"Object[241∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant238 & Constant225 & Constant197 --> Object241
     Object78{{"Object[78∈4] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access77 --> Object78
     PgPageInfo62{{"PgPageInfo[62∈4] ➊"}}:::plan
@@ -178,10 +210,6 @@ graph TD
     First85 --> PgSelectSingle86
     PgClassExpression87{{"PgClassExpression[87∈4] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle86 --> PgClassExpression87
-    Object227 --> Lambda228
-    Constant313 --> Lambda233
-    Object241 --> Lambda242
-    Constant314 --> Lambda247
     __Item89[/"__Item[89∈5]<br />ᐸ61ᐳ"\]:::itemplan
     PgSelect61 ==> __Item89
     PgSelectSingle90{{"PgSelectSingle[90∈5]<br />ᐸnetworkᐳ"}}:::plan
@@ -201,20 +229,12 @@ graph TD
     PgClassExpression98{{"PgClassExpression[98∈6]<br />ᐸ__network__.”macaddr8”ᐳ"}}:::plan
     PgSelectSingle90 --> PgClassExpression98
     PgSelect106[["PgSelect[106∈7] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda256{{"Lambda[256∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda261{{"Lambda[261∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant306 & Connection105 & Lambda191 & Lambda194 & Lambda256 & Lambda261 --> PgSelect106
+    Object14 & Constant314 & Connection105 & Lambda191 & Access195 & Lambda261 & Lambda266 --> PgSelect106
     PgSelect129[["PgSelect[129∈7] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda270{{"Lambda[270∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda275{{"Lambda[275∈7] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant306 & Connection105 & Lambda191 & Lambda209 & Lambda270 & Lambda275 --> PgSelect129
+    Object14 & Constant314 & Connection105 & Lambda191 & Access211 & Lambda276 & Lambda281 --> PgSelect129
     Object127{{"Object[127∈7] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access122{{"Access[122∈7] ➊<br />ᐸ106.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access122 --> Object127
-    Object255{{"Object[255∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant252 & Constant253 & Constant197 --> Object255
-    Object269{{"Object[269∈7] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant266 & Constant253 & Constant197 --> Object269
     Object123{{"Object[123∈7] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access122 --> Object123
     PgPageInfo107{{"PgPageInfo[107∈7] ➊"}}:::plan
@@ -250,10 +270,6 @@ graph TD
     First130 --> PgSelectSingle131
     PgClassExpression132{{"PgClassExpression[132∈7] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle131 --> PgClassExpression132
-    Object255 --> Lambda256
-    Constant315 --> Lambda261
-    Object269 --> Lambda270
-    Constant316 --> Lambda275
     __Item134[/"__Item[134∈8]<br />ᐸ106ᐳ"\]:::itemplan
     PgSelect106 ==> __Item134
     PgSelectSingle135{{"PgSelectSingle[135∈8]<br />ᐸnetworkᐳ"}}:::plan
@@ -273,20 +289,12 @@ graph TD
     PgClassExpression143{{"PgClassExpression[143∈9]<br />ᐸ__network__.”macaddr8”ᐳ"}}:::plan
     PgSelectSingle135 --> PgClassExpression143
     PgSelect151[["PgSelect[151∈10] ➊<br />ᐸnetwork+1ᐳ"]]:::plan
-    Lambda284{{"Lambda[284∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda289{{"Lambda[289∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant307 & Connection150 & Lambda191 & Lambda194 & Lambda284 & Lambda289 --> PgSelect151
+    Object14 & Constant315 & Connection150 & Lambda191 & Access195 & Lambda291 & Lambda296 --> PgSelect151
     PgSelect174[["PgSelect[174∈10] ➊<br />ᐸnetwork(aggregate)ᐳ"]]:::plan
-    Lambda298{{"Lambda[298∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda303{{"Lambda[303∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object14 & Constant307 & Connection150 & Lambda191 & Lambda209 & Lambda298 & Lambda303 --> PgSelect174
+    Object14 & Constant315 & Connection150 & Lambda191 & Access211 & Lambda306 & Lambda311 --> PgSelect174
     Object172{{"Object[172∈10] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access167{{"Access[167∈10] ➊<br />ᐸ151.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access167 --> Object172
-    Object283{{"Object[283∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant280 & Constant281 & Constant197 --> Object283
-    Object297{{"Object[297∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda191 & Constant294 & Constant281 & Constant197 --> Object297
     Object168{{"Object[168∈10] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access167 --> Object168
     PgPageInfo152{{"PgPageInfo[152∈10] ➊"}}:::plan
@@ -322,10 +330,6 @@ graph TD
     First175 --> PgSelectSingle176
     PgClassExpression177{{"PgClassExpression[177∈10] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle176 --> PgClassExpression177
-    Object283 --> Lambda284
-    Constant317 --> Lambda289
-    Object297 --> Lambda298
-    Constant318 --> Lambda303
     __Item179[/"__Item[179∈11]<br />ᐸ151ᐳ"\]:::itemplan
     PgSelect151 ==> __Item179
     PgSelectSingle180{{"PgSelectSingle[180∈11]<br />ᐸnetworkᐳ"}}:::plan
@@ -350,37 +354,37 @@ graph TD
     subgraph "Buckets for queries/v4/pg11.network_types"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Access12,Access13,Object14,Connection15,Connection60,Connection105,Connection150,Lambda191,Lambda194,Constant195,Constant196,Constant197,Lambda209,Constant210,Constant224,Constant225,Constant238,Constant252,Constant253,Constant266,Constant280,Constant281,Constant294,Constant304,Constant305,Constant306,Constant307,Constant308,Constant309,Constant310,Constant311,Constant312,Constant313,Constant314,Constant315,Constant316,Constant317,Constant318 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 304, 15, 191, 194, 6, 209, 195, 196, 197, 311, 210, 312<br /><br />ROOT Connectionᐸ11ᐳ[15]<br />1: <br />ᐳ: 17, 198, 205, 213, 219, 199, 214<br />2: PgSelect[16], PgSelect[39]<br />ᐳ: 19, 20, 22, 23, 25, 26, 28, 29, 32, 33, 34, 37, 38, 40, 41, 42, 21, 27"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access12,Access13,Object14,Connection15,Connection60,Connection105,Connection150,Lambda191,Lambda194,Access195,Constant196,Constant197,Constant198,Object199,Lambda200,Lambda206,Lambda210,Access211,Constant212,Object215,Lambda216,Lambda221,Constant227,Constant228,Object230,Lambda231,Lambda236,Constant242,Object245,Lambda246,Lambda251,Constant257,Constant258,Object260,Lambda261,Lambda266,Constant272,Object275,Lambda276,Lambda281,Constant287,Constant288,Object290,Lambda291,Lambda296,Constant302,Object305,Lambda306,Lambda311,Constant312,Constant313,Constant314,Constant315,Constant316,Constant317,Constant318,Constant319,Constant320,Constant321,Constant322,Constant323,Constant324,Constant325,Constant326 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 312, 15, 191, 195, 200, 206, 6, 211, 216, 221<br /><br />ROOT Connectionᐸ11ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect16,PgPageInfo17,First19,PgSelectSingle20,PgCursor21,PgClassExpression22,List23,Last25,PgSelectSingle26,PgCursor27,PgClassExpression28,List29,Access32,Object33,Lambda34,Object37,Lambda38,PgSelect39,First40,PgSelectSingle41,PgClassExpression42,Object198,Lambda199,Lambda205,Object213,Lambda214,Lambda219 bucket1
+    class Bucket1,PgSelect16,PgPageInfo17,First19,PgSelectSingle20,PgCursor21,PgClassExpression22,List23,Last25,PgSelectSingle26,PgCursor27,PgClassExpression28,List29,Access32,Object33,Lambda34,Object37,Lambda38,PgSelect39,First40,PgSelectSingle41,PgClassExpression42 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ16ᐳ[44]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item44,PgSelectSingle45 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{2}ᐸnetworkᐳ[45]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor46,PgClassExpression47,List48,PgClassExpression50,PgClassExpression51,PgClassExpression52,PgClassExpression53 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 305, 60, 191, 194, 6, 209, 224, 225, 197, 313, 238, 314<br /><br />ROOT Connectionᐸ58ᐳ[60]<br />1: <br />ᐳ: 62, 227, 233, 241, 247, 228, 242<br />2: PgSelect[61], PgSelect[84]<br />ᐳ: 64, 65, 67, 68, 70, 71, 73, 74, 77, 78, 79, 82, 83, 85, 86, 87, 66, 72"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 14, 313, 60, 191, 195, 231, 236, 6, 211, 246, 251<br /><br />ROOT Connectionᐸ58ᐳ[60]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect61,PgPageInfo62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,Access77,Object78,Lambda79,Object82,Lambda83,PgSelect84,First85,PgSelectSingle86,PgClassExpression87,Object227,Lambda228,Lambda233,Object241,Lambda242,Lambda247 bucket4
+    class Bucket4,PgSelect61,PgPageInfo62,First64,PgSelectSingle65,PgCursor66,PgClassExpression67,List68,Last70,PgSelectSingle71,PgCursor72,PgClassExpression73,List74,Access77,Object78,Lambda79,Object82,Lambda83,PgSelect84,First85,PgSelectSingle86,PgClassExpression87 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ61ᐳ[89]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item89,PgSelectSingle90 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 90<br /><br />ROOT PgSelectSingle{5}ᐸnetworkᐳ[90]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgCursor91,PgClassExpression92,List93,PgClassExpression95,PgClassExpression96,PgClassExpression97,PgClassExpression98 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 14, 306, 105, 191, 194, 6, 209, 252, 253, 197, 315, 266, 316<br /><br />ROOT Connectionᐸ103ᐳ[105]<br />1: <br />ᐳ: 107, 255, 261, 269, 275, 256, 270<br />2: PgSelect[106], PgSelect[129]<br />ᐳ: 109, 110, 112, 113, 115, 116, 118, 119, 122, 123, 124, 127, 128, 130, 131, 132, 111, 117"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 14, 314, 105, 191, 195, 261, 266, 6, 211, 276, 281<br /><br />ROOT Connectionᐸ103ᐳ[105]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelect106,PgPageInfo107,First109,PgSelectSingle110,PgCursor111,PgClassExpression112,List113,Last115,PgSelectSingle116,PgCursor117,PgClassExpression118,List119,Access122,Object123,Lambda124,Object127,Lambda128,PgSelect129,First130,PgSelectSingle131,PgClassExpression132,Object255,Lambda256,Lambda261,Object269,Lambda270,Lambda275 bucket7
+    class Bucket7,PgSelect106,PgPageInfo107,First109,PgSelectSingle110,PgCursor111,PgClassExpression112,List113,Last115,PgSelectSingle116,PgCursor117,PgClassExpression118,List119,Access122,Object123,Lambda124,Object127,Lambda128,PgSelect129,First130,PgSelectSingle131,PgClassExpression132 bucket7
     Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ106ᐳ[134]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item134,PgSelectSingle135 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 135<br /><br />ROOT PgSelectSingle{8}ᐸnetworkᐳ[135]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgCursor136,PgClassExpression137,List138,PgClassExpression140,PgClassExpression141,PgClassExpression142,PgClassExpression143 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 14, 307, 150, 191, 194, 6, 209, 280, 281, 197, 317, 294, 318<br /><br />ROOT Connectionᐸ148ᐳ[150]<br />1: <br />ᐳ: 152, 283, 289, 297, 303, 284, 298<br />2: PgSelect[151], PgSelect[174]<br />ᐳ: 154, 155, 157, 158, 160, 161, 163, 164, 167, 168, 169, 172, 173, 175, 176, 177, 156, 162"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 14, 315, 150, 191, 195, 291, 296, 6, 211, 306, 311<br /><br />ROOT Connectionᐸ148ᐳ[150]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect151,PgPageInfo152,First154,PgSelectSingle155,PgCursor156,PgClassExpression157,List158,Last160,PgSelectSingle161,PgCursor162,PgClassExpression163,List164,Access167,Object168,Lambda169,Object172,Lambda173,PgSelect174,First175,PgSelectSingle176,PgClassExpression177,Object283,Lambda284,Lambda289,Object297,Lambda298,Lambda303 bucket10
+    class Bucket10,PgSelect151,PgPageInfo152,First154,PgSelectSingle155,PgCursor156,PgClassExpression157,List158,Last160,PgSelectSingle161,PgCursor162,PgClassExpression163,List164,Access167,Object168,Lambda169,Object172,Lambda173,PgSelect174,First175,PgSelectSingle176,PgClassExpression177 bucket10
     Bucket11("Bucket 11 (listItem)<br /><br />ROOT __Item{11}ᐸ151ᐳ[179]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,__Item179,PgSelectSingle180 bucket11

--- a/postgraphile/postgraphile/__tests__/queries/v4/pg11.types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/pg11.types.mermaid
@@ -9,60 +9,75 @@ graph TD
 
 
     %% plan dependencies
+    Object94{{"Object[94∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant91{{"Constant[91∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant92{{"Constant[92∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
+    Constant93{{"Constant[93∈0] ➊<br />ᐸDomainCodecᐸcompoundTypeᐳ(domainConstrainedCompoundType)ᐳ"}}:::plan
+    Lambda86 & Constant91 & Constant92 & Constant93 --> Object94
+    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
+    Lambda86 & Constant108 & Constant109 & Constant93 --> Object111
+    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda86 & Constant126 & Constant127 & Constant128 --> Object129
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda86 & Constant141 & Constant127 & Constant128 --> Object144
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access10
+    __Value2 --> Access11
+    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant151 --> Lambda86
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant152 --> Lambda89
+    Access90{{"Access[90∈0] ➊<br />ᐸ89.0ᐳ"}}:::plan
+    Lambda89 --> Access90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object94 --> Lambda95
+    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant154 --> Lambda100
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object111 --> Lambda112
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant155 --> Lambda117
+    Lambda124{{"Lambda[124∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant153 --> Lambda124
+    Access125{{"Access[125∈0] ➊<br />ᐸ124.0ᐳ"}}:::plan
+    Lambda124 --> Access125
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object129 --> Lambda130
+    Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant156 --> Lambda135
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant157 --> Lambda150
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant90{{"Constant[90∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant91{{"Constant[91∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸDomainCodecᐸcompoundTypeᐳ(domainConstrainedCompoundType)ᐳ"}}:::plan
-    Constant106{{"Constant[106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸsql.identifier(”frmcdc_domain_constrained_compound_type”)ᐳ"}}:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸtypes+1ᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda94{{"Lambda[94∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda99{{"Lambda[99∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda110{{"Lambda[110∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda115{{"Lambda[115∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda127{{"Lambda[127∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda132{{"Lambda[132∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda89 & Lambda94 & Lambda99 & Lambda89 & Lambda110 & Lambda115 & Lambda86 & Lambda122 & Lambda127 & Lambda132 --> PgSelect14
+    Object12 & Connection13 & Access90 & Lambda95 & Lambda100 & Access90 & Lambda112 & Lambda117 & Lambda86 & Access125 & Lambda130 & Lambda135 --> PgSelect14
     PgSelect57[["PgSelect[57∈1] ➊<br />ᐸtypes(aggregate)ᐳ"]]:::plan
-    Lambda141{{"Lambda[141∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda86 & Lambda89 & Lambda141 & Lambda146 --> PgSelect57
+    Object12 & Connection13 & Lambda86 & Access90 & Lambda145 & Lambda150 --> PgSelect57
     Object70{{"Object[70∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access65{{"Access[65∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access65 --> Object70
-    Object93{{"Object[93∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda86 & Constant90 & Constant91 & Constant92 --> Object93
-    Object109{{"Object[109∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda86 & Constant106 & Constant107 & Constant92 --> Object109
-    Object126{{"Object[126∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda86 & Constant123 & Constant124 & Constant125 --> Object126
-    Object140{{"Object[140∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda86 & Constant137 & Constant124 & Constant125 --> Object140
     Object66{{"Object[66∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access65 --> Object66
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
-    Access10 & Access11 --> Object12
-    __Value2 --> Access10
-    __Value2 --> Access11
     First58{{"First[58∈1] ➊"}}:::plan
     PgSelect57 --> First58
     PgSelectSingle59{{"PgSelectSingle[59∈1] ➊<br />ᐸtypesᐳ"}}:::plan
@@ -96,17 +111,6 @@ graph TD
     PgClassExpression82{{"PgClassExpression[82∈1] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     PgSelectSingle80 --> PgClassExpression82
     PgClassExpression82 --> List83
-    Constant147 --> Lambda86
-    Constant148 --> Lambda89
-    Object93 --> Lambda94
-    Constant150 --> Lambda99
-    Object109 --> Lambda110
-    Constant151 --> Lambda115
-    Constant149 --> Lambda122
-    Object126 --> Lambda127
-    Constant152 --> Lambda132
-    Object140 --> Lambda141
-    Constant153 --> Lambda146
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸtypesᐳ"}}:::plan
@@ -120,9 +124,9 @@ graph TD
     PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__types__....ay_domain”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression20
     PgSelectSingle28{{"PgSelectSingle[28∈3]<br />ᐸfrmcdc_domainConstrainedCompoundTypeᐳ"}}:::plan
-    RemapKeys100{{"RemapKeys[100∈3]<br />ᐸ16:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9,”6”:10,”7”:11}ᐳ"}}:::plan
-    RemapKeys100 --> PgSelectSingle28
-    PgSelectSingle16 --> RemapKeys100
+    RemapKeys101{{"RemapKeys[101∈3]<br />ᐸ16:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9,”6”:10,”7”:11}ᐳ"}}:::plan
+    RemapKeys101 --> PgSelectSingle28
+    PgSelectSingle16 --> RemapKeys101
     __Item21[/"__Item[21∈4]<br />ᐸ20ᐳ"\]:::itemplan
     PgClassExpression20 ==> __Item21
     PgClassExpression29{{"PgClassExpression[29∈5]<br />ᐸ__frmcdc_d...type__.”a”ᐳ"}}:::plan
@@ -148,9 +152,9 @@ graph TD
     PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__types__....ay_domain”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression41
     PgSelectSingle49{{"PgSelectSingle[49∈6]<br />ᐸfrmcdc_domainConstrainedCompoundTypeᐳ"}}:::plan
-    RemapKeys116{{"RemapKeys[116∈6]<br />ᐸ16:{”0”:12,”1”:13,”2”:14,”3”:15,”4”:16,”5”:17,”6”:18,”7”:19}ᐳ"}}:::plan
-    RemapKeys116 --> PgSelectSingle49
-    PgSelectSingle16 --> RemapKeys116
+    RemapKeys118{{"RemapKeys[118∈6]<br />ᐸ16:{”0”:12,”1”:13,”2”:14,”3”:15,”4”:16,”5”:17,”6”:18,”7”:19}ᐳ"}}:::plan
+    RemapKeys118 --> PgSelectSingle49
+    PgSelectSingle16 --> RemapKeys118
     __Item42[/"__Item[42∈7]<br />ᐸ41ᐳ"\]:::itemplan
     PgClassExpression41 ==> __Item42
     PgClassExpression50{{"PgClassExpression[50∈8]<br />ᐸ__frmcdc_d...type__.”a”ᐳ"}}:::plan
@@ -173,16 +177,16 @@ graph TD
     subgraph "Buckets for queries/v4/pg11.types"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Connection13,Constant90,Constant91,Constant92,Constant106,Constant107,Constant123,Constant124,Constant125,Constant137,Constant147,Constant148,Constant149,Constant150,Constant151,Constant152,Constant153 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 6, 147, 148, 90, 91, 92, 150, 106, 107, 151, 149, 123, 124, 125, 152, 137, 153<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 62, 86, 89, 99, 115, 122, 132, 146, 12, 93, 94, 109, 110, 126, 127, 140, 141<br />2: PgSelect[14], PgSelect[57]<br />ᐳ: 58, 59, 60, 65, 66, 67, 70, 71, 73, 74, 76, 77, 79, 80, 82, 83, 75, 81"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Access10,Access11,Object12,Connection13,Lambda86,Lambda89,Access90,Constant91,Constant92,Constant93,Object94,Lambda95,Lambda100,Constant108,Constant109,Object111,Lambda112,Lambda117,Lambda124,Access125,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant141,Object144,Lambda145,Lambda150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 90, 95, 100, 112, 117, 86, 125, 130, 135, 145, 150, 6<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,PgSelect57,First58,PgSelectSingle59,PgClassExpression60,PgPageInfo62,Access65,Object66,Lambda67,Object70,Lambda71,First73,PgSelectSingle74,PgCursor75,PgClassExpression76,List77,Last79,PgSelectSingle80,PgCursor81,PgClassExpression82,List83,Lambda86,Lambda89,Object93,Lambda94,Lambda99,Object109,Lambda110,Lambda115,Lambda122,Object126,Lambda127,Lambda132,Object140,Lambda141,Lambda146 bucket1
+    class Bucket1,PgSelect14,PgSelect57,First58,PgSelectSingle59,PgClassExpression60,PgPageInfo62,Access65,Object66,Lambda67,Object70,Lambda71,First73,PgSelectSingle74,PgCursor75,PgClassExpression76,List77,Last79,PgSelectSingle80,PgCursor81,PgClassExpression82,List83 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸtypesᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgSelectSingle28,RemapKeys100 bucket3
+    class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgSelectSingle28,RemapKeys101 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ20ᐳ[21]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item21 bucket4
@@ -191,7 +195,7 @@ graph TD
     class Bucket5,PgClassExpression29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸtypesᐳ[16]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgSelectSingle49,RemapKeys116 bucket6
+    class Bucket6,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgSelectSingle49,RemapKeys118 bucket6
     Bucket7("Bucket 7 (listItem)<br /><br />ROOT __Item{7}ᐸ41ᐳ[42]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item42 bucket7

--- a/postgraphile/postgraphile/__tests__/queries/v4/posts.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/posts.mermaid
@@ -9,83 +9,85 @@ graph TD
 
 
     %% plan dependencies
+    Object90{{"Object[90∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant180{{"Constant[180∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant180 --> Lambda82
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Connection60{{"Connection[60∈0] ➊<br />ᐸ58ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant88{{"Constant[88∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant103{{"Constant[103∈0] ➊<br />ᐸsql.identifier(”person_first_post”)ᐳ"}}:::plan
-    Constant104{{"Constant[104∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Constant137{{"Constant[137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant155{{"Constant[155∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant170{{"Constant[170∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant171{{"Constant[171∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant181{{"Constant[181∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant182{{"Constant[182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant183{{"Constant[183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant184{{"Constant[184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpostᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda95{{"Lambda[95∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda111{{"Lambda[111∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda122{{"Lambda[122∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda127{{"Lambda[127∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda141{{"Lambda[141∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda146{{"Lambda[146∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda158{{"Lambda[158∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda163{{"Lambda[163∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda174{{"Lambda[174∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda179{{"Lambda[179∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda85 & Lambda90 & Lambda95 & Lambda106 & Lambda111 & Lambda122 & Lambda127 & Lambda141 & Lambda146 & Lambda85 & Lambda158 & Lambda163 & Lambda82 & Lambda85 & Lambda174 & Lambda179 --> PgSelect14
-    Object89{{"Object[89∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant86 & Constant87 & Constant88 --> Object89
-    Object105{{"Object[105∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant102 & Constant103 & Constant104 --> Object105
-    Object121{{"Object[121∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant118 & Constant119 & Constant88 --> Object121
-    Object140{{"Object[140∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant137 & Constant119 & Constant88 --> Object140
-    Object157{{"Object[157∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant154 & Constant155 & Constant88 --> Object157
-    Object173{{"Object[173∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda82 & Constant170 & Constant171 & Constant104 --> Object173
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant88{{"Constant[88∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant89{{"Constant[89∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda82 & Constant87 & Constant88 & Constant89 --> Object90
+    Object107{{"Object[107∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸsql.identifier(”person_first_post”)ᐳ"}}:::plan
+    Constant106{{"Constant[106∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda82 & Constant104 & Constant105 & Constant106 --> Object107
+    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Lambda82 & Constant121 & Constant122 & Constant89 --> Object124
+    Object144{{"Object[144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant141{{"Constant[141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda82 & Constant141 & Constant122 & Constant89 --> Object144
+    Object162{{"Object[162∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda82 & Constant159 & Constant160 & Constant89 --> Object162
+    Object179{{"Object[179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant176{{"Constant[176∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant177{{"Constant[177∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda82 & Constant176 & Constant177 & Constant106 --> Object179
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    PgPageInfo73{{"PgPageInfo[73∈1] ➊"}}:::plan
+    PgPageInfo73{{"PgPageInfo[73∈0] ➊"}}:::plan
+    Connection60{{"Connection[60∈0] ➊<br />ᐸ58ᐳ"}}:::plan
     Connection60 --> PgPageInfo73
-    Constant181 --> Lambda85
-    Object89 --> Lambda90
-    Constant182 --> Lambda95
-    Object105 --> Lambda106
-    Constant183 --> Lambda111
-    Object121 --> Lambda122
-    Constant184 --> Lambda127
-    Object140 --> Lambda141
-    Constant185 --> Lambda146
-    Object157 --> Lambda158
-    Constant186 --> Lambda163
-    Object173 --> Lambda174
-    Constant187 --> Lambda179
+    Constant186{{"Constant[186∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant186 --> Lambda82
+    Lambda85{{"Lambda[85∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant187{{"Constant[187∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant187 --> Lambda85
+    Access86{{"Access[86∈0] ➊<br />ᐸ85.0ᐳ"}}:::plan
+    Lambda85 --> Access86
+    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object90 --> Lambda91
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant188{{"Constant[188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant188 --> Lambda96
+    Lambda108{{"Lambda[108∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object107 --> Lambda108
+    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant189{{"Constant[189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant189 --> Lambda113
+    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object124 --> Lambda125
+    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant190{{"Constant[190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant190 --> Lambda130
+    Lambda145{{"Lambda[145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object144 --> Lambda145
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant191{{"Constant[191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant191 --> Lambda150
+    Lambda163{{"Lambda[163∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object162 --> Lambda163
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant192{{"Constant[192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant192 --> Lambda168
+    Lambda180{{"Lambda[180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object179 --> Lambda180
+    Lambda185{{"Lambda[185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant193 --> Lambda185
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸnullᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸfalseᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpostᐳ"]]:::plan
+    Object12 & Connection13 & Access86 & Lambda91 & Lambda96 & Lambda108 & Lambda113 & Lambda125 & Lambda130 & Lambda145 & Lambda150 & Access86 & Lambda163 & Lambda168 & Lambda82 & Access86 & Lambda180 & Lambda185 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpostᐳ"}}:::plan
@@ -101,15 +103,15 @@ graph TD
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression23
     PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys164{{"RemapKeys[164∈3]<br />ᐸ16:{”0”:3,”1”:4,”2”:5,”3”:6,”4”:7,”5”:8,”6”:9,”7”:10,”8”:11,”9”:12,”10”:13}ᐳ"}}:::plan
-    RemapKeys164 --> PgSelectSingle30
-    PgSelectSingle16 --> RemapKeys164
-    Object131{{"Object[131∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access129{{"Access[129∈4]<br />ᐸ164.8ᐳ"}}:::plan
-    Access129 & Constant80 & Constant80 & Lambda82 & Constant83 --> Object131
-    Object148{{"Object[148∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access147{{"Access[147∈4]<br />ᐸ164.9ᐳ"}}:::plan
-    Access147 & Constant80 & Constant80 & Lambda82 & Constant83 --> Object148
+    RemapKeys169{{"RemapKeys[169∈3]<br />ᐸ16:{”0”:3,”1”:4,”2”:5,”3”:6,”4”:7,”5”:8,”6”:9,”7”:10,”8”:11,”9”:12,”10”:13}ᐳ"}}:::plan
+    RemapKeys169 --> PgSelectSingle30
+    PgSelectSingle16 --> RemapKeys169
+    Object134{{"Object[134∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access132{{"Access[132∈4]<br />ᐸ169.8ᐳ"}}:::plan
+    Access132 & Constant80 & Constant80 & Lambda82 & Constant83 --> Object134
+    Object152{{"Object[152∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access151{{"Access[151∈4]<br />ᐸ169.9ᐳ"}}:::plan
+    Access151 & Constant80 & Constant80 & Lambda82 & Constant83 --> Object152
     PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle30 --> PgClassExpression31
     PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
@@ -117,18 +119,18 @@ graph TD
     PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle30 --> PgClassExpression34
     PgSelectSingle41{{"PgSelectSingle[41∈4]<br />ᐸperson_first_postᐳ"}}:::plan
-    RemapKeys112{{"RemapKeys[112∈4]<br />ᐸ30:{”0”:2,”1”:3,”2”:4,”3”:5,”4”:6,”5”:7}ᐳ"}}:::plan
-    RemapKeys112 --> PgSelectSingle41
+    RemapKeys114{{"RemapKeys[114∈4]<br />ᐸ30:{”0”:2,”1”:3,”2”:4,”3”:5,”4”:6,”5”:7}ᐳ"}}:::plan
+    RemapKeys114 --> PgSelectSingle41
     First69{{"First[69∈4]"}}:::plan
-    Lambda149{{"Lambda[149∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda149 --> First69
+    Lambda153{{"Lambda[153∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda153 --> First69
     PgSelectSingle70{{"PgSelectSingle[70∈4]<br />ᐸperson_friendsᐳ"}}:::plan
     First69 --> PgSelectSingle70
     PgClassExpression71{{"PgClassExpression[71∈4]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle70 --> PgClassExpression71
     First75{{"First[75∈4]"}}:::plan
-    Lambda132{{"Lambda[132∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda132 --> First75
+    Lambda135{{"Lambda[135∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda135 --> First75
     PgSelectSingle76{{"PgSelectSingle[76∈4]<br />ᐸperson_friendsᐳ"}}:::plan
     First75 --> PgSelectSingle76
     PgCursor77{{"PgCursor[77∈4]"}}:::plan
@@ -137,11 +139,11 @@ graph TD
     PgClassExpression78{{"PgClassExpression[78∈4]<br />ᐸrow_number...tion by 1)ᐳ"}}:::plan
     PgSelectSingle76 --> PgClassExpression78
     PgClassExpression78 --> List79
-    PgSelectSingle30 --> RemapKeys112
-    RemapKeys164 --> Access129
-    Object131 --> Lambda132
-    RemapKeys164 --> Access147
-    Object148 --> Lambda149
+    PgSelectSingle30 --> RemapKeys114
+    RemapKeys169 --> Access132
+    Object134 --> Lambda135
+    RemapKeys169 --> Access151
+    Object152 --> Lambda153
     PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__person_f...ost__.”id”ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression42
     PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__person_f...”headline”ᐳ"}}:::plan
@@ -149,17 +151,17 @@ graph TD
     PgClassExpression45{{"PgClassExpression[45∈5]<br />ᐸ”a”.”post_...st_post__)ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression45
     PgSelectSingle52{{"PgSelectSingle[52∈5]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys96{{"RemapKeys[96∈5]<br />ᐸ41:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
-    RemapKeys96 --> PgSelectSingle52
-    PgSelectSingle41 --> RemapKeys96
+    RemapKeys97{{"RemapKeys[97∈5]<br />ᐸ41:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
+    RemapKeys97 --> PgSelectSingle52
+    PgSelectSingle41 --> RemapKeys97
     PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle52 --> PgClassExpression53
     PgClassExpression54{{"PgClassExpression[54∈6]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle52 --> PgClassExpression54
     PgClassExpression56{{"PgClassExpression[56∈6]<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle52 --> PgClassExpression56
-    __Item62[/"__Item[62∈7]<br />ᐸ132ᐳ"\]:::itemplan
-    Lambda132 ==> __Item62
+    __Item62[/"__Item[62∈7]<br />ᐸ135ᐳ"\]:::itemplan
+    Lambda135 ==> __Item62
     PgSelectSingle63{{"PgSelectSingle[63∈7]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item62 --> PgSelectSingle63
     PgClassExpression64{{"PgClassExpression[64∈8]<br />ᐸ__person_friends__.”id”ᐳ"}}:::plan
@@ -174,26 +176,26 @@ graph TD
     subgraph "Buckets for queries/v4/posts"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Connection60,Constant80,Lambda82,Constant83,Constant86,Constant87,Constant88,Constant102,Constant103,Constant104,Constant118,Constant119,Constant137,Constant154,Constant155,Constant170,Constant171,Constant180,Constant181,Constant182,Constant183,Constant184,Constant185,Constant186,Constant187 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 82, 60, 181, 86, 87, 88, 182, 102, 103, 104, 183, 118, 119, 184, 137, 185, 154, 155, 186, 170, 171, 187, 80, 83<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 73, 85, 89, 95, 105, 111, 121, 127, 140, 146, 157, 163, 173, 179, 12, 90, 106, 122, 141, 158, 174<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection60,PgPageInfo73,Constant80,Lambda82,Constant83,Lambda85,Access86,Constant87,Constant88,Constant89,Object90,Lambda91,Lambda96,Constant104,Constant105,Constant106,Object107,Lambda108,Lambda113,Constant121,Constant122,Object124,Lambda125,Lambda130,Constant141,Object144,Lambda145,Lambda150,Constant159,Constant160,Object162,Lambda163,Lambda168,Constant176,Constant177,Object179,Lambda180,Lambda185,Constant186,Constant187,Constant188,Constant189,Constant190,Constant191,Constant192,Constant193 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 86, 91, 96, 108, 113, 125, 130, 145, 150, 163, 168, 82, 180, 185, 80, 83, 60, 73<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,PgPageInfo73,Lambda85,Object89,Lambda90,Lambda95,Object105,Lambda106,Lambda111,Object121,Lambda122,Lambda127,Object140,Lambda141,Lambda146,Object157,Lambda158,Lambda163,Object173,Lambda174,Lambda179 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 80, 82, 83, 60, 73<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 80, 82, 83, 60, 73<br /><br />ROOT PgSelectSingle{2}ᐸpostᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression21,PgClassExpression23,PgSelectSingle30,RemapKeys164 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 30, 164, 80, 82, 83, 60, 73<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[30]"):::bucket
+    class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression21,PgClassExpression23,PgSelectSingle30,RemapKeys169 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 30, 169, 80, 82, 83, 60, 73<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[30]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression31,PgClassExpression32,PgClassExpression34,PgSelectSingle41,First69,PgSelectSingle70,PgClassExpression71,First75,PgSelectSingle76,PgCursor77,PgClassExpression78,List79,RemapKeys112,Access129,Object131,Lambda132,Access147,Object148,Lambda149 bucket4
+    class Bucket4,PgClassExpression31,PgClassExpression32,PgClassExpression34,PgSelectSingle41,First69,PgSelectSingle70,PgClassExpression71,First75,PgSelectSingle76,PgCursor77,PgClassExpression78,List79,RemapKeys114,Access132,Object134,Lambda135,Access151,Object152,Lambda153 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 41<br /><br />ROOT PgSelectSingle{4}ᐸperson_first_postᐳ[41]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression42,PgClassExpression43,PgClassExpression45,PgSelectSingle52,RemapKeys96 bucket5
+    class Bucket5,PgClassExpression42,PgClassExpression43,PgClassExpression45,PgSelectSingle52,RemapKeys97 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 52<br /><br />ROOT PgSelectSingle{5}ᐸpersonᐳ[52]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression53,PgClassExpression54,PgClassExpression56 bucket6
-    Bucket7("Bucket 7 (listItem)<br /><br />ROOT __Item{7}ᐸ132ᐳ[62]"):::bucket
+    Bucket7("Bucket 7 (listItem)<br /><br />ROOT __Item{7}ᐸ135ᐳ[62]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item62,PgSelectSingle63 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 63<br /><br />ROOT PgSelectSingle{7}ᐸperson_friendsᐳ[63]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.mermaid
@@ -11,31 +11,31 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpostᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
-    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda44{{"Lambda[44∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
+    Access35{{"Access[35∈0] ➊<br />ᐸ34.0ᐳ"}}:::plan
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda31{{"Lambda[31∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant80 & Constant81 & Lambda34 & Lambda39 & Lambda44 & Lambda34 & Lambda58 & Lambda63 & Lambda31 & Lambda34 & Lambda74 & Lambda79 --> PgSelect7
-    Object38{{"Object[38∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant36{{"Constant[36∈0] ➊<br />ᐸsql.identifier(”post_computed_compound_type_array”)ᐳ"}}:::plan
-    Constant37{{"Constant[37∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda31 & Constant35 & Constant36 & Constant37 --> Object38
-    Object57{{"Object[57∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant55{{"Constant[55∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda31 & Constant54 & Constant55 & Constant56 --> Object57
-    Object73{{"Object[73∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant71{{"Constant[71∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda31 & Constant70 & Constant71 & Constant56 --> Object73
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant83 & Constant84 & Access35 & Lambda40 & Lambda45 & Access35 & Lambda60 & Lambda65 & Lambda31 & Access35 & Lambda77 & Lambda82 --> PgSelect7
+    Object39{{"Object[39∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant37{{"Constant[37∈0] ➊<br />ᐸsql.identifier(”post_computed_compound_type_array”)ᐳ"}}:::plan
+    Constant38{{"Constant[38∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda31 & Constant36 & Constant37 & Constant38 --> Object39
+    Object59{{"Object[59∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant56{{"Constant[56∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda31 & Constant56 & Constant57 & Constant58 --> Object59
+    Object76{{"Object[76∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant73{{"Constant[73∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant74{{"Constant[74∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda31 & Constant73 & Constant74 & Constant58 --> Object76
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -46,47 +46,49 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸpostᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant82 --> Lambda31
-    Constant83{{"Constant[83∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant83 --> Lambda34
-    Object38 --> Lambda39
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant84 --> Lambda44
-    Object57 --> Lambda58
-    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant85 --> Lambda63
-    Object73 --> Lambda74
-    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant86 --> Lambda79
+    Constant85{{"Constant[85∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant85 --> Lambda31
+    Lambda34{{"Lambda[34∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant86 --> Lambda34
+    Lambda34 --> Access35
+    Object39 --> Lambda40
+    Constant87{{"Constant[87∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant87 --> Lambda45
+    Object59 --> Lambda60
+    Constant88{{"Constant[88∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant88 --> Lambda65
+    Object76 --> Lambda77
+    Constant89{{"Constant[89∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant89 --> Lambda82
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant32{{"Constant[32∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Object48{{"Object[48∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access46{{"Access[46∈1] ➊<br />ᐸ64.0ᐳ"}}:::plan
-    Access46 & Constant29 & Constant29 & Lambda31 & Constant32 --> Object48
+    Object49{{"Object[49∈1] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access47{{"Access[47∈1] ➊<br />ᐸ66.0ᐳ"}}:::plan
+    Access47 & Constant29 & Constant29 & Lambda31 & Constant32 --> Object49
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
-    RemapKeys64{{"RemapKeys[64∈1] ➊<br />ᐸ12:{”0”:1}ᐳ"}}:::plan
-    RemapKeys64 --> Access46
-    Lambda49{{"Lambda[49∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object48 --> Lambda49
-    PgSelectSingle12 --> RemapKeys64
-    __Item27[/"__Item[27∈2]<br />ᐸ49ᐳ"\]:::itemplan
-    Lambda49 ==> __Item27
+    RemapKeys66{{"RemapKeys[66∈1] ➊<br />ᐸ12:{”0”:1}ᐳ"}}:::plan
+    RemapKeys66 --> Access47
+    Lambda50{{"Lambda[50∈1] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object49 --> Lambda50
+    PgSelectSingle12 --> RemapKeys66
+    __Item27[/"__Item[27∈2]<br />ᐸ50ᐳ"\]:::itemplan
+    Lambda50 ==> __Item27
     PgSelectSingle28{{"PgSelectSingle[28∈2]<br />ᐸpost_computed_compound_type_arrayᐳ"}}:::plan
     __Item27 --> PgSelectSingle28
 
     %% define steps
 
     subgraph "Buckets for queries/v4/procedure-computed-fields-cut-down-for-export"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 32, 35, 36, 37, 54, 55, 56, 70, 71, 80, 81, 82, 83, 84, 85, 86, 10, 31, 34, 38, 39, 44, 57, 58, 63, 73, 74, 79<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 29, 32, 36, 37, 38, 56, 57, 58, 73, 74, 83, 84, 85, 86, 87, 88, 89, 10, 31, 34, 35, 39, 40, 45, 59, 60, 65, 76, 77, 82<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant29,Lambda31,Constant32,Lambda34,Constant35,Constant36,Constant37,Object38,Lambda39,Lambda44,Constant54,Constant55,Constant56,Object57,Lambda58,Lambda63,Constant70,Constant71,Object73,Lambda74,Lambda79,Constant80,Constant81,Constant82,Constant83,Constant84,Constant85,Constant86 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant29,Lambda31,Constant32,Lambda34,Access35,Constant36,Constant37,Constant38,Object39,Lambda40,Lambda45,Constant56,Constant57,Constant58,Object59,Lambda60,Lambda65,Constant73,Constant74,Object76,Lambda77,Lambda82,Constant83,Constant84,Constant85,Constant86,Constant87,Constant88,Constant89 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 29, 31, 32<br /><br />ROOT PgSelectSingleᐸpostᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression13,Access46,Object48,Lambda49,RemapKeys64 bucket1
-    Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ49ᐳ[27]"):::bucket
+    class Bucket1,PgClassExpression13,Access47,Object49,Lambda50,RemapKeys66 bucket1
+    Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ50ᐳ[27]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item27,PgSelectSingle28 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{2}ᐸpost_computed_compound_type_arrayᐳ[28]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
@@ -11,168 +11,231 @@ graph TD
     %% plan dependencies
     PgSelect251[["PgSelect[251∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant599{{"Constant[599∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant600{{"Constant[600∈0] ➊<br />ᐸ7ᐳ"}}:::plan
-    Constant598{{"Constant[598∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Constant618{{"Constant[618∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant619{{"Constant[619∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    Constant617{{"Constant[617∈0] ➊<br />ᐸ8ᐳ"}}:::plan
     Constant113{{"Constant[113∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Lambda283{{"Lambda[283∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda286{{"Lambda[286∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda581{{"Lambda[581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda586{{"Lambda[586∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant599 & Constant599 & Constant600 & Constant599 & Constant598 & Constant600 & Constant599 & Constant600 & Constant599 & Constant600 & Constant599 & Constant113 & Constant600 & Constant599 & Constant600 & Lambda283 & Lambda286 & Lambda581 & Lambda586 --> PgSelect251
-    Object580{{"Object[580∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant577{{"Constant[577∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant578{{"Constant[578∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant497{{"Constant[497∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda283 & Constant577 & Constant578 & Constant497 --> Object580
+    Access287{{"Access[287∈0] ➊<br />ᐸ286.0ᐳ"}}:::plan
+    Lambda600{{"Lambda[600∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda605{{"Lambda[605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant618 & Constant618 & Constant619 & Constant618 & Constant617 & Constant619 & Constant618 & Constant619 & Constant618 & Constant619 & Constant618 & Constant113 & Constant619 & Constant618 & Constant619 & Lambda283 & Access287 & Lambda600 & Lambda605 --> PgSelect251
+    Object291{{"Object[291∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant288{{"Constant[288∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant289{{"Constant[289∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda283 & Constant288 & Constant289 & Constant290 --> Object291
+    Object308{{"Object[308∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant305{{"Constant[305∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant306{{"Constant[306∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda283 & Constant305 & Constant306 & Constant290 --> Object308
+    Object325{{"Object[325∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant322{{"Constant[322∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant323{{"Constant[323∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda283 & Constant322 & Constant323 & Constant290 --> Object325
+    Object342{{"Object[342∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant339{{"Constant[339∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant340{{"Constant[340∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Constant341{{"Constant[341∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
+    Lambda283 & Constant339 & Constant340 & Constant341 --> Object342
+    Object359{{"Object[359∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant356{{"Constant[356∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant357{{"Constant[357∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda283 & Constant356 & Constant357 & Constant290 --> Object359
+    Object376{{"Object[376∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant373{{"Constant[373∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant374{{"Constant[374∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda283 & Constant373 & Constant374 & Constant290 --> Object376
+    Object393{{"Object[393∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda283 & Constant390 & Constant391 & Constant290 --> Object393
+    Object410{{"Object[410∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant408{{"Constant[408∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda283 & Constant407 & Constant408 & Constant341 --> Object410
+    Object427{{"Object[427∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant424{{"Constant[424∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant425{{"Constant[425∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant426{{"Constant[426∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda283 & Constant424 & Constant425 & Constant426 --> Object427
+    Object442{{"Object[442∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant439{{"Constant[439∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant440{{"Constant[440∈0] ➊<br />ᐸsql.identifier(”post_computed_compound_type_array”)ᐳ"}}:::plan
+    Lambda283 & Constant439 & Constant440 & Constant290 --> Object442
+    Object462{{"Object[462∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant459{{"Constant[459∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant460{{"Constant[460∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant461{{"Constant[461∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda283 & Constant459 & Constant460 & Constant461 --> Object462
+    Object479{{"Object[479∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant476{{"Constant[476∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Constant478{{"Constant[478∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
+    Lambda283 & Constant476 & Constant477 & Constant478 --> Object479
+    Object497{{"Object[497∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant495{{"Constant[495∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda283 & Constant494 & Constant495 & Constant461 --> Object497
+    Object512{{"Object[512∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda505{{"Lambda[505∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant509{{"Constant[509∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant510{{"Constant[510∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Constant511{{"Constant[511∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda505 & Constant509 & Constant510 & Constant511 --> Object512
+    Object532{{"Object[532∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant529{{"Constant[529∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant530{{"Constant[530∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Lambda283 & Constant529 & Constant530 & Constant511 --> Object532
+    Object552{{"Object[552∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant549{{"Constant[549∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant550{{"Constant[550∈0] ➊<br />ᐸsql.identifier(”person_first_post”)ᐳ"}}:::plan
+    Lambda283 & Constant549 & Constant550 & Constant461 --> Object552
+    Object569{{"Object[569∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant566{{"Constant[566∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant567{{"Constant[567∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda283 & Constant566 & Constant567 & Constant511 --> Object569
+    Object584{{"Object[584∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant581{{"Constant[581∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant582{{"Constant[582∈0] ➊<br />ᐸsql.identifier(”edge_case”)ᐳ"}}:::plan
+    Constant583{{"Constant[583∈0] ➊<br />ᐸRecordCodec(edgeCase)ᐳ"}}:::plan
+    Lambda283 & Constant581 & Constant582 & Constant583 --> Object584
+    Object599{{"Object[599∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant596{{"Constant[596∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant597{{"Constant[597∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda283 & Constant596 & Constant597 & Constant511 --> Object599
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
+    Connection224{{"Connection[224∈0] ➊<br />ᐸ220ᐳ"}}:::plan
+    Constant618 --> Connection224
     First253{{"First[253∈0] ➊"}}:::plan
     PgSelect251 --> First253
     PgSelectSingle254{{"PgSelectSingle[254∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First253 --> PgSelectSingle254
-    Constant590{{"Constant[590∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant590 --> Lambda283
-    Constant591{{"Constant[591∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant591 --> Lambda286
-    Lambda492{{"Lambda[492∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant621{{"Constant[621∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant621 --> Lambda492
-    Object580 --> Lambda581
-    Constant619{{"Constant[619∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant619 --> Lambda586
+    Constant609{{"Constant[609∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant609 --> Lambda283
+    Lambda286{{"Lambda[286∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant610{{"Constant[610∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant610 --> Lambda286
+    Lambda286 --> Access287
+    Lambda292{{"Lambda[292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object291 --> Lambda292
+    Lambda297{{"Lambda[297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant620{{"Constant[620∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant620 --> Lambda297
+    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object308 --> Lambda309
+    Lambda314{{"Lambda[314∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant621{{"Constant[621∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant621 --> Lambda314
+    Lambda326{{"Lambda[326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object325 --> Lambda326
+    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant622{{"Constant[622∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant622 --> Lambda331
+    Lambda343{{"Lambda[343∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object342 --> Lambda343
+    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant623 --> Lambda348
+    Lambda360{{"Lambda[360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object359 --> Lambda360
+    Lambda365{{"Lambda[365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant624 --> Lambda365
+    Lambda377{{"Lambda[377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object376 --> Lambda377
+    Lambda382{{"Lambda[382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant625{{"Constant[625∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant625 --> Lambda382
+    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object393 --> Lambda394
+    Lambda399{{"Lambda[399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant626{{"Constant[626∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant626 --> Lambda399
+    Lambda411{{"Lambda[411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object410 --> Lambda411
+    Lambda416{{"Lambda[416∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant627{{"Constant[627∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant627 --> Lambda416
+    Lambda428{{"Lambda[428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object427 --> Lambda428
+    Lambda433{{"Lambda[433∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant628{{"Constant[628∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant628 --> Lambda433
+    Lambda443{{"Lambda[443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object442 --> Lambda443
+    Lambda448{{"Lambda[448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant629{{"Constant[629∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant629 --> Lambda448
+    Lambda463{{"Lambda[463∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object462 --> Lambda463
+    Lambda468{{"Lambda[468∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant630{{"Constant[630∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant630 --> Lambda468
+    Lambda480{{"Lambda[480∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object479 --> Lambda480
+    Lambda485{{"Lambda[485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant631{{"Constant[631∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant631 --> Lambda485
+    Lambda498{{"Lambda[498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object497 --> Lambda498
+    Lambda503{{"Lambda[503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant632{{"Constant[632∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant632 --> Lambda503
+    Constant640{{"Constant[640∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant640 --> Lambda505
+    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant641{{"Constant[641∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant641 --> Lambda507
+    Access508{{"Access[508∈0] ➊<br />ᐸ507.0ᐳ"}}:::plan
+    Lambda507 --> Access508
+    Lambda513{{"Lambda[513∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object512 --> Lambda513
+    Lambda518{{"Lambda[518∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant633{{"Constant[633∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant633 --> Lambda518
+    Lambda533{{"Lambda[533∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object532 --> Lambda533
+    Lambda538{{"Lambda[538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant634{{"Constant[634∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant634 --> Lambda538
+    Lambda553{{"Lambda[553∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object552 --> Lambda553
+    Lambda558{{"Lambda[558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant635{{"Constant[635∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant635 --> Lambda558
+    Lambda570{{"Lambda[570∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object569 --> Lambda570
+    Lambda575{{"Lambda[575∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant636{{"Constant[636∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant636 --> Lambda575
+    Lambda585{{"Lambda[585∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object584 --> Lambda585
+    Lambda590{{"Lambda[590∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant637{{"Constant[637∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”edge_cᐳ"}}:::plan
+    Constant637 --> Lambda590
+    Object599 --> Lambda600
+    Constant638{{"Constant[638∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant638 --> Lambda605
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection89{{"Connection[89∈0] ➊<br />ᐸ87ᐳ"}}:::plan
     Connection169{{"Connection[169∈0] ➊<br />ᐸ167ᐳ"}}:::plan
     Connection199{{"Connection[199∈0] ➊<br />ᐸ197ᐳ"}}:::plan
+    Connection211{{"Connection[211∈0] ➊<br />ᐸ207ᐳ"}}:::plan
     Connection242{{"Connection[242∈0] ➊<br />ᐸ240ᐳ"}}:::plan
     Constant284{{"Constant[284∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant288{{"Constant[288∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant289{{"Constant[289∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Constant303{{"Constant[303∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant319{{"Constant[319∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant320{{"Constant[320∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant335{{"Constant[335∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant336{{"Constant[336∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant337{{"Constant[337∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
-    Constant351{{"Constant[351∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant352{{"Constant[352∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant367{{"Constant[367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant368{{"Constant[368∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant399{{"Constant[399∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant417{{"Constant[417∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Constant429{{"Constant[429∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant430{{"Constant[430∈0] ➊<br />ᐸsql.identifier(”post_computed_compound_type_array”)ᐳ"}}:::plan
-    Constant448{{"Constant[448∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant466{{"Constant[466∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant482{{"Constant[482∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant495{{"Constant[495∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant496{{"Constant[496∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Constant514{{"Constant[514∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant515{{"Constant[515∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Constant533{{"Constant[533∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant534{{"Constant[534∈0] ➊<br />ᐸsql.identifier(”person_first_post”)ᐳ"}}:::plan
-    Constant549{{"Constant[549∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant550{{"Constant[550∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant563{{"Constant[563∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant564{{"Constant[564∈0] ➊<br />ᐸsql.identifier(”edge_case”)ᐳ"}}:::plan
-    Constant565{{"Constant[565∈0] ➊<br />ᐸRecordCodec(edgeCase)ᐳ"}}:::plan
-    Constant587{{"Constant[587∈0] ➊<br />ᐸ15ᐳ"}}:::plan
-    Constant588{{"Constant[588∈0] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant589{{"Constant[589∈0] ➊<br />ᐸ'[...]'ᐳ"}}:::plan
-    Constant601{{"Constant[601∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant602{{"Constant[602∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant603{{"Constant[603∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant604{{"Constant[604∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant605{{"Constant[605∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant606{{"Constant[606∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant607{{"Constant[607∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant608{{"Constant[608∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant609{{"Constant[609∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant610{{"Constant[610∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant611{{"Constant[611∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant612{{"Constant[612∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant613{{"Constant[613∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant614{{"Constant[614∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant615{{"Constant[615∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant616{{"Constant[616∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant617{{"Constant[617∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant618{{"Constant[618∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”edge_cᐳ"}}:::plan
-    Constant622{{"Constant[622∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant623{{"Constant[623∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
+    Constant606{{"Constant[606∈0] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant607{{"Constant[607∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    Constant608{{"Constant[608∈0] ➊<br />ᐸ'[...]'ᐳ"}}:::plan
+    Constant642{{"Constant[642∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸtypesᐳ"]]:::plan
-    Lambda291{{"Lambda[291∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda296{{"Lambda[296∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda307{{"Lambda[307∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda312{{"Lambda[312∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda323{{"Lambda[323∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda328{{"Lambda[328∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda339{{"Lambda[339∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda344{{"Lambda[344∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda355{{"Lambda[355∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda360{{"Lambda[360∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda371{{"Lambda[371∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda376{{"Lambda[376∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda387{{"Lambda[387∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda392{{"Lambda[392∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda403{{"Lambda[403∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda408{{"Lambda[408∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda419{{"Lambda[419∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda424{{"Lambda[424∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda286 & Lambda291 & Lambda296 & Lambda307 & Lambda312 & Lambda323 & Lambda328 & Lambda286 & Lambda339 & Lambda344 & Lambda286 & Lambda355 & Lambda360 & Lambda371 & Lambda376 & Lambda387 & Lambda392 & Lambda286 & Lambda403 & Lambda408 & Lambda283 & Lambda286 & Lambda419 & Lambda424 --> PgSelect14
-    Object290{{"Object[290∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant287 & Constant288 & Constant289 --> Object290
-    Object306{{"Object[306∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant303 & Constant304 & Constant289 --> Object306
-    Object322{{"Object[322∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant319 & Constant320 & Constant289 --> Object322
-    Object338{{"Object[338∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant335 & Constant336 & Constant337 --> Object338
-    Object354{{"Object[354∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant351 & Constant352 & Constant289 --> Object354
-    Object370{{"Object[370∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant367 & Constant368 & Constant289 --> Object370
-    Object386{{"Object[386∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant383 & Constant384 & Constant289 --> Object386
-    Object402{{"Object[402∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant399 & Constant400 & Constant337 --> Object402
-    Object418{{"Object[418∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant415 & Constant416 & Constant417 --> Object418
-    Object290 --> Lambda291
-    Constant601 --> Lambda296
-    Object306 --> Lambda307
-    Constant602 --> Lambda312
-    Object322 --> Lambda323
-    Constant603 --> Lambda328
-    Object338 --> Lambda339
-    Constant604 --> Lambda344
-    Object354 --> Lambda355
-    Constant605 --> Lambda360
-    Object370 --> Lambda371
-    Constant606 --> Lambda376
-    Object386 --> Lambda387
-    Constant607 --> Lambda392
-    Object402 --> Lambda403
-    Constant608 --> Lambda408
-    Object418 --> Lambda419
-    Constant609 --> Lambda424
+    Object12 & Connection13 & Access287 & Lambda292 & Lambda297 & Lambda309 & Lambda314 & Lambda326 & Lambda331 & Access287 & Lambda343 & Lambda348 & Access287 & Lambda360 & Lambda365 & Lambda377 & Lambda382 & Lambda394 & Lambda399 & Access287 & Lambda411 & Lambda416 & Lambda283 & Access287 & Lambda428 & Lambda433 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸtypesᐳ"}}:::plan
@@ -186,23 +249,23 @@ graph TD
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ”c”.”compo...nd_type__)ᐳ"}}:::plan
     PgSelectSingle23 --> PgClassExpression27
     PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys345{{"RemapKeys[345∈3]<br />ᐸ16:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9,”6”:10,”7”:11,”8”:12}ᐳ"}}:::plan
-    RemapKeys345 --> PgSelectSingle32
+    RemapKeys349{{"RemapKeys[349∈3]<br />ᐸ16:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9,”6”:10,”7”:11,”8”:12}ᐳ"}}:::plan
+    RemapKeys349 --> PgSelectSingle32
     PgSelectSingle37{{"PgSelectSingle[37∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle32 --> PgSelectSingle37
     PgSelectSingle46{{"PgSelectSingle[46∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys329{{"RemapKeys[329∈3]<br />ᐸ32:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
-    RemapKeys329 --> PgSelectSingle46
+    RemapKeys332{{"RemapKeys[332∈3]<br />ᐸ32:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
+    RemapKeys332 --> PgSelectSingle46
     PgSelectSingle55{{"PgSelectSingle[55∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys361{{"RemapKeys[361∈3]<br />ᐸ16:{”0”:13,”1”:14,”2”:15,”3”:16}ᐳ"}}:::plan
-    RemapKeys361 --> PgSelectSingle55
+    RemapKeys366{{"RemapKeys[366∈3]<br />ᐸ16:{”0”:13,”1”:14,”2”:15,”3”:16}ᐳ"}}:::plan
+    RemapKeys366 --> PgSelectSingle55
     PgSelectSingle64{{"PgSelectSingle[64∈3]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys409{{"RemapKeys[409∈3]<br />ᐸ16:{”0”:17,”1”:18,”2”:19,”3”:20,”4”:21,”5”:22,”6”:23,”7”:24,”8”:25}ᐳ"}}:::plan
-    RemapKeys409 --> PgSelectSingle64
-    PgSelectSingle32 --> RemapKeys329
-    PgSelectSingle16 --> RemapKeys345
-    PgSelectSingle16 --> RemapKeys361
-    PgSelectSingle16 --> RemapKeys409
+    RemapKeys417{{"RemapKeys[417∈3]<br />ᐸ16:{”0”:17,”1”:18,”2”:19,”3”:20,”4”:21,”5”:22,”6”:23,”7”:24,”8”:25}ᐳ"}}:::plan
+    RemapKeys417 --> PgSelectSingle64
+    PgSelectSingle32 --> RemapKeys332
+    PgSelectSingle16 --> RemapKeys349
+    PgSelectSingle16 --> RemapKeys366
+    PgSelectSingle16 --> RemapKeys417
     PgClassExpression38{{"PgClassExpression[38∈4]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle37 --> PgClassExpression38
     PgClassExpression39{{"PgClassExpression[39∈4]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -224,9 +287,9 @@ graph TD
     PgSelectSingle71{{"PgSelectSingle[71∈7]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle64 --> PgSelectSingle71
     PgSelectSingle80{{"PgSelectSingle[80∈7]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys393{{"RemapKeys[393∈7]<br />ᐸ64:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
-    RemapKeys393 --> PgSelectSingle80
-    PgSelectSingle64 --> RemapKeys393
+    RemapKeys400{{"RemapKeys[400∈7]<br />ᐸ64:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
+    RemapKeys400 --> PgSelectSingle80
+    PgSelectSingle64 --> RemapKeys400
     PgClassExpression72{{"PgClassExpression[72∈8]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle71 --> PgClassExpression72
     PgClassExpression73{{"PgClassExpression[73∈8]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -240,41 +303,17 @@ graph TD
     PgClassExpression84{{"PgClassExpression[84∈9]<br />ᐸ”c”.”compo...nd_type__)ᐳ"}}:::plan
     PgSelectSingle80 --> PgClassExpression84
     PgSelect90[["PgSelect[90∈10] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda433{{"Lambda[433∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda438{{"Lambda[438∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda452{{"Lambda[452∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda457{{"Lambda[457∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda468{{"Lambda[468∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda473{{"Lambda[473∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda485{{"Lambda[485∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda490{{"Lambda[490∈10] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection89 & Constant587 & Constant588 & Constant589 & Constant587 & Constant588 & Constant589 & Constant587 & Constant113 & Constant588 & Constant589 & Constant623 & Lambda286 & Lambda433 & Lambda438 & Lambda286 & Lambda452 & Lambda457 & Lambda286 & Lambda468 & Lambda473 & Lambda283 & Lambda286 & Lambda485 & Lambda490 --> PgSelect90
-    Object432{{"Object[432∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant429 & Constant430 & Constant289 --> Object432
-    Object451{{"Object[451∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant448 & Constant449 & Constant450 --> Object451
-    Object467{{"Object[467∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant464 & Constant465 & Constant466 --> Object467
-    Object484{{"Object[484∈10] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant481 & Constant482 & Constant450 --> Object484
-    Object432 --> Lambda433
-    Constant610 --> Lambda438
-    Object451 --> Lambda452
-    Constant611 --> Lambda457
-    Object467 --> Lambda468
-    Constant612 --> Lambda473
-    Object484 --> Lambda485
-    Constant613 --> Lambda490
+    Object12 & Connection89 & Constant606 & Constant607 & Constant608 & Constant606 & Constant607 & Constant608 & Constant606 & Constant113 & Constant607 & Constant608 & Constant642 & Access287 & Lambda443 & Lambda448 & Access287 & Lambda463 & Lambda468 & Access287 & Lambda480 & Lambda485 & Lambda283 & Access287 & Lambda498 & Lambda503 --> PgSelect90
     __Item91[/"__Item[91∈11]<br />ᐸ90ᐳ"\]:::itemplan
     PgSelect90 ==> __Item91
     PgSelectSingle92{{"PgSelectSingle[92∈11]<br />ᐸpostᐳ"}}:::plan
     __Item91 --> PgSelectSingle92
-    Object442{{"Object[442∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access440{{"Access[440∈12]<br />ᐸ458.0ᐳ"}}:::plan
-    Access440 & Constant113 & Constant113 & Lambda283 & Constant284 --> Object442
-    Object475{{"Object[475∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access474{{"Access[474∈12]<br />ᐸ91.2ᐳ"}}:::plan
-    Access474 & Constant113 & Constant113 & Lambda283 & Constant284 --> Object475
+    Object452{{"Object[452∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access450{{"Access[450∈12]<br />ᐸ469.0ᐳ"}}:::plan
+    Access450 & Constant113 & Constant113 & Lambda283 & Constant284 --> Object452
+    Object487{{"Object[487∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access486{{"Access[486∈12]<br />ᐸ91.2ᐳ"}}:::plan
+    Access486 & Constant113 & Constant113 & Lambda283 & Constant284 --> Object487
     PgClassExpression93{{"PgClassExpression[93∈12]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle92 --> PgClassExpression93
     PgClassExpression95{{"PgClassExpression[95∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
@@ -298,17 +337,17 @@ graph TD
     PgClassExpression158{{"PgClassExpression[158∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle92 --> PgClassExpression158
     __ListTransform181[["__ListTransform[181∈12]<br />ᐸeach:180ᐳ"]]:::plan
-    Lambda476{{"Lambda[476∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda476 --> __ListTransform181
-    RemapKeys458{{"RemapKeys[458∈12]<br />ᐸ92:{”0”:1}ᐳ"}}:::plan
-    RemapKeys458 --> Access440
-    Lambda443{{"Lambda[443∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object442 --> Lambda443
-    PgSelectSingle92 --> RemapKeys458
-    __Item91 --> Access474
-    Object475 --> Lambda476
-    __Item141[/"__Item[141∈13]<br />ᐸ443ᐳ"\]:::itemplan
-    Lambda443 ==> __Item141
+    Lambda488{{"Lambda[488∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda488 --> __ListTransform181
+    RemapKeys469{{"RemapKeys[469∈12]<br />ᐸ92:{”0”:1}ᐳ"}}:::plan
+    RemapKeys469 --> Access450
+    Lambda453{{"Lambda[453∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object452 --> Lambda453
+    PgSelectSingle92 --> RemapKeys469
+    __Item91 --> Access486
+    Object487 --> Lambda488
+    __Item141[/"__Item[141∈13]<br />ᐸ453ᐳ"\]:::itemplan
+    Lambda453 ==> __Item141
     PgSelectSingle142{{"PgSelectSingle[142∈13]<br />ᐸpost_computed_compound_type_arrayᐳ"}}:::plan
     __Item141 --> PgSelectSingle142
     PgClassExpression143{{"PgClassExpression[143∈14]<br />ᐸ__post_com...rray__.”a”ᐳ"}}:::plan
@@ -331,14 +370,14 @@ graph TD
     PgClassExpression155 ==> __Item156
     __Item159[/"__Item[159∈17]<br />ᐸ158ᐳ"\]:::itemplan
     PgClassExpression158 ==> __Item159
-    __Item171[/"__Item[171∈19]<br />ᐸ476ᐳ"\]:::itemplan
-    Lambda476 ==> __Item171
+    __Item171[/"__Item[171∈19]<br />ᐸ488ᐳ"\]:::itemplan
+    Lambda488 ==> __Item171
     PgSelectSingle172{{"PgSelectSingle[172∈19]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item171 --> PgSelectSingle172
     PgClassExpression173{{"PgClassExpression[173∈19]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle172 --> PgClassExpression173
-    __Item182[/"__Item[182∈21]<br />ᐸ476ᐳ"\]:::itemplan
-    Lambda476 -.-> __Item182
+    __Item182[/"__Item[182∈21]<br />ᐸ488ᐳ"\]:::itemplan
+    Lambda488 -.-> __Item182
     PgSelectSingle183{{"PgSelectSingle[183∈21]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item182 --> PgSelectSingle183
     PgClassExpression184{{"PgClassExpression[184∈21]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
@@ -358,70 +397,41 @@ graph TD
     PgSelectSingle186 --> PgClassExpression190
     PgClassExpression190 --> List191
     PgSelect200[["PgSelect[200∈25] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda494{{"Lambda[494∈25] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda499{{"Lambda[499∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda504{{"Lambda[504∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda518{{"Lambda[518∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda523{{"Lambda[523∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda537{{"Lambda[537∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda542{{"Lambda[542∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda553{{"Lambda[553∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda558{{"Lambda[558∈25] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection199 & Lambda494 & Lambda499 & Lambda504 & Lambda286 & Lambda518 & Lambda523 & Lambda286 & Lambda537 & Lambda542 & Lambda283 & Lambda286 & Lambda553 & Lambda558 --> PgSelect200
-    Object498{{"Object[498∈25] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda492 & Constant495 & Constant496 & Constant497 --> Object498
-    Object517{{"Object[517∈25] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant514 & Constant515 & Constant497 --> Object517
-    Object536{{"Object[536∈25] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant533 & Constant534 & Constant450 --> Object536
-    Object552{{"Object[552∈25] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant549 & Constant550 & Constant497 --> Object552
-    Connection224{{"Connection[224∈25] ➊<br />ᐸ220ᐳ"}}:::plan
-    Constant599 --> Connection224
-    Constant622 --> Lambda494
-    Object498 --> Lambda499
-    Constant614 --> Lambda504
-    Object517 --> Lambda518
-    Constant615 --> Lambda523
-    Object536 --> Lambda537
-    Constant616 --> Lambda542
-    Object552 --> Lambda553
-    Constant617 --> Lambda558
-    Connection211{{"Connection[211∈25] ➊<br />ᐸ207ᐳ"}}:::plan
+    Object12 & Connection199 & Access508 & Lambda513 & Lambda518 & Access287 & Lambda533 & Lambda538 & Access287 & Lambda553 & Lambda558 & Lambda283 & Access287 & Lambda570 & Lambda575 --> PgSelect200
     __Item201[/"__Item[201∈26]<br />ᐸ200ᐳ"\]:::itemplan
     PgSelect200 ==> __Item201
     PgSelectSingle202{{"PgSelectSingle[202∈26]<br />ᐸpersonᐳ"}}:::plan
     __Item201 --> PgSelectSingle202
-    Object527{{"Object[527∈27]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access525{{"Access[525∈27]<br />ᐸ201.1ᐳ"}}:::plan
-    Access525 & Constant113 & Constant113 & Lambda283 & Constant284 --> Object527
+    Object542{{"Object[542∈27]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access540{{"Access[540∈27]<br />ᐸ201.1ᐳ"}}:::plan
+    Access540 & Constant113 & Constant113 & Lambda283 & Constant284 --> Object542
     PgClassExpression203{{"PgClassExpression[203∈27]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle202 --> PgClassExpression203
     PgClassExpression205{{"PgClassExpression[205∈27]<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle202 --> PgClassExpression205
     PgSelectSingle235{{"PgSelectSingle[235∈27]<br />ᐸperson_first_postᐳ"}}:::plan
-    RemapKeys543{{"RemapKeys[543∈27]<br />ᐸ202:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys543 --> PgSelectSingle235
-    __Item201 --> Access525
-    Lambda528{{"Lambda[528∈27]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object527 --> Lambda528
-    PgSelectSingle202 --> RemapKeys543
-    __Item213[/"__Item[213∈28]<br />ᐸ528ᐳ"\]:::itemplan
-    Lambda528 ==> __Item213
+    RemapKeys559{{"RemapKeys[559∈27]<br />ᐸ202:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys559 --> PgSelectSingle235
+    __Item201 --> Access540
+    Lambda543{{"Lambda[543∈27]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object542 --> Lambda543
+    PgSelectSingle202 --> RemapKeys559
+    __Item213[/"__Item[213∈28]<br />ᐸ543ᐳ"\]:::itemplan
+    Lambda543 ==> __Item213
     PgSelectSingle214{{"PgSelectSingle[214∈28]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item213 --> PgSelectSingle214
-    Object508{{"Object[508∈29]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access506{{"Access[506∈29]<br />ᐸ213.1ᐳ"}}:::plan
-    Access506 & Constant599 & Constant113 & Lambda492 & Constant284 --> Object508
+    Object522{{"Object[522∈29]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access520{{"Access[520∈29]<br />ᐸ213.1ᐳ"}}:::plan
+    Access520 & Constant618 & Constant113 & Lambda505 & Constant284 --> Object522
     PgClassExpression215{{"PgClassExpression[215∈29]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
     PgSelectSingle214 --> PgClassExpression215
     PgClassExpression217{{"PgClassExpression[217∈29]<br />ᐸ”c”.”perso...friends__)ᐳ"}}:::plan
     PgSelectSingle214 --> PgClassExpression217
-    __Item213 --> Access506
-    Lambda509{{"Lambda[509∈29]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object508 --> Lambda509
-    __Item226[/"__Item[226∈30]<br />ᐸ509ᐳ"\]:::itemplan
-    Lambda509 ==> __Item226
+    __Item213 --> Access520
+    Lambda523{{"Lambda[523∈29]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object522 --> Lambda523
+    __Item226[/"__Item[226∈30]<br />ᐸ523ᐳ"\]:::itemplan
+    Lambda523 ==> __Item226
     PgSelectSingle227{{"PgSelectSingle[227∈30]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item226 --> PgSelectSingle227
     PgClassExpression228{{"PgClassExpression[228∈31]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
@@ -433,13 +443,7 @@ graph TD
     PgClassExpression237{{"PgClassExpression[237∈32]<br />ᐸ__person_f...”headline”ᐳ"}}:::plan
     PgSelectSingle235 --> PgClassExpression237
     PgSelect243[["PgSelect[243∈33] ➊<br />ᐸedge_caseᐳ"]]:::plan
-    Lambda567{{"Lambda[567∈33] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda572{{"Lambda[572∈33] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection242 & Lambda283 & Lambda286 & Lambda567 & Lambda572 --> PgSelect243
-    Object566{{"Object[566∈33] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda283 & Constant563 & Constant564 & Constant565 --> Object566
-    Object566 --> Lambda567
-    Constant618 --> Lambda572
+    Object12 & Connection242 & Lambda283 & Access287 & Lambda585 & Lambda590 --> PgSelect243
     __Item244[/"__Item[244∈34]<br />ᐸ243ᐳ"\]:::itemplan
     PgSelect243 ==> __Item244
     PgSelectSingle245{{"PgSelectSingle[245∈34]<br />ᐸedge_caseᐳ"}}:::plan
@@ -466,18 +470,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/procedure-computed-fields"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 89, 113, 169, 199, 242, 284, 287, 288, 289, 303, 304, 319, 320, 335, 336, 337, 351, 352, 367, 368, 383, 384, 399, 400, 415, 416, 417, 429, 430, 448, 449, 450, 464, 465, 466, 481, 482, 495, 496, 497, 514, 515, 533, 534, 549, 550, 563, 564, 565, 577, 578, 587, 588, 589, 590, 591, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 621, 622, 623, 12, 283, 286, 492, 580, 581, 586<br />2: PgSelect[251]<br />ᐳ: First[253], PgSelectSingle[254]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 89, 113, 169, 199, 211, 242, 284, 288, 289, 290, 305, 306, 322, 323, 339, 340, 341, 356, 357, 373, 374, 390, 391, 407, 408, 424, 425, 426, 439, 440, 459, 460, 461, 476, 477, 478, 494, 495, 509, 510, 511, 529, 530, 549, 550, 566, 567, 581, 582, 583, 596, 597, 606, 607, 608, 609, 610, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 640, 641, 642, 12, 224, 283, 286, 287, 291, 292, 297, 308, 309, 314, 325, 326, 331, 342, 343, 348, 359, 360, 365, 376, 377, 382, 393, 394, 399, 410, 411, 416, 427, 428, 433, 442, 443, 448, 462, 463, 468, 479, 480, 485, 497, 498, 503, 505, 507, 508, 512, 513, 518, 532, 533, 538, 552, 553, 558, 569, 570, 575, 584, 585, 590, 599, 600, 605<br />2: PgSelect[251]<br />ᐳ: First[253], PgSelectSingle[254]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection89,Constant113,Connection169,Connection199,Connection242,PgSelect251,First253,PgSelectSingle254,Lambda283,Constant284,Lambda286,Constant287,Constant288,Constant289,Constant303,Constant304,Constant319,Constant320,Constant335,Constant336,Constant337,Constant351,Constant352,Constant367,Constant368,Constant383,Constant384,Constant399,Constant400,Constant415,Constant416,Constant417,Constant429,Constant430,Constant448,Constant449,Constant450,Constant464,Constant465,Constant466,Constant481,Constant482,Lambda492,Constant495,Constant496,Constant497,Constant514,Constant515,Constant533,Constant534,Constant549,Constant550,Constant563,Constant564,Constant565,Constant577,Constant578,Object580,Lambda581,Lambda586,Constant587,Constant588,Constant589,Constant590,Constant591,Constant598,Constant599,Constant600,Constant601,Constant602,Constant603,Constant604,Constant605,Constant606,Constant607,Constant608,Constant609,Constant610,Constant611,Constant612,Constant613,Constant614,Constant615,Constant616,Constant617,Constant618,Constant619,Constant621,Constant622,Constant623 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 286, 283, 287, 288, 289, 601, 303, 304, 602, 319, 320, 603, 335, 336, 337, 604, 351, 352, 605, 367, 368, 606, 383, 384, 607, 399, 400, 608, 415, 416, 417, 609<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 290, 296, 306, 312, 322, 328, 338, 344, 354, 360, 370, 376, 386, 392, 402, 408, 418, 424, 291, 307, 323, 339, 355, 371, 387, 403, 419<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection89,Constant113,Connection169,Connection199,Connection211,Connection224,Connection242,PgSelect251,First253,PgSelectSingle254,Lambda283,Constant284,Lambda286,Access287,Constant288,Constant289,Constant290,Object291,Lambda292,Lambda297,Constant305,Constant306,Object308,Lambda309,Lambda314,Constant322,Constant323,Object325,Lambda326,Lambda331,Constant339,Constant340,Constant341,Object342,Lambda343,Lambda348,Constant356,Constant357,Object359,Lambda360,Lambda365,Constant373,Constant374,Object376,Lambda377,Lambda382,Constant390,Constant391,Object393,Lambda394,Lambda399,Constant407,Constant408,Object410,Lambda411,Lambda416,Constant424,Constant425,Constant426,Object427,Lambda428,Lambda433,Constant439,Constant440,Object442,Lambda443,Lambda448,Constant459,Constant460,Constant461,Object462,Lambda463,Lambda468,Constant476,Constant477,Constant478,Object479,Lambda480,Lambda485,Constant494,Constant495,Object497,Lambda498,Lambda503,Lambda505,Lambda507,Access508,Constant509,Constant510,Constant511,Object512,Lambda513,Lambda518,Constant529,Constant530,Object532,Lambda533,Lambda538,Constant549,Constant550,Object552,Lambda553,Lambda558,Constant566,Constant567,Object569,Lambda570,Lambda575,Constant581,Constant582,Constant583,Object584,Lambda585,Lambda590,Constant596,Constant597,Object599,Lambda600,Lambda605,Constant606,Constant607,Constant608,Constant609,Constant610,Constant617,Constant618,Constant619,Constant620,Constant621,Constant622,Constant623,Constant624,Constant625,Constant626,Constant627,Constant628,Constant629,Constant630,Constant631,Constant632,Constant633,Constant634,Constant635,Constant636,Constant637,Constant638,Constant640,Constant641,Constant642 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 287, 292, 297, 309, 314, 326, 331, 343, 348, 360, 365, 377, 382, 394, 399, 411, 416, 283, 428, 433<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object290,Lambda291,Lambda296,Object306,Lambda307,Lambda312,Object322,Lambda323,Lambda328,Object338,Lambda339,Lambda344,Object354,Lambda355,Lambda360,Object370,Lambda371,Lambda376,Object386,Lambda387,Lambda392,Object402,Lambda403,Lambda408,Object418,Lambda419,Lambda424 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸtypesᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgClassExpression27,PgSelectSingle32,PgSelectSingle37,PgSelectSingle46,PgSelectSingle55,PgSelectSingle64,RemapKeys329,RemapKeys345,RemapKeys361,RemapKeys409 bucket3
+    class Bucket3,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgClassExpression27,PgSelectSingle32,PgSelectSingle37,PgSelectSingle46,PgSelectSingle55,PgSelectSingle64,RemapKeys332,RemapKeys349,RemapKeys366,RemapKeys417 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 37<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_compoundTypeᐳ[37]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression38,PgClassExpression39,PgClassExpression41 bucket4
@@ -489,23 +493,23 @@ graph TD
     class Bucket6,PgClassExpression56,PgClassExpression57,PgClassExpression59 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 64<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_nestedCompoundTypeᐳ[64]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelectSingle71,PgSelectSingle80,RemapKeys393 bucket7
+    class Bucket7,PgSelectSingle71,PgSelectSingle80,RemapKeys400 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 71<br /><br />ROOT PgSelectSingle{7}ᐸfrmcdc_compoundTypeᐳ[71]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression72,PgClassExpression73,PgClassExpression75 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 80<br /><br />ROOT PgSelectSingle{7}ᐸfrmcdc_compoundTypeᐳ[80]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression81,PgClassExpression82,PgClassExpression84 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 12, 89, 587, 588, 589, 113, 623, 286, 283, 429, 430, 289, 610, 448, 449, 450, 611, 464, 465, 466, 612, 481, 482, 613, 284, 169<br /><br />ROOT Connectionᐸ87ᐳ[89]<br />1: <br />ᐳ: 432, 438, 451, 457, 467, 473, 484, 490, 433, 452, 468, 485<br />2: PgSelect[90]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 12, 89, 606, 607, 608, 113, 642, 287, 443, 448, 463, 468, 480, 485, 283, 498, 503, 284, 169<br /><br />ROOT Connectionᐸ87ᐳ[89]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect90,Object432,Lambda433,Lambda438,Object451,Lambda452,Lambda457,Object467,Lambda468,Lambda473,Object484,Lambda485,Lambda490 bucket10
+    class Bucket10,PgSelect90 bucket10
     Bucket11("Bucket 11 (listItem)<br />Deps: 113, 283, 284, 169<br /><br />ROOT __Item{11}ᐸ90ᐳ[91]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,__Item91,PgSelectSingle92 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 92, 113, 283, 284, 91, 169<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[92]<br />1: <br />ᐳ: 93, 95, 98, 102, 104, 107, 111, 115, 119, 155, 158, 458, 474, 440, 442, 443, 475, 476<br />2: __ListTransform[181]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 92, 113, 283, 284, 91, 169<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[92]<br />1: <br />ᐳ: 93, 95, 98, 102, 104, 107, 111, 115, 119, 155, 158, 469, 486, 450, 452, 453, 487, 488<br />2: __ListTransform[181]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression93,PgClassExpression95,PgClassExpression98,PgClassExpression102,PgClassExpression104,PgClassExpression107,PgClassExpression111,PgClassExpression115,PgClassExpression119,PgClassExpression155,PgClassExpression158,__ListTransform181,Access440,Object442,Lambda443,RemapKeys458,Access474,Object475,Lambda476 bucket12
-    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ443ᐳ[141]"):::bucket
+    class Bucket12,PgClassExpression93,PgClassExpression95,PgClassExpression98,PgClassExpression102,PgClassExpression104,PgClassExpression107,PgClassExpression111,PgClassExpression115,PgClassExpression119,PgClassExpression155,PgClassExpression158,__ListTransform181,Access450,Object452,Lambda453,RemapKeys469,Access486,Object487,Lambda488 bucket12
+    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ453ᐳ[141]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item141,PgSelectSingle142 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 142<br /><br />ROOT PgSelectSingle{13}ᐸpost_computed_compound_type_arrayᐳ[142]"):::bucket
@@ -523,7 +527,7 @@ graph TD
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 159<br /><br />ROOT __Item{17}ᐸ158ᐳ[159]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18 bucket18
-    Bucket19("Bucket 19 (listItem)<br /><br />ROOT __Item{19}ᐸ476ᐳ[171]"):::bucket
+    Bucket19("Bucket 19 (listItem)<br /><br />ROOT __Item{19}ᐸ488ᐳ[171]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item171,PgSelectSingle172,PgClassExpression173 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 173<br /><br />ROOT PgClassExpression{19}ᐸ__post_com...al_set__.vᐳ[173]"):::bucket
@@ -541,22 +545,22 @@ graph TD
     Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 187<br /><br />ROOT PgClassExpression{22}ᐸ__post_com...al_set__.vᐳ[187]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24 bucket24
-    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 12, 199, 286, 283, 599, 622, 492, 495, 496, 497, 614, 514, 515, 615, 533, 534, 450, 616, 549, 550, 617, 113, 284<br /><br />ROOT Connectionᐸ197ᐳ[199]<br />1: <br />ᐳ: 211, 224, 494, 498, 504, 517, 523, 536, 542, 552, 558, 499, 518, 537, 553<br />2: PgSelect[200]"):::bucket
+    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 12, 199, 508, 513, 518, 287, 533, 538, 553, 558, 283, 570, 575, 113, 284, 618, 505, 211, 224<br /><br />ROOT Connectionᐸ197ᐳ[199]"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,PgSelect200,Connection211,Connection224,Lambda494,Object498,Lambda499,Lambda504,Object517,Lambda518,Lambda523,Object536,Lambda537,Lambda542,Object552,Lambda553,Lambda558 bucket25
-    Bucket26("Bucket 26 (listItem)<br />Deps: 113, 283, 284, 599, 492, 211, 224<br /><br />ROOT __Item{26}ᐸ200ᐳ[201]"):::bucket
+    class Bucket25,PgSelect200 bucket25
+    Bucket26("Bucket 26 (listItem)<br />Deps: 113, 283, 284, 618, 505, 211, 224<br /><br />ROOT __Item{26}ᐸ200ᐳ[201]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,__Item201,PgSelectSingle202 bucket26
-    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 202, 201, 113, 283, 284, 599, 492, 211, 224<br /><br />ROOT PgSelectSingle{26}ᐸpersonᐳ[202]"):::bucket
+    Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 202, 201, 113, 283, 284, 618, 505, 211, 224<br /><br />ROOT PgSelectSingle{26}ᐸpersonᐳ[202]"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression203,PgClassExpression205,PgSelectSingle235,Access525,Object527,Lambda528,RemapKeys543 bucket27
-    Bucket28("Bucket 28 (listItem)<br />Deps: 599, 113, 492, 284, 224<br /><br />ROOT __Item{28}ᐸ528ᐳ[213]"):::bucket
+    class Bucket27,PgClassExpression203,PgClassExpression205,PgSelectSingle235,Access540,Object542,Lambda543,RemapKeys559 bucket27
+    Bucket28("Bucket 28 (listItem)<br />Deps: 618, 113, 505, 284, 224<br /><br />ROOT __Item{28}ᐸ543ᐳ[213]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,__Item213,PgSelectSingle214 bucket28
-    Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 214, 213, 599, 113, 492, 284, 224<br /><br />ROOT PgSelectSingle{28}ᐸperson_friendsᐳ[214]"):::bucket
+    Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 214, 213, 618, 113, 505, 284, 224<br /><br />ROOT PgSelectSingle{28}ᐸperson_friendsᐳ[214]"):::bucket
     classDef bucket29 stroke:#4169e1
-    class Bucket29,PgClassExpression215,PgClassExpression217,Access506,Object508,Lambda509 bucket29
-    Bucket30("Bucket 30 (listItem)<br /><br />ROOT __Item{30}ᐸ509ᐳ[226]"):::bucket
+    class Bucket29,PgClassExpression215,PgClassExpression217,Access520,Object522,Lambda523 bucket29
+    Bucket30("Bucket 30 (listItem)<br /><br />ROOT __Item{30}ᐸ523ᐳ[226]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,__Item226,PgSelectSingle227 bucket30
     Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 227<br /><br />ROOT PgSelectSingle{30}ᐸperson_friendsᐳ[227]"):::bucket
@@ -565,9 +569,9 @@ graph TD
     Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 235<br /><br />ROOT PgSelectSingle{27}ᐸperson_first_postᐳ[235]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32,PgClassExpression236,PgClassExpression237 bucket32
-    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 12, 242, 283, 286, 563, 564, 565, 618<br /><br />ROOT Connectionᐸ240ᐳ[242]<br />1: <br />ᐳ: Object[566], Lambda[572], Lambda[567]<br />2: PgSelect[243]"):::bucket
+    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 12, 242, 283, 287, 585, 590<br /><br />ROOT Connectionᐸ240ᐳ[242]"):::bucket
     classDef bucket33 stroke:#f5deb3
-    class Bucket33,PgSelect243,Object566,Lambda567,Lambda572 bucket33
+    class Bucket33,PgSelect243 bucket33
     Bucket34("Bucket 34 (listItem)<br /><br />ROOT __Item{34}ᐸ243ᐳ[244]"):::bucket
     classDef bucket34 stroke:#696969
     class Bucket34,__Item244,PgSelectSingle245 bucket34

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
@@ -21,263 +21,379 @@ graph TD
     Lambda378 & Lambda379 & PgValidateParsedCursor439 & PgValidateParsedCursor441 & PgValidateParsedCursor439 & PgValidateParsedCursor441 & PgValidateParsedCursor439 & PgValidateParsedCursor441 & PgValidateParsedCursor439 & PgValidateParsedCursor441 & PgValidateParsedCursor439 & PgValidateParsedCursor441 & PgValidateParsedCursor439 & PgValidateParsedCursor441 --> Connection432
     PgSelect123[["PgSelect[123∈0] ➊<br />ᐸtypes_queryᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant1743{{"Constant[1743∈0] ➊<br />ᐸ'50'ᐳ"}}:::plan
+    Constant1789{{"Constant[1789∈0] ➊<br />ᐸ'50'ᐳ"}}:::plan
     Constant1084{{"Constant[1084∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant1744{{"Constant[1744∈0] ➊<br />ᐸ'xyz'ᐳ"}}:::plan
-    Constant1819{{"Constant[1819∈0] ➊<br />ᐸ[ 1, 2, 3 ]ᐳ"}}:::plan
-    Constant1745{{"Constant[1745∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Constant1824{{"Constant[1824∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: false }, end: §{ value: 5,ᐳ"}}:::plan
+    Constant1790{{"Constant[1790∈0] ➊<br />ᐸ'xyz'ᐳ"}}:::plan
+    Constant1865{{"Constant[1865∈0] ➊<br />ᐸ[ 1, 2, 3 ]ᐳ"}}:::plan
+    Constant1791{{"Constant[1791∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Constant1870{{"Constant[1870∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: false }, end: §{ value: 5,ᐳ"}}:::plan
     Lambda1083{{"Lambda[1083∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1086{{"Lambda[1086∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1287{{"Lambda[1287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1292{{"Lambda[1292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1743 & Constant1084 & Constant1744 & Constant1819 & Constant1745 & Constant1824 & Lambda1083 & Lambda1086 & Lambda1287 & Lambda1292 --> PgSelect123
+    Access1087{{"Access[1087∈0] ➊<br />ᐸ1086.0ᐳ"}}:::plan
+    Lambda1302{{"Lambda[1302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1307{{"Lambda[1307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1789 & Constant1084 & Constant1790 & Constant1865 & Constant1791 & Constant1870 & Lambda1083 & Access1087 & Lambda1302 & Lambda1307 --> PgSelect123
     PgSelect138[["PgSelect[138∈0] ➊<br />ᐸtypes_queryᐳ"]]:::plan
-    Constant1746{{"Constant[1746∈0] ➊<br />ᐸ''ᐳ"}}:::plan
-    Constant1748{{"Constant[1748∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1747{{"Constant[1747∈0] ➊<br />ᐸ{}ᐳ"}}:::plan
-    Constant1822{{"Constant[1822∈0] ➊<br />ᐸ§{ start: §{ value: undefined, inclusive: undefined }, end: ᐳ"}}:::plan
-    Lambda1301{{"Lambda[1301∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1306{{"Lambda[1306∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1743 & Constant1084 & Constant1746 & Constant1748 & Constant1747 & Constant1822 & Lambda1083 & Lambda1086 & Lambda1301 & Lambda1306 --> PgSelect138
+    Constant1792{{"Constant[1792∈0] ➊<br />ᐸ''ᐳ"}}:::plan
+    Constant1794{{"Constant[1794∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1793{{"Constant[1793∈0] ➊<br />ᐸ{}ᐳ"}}:::plan
+    Constant1868{{"Constant[1868∈0] ➊<br />ᐸ§{ start: §{ value: undefined, inclusive: undefined }, end: ᐳ"}}:::plan
+    Lambda1317{{"Lambda[1317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1322{{"Lambda[1322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1789 & Constant1084 & Constant1792 & Constant1794 & Constant1793 & Constant1868 & Lambda1083 & Access1087 & Lambda1317 & Lambda1322 --> PgSelect138
     Connection832{{"Connection[832∈0] ➊<br />ᐸ830ᐳ"}}:::plan
-    Constant1734{{"Constant[1734∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant1733{{"Constant[1733∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant1780{{"Constant[1780∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant1779{{"Constant[1779∈0] ➊<br />ᐸ1ᐳ"}}:::plan
     Lambda785{{"Lambda[785∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor838["PgValidateParsedCursor[838∈0] ➊"]:::plan
-    Constant1734 & Constant1733 & Lambda785 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 --> Connection832
+    Constant1780 & Constant1779 & Lambda785 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 & PgValidateParsedCursor838 --> Connection832
     PgSelect71[["PgSelect[71∈0] ➊<br />ᐸoptional_missing_middle_1ᐳ"]]:::plan
-    Constant1742{{"Constant[1742∈0] ➊<br />ᐸ8ᐳ"}}:::plan
-    Constant1741{{"Constant[1741∈0] ➊<br />ᐸ7ᐳ"}}:::plan
-    Lambda1217{{"Lambda[1217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1222{{"Lambda[1222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant1742 & Constant1741 & Lambda1083 & Lambda1086 & Lambda1217 & Lambda1222 --> PgSelect71
+    Constant1788{{"Constant[1788∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Constant1787{{"Constant[1787∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    Lambda1227{{"Lambda[1227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1232{{"Lambda[1232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant1788 & Constant1787 & Lambda1083 & Access1087 & Lambda1227 & Lambda1232 --> PgSelect71
     PgSelect92[["PgSelect[92∈0] ➊<br />ᐸoptional_missing_middle_4ᐳ"]]:::plan
     Constant48{{"Constant[48∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Lambda1259{{"Lambda[1259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1264{{"Lambda[1264∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant48 & Constant1741 & Lambda1083 & Lambda1086 & Lambda1259 & Lambda1264 --> PgSelect92
+    Lambda1272{{"Lambda[1272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1277{{"Lambda[1277∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant48 & Constant1787 & Lambda1083 & Access1087 & Lambda1272 & Lambda1277 --> PgSelect92
     PgSelect99[["PgSelect[99∈0] ➊<br />ᐸoptional_missing_middle_5ᐳ"]]:::plan
-    Lambda1273{{"Lambda[1273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1278{{"Lambda[1278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant48 & Constant1741 & Lambda1083 & Lambda1086 & Lambda1273 & Lambda1278 --> PgSelect99
+    Lambda1287{{"Lambda[1287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1292{{"Lambda[1292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant48 & Constant1787 & Lambda1083 & Access1087 & Lambda1287 & Lambda1292 --> PgSelect99
     Connection487{{"Connection[487∈0] ➊<br />ᐸ485ᐳ"}}:::plan
     PgValidateParsedCursor493["PgValidateParsedCursor[493∈0] ➊"]:::plan
-    Constant1734 & Lambda378 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 --> Connection487
+    Constant1780 & Lambda378 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 & PgValidateParsedCursor493 --> Connection487
     Connection534{{"Connection[534∈0] ➊<br />ᐸ532ᐳ"}}:::plan
     PgValidateParsedCursor540["PgValidateParsedCursor[540∈0] ➊"]:::plan
-    Constant1734 & Lambda378 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 --> Connection534
+    Constant1780 & Lambda378 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 & PgValidateParsedCursor540 --> Connection534
     Connection581{{"Connection[581∈0] ➊<br />ᐸ579ᐳ"}}:::plan
     PgValidateParsedCursor587["PgValidateParsedCursor[587∈0] ➊"]:::plan
-    Constant1734 & Lambda379 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 --> Connection581
+    Constant1780 & Lambda379 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 & PgValidateParsedCursor587 --> Connection581
     Connection784{{"Connection[784∈0] ➊<br />ᐸ782ᐳ"}}:::plan
     PgValidateParsedCursor790["PgValidateParsedCursor[790∈0] ➊"]:::plan
-    Constant1734 & Lambda785 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 --> Connection784
+    Constant1780 & Lambda785 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 & PgValidateParsedCursor790 --> Connection784
     Connection917{{"Connection[917∈0] ➊<br />ᐸ915ᐳ"}}:::plan
     Lambda918{{"Lambda[918∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgValidateParsedCursor923["PgValidateParsedCursor[923∈0] ➊"]:::plan
-    Constant1734 & Lambda918 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 --> Connection917
+    Constant1780 & Lambda918 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 & PgValidateParsedCursor923 --> Connection917
     PgSelect34[["PgSelect[34∈0] ➊<br />ᐸadd_1_queryᐳ"]]:::plan
-    Lambda1147{{"Lambda[1147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1152{{"Lambda[1152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant1734 & Lambda1083 & Lambda1086 & Lambda1147 & Lambda1152 --> PgSelect34
+    Lambda1157{{"Lambda[1157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant1780 & Lambda1083 & Access1087 & Lambda1152 & Lambda1157 --> PgSelect34
     PgSelect41[["PgSelect[41∈0] ➊<br />ᐸadd_2_queryᐳ"]]:::plan
-    Lambda1161{{"Lambda[1161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1166{{"Lambda[1166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1734 & Constant1734 & Lambda1083 & Lambda1086 & Lambda1161 & Lambda1166 --> PgSelect41
+    Lambda1167{{"Lambda[1167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1172{{"Lambda[1172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1780 & Constant1780 & Lambda1083 & Access1087 & Lambda1167 & Lambda1172 --> PgSelect41
     PgSelect49[["PgSelect[49∈0] ➊<br />ᐸadd_3_queryᐳ"]]:::plan
-    Constant1736{{"Constant[1736∈0] ➊<br />ᐸ5ᐳ"}}:::plan
-    Lambda1175{{"Lambda[1175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1180{{"Lambda[1180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant48 & Constant1736 & Lambda1083 & Lambda1086 & Lambda1175 & Lambda1180 --> PgSelect49
+    Constant1782{{"Constant[1782∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Lambda1182{{"Lambda[1182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1187{{"Lambda[1187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant48 & Constant1782 & Lambda1083 & Access1087 & Lambda1182 & Lambda1187 --> PgSelect49
     PgSelect56[["PgSelect[56∈0] ➊<br />ᐸadd_4_queryᐳ"]]:::plan
-    Constant1740{{"Constant[1740∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Lambda1189{{"Lambda[1189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1194{{"Lambda[1194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant1740 & Lambda1083 & Lambda1086 & Lambda1189 & Lambda1194 --> PgSelect56
+    Constant1786{{"Constant[1786∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Lambda1197{{"Lambda[1197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1202{{"Lambda[1202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant1786 & Lambda1083 & Access1087 & Lambda1197 & Lambda1202 --> PgSelect56
     PgSelect63[["PgSelect[63∈0] ➊<br />ᐸoptional_missing_middle_1ᐳ"]]:::plan
-    Lambda1203{{"Lambda[1203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1208{{"Lambda[1208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant1741 & Lambda1083 & Lambda1086 & Lambda1203 & Lambda1208 --> PgSelect63
+    Lambda1212{{"Lambda[1212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1217{{"Lambda[1217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant1787 & Lambda1083 & Access1087 & Lambda1212 & Lambda1217 --> PgSelect63
     PgSelect78[["PgSelect[78∈0] ➊<br />ᐸoptional_missing_middle_2ᐳ"]]:::plan
-    Lambda1231{{"Lambda[1231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1236{{"Lambda[1236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant1741 & Lambda1083 & Lambda1086 & Lambda1231 & Lambda1236 --> PgSelect78
+    Lambda1242{{"Lambda[1242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1247{{"Lambda[1247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant1787 & Lambda1083 & Access1087 & Lambda1242 & Lambda1247 --> PgSelect78
     PgSelect85[["PgSelect[85∈0] ➊<br />ᐸoptional_missing_middle_3ᐳ"]]:::plan
-    Lambda1245{{"Lambda[1245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1250{{"Lambda[1250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1733 & Constant1741 & Lambda1083 & Lambda1086 & Lambda1245 & Lambda1250 --> PgSelect85
+    Lambda1257{{"Lambda[1257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1262{{"Lambda[1262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1779 & Constant1787 & Lambda1083 & Access1087 & Lambda1257 & Lambda1262 --> PgSelect85
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
-    Constant1729{{"Constant[1729∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Lambda1091{{"Lambda[1091∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1096{{"Lambda[1096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1729 & Lambda1083 & Lambda1086 & Lambda1091 & Lambda1096 --> PgSelect7
+    Constant1775{{"Constant[1775∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Lambda1092{{"Lambda[1092∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1097{{"Lambda[1097∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1775 & Lambda1083 & Access1087 & Lambda1092 & Lambda1097 --> PgSelect7
     PgSelect15[["PgSelect[15∈0] ➊<br />ᐸjsonb_identityᐳ"]]:::plan
-    Constant1730{{"Constant[1730∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Lambda1105{{"Lambda[1105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1110{{"Lambda[1110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1730 & Lambda1083 & Lambda1086 & Lambda1105 & Lambda1110 --> PgSelect15
+    Constant1776{{"Constant[1776∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
+    Lambda1107{{"Lambda[1107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1112{{"Lambda[1112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1776 & Lambda1083 & Access1087 & Lambda1107 & Lambda1112 --> PgSelect15
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
-    Constant1731{{"Constant[1731∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
-    Lambda1119{{"Lambda[1119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1124{{"Lambda[1124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1731 & Lambda1083 & Lambda1086 & Lambda1119 & Lambda1124 --> PgSelect21
+    Constant1777{{"Constant[1777∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
+    Lambda1122{{"Lambda[1122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1127{{"Lambda[1127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1777 & Lambda1083 & Access1087 & Lambda1122 & Lambda1127 --> PgSelect21
     PgSelect27[["PgSelect[27∈0] ➊<br />ᐸjsonb_identityᐳ"]]:::plan
-    Constant1732{{"Constant[1732∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
-    Lambda1133{{"Lambda[1133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1138{{"Lambda[1138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1732 & Lambda1083 & Lambda1086 & Lambda1133 & Lambda1138 --> PgSelect27
+    Constant1778{{"Constant[1778∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
+    Lambda1137{{"Lambda[1137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1142{{"Lambda[1142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1778 & Lambda1083 & Access1087 & Lambda1137 & Lambda1142 --> PgSelect27
     PgSelect156[["PgSelect[156∈0] ➊<br />ᐸcompound_type_queryᐳ"]]:::plan
-    Constant1823{{"Constant[1823∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
-    Lambda1315{{"Lambda[1315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1320{{"Lambda[1320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1823 & Lambda1083 & Lambda1086 & Lambda1315 & Lambda1320 --> PgSelect156
+    Constant1869{{"Constant[1869∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
+    Lambda1332{{"Lambda[1332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1337{{"Lambda[1337∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1869 & Lambda1083 & Access1087 & Lambda1332 & Lambda1337 --> PgSelect156
     PgSelect232[["PgSelect[232∈0] ➊<br />ᐸcompound_type_array_queryᐳ"]]:::plan
-    Lambda1344{{"Lambda[1344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1349{{"Lambda[1349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1823 & Lambda1083 & Lambda1086 & Lambda1344 & Lambda1349 --> PgSelect232
-    PgSelect248[["PgSelect[248∈0] ➊<br />ᐸtable_queryᐳ"]]:::plan
-    Lambda1358{{"Lambda[1358∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda1363{{"Lambda[1363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1736 & Lambda1083 & Lambda1086 & Lambda1358 & Lambda1363 --> PgSelect248
+    Lambda1368{{"Lambda[1368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1869 & Lambda1083 & Access1087 & Lambda1363 & Lambda1368 --> PgSelect232
+    PgSelect248[["PgSelect[248∈0] ➊<br />ᐸtable_queryᐳ"]]:::plan
+    Lambda1378{{"Lambda[1378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1383{{"Lambda[1383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1782 & Lambda1083 & Access1087 & Lambda1378 & Lambda1383 --> PgSelect248
     PgSelect1016[["PgSelect[1016∈0] ➊<br />ᐸquery_compound_type_arrayᐳ"]]:::plan
-    Constant1826{{"Constant[1826∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
-    Lambda1667{{"Lambda[1667∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1672{{"Lambda[1672∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1826 & Lambda1083 & Lambda1086 & Lambda1667 & Lambda1672 --> PgSelect1016
-    Object1408{{"Object[1408∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Constant1872{{"Constant[1872∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
+    Lambda1709{{"Lambda[1709∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1714{{"Lambda[1714∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant1872 & Lambda1083 & Access1087 & Lambda1709 & Lambda1714 --> PgSelect1016
+    Object1431{{"Object[1431∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
     Access387{{"Access[387∈0] ➊<br />ᐸ379.1ᐳ"}}:::plan
     Access385{{"Access[385∈0] ➊<br />ᐸ378.1ᐳ"}}:::plan
-    Constant1323{{"Constant[1323∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant48 & Constant48 & Access387 & Access385 & Constant48 & Constant1323 --> Object1408
+    Constant1340{{"Constant[1340∈0] ➊<br />ᐸtrueᐳ"}}:::plan
+    Constant48 & Constant48 & Access387 & Access385 & Constant48 & Constant1340 --> Object1431
+    Object1461{{"Object[1461∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Constant48 & Constant1780 & Constant48 & Access385 & Constant48 & Constant1340 --> Object1461
+    Object1476{{"Object[1476∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Constant48 & Access385 & Constant48 & Constant1340 --> Object1476
+    Object1491{{"Object[1491∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Access387 & Constant48 & Constant48 & Constant1340 --> Object1491
+    Object1566{{"Object[1566∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Access791{{"Access[791∈0] ➊<br />ᐸ785.1ᐳ"}}:::plan
+    Constant48 & Constant1780 & Constant48 & Access791 & Constant48 & Constant1340 --> Object1566
+    Object1581{{"Object[1581∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Access791 & Constant48 & Constant1779 & Constant1340 --> Object1581
+    Object1611{{"Object[1611∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
+    Access924{{"Access[924∈0] ➊<br />ᐸ918.1ᐳ"}}:::plan
+    Constant1780 & Constant48 & Access924 & Constant48 & Constant48 & Constant1340 --> Object1611
     PgSelect981[["PgSelect[981∈0] ➊<br />ᐸno_args_queryᐳ"]]:::plan
-    Lambda1624{{"Lambda[1624∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1629{{"Lambda[1629∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda1083 & Lambda1086 & Lambda1624 & Lambda1629 --> PgSelect981
+    Lambda1663{{"Lambda[1663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1668{{"Lambda[1668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda1083 & Access1087 & Lambda1663 & Lambda1668 --> PgSelect981
     PgSelect1031[["PgSelect[1031∈0] ➊<br />ᐸquery_text_arrayᐳ"]]:::plan
-    Lambda1681{{"Lambda[1681∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1686{{"Lambda[1686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda1083 & Lambda1086 & Lambda1681 & Lambda1686 --> PgSelect1031
+    Lambda1724{{"Lambda[1724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1729{{"Lambda[1729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda1083 & Access1087 & Lambda1724 & Lambda1729 --> PgSelect1031
     PgSelect1037[["PgSelect[1037∈0] ➊<br />ᐸquery_interval_arrayᐳ"]]:::plan
-    Lambda1695{{"Lambda[1695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1700{{"Lambda[1700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda1083 & Lambda1086 & Lambda1695 & Lambda1700 --> PgSelect1037
-    Object1090{{"Object[1090∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1087{{"Constant[1087∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1088{{"Constant[1088∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Constant1089{{"Constant[1089∈0] ➊<br />ᐸCodec(json)ᐳ"}}:::plan
-    Lambda1083 & Constant1087 & Constant1088 & Constant1089 --> Object1090
-    Object1104{{"Object[1104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1101{{"Constant[1101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1102{{"Constant[1102∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
-    Constant1103{{"Constant[1103∈0] ➊<br />ᐸCodec(jsonb)ᐳ"}}:::plan
-    Lambda1083 & Constant1101 & Constant1102 & Constant1103 --> Object1104
-    Object1118{{"Object[1118∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1115{{"Constant[1115∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1116{{"Constant[1116∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
-    Lambda1083 & Constant1115 & Constant1116 & Constant1089 --> Object1118
-    Object1132{{"Object[1132∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1129{{"Constant[1129∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1130{{"Constant[1130∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
-    Lambda1083 & Constant1129 & Constant1130 & Constant1103 --> Object1132
-    Object1146{{"Object[1146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1143{{"Constant[1143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1144{{"Constant[1144∈0] ➊<br />ᐸsql.identifier(”add_1_query”)ᐳ"}}:::plan
-    Constant1145{{"Constant[1145∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda1083 & Constant1143 & Constant1144 & Constant1145 --> Object1146
-    Object1160{{"Object[1160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1157{{"Constant[1157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1158{{"Constant[1158∈0] ➊<br />ᐸsql.identifier(”add_2_query”)ᐳ"}}:::plan
-    Lambda1083 & Constant1157 & Constant1158 & Constant1145 --> Object1160
-    Object1174{{"Object[1174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1171{{"Constant[1171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1172{{"Constant[1172∈0] ➊<br />ᐸsql.identifier(”add_3_query”)ᐳ"}}:::plan
-    Lambda1083 & Constant1171 & Constant1172 & Constant1145 --> Object1174
-    Object1188{{"Object[1188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1185{{"Constant[1185∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1186{{"Constant[1186∈0] ➊<br />ᐸsql.identifier(”add_4_query”)ᐳ"}}:::plan
-    Lambda1083 & Constant1185 & Constant1186 & Constant1145 --> Object1188
-    Object1202{{"Object[1202∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1199{{"Constant[1199∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1200{{"Constant[1200∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_1”)ᐳ"}}:::plan
-    Lambda1083 & Constant1199 & Constant1200 & Constant1145 --> Object1202
-    Object1216{{"Object[1216∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1213{{"Constant[1213∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1214{{"Constant[1214∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_1”)ᐳ"}}:::plan
-    Lambda1083 & Constant1213 & Constant1214 & Constant1145 --> Object1216
-    Object1230{{"Object[1230∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1227{{"Constant[1227∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1228{{"Constant[1228∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_2”)ᐳ"}}:::plan
-    Lambda1083 & Constant1227 & Constant1228 & Constant1145 --> Object1230
-    Object1244{{"Object[1244∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1241{{"Constant[1241∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1242{{"Constant[1242∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_3”)ᐳ"}}:::plan
-    Lambda1083 & Constant1241 & Constant1242 & Constant1145 --> Object1244
-    Object1258{{"Object[1258∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1255{{"Constant[1255∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1256{{"Constant[1256∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_4”)ᐳ"}}:::plan
-    Lambda1083 & Constant1255 & Constant1256 & Constant1145 --> Object1258
-    Object1272{{"Object[1272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1269{{"Constant[1269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1270{{"Constant[1270∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_5”)ᐳ"}}:::plan
-    Lambda1083 & Constant1269 & Constant1270 & Constant1145 --> Object1272
+    Lambda1739{{"Lambda[1739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda1744{{"Lambda[1744∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda1083 & Access1087 & Lambda1739 & Lambda1744 --> PgSelect1037
+    Object1091{{"Object[1091∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1088{{"Constant[1088∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1089{{"Constant[1089∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Constant1090{{"Constant[1090∈0] ➊<br />ᐸCodec(json)ᐳ"}}:::plan
+    Lambda1083 & Constant1088 & Constant1089 & Constant1090 --> Object1091
+    Object1106{{"Object[1106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1103{{"Constant[1103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1104{{"Constant[1104∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
+    Constant1105{{"Constant[1105∈0] ➊<br />ᐸCodec(jsonb)ᐳ"}}:::plan
+    Lambda1083 & Constant1103 & Constant1104 & Constant1105 --> Object1106
+    Object1121{{"Object[1121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1118{{"Constant[1118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1119{{"Constant[1119∈0] ➊<br />ᐸsql.identifier(”json_identity”)ᐳ"}}:::plan
+    Lambda1083 & Constant1118 & Constant1119 & Constant1090 --> Object1121
+    Object1136{{"Object[1136∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1133{{"Constant[1133∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1134{{"Constant[1134∈0] ➊<br />ᐸsql.identifier(”jsonb_identity”)ᐳ"}}:::plan
+    Lambda1083 & Constant1133 & Constant1134 & Constant1105 --> Object1136
+    Object1151{{"Object[1151∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1148{{"Constant[1148∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1149{{"Constant[1149∈0] ➊<br />ᐸsql.identifier(”add_1_query”)ᐳ"}}:::plan
+    Constant1150{{"Constant[1150∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda1083 & Constant1148 & Constant1149 & Constant1150 --> Object1151
+    Object1166{{"Object[1166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1163{{"Constant[1163∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1164{{"Constant[1164∈0] ➊<br />ᐸsql.identifier(”add_2_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1163 & Constant1164 & Constant1150 --> Object1166
+    Object1181{{"Object[1181∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1178{{"Constant[1178∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1179{{"Constant[1179∈0] ➊<br />ᐸsql.identifier(”add_3_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1178 & Constant1179 & Constant1150 --> Object1181
+    Object1196{{"Object[1196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1193{{"Constant[1193∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1194{{"Constant[1194∈0] ➊<br />ᐸsql.identifier(”add_4_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1193 & Constant1194 & Constant1150 --> Object1196
+    Object1211{{"Object[1211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1208{{"Constant[1208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1209{{"Constant[1209∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_1”)ᐳ"}}:::plan
+    Lambda1083 & Constant1208 & Constant1209 & Constant1150 --> Object1211
+    Object1226{{"Object[1226∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1223{{"Constant[1223∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1224{{"Constant[1224∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_1”)ᐳ"}}:::plan
+    Lambda1083 & Constant1223 & Constant1224 & Constant1150 --> Object1226
+    Object1241{{"Object[1241∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1238{{"Constant[1238∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1239{{"Constant[1239∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_2”)ᐳ"}}:::plan
+    Lambda1083 & Constant1238 & Constant1239 & Constant1150 --> Object1241
+    Object1256{{"Object[1256∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1253{{"Constant[1253∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1254{{"Constant[1254∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_3”)ᐳ"}}:::plan
+    Lambda1083 & Constant1253 & Constant1254 & Constant1150 --> Object1256
+    Object1271{{"Object[1271∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1268{{"Constant[1268∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1269{{"Constant[1269∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_4”)ᐳ"}}:::plan
+    Lambda1083 & Constant1268 & Constant1269 & Constant1150 --> Object1271
     Object1286{{"Object[1286∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant1283{{"Constant[1283∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1284{{"Constant[1284∈0] ➊<br />ᐸsql.identifier(”types_query”)ᐳ"}}:::plan
-    Constant1285{{"Constant[1285∈0] ➊<br />ᐸCodec(bool)ᐳ"}}:::plan
-    Lambda1083 & Constant1283 & Constant1284 & Constant1285 --> Object1286
-    Object1300{{"Object[1300∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1297{{"Constant[1297∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1298{{"Constant[1298∈0] ➊<br />ᐸsql.identifier(”types_query”)ᐳ"}}:::plan
-    Lambda1083 & Constant1297 & Constant1298 & Constant1285 --> Object1300
-    Object1314{{"Object[1314∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1311{{"Constant[1311∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1312{{"Constant[1312∈0] ➊<br />ᐸsql.identifier(”compound_type_query”)ᐳ"}}:::plan
-    Constant1313{{"Constant[1313∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda1083 & Constant1311 & Constant1312 & Constant1313 --> Object1314
-    Object1343{{"Object[1343∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1340{{"Constant[1340∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1341{{"Constant[1341∈0] ➊<br />ᐸsql.identifier(”compound_type_array_query”)ᐳ"}}:::plan
-    Lambda1083 & Constant1340 & Constant1341 & Constant1313 --> Object1343
-    Object1357{{"Object[1357∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1354{{"Constant[1354∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1355{{"Constant[1355∈0] ➊<br />ᐸsql.identifier(”table_query”)ᐳ"}}:::plan
-    Constant1356{{"Constant[1356∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda1083 & Constant1354 & Constant1355 & Constant1356 --> Object1357
-    Object1406{{"Object[1406∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant48 & Constant48 & Access387 & Access385 --> Object1406
-    Object1623{{"Object[1623∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1620{{"Constant[1620∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1621{{"Constant[1621∈0] ➊<br />ᐸsql.identifier(”no_args_query”)ᐳ"}}:::plan
-    Lambda1083 & Constant1620 & Constant1621 & Constant1145 --> Object1623
-    Object1666{{"Object[1666∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1663{{"Constant[1663∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1664{{"Constant[1664∈0] ➊<br />ᐸsql.identifier(”query_compound_type_array”)ᐳ"}}:::plan
-    Lambda1083 & Constant1663 & Constant1664 & Constant1313 --> Object1666
-    Object1680{{"Object[1680∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1677{{"Constant[1677∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1678{{"Constant[1678∈0] ➊<br />ᐸsql.identifier(”query_text_array”)ᐳ"}}:::plan
-    Constant1679{{"Constant[1679∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(textArray)ᐳ"}}:::plan
-    Lambda1083 & Constant1677 & Constant1678 & Constant1679 --> Object1680
-    Object1694{{"Object[1694∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant1691{{"Constant[1691∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1692{{"Constant[1692∈0] ➊<br />ᐸsql.identifier(”query_interval_array”)ᐳ"}}:::plan
-    Constant1693{{"Constant[1693∈0] ➊<br />ᐸListCodecᐸinterval[]ᐳ(intervalArray)ᐳ"}}:::plan
-    Lambda1083 & Constant1691 & Constant1692 & Constant1693 --> Object1694
+    Constant1284{{"Constant[1284∈0] ➊<br />ᐸsql.identifier(”optional_missing_middle_5”)ᐳ"}}:::plan
+    Lambda1083 & Constant1283 & Constant1284 & Constant1150 --> Object1286
+    Object1301{{"Object[1301∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1298{{"Constant[1298∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1299{{"Constant[1299∈0] ➊<br />ᐸsql.identifier(”types_query”)ᐳ"}}:::plan
+    Constant1300{{"Constant[1300∈0] ➊<br />ᐸCodec(bool)ᐳ"}}:::plan
+    Lambda1083 & Constant1298 & Constant1299 & Constant1300 --> Object1301
+    Object1316{{"Object[1316∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1313{{"Constant[1313∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1314{{"Constant[1314∈0] ➊<br />ᐸsql.identifier(”types_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1313 & Constant1314 & Constant1300 --> Object1316
+    Object1331{{"Object[1331∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1328{{"Constant[1328∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1329{{"Constant[1329∈0] ➊<br />ᐸsql.identifier(”compound_type_query”)ᐳ"}}:::plan
+    Constant1330{{"Constant[1330∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda1083 & Constant1328 & Constant1329 & Constant1330 --> Object1331
+    Object1347{{"Object[1347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1339{{"Lambda[1339∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1344{{"Constant[1344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1345{{"Constant[1345∈0] ➊<br />ᐸsql.identifier(”compound_type_set_query”)ᐳ"}}:::plan
+    Lambda1339 & Constant1344 & Constant1345 & Constant1330 --> Object1347
+    Object1362{{"Object[1362∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1359{{"Constant[1359∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1360{{"Constant[1360∈0] ➊<br />ᐸsql.identifier(”compound_type_array_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1359 & Constant1360 & Constant1330 --> Object1362
+    Object1377{{"Object[1377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1374{{"Constant[1374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1375{{"Constant[1375∈0] ➊<br />ᐸsql.identifier(”table_query”)ᐳ"}}:::plan
+    Constant1376{{"Constant[1376∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda1083 & Constant1374 & Constant1375 & Constant1376 --> Object1377
+    Object1392{{"Object[1392∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1389{{"Constant[1389∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1390{{"Constant[1390∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
+    Constant1391{{"Constant[1391∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda1083 & Constant1389 & Constant1390 & Constant1391 --> Object1392
+    Object1407{{"Object[1407∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1404{{"Constant[1404∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'ASC' } ]ᐳ"}}:::plan
+    Constant1405{{"Constant[1405∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1404 & Constant1405 & Constant1391 --> Object1407
+    Object1422{{"Object[1422∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1419{{"Constant[1419∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1420{{"Constant[1420∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1419 & Constant1420 & Constant1391 --> Object1422
+    Object1429{{"Object[1429∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant48 & Constant48 & Access387 & Access385 --> Object1429
+    Object1437{{"Object[1437∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1430{{"Lambda[1430∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1434{{"Constant[1434∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1430 & Constant1434 & Constant1390 & Constant1391 --> Object1437
+    Object1452{{"Object[1452∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1449{{"Constant[1449∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1430 & Constant1449 & Constant1390 & Constant1391 --> Object1452
+    Object1459{{"Object[1459∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant48 & Constant1780 & Constant48 & Access385 --> Object1459
+    Object1467{{"Object[1467∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1460{{"Lambda[1460∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1464{{"Constant[1464∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1460 & Constant1464 & Constant1390 & Constant1391 --> Object1467
+    Object1474{{"Object[1474∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Constant48 & Access385 --> Object1474
+    Object1482{{"Object[1482∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1475{{"Lambda[1475∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1479{{"Constant[1479∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1475 & Constant1479 & Constant1390 & Constant1391 --> Object1482
+    Object1489{{"Object[1489∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Access387 & Constant48 --> Object1489
+    Object1497{{"Object[1497∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1490{{"Lambda[1490∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1494{{"Constant[1494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1490 & Constant1494 & Constant1390 & Constant1391 --> Object1497
+    Object1512{{"Object[1512∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1505{{"Lambda[1505∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1509{{"Constant[1509∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1505 & Constant1509 & Constant1390 & Constant1391 --> Object1512
+    Object1527{{"Object[1527∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1524{{"Constant[1524∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1505 & Constant1524 & Constant1390 & Constant1391 --> Object1527
+    Object1542{{"Object[1542∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1539{{"Constant[1539∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1505 & Constant1539 & Constant1390 & Constant1391 --> Object1542
+    Object1557{{"Object[1557∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1550{{"Lambda[1550∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1554{{"Constant[1554∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1550 & Constant1554 & Constant1390 & Constant1391 --> Object1557
+    Object1564{{"Object[1564∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant48 & Constant1780 & Constant48 & Access791 --> Object1564
+    Object1572{{"Object[1572∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1565{{"Lambda[1565∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1569{{"Constant[1569∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1565 & Constant1569 & Constant1390 & Constant1391 --> Object1572
+    Object1579{{"Object[1579∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Access791 & Constant48 --> Object1579
+    Object1587{{"Object[1587∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1580{{"Lambda[1580∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1584{{"Constant[1584∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1580 & Constant1584 & Constant1390 & Constant1391 --> Object1587
+    Object1602{{"Object[1602∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1599{{"Constant[1599∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1600{{"Constant[1600∈0] ➊<br />ᐸsql.identifier(”table_set_query_plpgsql”)ᐳ"}}:::plan
+    Lambda1505 & Constant1599 & Constant1600 & Constant1391 --> Object1602
+    Object1609{{"Object[1609∈0] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
+    Constant1780 & Constant48 & Access924 & Constant48 --> Object1609
+    Object1617{{"Object[1617∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda1610{{"Lambda[1610∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant1614{{"Constant[1614∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1610 & Constant1614 & Constant1600 & Constant1391 --> Object1617
+    Object1632{{"Object[1632∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1629{{"Constant[1629∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1630{{"Constant[1630∈0] ➊<br />ᐸsql.identifier(”int_set_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1629 & Constant1630 & Constant1150 --> Object1632
+    Object1647{{"Object[1647∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1644{{"Constant[1644∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1083 & Constant1644 & Constant1630 & Constant1150 --> Object1647
+    Object1662{{"Object[1662∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1659{{"Constant[1659∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1660{{"Constant[1660∈0] ➊<br />ᐸsql.identifier(”no_args_query”)ᐳ"}}:::plan
+    Lambda1083 & Constant1659 & Constant1660 & Constant1150 --> Object1662
+    Object1678{{"Object[1678∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1675{{"Constant[1675∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1676{{"Constant[1676∈0] ➊<br />ᐸsql.identifier(”static_big_integer”)ᐳ"}}:::plan
+    Constant1677{{"Constant[1677∈0] ➊<br />ᐸCodec(int8)ᐳ"}}:::plan
+    Lambda1083 & Constant1675 & Constant1676 & Constant1677 --> Object1678
+    Object1693{{"Object[1693∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1690{{"Constant[1690∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1083 & Constant1690 & Constant1676 & Constant1677 --> Object1693
+    Object1708{{"Object[1708∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1705{{"Constant[1705∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1706{{"Constant[1706∈0] ➊<br />ᐸsql.identifier(”query_compound_type_array”)ᐳ"}}:::plan
+    Lambda1083 & Constant1705 & Constant1706 & Constant1330 --> Object1708
+    Object1723{{"Object[1723∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1720{{"Constant[1720∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1721{{"Constant[1721∈0] ➊<br />ᐸsql.identifier(”query_text_array”)ᐳ"}}:::plan
+    Constant1722{{"Constant[1722∈0] ➊<br />ᐸListCodecᐸtext[]ᐳ(textArray)ᐳ"}}:::plan
+    Lambda1083 & Constant1720 & Constant1721 & Constant1722 --> Object1723
+    Object1738{{"Object[1738∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1735{{"Constant[1735∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1736{{"Constant[1736∈0] ➊<br />ᐸsql.identifier(”query_interval_array”)ᐳ"}}:::plan
+    Constant1737{{"Constant[1737∈0] ➊<br />ᐸListCodecᐸinterval[]ᐳ(intervalArray)ᐳ"}}:::plan
+    Lambda1083 & Constant1735 & Constant1736 & Constant1737 --> Object1738
+    Object1753{{"Object[1753∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1750{{"Constant[1750∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant1751{{"Constant[1751∈0] ➊<br />ᐸsql.identifier(”query_interval_set”)ᐳ"}}:::plan
+    Constant1752{{"Constant[1752∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
+    Lambda1083 & Constant1750 & Constant1751 & Constant1752 --> Object1753
+    Object1768{{"Object[1768∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1765{{"Constant[1765∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda1083 & Constant1765 & Constant1751 & Constant1752 --> Object1768
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
     Connection628{{"Connection[628∈0] ➊<br />ᐸ626ᐳ"}}:::plan
-    Constant1734 & Constant1734 --> Connection628
+    Constant1780 & Constant1780 --> Connection628
     Connection667{{"Connection[667∈0] ➊<br />ᐸ665ᐳ"}}:::plan
-    Constant1757{{"Constant[1757∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Constant1734 & Constant1757 --> Connection667
+    Constant1803{{"Constant[1803∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Constant1780 & Constant1803 --> Connection667
     Connection706{{"Connection[706∈0] ➊<br />ᐸ704ᐳ"}}:::plan
-    Constant1758{{"Constant[1758∈0] ➊<br />ᐸ0ᐳ"}}:::plan
-    Constant1734 & Constant1758 --> Connection706
+    Constant1804{{"Constant[1804∈0] ➊<br />ᐸ0ᐳ"}}:::plan
+    Constant1780 & Constant1804 --> Connection706
     Connection745{{"Connection[745∈0] ➊<br />ᐸ743ᐳ"}}:::plan
-    Constant1759{{"Constant[1759∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Constant1759 & Constant1758 --> Connection745
+    Constant1805{{"Constant[1805∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Constant1805 & Constant1804 --> Connection745
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -382,15 +498,15 @@ graph TD
     PgSelectSingle159{{"PgSelectSingle[159∈0] ➊<br />ᐸcompound_type_queryᐳ"}}:::plan
     First158 --> PgSelectSingle159
     Connection174{{"Connection[174∈0] ➊<br />ᐸ172ᐳ"}}:::plan
-    Constant1736 --> Connection174
+    Constant1782 --> Connection174
     First250{{"First[250∈0] ➊"}}:::plan
     PgSelect248 --> First250
     PgSelectSingle251{{"PgSelectSingle[251∈0] ➊<br />ᐸtable_queryᐳ"}}:::plan
     First250 --> PgSelectSingle251
-    Constant1755{{"Constant[1755∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiw1XQ=='ᐳ"}}:::plan
-    Constant1755 --> Lambda378
-    Constant1756{{"Constant[1756∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiwzXQ=='ᐳ"}}:::plan
-    Constant1756 --> Lambda379
+    Constant1801{{"Constant[1801∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiw1XQ=='ᐳ"}}:::plan
+    Constant1801 --> Lambda378
+    Constant1802{{"Constant[1802∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiwzXQ=='ᐳ"}}:::plan
+    Constant1802 --> Lambda379
     Lambda378 --> PgValidateParsedCursor384
     Lambda378 --> Access385
     Lambda379 --> PgValidateParsedCursor386
@@ -400,17 +516,17 @@ graph TD
     Lambda378 --> PgValidateParsedCursor493
     Lambda378 --> PgValidateParsedCursor540
     Lambda379 --> PgValidateParsedCursor587
-    Constant1760{{"Constant[1760∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiwxXQ=='ᐳ"}}:::plan
-    Constant1760 --> Lambda785
+    Constant1806{{"Constant[1806∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiwxXQ=='ᐳ"}}:::plan
+    Constant1806 --> Lambda785
     Lambda785 --> PgValidateParsedCursor790
-    Access791{{"Access[791∈0] ➊<br />ᐸ785.1ᐳ"}}:::plan
     Lambda785 --> Access791
     Lambda785 --> PgValidateParsedCursor838
     Connection878{{"Connection[878∈0] ➊<br />ᐸ876ᐳ"}}:::plan
-    Constant1734 --> Connection878
-    Constant1761{{"Constant[1761∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiwyXQ=='ᐳ"}}:::plan
-    Constant1761 --> Lambda918
+    Constant1780 --> Connection878
+    Constant1807{{"Constant[1807∈0] ➊<br />ᐸ'WyJuYXR1cmFsIiwyXQ=='ᐳ"}}:::plan
+    Constant1807 --> Lambda918
     Lambda918 --> PgValidateParsedCursor923
+    Lambda918 --> Access924
     First983{{"First[983∈0] ➊"}}:::plan
     PgSelect981 --> First983
     PgSelectSingle984{{"PgSelectSingle[984∈0] ➊<br />ᐸno_args_queryᐳ"}}:::plan
@@ -429,89 +545,272 @@ graph TD
     First1039 --> PgSelectSingle1040
     PgClassExpression1041{{"PgClassExpression[1041∈0] ➊<br />ᐸ__query_in..._array__.vᐳ"}}:::plan
     PgSelectSingle1040 --> PgClassExpression1041
-    Constant1737{{"Constant[1737∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1737 --> Lambda1083
-    Constant1738{{"Constant[1738∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1738 --> Lambda1086
-    Object1090 --> Lambda1091
-    Constant1762{{"Constant[1762∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant1762 --> Lambda1096
-    Object1104 --> Lambda1105
-    Constant1763{{"Constant[1763∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1763 --> Lambda1110
-    Object1118 --> Lambda1119
-    Constant1764{{"Constant[1764∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
-    Constant1764 --> Lambda1124
-    Object1132 --> Lambda1133
-    Constant1765{{"Constant[1765∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
-    Constant1765 --> Lambda1138
-    Object1146 --> Lambda1147
-    Constant1766{{"Constant[1766∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_1_ᐳ"}}:::plan
-    Constant1766 --> Lambda1152
-    Object1160 --> Lambda1161
-    Constant1767{{"Constant[1767∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_2_ᐳ"}}:::plan
-    Constant1767 --> Lambda1166
-    Object1174 --> Lambda1175
-    Constant1768{{"Constant[1768∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_3_ᐳ"}}:::plan
-    Constant1768 --> Lambda1180
-    Object1188 --> Lambda1189
-    Constant1769{{"Constant[1769∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_4_ᐳ"}}:::plan
-    Constant1769 --> Lambda1194
-    Object1202 --> Lambda1203
-    Constant1770{{"Constant[1770∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
-    Constant1770 --> Lambda1208
-    Object1216 --> Lambda1217
-    Constant1771{{"Constant[1771∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
-    Constant1771 --> Lambda1222
-    Object1230 --> Lambda1231
-    Constant1772{{"Constant[1772∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
-    Constant1772 --> Lambda1236
-    Object1244 --> Lambda1245
-    Constant1773{{"Constant[1773∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
-    Constant1773 --> Lambda1250
-    Object1258 --> Lambda1259
-    Constant1774{{"Constant[1774∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
-    Constant1774 --> Lambda1264
-    Object1272 --> Lambda1273
-    Constant1775{{"Constant[1775∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
-    Constant1775 --> Lambda1278
+    Constant1783{{"Constant[1783∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1783 --> Lambda1083
+    Lambda1086{{"Lambda[1086∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1784{{"Constant[1784∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1784 --> Lambda1086
+    Lambda1086 --> Access1087
+    Object1091 --> Lambda1092
+    Constant1808{{"Constant[1808∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant1808 --> Lambda1097
+    Object1106 --> Lambda1107
+    Constant1809{{"Constant[1809∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1809 --> Lambda1112
+    Object1121 --> Lambda1122
+    Constant1810{{"Constant[1810∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”json_iᐳ"}}:::plan
+    Constant1810 --> Lambda1127
+    Object1136 --> Lambda1137
+    Constant1811{{"Constant[1811∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”jsonb_ᐳ"}}:::plan
+    Constant1811 --> Lambda1142
+    Object1151 --> Lambda1152
+    Constant1812{{"Constant[1812∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_1_ᐳ"}}:::plan
+    Constant1812 --> Lambda1157
+    Object1166 --> Lambda1167
+    Constant1813{{"Constant[1813∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_2_ᐳ"}}:::plan
+    Constant1813 --> Lambda1172
+    Object1181 --> Lambda1182
+    Constant1814{{"Constant[1814∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_3_ᐳ"}}:::plan
+    Constant1814 --> Lambda1187
+    Object1196 --> Lambda1197
+    Constant1815{{"Constant[1815∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”add_4_ᐳ"}}:::plan
+    Constant1815 --> Lambda1202
+    Object1211 --> Lambda1212
+    Constant1816{{"Constant[1816∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
+    Constant1816 --> Lambda1217
+    Object1226 --> Lambda1227
+    Constant1817{{"Constant[1817∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
+    Constant1817 --> Lambda1232
+    Object1241 --> Lambda1242
+    Constant1818{{"Constant[1818∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
+    Constant1818 --> Lambda1247
+    Object1256 --> Lambda1257
+    Constant1819{{"Constant[1819∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
+    Constant1819 --> Lambda1262
+    Object1271 --> Lambda1272
+    Constant1820{{"Constant[1820∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
+    Constant1820 --> Lambda1277
     Object1286 --> Lambda1287
-    Constant1776{{"Constant[1776∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types_ᐳ"}}:::plan
-    Constant1776 --> Lambda1292
-    Object1300 --> Lambda1301
-    Constant1777{{"Constant[1777∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types_ᐳ"}}:::plan
-    Constant1777 --> Lambda1306
-    Object1314 --> Lambda1315
-    Constant1778{{"Constant[1778∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant1778 --> Lambda1320
-    Object1343 --> Lambda1344
-    Constant1780{{"Constant[1780∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant1780 --> Lambda1349
-    Object1357 --> Lambda1358
-    Constant1781{{"Constant[1781∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1781 --> Lambda1363
-    Lambda1367{{"Lambda[1367∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant1739{{"Constant[1739∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1739 --> Lambda1367
-    Lambda1407{{"Lambda[1407∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Object1406 --> Lambda1407
-    Lambda1409{{"Lambda[1409∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Object1408 --> Lambda1409
-    Lambda1477{{"Lambda[1477∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant1812{{"Constant[1812∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1812 --> Lambda1477
-    Object1623 --> Lambda1624
-    Constant1800{{"Constant[1800∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”no_argᐳ"}}:::plan
-    Constant1800 --> Lambda1629
-    Object1666 --> Lambda1667
-    Constant1803{{"Constant[1803∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1803 --> Lambda1672
-    Object1680 --> Lambda1681
-    Constant1804{{"Constant[1804∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1804 --> Lambda1686
-    Object1694 --> Lambda1695
-    Constant1805{{"Constant[1805∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1805 --> Lambda1700
+    Constant1821{{"Constant[1821∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”optionᐳ"}}:::plan
+    Constant1821 --> Lambda1292
+    Object1301 --> Lambda1302
+    Constant1822{{"Constant[1822∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types_ᐳ"}}:::plan
+    Constant1822 --> Lambda1307
+    Object1316 --> Lambda1317
+    Constant1823{{"Constant[1823∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types_ᐳ"}}:::plan
+    Constant1823 --> Lambda1322
+    Object1331 --> Lambda1332
+    Constant1824{{"Constant[1824∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant1824 --> Lambda1337
+    Constant1856{{"Constant[1856∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1856 --> Lambda1339
+    Lambda1342{{"Lambda[1342∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1857{{"Constant[1857∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1857 --> Lambda1342
+    Access1343{{"Access[1343∈0] ➊<br />ᐸ1342.0ᐳ"}}:::plan
+    Lambda1342 --> Access1343
+    Lambda1348{{"Lambda[1348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1347 --> Lambda1348
+    Lambda1353{{"Lambda[1353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1825{{"Constant[1825∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant1825 --> Lambda1353
+    Object1362 --> Lambda1363
+    Constant1826{{"Constant[1826∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant1826 --> Lambda1368
+    Object1377 --> Lambda1378
+    Constant1827{{"Constant[1827∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1827 --> Lambda1383
+    Lambda1387{{"Lambda[1387∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1785{{"Constant[1785∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1785 --> Lambda1387
+    Access1388{{"Access[1388∈0] ➊<br />ᐸ1387.0ᐳ"}}:::plan
+    Lambda1387 --> Access1388
+    Lambda1393{{"Lambda[1393∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1392 --> Lambda1393
+    Lambda1398{{"Lambda[1398∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1828{{"Constant[1828∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1828 --> Lambda1398
+    Lambda1408{{"Lambda[1408∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1407 --> Lambda1408
+    Lambda1413{{"Lambda[1413∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1829{{"Constant[1829∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
+    Constant1829 --> Lambda1413
+    Lambda1423{{"Lambda[1423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1422 --> Lambda1423
+    Lambda1428{{"Lambda[1428∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1830{{"Constant[1830∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1830 --> Lambda1428
+    Object1429 --> Lambda1430
+    Lambda1432{{"Lambda[1432∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1431 --> Lambda1432
+    Access1433{{"Access[1433∈0] ➊<br />ᐸ1432.0ᐳ"}}:::plan
+    Lambda1432 --> Access1433
+    Lambda1438{{"Lambda[1438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1437 --> Lambda1438
+    Lambda1443{{"Lambda[1443∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1831{{"Constant[1831∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1831 --> Lambda1443
+    Lambda1453{{"Lambda[1453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1452 --> Lambda1453
+    Lambda1458{{"Lambda[1458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1832{{"Constant[1832∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1832 --> Lambda1458
+    Object1459 --> Lambda1460
+    Lambda1462{{"Lambda[1462∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1461 --> Lambda1462
+    Access1463{{"Access[1463∈0] ➊<br />ᐸ1462.0ᐳ"}}:::plan
+    Lambda1462 --> Access1463
+    Lambda1468{{"Lambda[1468∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1467 --> Lambda1468
+    Lambda1473{{"Lambda[1473∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1833{{"Constant[1833∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1833 --> Lambda1473
+    Object1474 --> Lambda1475
+    Lambda1477{{"Lambda[1477∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1476 --> Lambda1477
+    Access1478{{"Access[1478∈0] ➊<br />ᐸ1477.0ᐳ"}}:::plan
+    Lambda1477 --> Access1478
+    Lambda1483{{"Lambda[1483∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1482 --> Lambda1483
+    Lambda1488{{"Lambda[1488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1834{{"Constant[1834∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1834 --> Lambda1488
+    Object1489 --> Lambda1490
+    Lambda1492{{"Lambda[1492∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1491 --> Lambda1492
+    Access1493{{"Access[1493∈0] ➊<br />ᐸ1492.0ᐳ"}}:::plan
+    Lambda1492 --> Access1493
+    Lambda1498{{"Lambda[1498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1497 --> Lambda1498
+    Lambda1503{{"Lambda[1503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1835{{"Constant[1835∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1835 --> Lambda1503
+    Constant1858{{"Constant[1858∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1858 --> Lambda1505
+    Lambda1507{{"Lambda[1507∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1859{{"Constant[1859∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1859 --> Lambda1507
+    Access1508{{"Access[1508∈0] ➊<br />ᐸ1507.0ᐳ"}}:::plan
+    Lambda1507 --> Access1508
+    Lambda1513{{"Lambda[1513∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1512 --> Lambda1513
+    Lambda1518{{"Lambda[1518∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1836{{"Constant[1836∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1836 --> Lambda1518
+    Lambda1522{{"Lambda[1522∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1860{{"Constant[1860∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1860 --> Lambda1522
+    Access1523{{"Access[1523∈0] ➊<br />ᐸ1522.0ᐳ"}}:::plan
+    Lambda1522 --> Access1523
+    Lambda1528{{"Lambda[1528∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1527 --> Lambda1528
+    Lambda1533{{"Lambda[1533∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1837{{"Constant[1837∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1837 --> Lambda1533
+    Lambda1537{{"Lambda[1537∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1861{{"Constant[1861∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1861 --> Lambda1537
+    Access1538{{"Access[1538∈0] ➊<br />ᐸ1537.0ᐳ"}}:::plan
+    Lambda1537 --> Access1538
+    Lambda1543{{"Lambda[1543∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1542 --> Lambda1543
+    Lambda1548{{"Lambda[1548∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1838{{"Constant[1838∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1838 --> Lambda1548
+    Constant1862{{"Constant[1862∈0] ➊<br />ᐸ§{ first: 6, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1862 --> Lambda1550
+    Lambda1552{{"Lambda[1552∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1863{{"Constant[1863∈0] ➊<br />ᐸ§{ first: 6, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1863 --> Lambda1552
+    Access1553{{"Access[1553∈0] ➊<br />ᐸ1552.0ᐳ"}}:::plan
+    Lambda1552 --> Access1553
+    Lambda1558{{"Lambda[1558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1557 --> Lambda1558
+    Lambda1563{{"Lambda[1563∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1839{{"Constant[1839∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1839 --> Lambda1563
+    Object1564 --> Lambda1565
+    Lambda1567{{"Lambda[1567∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1566 --> Lambda1567
+    Access1568{{"Access[1568∈0] ➊<br />ᐸ1567.0ᐳ"}}:::plan
+    Lambda1567 --> Access1568
+    Lambda1573{{"Lambda[1573∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1572 --> Lambda1573
+    Lambda1578{{"Lambda[1578∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1840{{"Constant[1840∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1840 --> Lambda1578
+    Object1579 --> Lambda1580
+    Lambda1582{{"Lambda[1582∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1581 --> Lambda1582
+    Access1583{{"Access[1583∈0] ➊<br />ᐸ1582.0ᐳ"}}:::plan
+    Lambda1582 --> Access1583
+    Lambda1588{{"Lambda[1588∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1587 --> Lambda1588
+    Lambda1593{{"Lambda[1593∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1841{{"Constant[1841∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1841 --> Lambda1593
+    Lambda1597{{"Lambda[1597∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1864{{"Constant[1864∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1864 --> Lambda1597
+    Access1598{{"Access[1598∈0] ➊<br />ᐸ1597.0ᐳ"}}:::plan
+    Lambda1597 --> Access1598
+    Lambda1603{{"Lambda[1603∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1602 --> Lambda1603
+    Lambda1608{{"Lambda[1608∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1842{{"Constant[1842∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1842 --> Lambda1608
+    Object1609 --> Lambda1610
+    Lambda1612{{"Lambda[1612∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Object1611 --> Lambda1612
+    Access1613{{"Access[1613∈0] ➊<br />ᐸ1612.0ᐳ"}}:::plan
+    Lambda1612 --> Access1613
+    Lambda1618{{"Lambda[1618∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1617 --> Lambda1618
+    Lambda1623{{"Lambda[1623∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1843{{"Constant[1843∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant1843 --> Lambda1623
+    Lambda1633{{"Lambda[1633∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1632 --> Lambda1633
+    Lambda1638{{"Lambda[1638∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1844{{"Constant[1844∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
+    Constant1844 --> Lambda1638
+    Lambda1648{{"Lambda[1648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1647 --> Lambda1648
+    Lambda1653{{"Lambda[1653∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1845{{"Constant[1845∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
+    Constant1845 --> Lambda1653
+    Object1662 --> Lambda1663
+    Constant1846{{"Constant[1846∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”no_argᐳ"}}:::plan
+    Constant1846 --> Lambda1668
+    Lambda1679{{"Lambda[1679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1678 --> Lambda1679
+    Lambda1684{{"Lambda[1684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1847{{"Constant[1847∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”staticᐳ"}}:::plan
+    Constant1847 --> Lambda1684
+    Lambda1694{{"Lambda[1694∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1693 --> Lambda1694
+    Lambda1699{{"Lambda[1699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1848{{"Constant[1848∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”staticᐳ"}}:::plan
+    Constant1848 --> Lambda1699
+    Object1708 --> Lambda1709
+    Constant1849{{"Constant[1849∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1849 --> Lambda1714
+    Object1723 --> Lambda1724
+    Constant1850{{"Constant[1850∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1850 --> Lambda1729
+    Object1738 --> Lambda1739
+    Constant1851{{"Constant[1851∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1851 --> Lambda1744
+    Lambda1754{{"Lambda[1754∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1753 --> Lambda1754
+    Lambda1759{{"Lambda[1759∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1852{{"Constant[1852∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1852 --> Lambda1759
+    Lambda1769{{"Lambda[1769∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1768 --> Lambda1769
+    Lambda1774{{"Lambda[1774∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1853{{"Constant[1853∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant1853 --> Lambda1774
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant46{{"Constant[46∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Constant252{{"Constant[252∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
@@ -521,72 +820,7 @@ graph TD
     Connection964{{"Connection[964∈0] ➊<br />ᐸ962ᐳ"}}:::plan
     Connection988{{"Connection[988∈0] ➊<br />ᐸ986ᐳ"}}:::plan
     Connection1051{{"Connection[1051∈0] ➊<br />ᐸ1049ᐳ"}}:::plan
-    Constant1326{{"Constant[1326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1327{{"Constant[1327∈0] ➊<br />ᐸsql.identifier(”compound_type_set_query”)ᐳ"}}:::plan
-    Constant1368{{"Constant[1368∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1369{{"Constant[1369∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
-    Constant1370{{"Constant[1370∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant1382{{"Constant[1382∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'ASC' } ]ᐳ"}}:::plan
-    Constant1383{{"Constant[1383∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
-    Constant1396{{"Constant[1396∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1397{{"Constant[1397∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
-    Constant1410{{"Constant[1410∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1424{{"Constant[1424∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1438{{"Constant[1438∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1452{{"Constant[1452∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1466{{"Constant[1466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1480{{"Constant[1480∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1494{{"Constant[1494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1508{{"Constant[1508∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1522{{"Constant[1522∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1536{{"Constant[1536∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1550{{"Constant[1550∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1564{{"Constant[1564∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1565{{"Constant[1565∈0] ➊<br />ᐸsql.identifier(”table_set_query_plpgsql”)ᐳ"}}:::plan
-    Constant1578{{"Constant[1578∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1592{{"Constant[1592∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1593{{"Constant[1593∈0] ➊<br />ᐸsql.identifier(”int_set_query”)ᐳ"}}:::plan
-    Constant1606{{"Constant[1606∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1635{{"Constant[1635∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1636{{"Constant[1636∈0] ➊<br />ᐸsql.identifier(”static_big_integer”)ᐳ"}}:::plan
-    Constant1637{{"Constant[1637∈0] ➊<br />ᐸCodec(int8)ᐳ"}}:::plan
-    Constant1649{{"Constant[1649∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1705{{"Constant[1705∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1706{{"Constant[1706∈0] ➊<br />ᐸsql.identifier(”query_interval_set”)ᐳ"}}:::plan
-    Constant1707{{"Constant[1707∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
-    Constant1719{{"Constant[1719∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant1754{{"Constant[1754∈0] ➊<br />ᐸ'Budd Deey'ᐳ"}}:::plan
-    Constant1779{{"Constant[1779∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant1782{{"Constant[1782∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1783{{"Constant[1783∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
-    Constant1784{{"Constant[1784∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1785{{"Constant[1785∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1786{{"Constant[1786∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1787{{"Constant[1787∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1788{{"Constant[1788∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1789{{"Constant[1789∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1790{{"Constant[1790∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1791{{"Constant[1791∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1792{{"Constant[1792∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1793{{"Constant[1793∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1794{{"Constant[1794∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1795{{"Constant[1795∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1796{{"Constant[1796∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1797{{"Constant[1797∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant1798{{"Constant[1798∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
-    Constant1799{{"Constant[1799∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
-    Constant1801{{"Constant[1801∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”staticᐳ"}}:::plan
-    Constant1802{{"Constant[1802∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”staticᐳ"}}:::plan
-    Constant1806{{"Constant[1806∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1807{{"Constant[1807∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant1810{{"Constant[1810∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1811{{"Constant[1811∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1813{{"Constant[1813∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1814{{"Constant[1814∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1815{{"Constant[1815∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1816{{"Constant[1816∈0] ➊<br />ᐸ§{ first: 6, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1817{{"Constant[1817∈0] ➊<br />ᐸ§{ first: 6, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1818{{"Constant[1818∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1800{{"Constant[1800∈0] ➊<br />ᐸ'Budd Deey'ᐳ"}}:::plan
     PgClassExpression160{{"PgClassExpression[160∈1] ➊<br />ᐸ__compound...uery__.”a”ᐳ"}}:::plan
     PgSelectSingle159 --> PgClassExpression160
     PgClassExpression161{{"PgClassExpression[161∈1] ➊<br />ᐸ__compound...uery__.”b”ᐳ"}}:::plan
@@ -604,18 +838,12 @@ graph TD
     PgClassExpression170{{"PgClassExpression[170∈1] ➊<br />ᐸ__compound....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle159 --> PgClassExpression170
     PgSelect175[["PgSelect[175∈3] ➊<br />ᐸcompound_type_set_query+1ᐳ"]]:::plan
-    Lambda1322{{"Lambda[1322∈3] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1325{{"Lambda[1325∈3] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1330{{"Lambda[1330∈3] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1335{{"Lambda[1335∈3] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection174 & Constant1736 & Lambda1322 & Lambda1325 & Lambda1330 & Lambda1335 --> PgSelect175
+    Object10 & Connection174 & Constant1782 & Lambda1339 & Access1343 & Lambda1348 & Lambda1353 --> PgSelect175
     Object217{{"Object[217∈3] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access212{{"Access[212∈3] ➊<br />ᐸ175.hasMoreᐳ"}}:::plan
-    Constant1736 & Constant46 & Constant46 & Access212 --> Object217
-    Object1329{{"Object[1329∈3] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1322 & Constant1326 & Constant1327 & Constant1313 --> Object1329
+    Constant1782 & Constant46 & Constant46 & Access212 --> Object217
     Object213{{"Object[213∈3] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1736 & Constant46 & Access212 --> Object213
+    Constant1782 & Constant46 & Access212 --> Object213
     __ListTransform176[["__ListTransform[176∈3] ➊<br />ᐸeach:175ᐳ"]]:::plan
     PgSelect175 --> __ListTransform176
     PgPageInfo197{{"PgPageInfo[197∈3] ➊"}}:::plan
@@ -645,10 +873,6 @@ graph TD
     Object213 --> Lambda214
     Lambda218{{"Lambda[218∈3] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object217 --> Lambda218
-    Constant1810 --> Lambda1322
-    Constant1811 --> Lambda1325
-    Object1329 --> Lambda1330
-    Constant1779 --> Lambda1335
     __Item177[/"__Item[177∈4]<br />ᐸ175ᐳ"\]:::itemplan
     PgSelect175 -.-> __Item177
     PgSelectSingle178{{"PgSelectSingle[178∈4]<br />ᐸcompound_type_set_queryᐳ"}}:::plan
@@ -712,14 +936,10 @@ graph TD
     PgClassExpression257{{"PgClassExpression[257∈12] ➊<br />ᐸ__table_qu...author_id”ᐳ"}}:::plan
     PgSelectSingle251 --> PgClassExpression257
     PgSelect261[["PgSelect[261∈13] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1372{{"Lambda[1372∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1377{{"Lambda[1377∈13] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection260 & Lambda1083 & Lambda1367 & Lambda1372 & Lambda1377 --> PgSelect261
+    Object10 & Connection260 & Lambda1083 & Access1388 & Lambda1393 & Lambda1398 --> PgSelect261
     Object293{{"Object[293∈13] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access288{{"Access[288∈13] ➊<br />ᐸ261.hasMoreᐳ"}}:::plan
     Constant46 & Constant46 & Constant46 & Access288 --> Object293
-    Object1371{{"Object[1371∈13] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1368 & Constant1369 & Constant1370 --> Object1371
     Object289{{"Object[289∈13] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant46 & Constant46 & Access288 --> Object289
     __ListTransform262[["__ListTransform[262∈13] ➊<br />ᐸeach:261ᐳ"]]:::plan
@@ -751,8 +971,6 @@ graph TD
     Object289 --> Lambda290
     Lambda294{{"Lambda[294∈13] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object293 --> Lambda294
-    Object1371 --> Lambda1372
-    Constant1782 --> Lambda1377
     __Item263[/"__Item[263∈14]<br />ᐸ261ᐳ"\]:::itemplan
     PgSelect261 -.-> __Item263
     PgSelectSingle264{{"PgSelectSingle[264∈14]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -772,14 +990,10 @@ graph TD
     PgClassExpression271{{"PgClassExpression[271∈17]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle266 --> PgClassExpression271
     PgSelect300[["PgSelect[300∈18] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1386{{"Lambda[1386∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1391{{"Lambda[1391∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection299 & Lambda1083 & Lambda1367 & Lambda1386 & Lambda1391 --> PgSelect300
+    Object10 & Connection299 & Lambda1083 & Access1388 & Lambda1408 & Lambda1413 --> PgSelect300
     Object332{{"Object[332∈18] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access327{{"Access[327∈18] ➊<br />ᐸ300.hasMoreᐳ"}}:::plan
     Constant46 & Constant46 & Constant46 & Access327 --> Object332
-    Object1385{{"Object[1385∈18] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1382 & Constant1383 & Constant1370 --> Object1385
     Object328{{"Object[328∈18] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant46 & Constant46 & Access327 --> Object328
     __ListTransform301[["__ListTransform[301∈18] ➊<br />ᐸeach:300ᐳ"]]:::plan
@@ -811,8 +1025,6 @@ graph TD
     Object328 --> Lambda329
     Lambda333{{"Lambda[333∈18] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object332 --> Lambda333
-    Object1385 --> Lambda1386
-    Constant1783 --> Lambda1391
     __Item302[/"__Item[302∈19]<br />ᐸ300ᐳ"\]:::itemplan
     PgSelect300 -.-> __Item302
     PgSelectSingle303{{"PgSelectSingle[303∈19]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -830,14 +1042,10 @@ graph TD
     PgSelectSingle305 --> PgClassExpression308
     PgClassExpression308 --> List309
     PgSelect339[["PgSelect[339∈23] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1400{{"Lambda[1400∈23] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1405{{"Lambda[1405∈23] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1754 & Connection338 & Lambda1083 & Lambda1367 & Lambda1400 & Lambda1405 --> PgSelect339
+    Object10 & Constant1800 & Connection338 & Lambda1083 & Access1388 & Lambda1423 & Lambda1428 --> PgSelect339
     Object371{{"Object[371∈23] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access366{{"Access[366∈23] ➊<br />ᐸ339.hasMoreᐳ"}}:::plan
     Constant46 & Constant46 & Constant46 & Access366 --> Object371
-    Object1399{{"Object[1399∈23] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1396 & Constant1397 & Constant1370 --> Object1399
     Object367{{"Object[367∈23] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant46 & Constant46 & Access366 --> Object367
     __ListTransform340[["__ListTransform[340∈23] ➊<br />ᐸeach:339ᐳ"]]:::plan
@@ -869,8 +1077,6 @@ graph TD
     Object367 --> Lambda368
     Lambda372{{"Lambda[372∈23] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object371 --> Lambda372
-    Object1399 --> Lambda1400
-    Constant1784 --> Lambda1405
     __Item341[/"__Item[341∈24]<br />ᐸ339ᐳ"\]:::itemplan
     PgSelect339 -.-> __Item341
     PgSelectSingle342{{"PgSelectSingle[342∈24]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -890,14 +1096,10 @@ graph TD
     PgClassExpression349{{"PgClassExpression[349∈27]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle344 --> PgClassExpression349
     PgSelect380[["PgSelect[380∈28] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1414{{"Lambda[1414∈28] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1419{{"Lambda[1419∈28] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection377 & Lambda378 & Lambda379 & Access385 & Access387 & Lambda1407 & Lambda1409 & Lambda1414 & Lambda1419 --> PgSelect380
+    Object10 & Connection377 & Lambda378 & Lambda379 & Access385 & Access387 & Lambda1430 & Access1433 & Lambda1438 & Lambda1443 --> PgSelect380
     Object424{{"Object[424∈28] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access417{{"Access[417∈28] ➊<br />ᐸ380.hasMoreᐳ"}}:::plan
     Constant46 & Constant46 & Constant46 & Access417 --> Object424
-    Object1413{{"Object[1413∈28] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1407 & Constant1410 & Constant1369 & Constant1370 --> Object1413
     Object418{{"Object[418∈28] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant46 & Constant46 & Access417 --> Object418
     __ListTransform381[["__ListTransform[381∈28] ➊<br />ᐸeach:380ᐳ"]]:::plan
@@ -929,8 +1131,6 @@ graph TD
     Object418 --> Lambda419
     Lambda425{{"Lambda[425∈28] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object424 --> Lambda425
-    Object1413 --> Lambda1414
-    Constant1785 --> Lambda1419
     __Item382[/"__Item[382∈29]<br />ᐸ380ᐳ"\]:::itemplan
     PgSelect380 -.-> __Item382
     PgSelectSingle383{{"PgSelectSingle[383∈29]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -950,14 +1150,10 @@ graph TD
     PgClassExpression394{{"PgClassExpression[394∈32]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle389 --> PgClassExpression394
     PgSelect435[["PgSelect[435∈33] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1428{{"Lambda[1428∈33] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1433{{"Lambda[1433∈33] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection432 & Lambda378 & Lambda379 & Access385 & Access387 & Lambda1407 & Lambda1409 & Lambda1428 & Lambda1433 --> PgSelect435
+    Object10 & Connection432 & Lambda378 & Lambda379 & Access385 & Access387 & Lambda1430 & Access1433 & Lambda1453 & Lambda1458 --> PgSelect435
     Object479{{"Object[479∈33] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access472{{"Access[472∈33] ➊<br />ᐸ435.hasMoreᐳ"}}:::plan
     Constant46 & Constant46 & Constant46 & Access472 --> Object479
-    Object1427{{"Object[1427∈33] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1407 & Constant1424 & Constant1369 & Constant1370 --> Object1427
     Object473{{"Object[473∈33] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant46 & Constant46 & Access472 --> Object473
     __ListTransform436[["__ListTransform[436∈33] ➊<br />ᐸeach:435ᐳ"]]:::plan
@@ -989,8 +1185,6 @@ graph TD
     Object473 --> Lambda474
     Lambda480{{"Lambda[480∈33] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object479 --> Lambda480
-    Object1427 --> Lambda1428
-    Constant1786 --> Lambda1433
     __Item437[/"__Item[437∈34]<br />ᐸ435ᐳ"\]:::itemplan
     PgSelect435 -.-> __Item437
     PgSelectSingle438{{"PgSelectSingle[438∈34]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1010,22 +1204,12 @@ graph TD
     PgClassExpression449{{"PgClassExpression[449∈37]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle444 --> PgClassExpression449
     PgSelect489[["PgSelect[489∈38] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1435{{"Lambda[1435∈38] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1437{{"Lambda[1437∈38] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1442{{"Lambda[1442∈38] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1447{{"Lambda[1447∈38] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection487 & Lambda378 & Constant1734 & Access385 & Lambda1435 & Lambda1437 & Lambda1442 & Lambda1447 --> PgSelect489
-    Object1436{{"Object[1436∈38] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
-    Constant48 & Constant1734 & Constant48 & Access385 & Constant48 & Constant1323 --> Object1436
+    Object10 & Connection487 & Lambda378 & Constant1780 & Access385 & Lambda1460 & Access1463 & Lambda1468 & Lambda1473 --> PgSelect489
     Object527{{"Object[527∈38] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access521{{"Access[521∈38] ➊<br />ᐸ489.hasMoreᐳ"}}:::plan
-    Constant46 & Constant1734 & Constant46 & Access521 --> Object527
-    Object1434{{"Object[1434∈38] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant48 & Constant1734 & Constant48 & Access385 --> Object1434
-    Object1441{{"Object[1441∈38] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1435 & Constant1438 & Constant1369 & Constant1370 --> Object1441
+    Constant46 & Constant1780 & Constant46 & Access521 --> Object527
     Object522{{"Object[522∈38] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant46 & Constant1734 & Access521 --> Object522
+    Constant46 & Constant1780 & Access521 --> Object522
     __ListTransform490[["__ListTransform[490∈38] ➊<br />ᐸeach:489ᐳ"]]:::plan
     PgSelect489 --> __ListTransform490
     PgPageInfo504{{"PgPageInfo[504∈38] ➊"}}:::plan
@@ -1055,10 +1239,6 @@ graph TD
     Object522 --> Lambda523
     Lambda528{{"Lambda[528∈38] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object527 --> Lambda528
-    Object1434 --> Lambda1435
-    Object1436 --> Lambda1437
-    Object1441 --> Lambda1442
-    Constant1787 --> Lambda1447
     __Item491[/"__Item[491∈39]<br />ᐸ489ᐳ"\]:::itemplan
     PgSelect489 -.-> __Item491
     PgSelectSingle492{{"PgSelectSingle[492∈39]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1078,22 +1258,12 @@ graph TD
     PgClassExpression501{{"PgClassExpression[501∈42]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle496 --> PgClassExpression501
     PgSelect536[["PgSelect[536∈43] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1449{{"Lambda[1449∈43] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1451{{"Lambda[1451∈43] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1456{{"Lambda[1456∈43] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1461{{"Lambda[1461∈43] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection534 & Lambda378 & Constant1734 & Access385 & Lambda1449 & Lambda1451 & Lambda1456 & Lambda1461 --> PgSelect536
-    Object1450{{"Object[1450∈43] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Constant48 & Access385 & Constant48 & Constant1323 --> Object1450
+    Object10 & Connection534 & Lambda378 & Constant1780 & Access385 & Lambda1475 & Access1478 & Lambda1483 & Lambda1488 --> PgSelect536
     Object574{{"Object[574∈43] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access568{{"Access[568∈43] ➊<br />ᐸ536.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant46 & Access568 --> Object574
-    Object1448{{"Object[1448∈43] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Constant48 & Access385 --> Object1448
-    Object1455{{"Object[1455∈43] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1449 & Constant1452 & Constant1369 & Constant1370 --> Object1455
+    Constant1780 & Constant46 & Constant46 & Access568 --> Object574
     Object569{{"Object[569∈43] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access568 --> Object569
+    Constant1780 & Constant46 & Access568 --> Object569
     __ListTransform537[["__ListTransform[537∈43] ➊<br />ᐸeach:536ᐳ"]]:::plan
     PgSelect536 --> __ListTransform537
     PgPageInfo551{{"PgPageInfo[551∈43] ➊"}}:::plan
@@ -1123,10 +1293,6 @@ graph TD
     Object569 --> Lambda570
     Lambda575{{"Lambda[575∈43] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object574 --> Lambda575
-    Object1448 --> Lambda1449
-    Object1450 --> Lambda1451
-    Object1455 --> Lambda1456
-    Constant1788 --> Lambda1461
     __Item538[/"__Item[538∈44]<br />ᐸ536ᐳ"\]:::itemplan
     PgSelect536 -.-> __Item538
     PgSelectSingle539{{"PgSelectSingle[539∈44]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1146,22 +1312,12 @@ graph TD
     PgClassExpression548{{"PgClassExpression[548∈47]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle543 --> PgClassExpression548
     PgSelect583[["PgSelect[583∈48] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1463{{"Lambda[1463∈48] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1465{{"Lambda[1465∈48] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1470{{"Lambda[1470∈48] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1475{{"Lambda[1475∈48] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection581 & Lambda379 & Constant1734 & Access387 & Lambda1463 & Lambda1465 & Lambda1470 & Lambda1475 --> PgSelect583
-    Object1464{{"Object[1464∈48] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Access387 & Constant48 & Constant48 & Constant1323 --> Object1464
+    Object10 & Connection581 & Lambda379 & Constant1780 & Access387 & Lambda1490 & Access1493 & Lambda1498 & Lambda1503 --> PgSelect583
     Object621{{"Object[621∈48] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access615{{"Access[615∈48] ➊<br />ᐸ583.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant46 & Access615 --> Object621
-    Object1462{{"Object[1462∈48] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Access387 & Constant48 --> Object1462
-    Object1469{{"Object[1469∈48] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1463 & Constant1466 & Constant1369 & Constant1370 --> Object1469
+    Constant1780 & Constant46 & Constant46 & Access615 --> Object621
     Object616{{"Object[616∈48] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access615 --> Object616
+    Constant1780 & Constant46 & Access615 --> Object616
     __ListTransform584[["__ListTransform[584∈48] ➊<br />ᐸeach:583ᐳ"]]:::plan
     PgSelect583 --> __ListTransform584
     PgPageInfo598{{"PgPageInfo[598∈48] ➊"}}:::plan
@@ -1191,10 +1347,6 @@ graph TD
     Object616 --> Lambda617
     Lambda622{{"Lambda[622∈48] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object621 --> Lambda622
-    Object1462 --> Lambda1463
-    Object1464 --> Lambda1465
-    Object1469 --> Lambda1470
-    Constant1789 --> Lambda1475
     __Item585[/"__Item[585∈49]<br />ᐸ583ᐳ"\]:::itemplan
     PgSelect583 -.-> __Item585
     PgSelectSingle586{{"PgSelectSingle[586∈49]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1214,17 +1366,12 @@ graph TD
     PgClassExpression595{{"PgClassExpression[595∈52]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle590 --> PgClassExpression595
     PgSelect629[["PgSelect[629∈53] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1479{{"Lambda[1479∈53] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1484{{"Lambda[1484∈53] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1489{{"Lambda[1489∈53] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection628 & Constant1734 & Constant1734 & Lambda1477 & Lambda1479 & Lambda1484 & Lambda1489 --> PgSelect629
+    Object10 & Connection628 & Constant1780 & Constant1780 & Lambda1505 & Access1508 & Lambda1513 & Lambda1518 --> PgSelect629
     Object661{{"Object[661∈53] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access656{{"Access[656∈53] ➊<br />ᐸ629.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant1734 & Access656 --> Object661
-    Object1483{{"Object[1483∈53] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1477 & Constant1480 & Constant1369 & Constant1370 --> Object1483
+    Constant1780 & Constant46 & Constant1780 & Access656 --> Object661
     Object657{{"Object[657∈53] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access656 --> Object657
+    Constant1780 & Constant46 & Access656 --> Object657
     __ListTransform630[["__ListTransform[630∈53] ➊<br />ᐸeach:629ᐳ"]]:::plan
     PgSelect629 --> __ListTransform630
     PgPageInfo641{{"PgPageInfo[641∈53] ➊"}}:::plan
@@ -1254,9 +1401,6 @@ graph TD
     Object657 --> Lambda658
     Lambda662{{"Lambda[662∈53] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object661 --> Lambda662
-    Constant1813 --> Lambda1479
-    Object1483 --> Lambda1484
-    Constant1790 --> Lambda1489
     __Item631[/"__Item[631∈54]<br />ᐸ629ᐳ"\]:::itemplan
     PgSelect629 -.-> __Item631
     PgSelectSingle632{{"PgSelectSingle[632∈54]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1276,17 +1420,12 @@ graph TD
     PgClassExpression639{{"PgClassExpression[639∈57]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle634 --> PgClassExpression639
     PgSelect668[["PgSelect[668∈58] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1493{{"Lambda[1493∈58] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1498{{"Lambda[1498∈58] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1503{{"Lambda[1503∈58] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection667 & Constant1734 & Constant1757 & Lambda1477 & Lambda1493 & Lambda1498 & Lambda1503 --> PgSelect668
+    Object10 & Connection667 & Constant1780 & Constant1803 & Lambda1505 & Access1523 & Lambda1528 & Lambda1533 --> PgSelect668
     Object700{{"Object[700∈58] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access695{{"Access[695∈58] ➊<br />ᐸ668.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant1757 & Access695 --> Object700
-    Object1497{{"Object[1497∈58] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1477 & Constant1494 & Constant1369 & Constant1370 --> Object1497
+    Constant1780 & Constant46 & Constant1803 & Access695 --> Object700
     Object696{{"Object[696∈58] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access695 --> Object696
+    Constant1780 & Constant46 & Access695 --> Object696
     __ListTransform669[["__ListTransform[669∈58] ➊<br />ᐸeach:668ᐳ"]]:::plan
     PgSelect668 --> __ListTransform669
     PgPageInfo680{{"PgPageInfo[680∈58] ➊"}}:::plan
@@ -1316,9 +1455,6 @@ graph TD
     Object696 --> Lambda697
     Lambda701{{"Lambda[701∈58] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object700 --> Lambda701
-    Constant1814 --> Lambda1493
-    Object1497 --> Lambda1498
-    Constant1791 --> Lambda1503
     __Item670[/"__Item[670∈59]<br />ᐸ668ᐳ"\]:::itemplan
     PgSelect668 -.-> __Item670
     PgSelectSingle671{{"PgSelectSingle[671∈59]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1338,17 +1474,12 @@ graph TD
     PgClassExpression678{{"PgClassExpression[678∈62]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle673 --> PgClassExpression678
     PgSelect707[["PgSelect[707∈63] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1507{{"Lambda[1507∈63] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1512{{"Lambda[1512∈63] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1517{{"Lambda[1517∈63] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection706 & Constant1734 & Constant1758 & Lambda1477 & Lambda1507 & Lambda1512 & Lambda1517 --> PgSelect707
+    Object10 & Connection706 & Constant1780 & Constant1804 & Lambda1505 & Access1538 & Lambda1543 & Lambda1548 --> PgSelect707
     Object739{{"Object[739∈63] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access734{{"Access[734∈63] ➊<br />ᐸ707.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant1758 & Access734 --> Object739
-    Object1511{{"Object[1511∈63] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1477 & Constant1508 & Constant1369 & Constant1370 --> Object1511
+    Constant1780 & Constant46 & Constant1804 & Access734 --> Object739
     Object735{{"Object[735∈63] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access734 --> Object735
+    Constant1780 & Constant46 & Access734 --> Object735
     __ListTransform708[["__ListTransform[708∈63] ➊<br />ᐸeach:707ᐳ"]]:::plan
     PgSelect707 --> __ListTransform708
     PgPageInfo719{{"PgPageInfo[719∈63] ➊"}}:::plan
@@ -1378,9 +1509,6 @@ graph TD
     Object735 --> Lambda736
     Lambda740{{"Lambda[740∈63] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object739 --> Lambda740
-    Constant1815 --> Lambda1507
-    Object1511 --> Lambda1512
-    Constant1792 --> Lambda1517
     __Item709[/"__Item[709∈64]<br />ᐸ707ᐳ"\]:::itemplan
     PgSelect707 -.-> __Item709
     PgSelectSingle710{{"PgSelectSingle[710∈64]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1400,18 +1528,12 @@ graph TD
     PgClassExpression717{{"PgClassExpression[717∈67]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle712 --> PgClassExpression717
     PgSelect746[["PgSelect[746∈68] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1519{{"Lambda[1519∈68] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1521{{"Lambda[1521∈68] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1526{{"Lambda[1526∈68] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1531{{"Lambda[1531∈68] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection745 & Constant1759 & Constant1758 & Lambda1519 & Lambda1521 & Lambda1526 & Lambda1531 --> PgSelect746
+    Object10 & Connection745 & Constant1805 & Constant1804 & Lambda1550 & Access1553 & Lambda1558 & Lambda1563 --> PgSelect746
     Object778{{"Object[778∈68] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access773{{"Access[773∈68] ➊<br />ᐸ746.hasMoreᐳ"}}:::plan
-    Constant1759 & Constant46 & Constant1758 & Access773 --> Object778
-    Object1525{{"Object[1525∈68] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1519 & Constant1522 & Constant1369 & Constant1370 --> Object1525
+    Constant1805 & Constant46 & Constant1804 & Access773 --> Object778
     Object774{{"Object[774∈68] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1759 & Constant46 & Access773 --> Object774
+    Constant1805 & Constant46 & Access773 --> Object774
     __ListTransform747[["__ListTransform[747∈68] ➊<br />ᐸeach:746ᐳ"]]:::plan
     PgSelect746 --> __ListTransform747
     PgPageInfo758{{"PgPageInfo[758∈68] ➊"}}:::plan
@@ -1441,10 +1563,6 @@ graph TD
     Object774 --> Lambda775
     Lambda779{{"Lambda[779∈68] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object778 --> Lambda779
-    Constant1816 --> Lambda1519
-    Constant1817 --> Lambda1521
-    Object1525 --> Lambda1526
-    Constant1793 --> Lambda1531
     __Item748[/"__Item[748∈69]<br />ᐸ746ᐳ"\]:::itemplan
     PgSelect746 -.-> __Item748
     PgSelectSingle749{{"PgSelectSingle[749∈69]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1464,22 +1582,12 @@ graph TD
     PgClassExpression756{{"PgClassExpression[756∈72]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle751 --> PgClassExpression756
     PgSelect786[["PgSelect[786∈73] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1533{{"Lambda[1533∈73] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1535{{"Lambda[1535∈73] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1540{{"Lambda[1540∈73] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1545{{"Lambda[1545∈73] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection784 & Lambda785 & Constant1734 & Access791 & Lambda1533 & Lambda1535 & Lambda1540 & Lambda1545 --> PgSelect786
-    Object1534{{"Object[1534∈73] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
-    Constant48 & Constant1734 & Constant48 & Access791 & Constant48 & Constant1323 --> Object1534
+    Object10 & Connection784 & Lambda785 & Constant1780 & Access791 & Lambda1565 & Access1568 & Lambda1573 & Lambda1578 --> PgSelect786
     Object824{{"Object[824∈73] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access818{{"Access[818∈73] ➊<br />ᐸ786.hasMoreᐳ"}}:::plan
-    Constant46 & Constant1734 & Constant46 & Access818 --> Object824
-    Object1532{{"Object[1532∈73] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant48 & Constant1734 & Constant48 & Access791 --> Object1532
-    Object1539{{"Object[1539∈73] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1533 & Constant1536 & Constant1369 & Constant1370 --> Object1539
+    Constant46 & Constant1780 & Constant46 & Access818 --> Object824
     Object819{{"Object[819∈73] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant46 & Constant1734 & Access818 --> Object819
+    Constant46 & Constant1780 & Access818 --> Object819
     __ListTransform787[["__ListTransform[787∈73] ➊<br />ᐸeach:786ᐳ"]]:::plan
     PgSelect786 --> __ListTransform787
     PgPageInfo801{{"PgPageInfo[801∈73] ➊"}}:::plan
@@ -1509,10 +1617,6 @@ graph TD
     Object819 --> Lambda820
     Lambda825{{"Lambda[825∈73] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object824 --> Lambda825
-    Object1532 --> Lambda1533
-    Object1534 --> Lambda1535
-    Object1539 --> Lambda1540
-    Constant1794 --> Lambda1545
     __Item788[/"__Item[788∈74]<br />ᐸ786ᐳ"\]:::itemplan
     PgSelect786 -.-> __Item788
     PgSelectSingle789{{"PgSelectSingle[789∈74]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1532,22 +1636,12 @@ graph TD
     PgClassExpression798{{"PgClassExpression[798∈77]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle793 --> PgClassExpression798
     PgSelect834[["PgSelect[834∈78] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
-    Lambda1547{{"Lambda[1547∈78] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1549{{"Lambda[1549∈78] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1554{{"Lambda[1554∈78] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1559{{"Lambda[1559∈78] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection832 & Lambda785 & Constant1734 & Constant1733 & Access791 & Lambda1547 & Lambda1549 & Lambda1554 & Lambda1559 --> PgSelect834
-    Object1548{{"Object[1548∈78] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Access791 & Constant48 & Constant1733 & Constant1323 --> Object1548
+    Object10 & Connection832 & Lambda785 & Constant1780 & Constant1779 & Access791 & Lambda1580 & Access1583 & Lambda1588 & Lambda1593 --> PgSelect834
     Object872{{"Object[872∈78] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access866{{"Access[866∈78] ➊<br />ᐸ834.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant1733 & Access866 --> Object872
-    Object1546{{"Object[1546∈78] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Access791 & Constant48 --> Object1546
-    Object1553{{"Object[1553∈78] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1547 & Constant1550 & Constant1369 & Constant1370 --> Object1553
+    Constant1780 & Constant46 & Constant1779 & Access866 --> Object872
     Object867{{"Object[867∈78] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access866 --> Object867
+    Constant1780 & Constant46 & Access866 --> Object867
     __ListTransform835[["__ListTransform[835∈78] ➊<br />ᐸeach:834ᐳ"]]:::plan
     PgSelect834 --> __ListTransform835
     PgPageInfo849{{"PgPageInfo[849∈78] ➊"}}:::plan
@@ -1577,10 +1671,6 @@ graph TD
     Object867 --> Lambda868
     Lambda873{{"Lambda[873∈78] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object872 --> Lambda873
-    Object1546 --> Lambda1547
-    Object1548 --> Lambda1549
-    Object1553 --> Lambda1554
-    Constant1795 --> Lambda1559
     __Item836[/"__Item[836∈79]<br />ᐸ834ᐳ"\]:::itemplan
     PgSelect834 -.-> __Item836
     PgSelectSingle837{{"PgSelectSingle[837∈79]<br />ᐸtable_set_queryᐳ"}}:::plan
@@ -1600,17 +1690,12 @@ graph TD
     PgClassExpression846{{"PgClassExpression[846∈82]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle841 --> PgClassExpression846
     PgSelect879[["PgSelect[879∈83] ➊<br />ᐸtable_set_query_plpgsql+1ᐳ"]]:::plan
-    Lambda1563{{"Lambda[1563∈83] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1568{{"Lambda[1568∈83] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1573{{"Lambda[1573∈83] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection878 & Constant1734 & Lambda1477 & Lambda1563 & Lambda1568 & Lambda1573 --> PgSelect879
+    Object10 & Connection878 & Constant1780 & Lambda1505 & Access1598 & Lambda1603 & Lambda1608 --> PgSelect879
     Object911{{"Object[911∈83] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access906{{"Access[906∈83] ➊<br />ᐸ879.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant46 & Access906 --> Object911
-    Object1567{{"Object[1567∈83] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1477 & Constant1564 & Constant1565 & Constant1370 --> Object1567
+    Constant1780 & Constant46 & Constant46 & Access906 --> Object911
     Object907{{"Object[907∈83] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access906 --> Object907
+    Constant1780 & Constant46 & Access906 --> Object907
     __ListTransform880[["__ListTransform[880∈83] ➊<br />ᐸeach:879ᐳ"]]:::plan
     PgSelect879 --> __ListTransform880
     PgPageInfo891{{"PgPageInfo[891∈83] ➊"}}:::plan
@@ -1640,9 +1725,6 @@ graph TD
     Object907 --> Lambda908
     Lambda912{{"Lambda[912∈83] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object911 --> Lambda912
-    Constant1818 --> Lambda1563
-    Object1567 --> Lambda1568
-    Constant1796 --> Lambda1573
     __Item881[/"__Item[881∈84]<br />ᐸ879ᐳ"\]:::itemplan
     PgSelect879 -.-> __Item881
     PgSelectSingle882{{"PgSelectSingle[882∈84]<br />ᐸtable_set_query_plpgsqlᐳ"}}:::plan
@@ -1662,26 +1744,14 @@ graph TD
     PgClassExpression889{{"PgClassExpression[889∈87]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle884 --> PgClassExpression889
     PgSelect919[["PgSelect[919∈88] ➊<br />ᐸtable_set_query_plpgsql+1ᐳ"]]:::plan
-    Access924{{"Access[924∈88] ➊<br />ᐸ918.1ᐳ"}}:::plan
-    Lambda1575{{"Lambda[1575∈88] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda1577{{"Lambda[1577∈88] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda1582{{"Lambda[1582∈88] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1587{{"Lambda[1587∈88] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection917 & Lambda918 & Constant1734 & Access924 & Lambda1575 & Lambda1577 & Lambda1582 & Lambda1587 --> PgSelect919
-    Object1576{{"Object[1576∈88] ➊<br />ᐸ{first,last,cursorLower,cursorUpper,offset,fetchOneExtra}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Access924 & Constant48 & Constant48 & Constant1323 --> Object1576
+    Object10 & Connection917 & Lambda918 & Constant1780 & Access924 & Lambda1610 & Access1613 & Lambda1618 & Lambda1623 --> PgSelect919
     Object957{{"Object[957∈88] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access951{{"Access[951∈88] ➊<br />ᐸ919.hasMoreᐳ"}}:::plan
-    Constant1734 & Constant46 & Constant46 & Access951 --> Object957
-    Object1574{{"Object[1574∈88] ➊<br />ᐸ{first,last,cursorLower,cursorUpper}ᐳ"}}:::plan
-    Constant1734 & Constant48 & Access924 & Constant48 --> Object1574
-    Object1581{{"Object[1581∈88] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1575 & Constant1578 & Constant1565 & Constant1370 --> Object1581
+    Constant1780 & Constant46 & Constant46 & Access951 --> Object957
     Object952{{"Object[952∈88] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
-    Constant1734 & Constant46 & Access951 --> Object952
+    Constant1780 & Constant46 & Access951 --> Object952
     __ListTransform920[["__ListTransform[920∈88] ➊<br />ᐸeach:919ᐳ"]]:::plan
     PgSelect919 --> __ListTransform920
-    Lambda918 --> Access924
     PgPageInfo934{{"PgPageInfo[934∈88] ➊"}}:::plan
     Connection917 --> PgPageInfo934
     First936{{"First[936∈88] ➊"}}:::plan
@@ -1709,10 +1779,6 @@ graph TD
     Object952 --> Lambda953
     Lambda958{{"Lambda[958∈88] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object957 --> Lambda958
-    Object1574 --> Lambda1575
-    Object1576 --> Lambda1577
-    Object1581 --> Lambda1582
-    Constant1797 --> Lambda1587
     __Item921[/"__Item[921∈89]<br />ᐸ919ᐳ"\]:::itemplan
     PgSelect919 -.-> __Item921
     PgSelectSingle922{{"PgSelectSingle[922∈89]<br />ᐸtable_set_query_plpgsqlᐳ"}}:::plan
@@ -1732,17 +1798,9 @@ graph TD
     PgClassExpression931{{"PgClassExpression[931∈92]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle926 --> PgClassExpression931
     PgSelect965[["PgSelect[965∈93] ➊<br />ᐸint_set_queryᐳ"]]:::plan
-    Lambda1596{{"Lambda[1596∈93] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1601{{"Lambda[1601∈93] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1736 & Constant48 & Constant1759 & Connection964 & Lambda1083 & Lambda1086 & Lambda1596 & Lambda1601 --> PgSelect965
+    Object10 & Constant1782 & Constant48 & Constant1805 & Connection964 & Lambda1083 & Access1087 & Lambda1633 & Lambda1638 --> PgSelect965
     PgSelect977[["PgSelect[977∈93] ➊<br />ᐸint_set_query(aggregate)ᐳ"]]:::plan
-    Lambda1610{{"Lambda[1610∈93] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1615{{"Lambda[1615∈93] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant1736 & Constant48 & Constant1759 & Connection964 & Lambda1083 & Lambda1086 & Lambda1610 & Lambda1615 --> PgSelect977
-    Object1595{{"Object[1595∈93] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1592 & Constant1593 & Constant1145 --> Object1595
-    Object1609{{"Object[1609∈93] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1606 & Constant1593 & Constant1145 --> Object1609
+    Object10 & Constant1782 & Constant48 & Constant1805 & Connection964 & Lambda1083 & Access1087 & Lambda1648 & Lambda1653 --> PgSelect977
     __ListTransform966[["__ListTransform[966∈93] ➊<br />ᐸeach:965ᐳ"]]:::plan
     PgSelect965 --> __ListTransform966
     First978{{"First[978∈93] ➊"}}:::plan
@@ -1751,10 +1809,6 @@ graph TD
     First978 --> PgSelectSingle979
     PgClassExpression980{{"PgClassExpression[980∈93] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle979 --> PgClassExpression980
-    Object1595 --> Lambda1596
-    Constant1798 --> Lambda1601
-    Object1609 --> Lambda1610
-    Constant1799 --> Lambda1615
     __Item967[/"__Item[967∈94]<br />ᐸ965ᐳ"\]:::itemplan
     PgSelect965 -.-> __Item967
     PgSelectSingle968{{"PgSelectSingle[968∈94]<br />ᐸint_set_queryᐳ"}}:::plan
@@ -1776,17 +1830,9 @@ graph TD
     PgSelectSingle971 --> PgClassExpression975
     PgClassExpression975 --> List976
     PgSelect989[["PgSelect[989∈97] ➊<br />ᐸstatic_big_integerᐳ"]]:::plan
-    Lambda1639{{"Lambda[1639∈97] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1644{{"Lambda[1644∈97] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection988 & Lambda1083 & Lambda1086 & Lambda1639 & Lambda1644 --> PgSelect989
+    Object10 & Connection988 & Lambda1083 & Access1087 & Lambda1679 & Lambda1684 --> PgSelect989
     PgSelect1001[["PgSelect[1001∈97] ➊<br />ᐸstatic_big_integer(aggregate)ᐳ"]]:::plan
-    Lambda1653{{"Lambda[1653∈97] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1658{{"Lambda[1658∈97] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection988 & Lambda1083 & Lambda1086 & Lambda1653 & Lambda1658 --> PgSelect1001
-    Object1638{{"Object[1638∈97] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1635 & Constant1636 & Constant1637 --> Object1638
-    Object1652{{"Object[1652∈97] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1649 & Constant1636 & Constant1637 --> Object1652
+    Object10 & Connection988 & Lambda1083 & Access1087 & Lambda1694 & Lambda1699 --> PgSelect1001
     __ListTransform990[["__ListTransform[990∈97] ➊<br />ᐸeach:989ᐳ"]]:::plan
     PgSelect989 --> __ListTransform990
     First1002{{"First[1002∈97] ➊"}}:::plan
@@ -1795,19 +1841,15 @@ graph TD
     First1002 --> PgSelectSingle1003
     PgClassExpression1004{{"PgClassExpression[1004∈97] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle1003 --> PgClassExpression1004
-    Object1638 --> Lambda1639
-    Constant1801 --> Lambda1644
-    Object1652 --> Lambda1653
-    Constant1802 --> Lambda1658
     __Item991[/"__Item[991∈98]<br />ᐸ989ᐳ"\]:::itemplan
     PgSelect989 -.-> __Item991
     PgSelectSingle992{{"PgSelectSingle[992∈98]<br />ᐸstatic_big_integerᐳ"}}:::plan
     __Item991 --> PgSelectSingle992
     PgClassExpression993{{"PgClassExpression[993∈98]<br />ᐸ__static_b...nteger__.vᐳ"}}:::plan
     PgSelectSingle992 --> PgClassExpression993
-    Edge1630{{"Edge[1630∈99]"}}:::plan
+    Edge1669{{"Edge[1669∈99]"}}:::plan
     PgClassExpression996{{"PgClassExpression[996∈99]<br />ᐸ__static_b...nteger__.vᐳ"}}:::plan
-    PgClassExpression996 & Connection988 --> Edge1630
+    PgClassExpression996 & Connection988 --> Edge1669
     __Item994[/"__Item[994∈99]<br />ᐸ990ᐳ"\]:::itemplan
     __ListTransform990 ==> __Item994
     PgSelectSingle995{{"PgSelectSingle[995∈99]<br />ᐸstatic_big_integerᐳ"}}:::plan
@@ -1838,17 +1880,9 @@ graph TD
     __Item1042[/"__Item[1042∈105]<br />ᐸ1041ᐳ"\]:::itemplan
     PgClassExpression1041 ==> __Item1042
     PgSelect1052[["PgSelect[1052∈107] ➊<br />ᐸquery_interval_setᐳ"]]:::plan
-    Lambda1709{{"Lambda[1709∈107] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1714{{"Lambda[1714∈107] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection1051 & Lambda1083 & Lambda1086 & Lambda1709 & Lambda1714 --> PgSelect1052
+    Object10 & Connection1051 & Lambda1083 & Access1087 & Lambda1754 & Lambda1759 --> PgSelect1052
     PgSelect1077[["PgSelect[1077∈107] ➊<br />ᐸquery_interval_set(aggregate)ᐳ"]]:::plan
-    Lambda1723{{"Lambda[1723∈107] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda1728{{"Lambda[1728∈107] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection1051 & Lambda1083 & Lambda1086 & Lambda1723 & Lambda1728 --> PgSelect1077
-    Object1708{{"Object[1708∈107] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1705 & Constant1706 & Constant1707 --> Object1708
-    Object1722{{"Object[1722∈107] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda1083 & Constant1719 & Constant1706 & Constant1707 --> Object1722
+    Object10 & Connection1051 & Lambda1083 & Access1087 & Lambda1769 & Lambda1774 --> PgSelect1077
     __ListTransform1063[["__ListTransform[1063∈107] ➊<br />ᐸeach:1062ᐳ"]]:::plan
     PgSelect1052 --> __ListTransform1063
     First1078{{"First[1078∈107] ➊"}}:::plan
@@ -1857,10 +1891,6 @@ graph TD
     First1078 --> PgSelectSingle1079
     PgClassExpression1080{{"PgClassExpression[1080∈107] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle1079 --> PgClassExpression1080
-    Object1708 --> Lambda1709
-    Constant1806 --> Lambda1714
-    Object1722 --> Lambda1723
-    Constant1807 --> Lambda1728
     __Item1053[/"__Item[1053∈108]<br />ᐸ1052ᐳ"\]:::itemplan
     PgSelect1052 ==> __Item1053
     PgSelectSingle1054{{"PgSelectSingle[1054∈108]<br />ᐸquery_interval_setᐳ"}}:::plan
@@ -1891,18 +1921,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/procedure-query"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 46, 48, 252, 260, 299, 338, 964, 988, 1051, 1084, 1087, 1088, 1089, 1101, 1102, 1103, 1115, 1116, 1129, 1130, 1143, 1144, 1145, 1157, 1158, 1171, 1172, 1185, 1186, 1199, 1200, 1213, 1214, 1227, 1228, 1241, 1242, 1255, 1256, 1269, 1270, 1283, 1284, 1285, 1297, 1298, 1311, 1312, 1313, 1323, 1326, 1327, 1340, 1341, 1354, 1355, 1356, 1368, 1369, 1370, 1382, 1383, 1396, 1397, 1410, 1424, 1438, 1452, 1466, 1480, 1494, 1508, 1522, 1536, 1550, 1564, 1565, 1578, 1592, 1593, 1606, 1620, 1621, 1635, 1636, 1637, 1649, 1663, 1664, 1677, 1678, 1679, 1691, 1692, 1693, 1705, 1706, 1707, 1719, 1729, 1730, 1731, 1732, 1733, 1734, 1736, 1737, 1738, 1739, 1740, 1741, 1742, 1743, 1744, 1745, 1746, 1747, 1748, 1754, 1755, 1756, 1757, 1758, 1759, 1760, 1761, 1762, 1763, 1764, 1765, 1766, 1767, 1768, 1769, 1770, 1771, 1772, 1773, 1774, 1775, 1776, 1777, 1778, 1779, 1780, 1781, 1782, 1783, 1784, 1785, 1786, 1787, 1788, 1789, 1790, 1791, 1792, 1793, 1794, 1795, 1796, 1797, 1798, 1799, 1800, 1801, 1802, 1803, 1804, 1805, 1806, 1807, 1810, 1811, 1812, 1813, 1814, 1815, 1816, 1817, 1818, 1819, 1822, 1823, 1824, 1826, 10, 174, 378, 379, 385, 387, 628, 667, 706, 745, 785, 791, 878, 918, 1083, 1086, 1090, 1091, 1096, 1104, 1105, 1110, 1118, 1119, 1124, 1132, 1133, 1138, 1146, 1147, 1152, 1160, 1161, 1166, 1174, 1175, 1180, 1188, 1189, 1194, 1202, 1203, 1208, 1216, 1217, 1222, 1230, 1231, 1236, 1244, 1245, 1250, 1258, 1259, 1264, 1272, 1273, 1278, 1286, 1287, 1292, 1300, 1301, 1306, 1314, 1315, 1320, 1343, 1344, 1349, 1357, 1358, 1363, 1367, 1406, 1407, 1408, 1409, 1477, 1623, 1624, 1629, 1666, 1667, 1672, 1680, 1681, 1686, 1694, 1695, 1700<br />2: 7, 15, 21, 27, 34, 41, 49, 56, 63, 71, 78, 85, 92, 99, 123, 138, 156, 232, 248, 384, 386, 439, 441, 493, 540, 587, 790, 838, 923, 981, 1016, 1031, 1037<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25, 29, 30, 31, 36, 37, 38, 43, 44, 45, 51, 52, 53, 58, 59, 60, 65, 66, 67, 73, 74, 75, 80, 81, 82, 87, 88, 89, 94, 95, 96, 101, 102, 103, 125, 126, 127, 140, 141, 142, 158, 159, 250, 251, 377, 432, 487, 534, 581, 784, 832, 917, 983, 984, 985, 1033, 1034, 1035, 1039, 1040, 1041"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 46, 48, 252, 260, 299, 338, 964, 988, 1051, 1084, 1088, 1089, 1090, 1103, 1104, 1105, 1118, 1119, 1133, 1134, 1148, 1149, 1150, 1163, 1164, 1178, 1179, 1193, 1194, 1208, 1209, 1223, 1224, 1238, 1239, 1253, 1254, 1268, 1269, 1283, 1284, 1298, 1299, 1300, 1313, 1314, 1328, 1329, 1330, 1340, 1344, 1345, 1359, 1360, 1374, 1375, 1376, 1389, 1390, 1391, 1404, 1405, 1419, 1420, 1434, 1449, 1464, 1479, 1494, 1509, 1524, 1539, 1554, 1569, 1584, 1599, 1600, 1614, 1629, 1630, 1644, 1659, 1660, 1675, 1676, 1677, 1690, 1705, 1706, 1720, 1721, 1722, 1735, 1736, 1737, 1750, 1751, 1752, 1765, 1775, 1776, 1777, 1778, 1779, 1780, 1782, 1783, 1784, 1785, 1786, 1787, 1788, 1789, 1790, 1791, 1792, 1793, 1794, 1800, 1801, 1802, 1803, 1804, 1805, 1806, 1807, 1808, 1809, 1810, 1811, 1812, 1813, 1814, 1815, 1816, 1817, 1818, 1819, 1820, 1821, 1822, 1823, 1824, 1825, 1826, 1827, 1828, 1829, 1830, 1831, 1832, 1833, 1834, 1835, 1836, 1837, 1838, 1839, 1840, 1841, 1842, 1843, 1844, 1845, 1846, 1847, 1848, 1849, 1850, 1851, 1852, 1853, 1856, 1857, 1858, 1859, 1860, 1861, 1862, 1863, 1864, 1865, 1868, 1869, 1870, 1872, 10, 174, 378, 379, 385, 387, 628, 667, 706, 745, 785, 791, 878, 918, 924, 1083, 1086, 1087, 1091, 1092, 1097, 1106, 1107, 1112, 1121, 1122, 1127, 1136, 1137, 1142, 1151, 1152, 1157, 1166, 1167, 1172, 1181, 1182, 1187, 1196, 1197, 1202, 1211, 1212, 1217, 1226, 1227, 1232, 1241, 1242, 1247, 1256, 1257, 1262, 1271, 1272, 1277, 1286, 1287, 1292, 1301, 1302, 1307, 1316, 1317, 1322, 1331, 1332, 1337, 1339, 1342, 1343, 1347, 1348, 1353, 1362, 1363, 1368, 1377, 1378, 1383, 1387, 1388, 1392, 1393, 1398, 1407, 1408, 1413, 1422, 1423, 1428, 1429, 1430, 1431, 1432, 1433, 1437, 1438, 1443, 1452, 1453, 1458, 1459, 1460, 1461, 1462, 1463, 1467, 1468, 1473, 1474, 1475, 1476, 1477, 1478, 1482, 1483, 1488, 1489, 1490, 1491, 1492, 1493, 1497, 1498, 1503, 1505, 1507, 1508, 1512, 1513, 1518, 1522, 1523, 1527, 1528, 1533, 1537, 1538, 1542, 1543, 1548, 1550, 1552, 1553, 1557, 1558, 1563, 1564, 1565, 1566, 1567, 1568, 1572, 1573, 1578, 1579, 1580, 1581, 1582, 1583, 1587, 1588, 1593, 1597, 1598, 1602, 1603, 1608, 1609, 1610, 1611, 1612, 1613, 1617, 1618, 1623, 1632, 1633, 1638, 1647, 1648, 1653, 1662, 1663, 1668, 1678, 1679, 1684, 1693, 1694, 1699, 1708, 1709, 1714, 1723, 1724, 1729, 1738, 1739, 1744, 1753, 1754, 1759, 1768, 1769, 1774<br />2: 7, 15, 21, 27, 34, 41, 49, 56, 63, 71, 78, 85, 92, 99, 123, 138, 156, 232, 248, 384, 386, 439, 441, 493, 540, 587, 790, 838, 923, 981, 1016, 1031, 1037<br />ᐳ: 11, 12, 13, 17, 18, 19, 23, 24, 25, 29, 30, 31, 36, 37, 38, 43, 44, 45, 51, 52, 53, 58, 59, 60, 65, 66, 67, 73, 74, 75, 80, 81, 82, 87, 88, 89, 94, 95, 96, 101, 102, 103, 125, 126, 127, 140, 141, 142, 158, 159, 250, 251, 377, 432, 487, 534, 581, 784, 832, 917, 983, 984, 985, 1033, 1034, 1035, 1039, 1040, 1041"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect27,First29,PgSelectSingle30,PgClassExpression31,PgSelect34,First36,PgSelectSingle37,PgClassExpression38,PgSelect41,First43,PgSelectSingle44,PgClassExpression45,Constant46,Constant48,PgSelect49,First51,PgSelectSingle52,PgClassExpression53,PgSelect56,First58,PgSelectSingle59,PgClassExpression60,PgSelect63,First65,PgSelectSingle66,PgClassExpression67,PgSelect71,First73,PgSelectSingle74,PgClassExpression75,PgSelect78,First80,PgSelectSingle81,PgClassExpression82,PgSelect85,First87,PgSelectSingle88,PgClassExpression89,PgSelect92,First94,PgSelectSingle95,PgClassExpression96,PgSelect99,First101,PgSelectSingle102,PgClassExpression103,PgSelect123,First125,PgSelectSingle126,PgClassExpression127,PgSelect138,First140,PgSelectSingle141,PgClassExpression142,PgSelect156,First158,PgSelectSingle159,Connection174,PgSelect232,PgSelect248,First250,PgSelectSingle251,Constant252,Connection260,Connection299,Connection338,Connection377,Lambda378,Lambda379,PgValidateParsedCursor384,Access385,PgValidateParsedCursor386,Access387,Connection432,PgValidateParsedCursor439,PgValidateParsedCursor441,Connection487,PgValidateParsedCursor493,Connection534,PgValidateParsedCursor540,Connection581,PgValidateParsedCursor587,Connection628,Connection667,Connection706,Connection745,Connection784,Lambda785,PgValidateParsedCursor790,Access791,Connection832,PgValidateParsedCursor838,Connection878,Connection917,Lambda918,PgValidateParsedCursor923,Connection964,PgSelect981,First983,PgSelectSingle984,PgClassExpression985,Connection988,PgSelect1016,PgSelect1031,First1033,PgSelectSingle1034,PgClassExpression1035,PgSelect1037,First1039,PgSelectSingle1040,PgClassExpression1041,Connection1051,Lambda1083,Constant1084,Lambda1086,Constant1087,Constant1088,Constant1089,Object1090,Lambda1091,Lambda1096,Constant1101,Constant1102,Constant1103,Object1104,Lambda1105,Lambda1110,Constant1115,Constant1116,Object1118,Lambda1119,Lambda1124,Constant1129,Constant1130,Object1132,Lambda1133,Lambda1138,Constant1143,Constant1144,Constant1145,Object1146,Lambda1147,Lambda1152,Constant1157,Constant1158,Object1160,Lambda1161,Lambda1166,Constant1171,Constant1172,Object1174,Lambda1175,Lambda1180,Constant1185,Constant1186,Object1188,Lambda1189,Lambda1194,Constant1199,Constant1200,Object1202,Lambda1203,Lambda1208,Constant1213,Constant1214,Object1216,Lambda1217,Lambda1222,Constant1227,Constant1228,Object1230,Lambda1231,Lambda1236,Constant1241,Constant1242,Object1244,Lambda1245,Lambda1250,Constant1255,Constant1256,Object1258,Lambda1259,Lambda1264,Constant1269,Constant1270,Object1272,Lambda1273,Lambda1278,Constant1283,Constant1284,Constant1285,Object1286,Lambda1287,Lambda1292,Constant1297,Constant1298,Object1300,Lambda1301,Lambda1306,Constant1311,Constant1312,Constant1313,Object1314,Lambda1315,Lambda1320,Constant1323,Constant1326,Constant1327,Constant1340,Constant1341,Object1343,Lambda1344,Lambda1349,Constant1354,Constant1355,Constant1356,Object1357,Lambda1358,Lambda1363,Lambda1367,Constant1368,Constant1369,Constant1370,Constant1382,Constant1383,Constant1396,Constant1397,Object1406,Lambda1407,Object1408,Lambda1409,Constant1410,Constant1424,Constant1438,Constant1452,Constant1466,Lambda1477,Constant1480,Constant1494,Constant1508,Constant1522,Constant1536,Constant1550,Constant1564,Constant1565,Constant1578,Constant1592,Constant1593,Constant1606,Constant1620,Constant1621,Object1623,Lambda1624,Lambda1629,Constant1635,Constant1636,Constant1637,Constant1649,Constant1663,Constant1664,Object1666,Lambda1667,Lambda1672,Constant1677,Constant1678,Constant1679,Object1680,Lambda1681,Lambda1686,Constant1691,Constant1692,Constant1693,Object1694,Lambda1695,Lambda1700,Constant1705,Constant1706,Constant1707,Constant1719,Constant1729,Constant1730,Constant1731,Constant1732,Constant1733,Constant1734,Constant1736,Constant1737,Constant1738,Constant1739,Constant1740,Constant1741,Constant1742,Constant1743,Constant1744,Constant1745,Constant1746,Constant1747,Constant1748,Constant1754,Constant1755,Constant1756,Constant1757,Constant1758,Constant1759,Constant1760,Constant1761,Constant1762,Constant1763,Constant1764,Constant1765,Constant1766,Constant1767,Constant1768,Constant1769,Constant1770,Constant1771,Constant1772,Constant1773,Constant1774,Constant1775,Constant1776,Constant1777,Constant1778,Constant1779,Constant1780,Constant1781,Constant1782,Constant1783,Constant1784,Constant1785,Constant1786,Constant1787,Constant1788,Constant1789,Constant1790,Constant1791,Constant1792,Constant1793,Constant1794,Constant1795,Constant1796,Constant1797,Constant1798,Constant1799,Constant1800,Constant1801,Constant1802,Constant1803,Constant1804,Constant1805,Constant1806,Constant1807,Constant1810,Constant1811,Constant1812,Constant1813,Constant1814,Constant1815,Constant1816,Constant1817,Constant1818,Constant1819,Constant1822,Constant1823,Constant1824,Constant1826 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgSelect15,First17,PgSelectSingle18,PgClassExpression19,PgSelect21,First23,PgSelectSingle24,PgClassExpression25,PgSelect27,First29,PgSelectSingle30,PgClassExpression31,PgSelect34,First36,PgSelectSingle37,PgClassExpression38,PgSelect41,First43,PgSelectSingle44,PgClassExpression45,Constant46,Constant48,PgSelect49,First51,PgSelectSingle52,PgClassExpression53,PgSelect56,First58,PgSelectSingle59,PgClassExpression60,PgSelect63,First65,PgSelectSingle66,PgClassExpression67,PgSelect71,First73,PgSelectSingle74,PgClassExpression75,PgSelect78,First80,PgSelectSingle81,PgClassExpression82,PgSelect85,First87,PgSelectSingle88,PgClassExpression89,PgSelect92,First94,PgSelectSingle95,PgClassExpression96,PgSelect99,First101,PgSelectSingle102,PgClassExpression103,PgSelect123,First125,PgSelectSingle126,PgClassExpression127,PgSelect138,First140,PgSelectSingle141,PgClassExpression142,PgSelect156,First158,PgSelectSingle159,Connection174,PgSelect232,PgSelect248,First250,PgSelectSingle251,Constant252,Connection260,Connection299,Connection338,Connection377,Lambda378,Lambda379,PgValidateParsedCursor384,Access385,PgValidateParsedCursor386,Access387,Connection432,PgValidateParsedCursor439,PgValidateParsedCursor441,Connection487,PgValidateParsedCursor493,Connection534,PgValidateParsedCursor540,Connection581,PgValidateParsedCursor587,Connection628,Connection667,Connection706,Connection745,Connection784,Lambda785,PgValidateParsedCursor790,Access791,Connection832,PgValidateParsedCursor838,Connection878,Connection917,Lambda918,PgValidateParsedCursor923,Access924,Connection964,PgSelect981,First983,PgSelectSingle984,PgClassExpression985,Connection988,PgSelect1016,PgSelect1031,First1033,PgSelectSingle1034,PgClassExpression1035,PgSelect1037,First1039,PgSelectSingle1040,PgClassExpression1041,Connection1051,Lambda1083,Constant1084,Lambda1086,Access1087,Constant1088,Constant1089,Constant1090,Object1091,Lambda1092,Lambda1097,Constant1103,Constant1104,Constant1105,Object1106,Lambda1107,Lambda1112,Constant1118,Constant1119,Object1121,Lambda1122,Lambda1127,Constant1133,Constant1134,Object1136,Lambda1137,Lambda1142,Constant1148,Constant1149,Constant1150,Object1151,Lambda1152,Lambda1157,Constant1163,Constant1164,Object1166,Lambda1167,Lambda1172,Constant1178,Constant1179,Object1181,Lambda1182,Lambda1187,Constant1193,Constant1194,Object1196,Lambda1197,Lambda1202,Constant1208,Constant1209,Object1211,Lambda1212,Lambda1217,Constant1223,Constant1224,Object1226,Lambda1227,Lambda1232,Constant1238,Constant1239,Object1241,Lambda1242,Lambda1247,Constant1253,Constant1254,Object1256,Lambda1257,Lambda1262,Constant1268,Constant1269,Object1271,Lambda1272,Lambda1277,Constant1283,Constant1284,Object1286,Lambda1287,Lambda1292,Constant1298,Constant1299,Constant1300,Object1301,Lambda1302,Lambda1307,Constant1313,Constant1314,Object1316,Lambda1317,Lambda1322,Constant1328,Constant1329,Constant1330,Object1331,Lambda1332,Lambda1337,Lambda1339,Constant1340,Lambda1342,Access1343,Constant1344,Constant1345,Object1347,Lambda1348,Lambda1353,Constant1359,Constant1360,Object1362,Lambda1363,Lambda1368,Constant1374,Constant1375,Constant1376,Object1377,Lambda1378,Lambda1383,Lambda1387,Access1388,Constant1389,Constant1390,Constant1391,Object1392,Lambda1393,Lambda1398,Constant1404,Constant1405,Object1407,Lambda1408,Lambda1413,Constant1419,Constant1420,Object1422,Lambda1423,Lambda1428,Object1429,Lambda1430,Object1431,Lambda1432,Access1433,Constant1434,Object1437,Lambda1438,Lambda1443,Constant1449,Object1452,Lambda1453,Lambda1458,Object1459,Lambda1460,Object1461,Lambda1462,Access1463,Constant1464,Object1467,Lambda1468,Lambda1473,Object1474,Lambda1475,Object1476,Lambda1477,Access1478,Constant1479,Object1482,Lambda1483,Lambda1488,Object1489,Lambda1490,Object1491,Lambda1492,Access1493,Constant1494,Object1497,Lambda1498,Lambda1503,Lambda1505,Lambda1507,Access1508,Constant1509,Object1512,Lambda1513,Lambda1518,Lambda1522,Access1523,Constant1524,Object1527,Lambda1528,Lambda1533,Lambda1537,Access1538,Constant1539,Object1542,Lambda1543,Lambda1548,Lambda1550,Lambda1552,Access1553,Constant1554,Object1557,Lambda1558,Lambda1563,Object1564,Lambda1565,Object1566,Lambda1567,Access1568,Constant1569,Object1572,Lambda1573,Lambda1578,Object1579,Lambda1580,Object1581,Lambda1582,Access1583,Constant1584,Object1587,Lambda1588,Lambda1593,Lambda1597,Access1598,Constant1599,Constant1600,Object1602,Lambda1603,Lambda1608,Object1609,Lambda1610,Object1611,Lambda1612,Access1613,Constant1614,Object1617,Lambda1618,Lambda1623,Constant1629,Constant1630,Object1632,Lambda1633,Lambda1638,Constant1644,Object1647,Lambda1648,Lambda1653,Constant1659,Constant1660,Object1662,Lambda1663,Lambda1668,Constant1675,Constant1676,Constant1677,Object1678,Lambda1679,Lambda1684,Constant1690,Object1693,Lambda1694,Lambda1699,Constant1705,Constant1706,Object1708,Lambda1709,Lambda1714,Constant1720,Constant1721,Constant1722,Object1723,Lambda1724,Lambda1729,Constant1735,Constant1736,Constant1737,Object1738,Lambda1739,Lambda1744,Constant1750,Constant1751,Constant1752,Object1753,Lambda1754,Lambda1759,Constant1765,Object1768,Lambda1769,Lambda1774,Constant1775,Constant1776,Constant1777,Constant1778,Constant1779,Constant1780,Constant1782,Constant1783,Constant1784,Constant1785,Constant1786,Constant1787,Constant1788,Constant1789,Constant1790,Constant1791,Constant1792,Constant1793,Constant1794,Constant1800,Constant1801,Constant1802,Constant1803,Constant1804,Constant1805,Constant1806,Constant1807,Constant1808,Constant1809,Constant1810,Constant1811,Constant1812,Constant1813,Constant1814,Constant1815,Constant1816,Constant1817,Constant1818,Constant1819,Constant1820,Constant1821,Constant1822,Constant1823,Constant1824,Constant1825,Constant1826,Constant1827,Constant1828,Constant1829,Constant1830,Constant1831,Constant1832,Constant1833,Constant1834,Constant1835,Constant1836,Constant1837,Constant1838,Constant1839,Constant1840,Constant1841,Constant1842,Constant1843,Constant1844,Constant1845,Constant1846,Constant1847,Constant1848,Constant1849,Constant1850,Constant1851,Constant1852,Constant1853,Constant1856,Constant1857,Constant1858,Constant1859,Constant1860,Constant1861,Constant1862,Constant1863,Constant1864,Constant1865,Constant1868,Constant1869,Constant1870,Constant1872 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 159<br /><br />ROOT PgSelectSingleᐸcompound_type_queryᐳ[159]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression160,PgClassExpression161,PgClassExpression162,PgClassExpression163,PgClassExpression164,PgClassExpression165,PgClassExpression166,PgClassExpression170 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 166<br /><br />ROOT PgClassExpression{1}ᐸ__compound...uery__.”g”ᐳ[166]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 10, 174, 1736, 46, 1810, 1811, 1326, 1327, 1313, 1779<br /><br />ROOT Connectionᐸ172ᐳ[174]<br />1: <br />ᐳ: 197, 1322, 1325, 1335, 1329, 1330<br />2: PgSelect[175]<br />ᐳ: 199, 200, 202, 203, 205, 206, 208, 209, 212, 213, 214, 217, 218, 201, 207<br />3: __ListTransform[176]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 10, 174, 1782, 1339, 1343, 1348, 1353, 46<br /><br />ROOT Connectionᐸ172ᐳ[174]<br />1: PgSelect[175]<br />ᐳ: 197, 199, 200, 202, 203, 205, 206, 208, 209, 212, 213, 214, 217, 218, 201, 207<br />2: __ListTransform[176]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect175,__ListTransform176,PgPageInfo197,First199,PgSelectSingle200,PgCursor201,PgClassExpression202,List203,Last205,PgSelectSingle206,PgCursor207,PgClassExpression208,List209,Access212,Object213,Lambda214,Object217,Lambda218,Lambda1322,Lambda1325,Object1329,Lambda1330,Lambda1335 bucket3
+    class Bucket3,PgSelect175,__ListTransform176,PgPageInfo197,First199,PgSelectSingle200,PgCursor201,PgClassExpression202,List203,Last205,PgSelectSingle206,PgCursor207,PgClassExpression208,List209,Access212,Object213,Lambda214,Object217,Lambda218 bucket3
     Bucket4("Bucket 4 (subroutine)<br /><br />ROOT PgSelectSingle{4}ᐸcompound_type_set_queryᐳ[178]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item177,PgSelectSingle178 bucket4
@@ -1930,9 +1960,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 251, 252<br /><br />ROOT PgSelectSingleᐸtable_queryᐳ[251]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression253,List254,Lambda255,PgClassExpression256,PgClassExpression257 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 10, 260, 1083, 1367, 46, 1368, 1369, 1370, 1782<br /><br />ROOT Connectionᐸ258ᐳ[260]<br />1: <br />ᐳ: 273, 1371, 1377, 1372<br />2: PgSelect[261]<br />ᐳ: 275, 276, 278, 279, 281, 282, 284, 285, 288, 289, 290, 293, 294, 277, 283<br />3: __ListTransform[262]"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 10, 260, 1083, 1388, 1393, 1398, 46<br /><br />ROOT Connectionᐸ258ᐳ[260]<br />1: PgSelect[261]<br />ᐳ: 273, 275, 276, 278, 279, 281, 282, 284, 285, 288, 289, 290, 293, 294, 277, 283<br />2: __ListTransform[262]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgSelect261,__ListTransform262,PgPageInfo273,First275,PgSelectSingle276,PgCursor277,PgClassExpression278,List279,Last281,PgSelectSingle282,PgCursor283,PgClassExpression284,List285,Access288,Object289,Lambda290,Object293,Lambda294,Object1371,Lambda1372,Lambda1377 bucket13
+    class Bucket13,PgSelect261,__ListTransform262,PgPageInfo273,First275,PgSelectSingle276,PgCursor277,PgClassExpression278,List279,Last281,PgSelectSingle282,PgCursor283,PgClassExpression284,List285,Access288,Object289,Lambda290,Object293,Lambda294 bucket13
     Bucket14("Bucket 14 (subroutine)<br /><br />ROOT PgSelectSingle{14}ᐸtable_set_queryᐳ[264]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item263,PgSelectSingle264 bucket14
@@ -1945,9 +1975,9 @@ graph TD
     Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 266<br /><br />ROOT PgSelectSingle{15}ᐸtable_set_queryᐳ[266]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgClassExpression271 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 10, 299, 1083, 1367, 46, 1382, 1383, 1370, 1783<br /><br />ROOT Connectionᐸ297ᐳ[299]<br />1: <br />ᐳ: 312, 1385, 1391, 1386<br />2: PgSelect[300]<br />ᐳ: 314, 315, 317, 318, 320, 321, 323, 324, 327, 328, 329, 332, 333, 316, 322<br />3: __ListTransform[301]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 10, 299, 1083, 1388, 1408, 1413, 46<br /><br />ROOT Connectionᐸ297ᐳ[299]<br />1: PgSelect[300]<br />ᐳ: 312, 314, 315, 317, 318, 320, 321, 323, 324, 327, 328, 329, 332, 333, 316, 322<br />2: __ListTransform[301]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PgSelect300,__ListTransform301,PgPageInfo312,First314,PgSelectSingle315,PgCursor316,PgClassExpression317,List318,Last320,PgSelectSingle321,PgCursor322,PgClassExpression323,List324,Access327,Object328,Lambda329,Object332,Lambda333,Object1385,Lambda1386,Lambda1391 bucket18
+    class Bucket18,PgSelect300,__ListTransform301,PgPageInfo312,First314,PgSelectSingle315,PgCursor316,PgClassExpression317,List318,Last320,PgSelectSingle321,PgCursor322,PgClassExpression323,List324,Access327,Object328,Lambda329,Object332,Lambda333 bucket18
     Bucket19("Bucket 19 (subroutine)<br /><br />ROOT PgSelectSingle{19}ᐸtable_set_queryᐳ[303]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item302,PgSelectSingle303 bucket19
@@ -1960,9 +1990,9 @@ graph TD
     Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 305, 308<br /><br />ROOT PgSelectSingle{20}ᐸtable_set_queryᐳ[305]"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22 bucket22
-    Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 10, 1754, 338, 1083, 1367, 46, 1396, 1397, 1370, 1784<br /><br />ROOT Connectionᐸ336ᐳ[338]<br />1: <br />ᐳ: 351, 1399, 1405, 1400<br />2: PgSelect[339]<br />ᐳ: 353, 354, 356, 357, 359, 360, 362, 363, 366, 367, 368, 371, 372, 355, 361<br />3: __ListTransform[340]"):::bucket
+    Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 10, 1800, 338, 1083, 1388, 1423, 1428, 46<br /><br />ROOT Connectionᐸ336ᐳ[338]<br />1: PgSelect[339]<br />ᐳ: 351, 353, 354, 356, 357, 359, 360, 362, 363, 366, 367, 368, 371, 372, 355, 361<br />2: __ListTransform[340]"):::bucket
     classDef bucket23 stroke:#ff1493
-    class Bucket23,PgSelect339,__ListTransform340,PgPageInfo351,First353,PgSelectSingle354,PgCursor355,PgClassExpression356,List357,Last359,PgSelectSingle360,PgCursor361,PgClassExpression362,List363,Access366,Object367,Lambda368,Object371,Lambda372,Object1399,Lambda1400,Lambda1405 bucket23
+    class Bucket23,PgSelect339,__ListTransform340,PgPageInfo351,First353,PgSelectSingle354,PgCursor355,PgClassExpression356,List357,Last359,PgSelectSingle360,PgCursor361,PgClassExpression362,List363,Access366,Object367,Lambda368,Object371,Lambda372 bucket23
     Bucket24("Bucket 24 (subroutine)<br /><br />ROOT PgSelectSingle{24}ᐸtable_set_queryᐳ[342]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,__Item341,PgSelectSingle342 bucket24
@@ -1975,9 +2005,9 @@ graph TD
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 344<br /><br />ROOT PgSelectSingle{25}ᐸtable_set_queryᐳ[344]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgClassExpression349 bucket27
-    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 10, 377, 378, 379, 385, 387, 1407, 1409, 46, 1410, 1369, 1370, 1785<br /><br />ROOT Connectionᐸ375ᐳ[377]<br />1: <br />ᐳ: 398, 1413, 1419, 1414<br />2: PgSelect[380]<br />ᐳ: 400, 401, 405, 406, 408, 409, 413, 414, 417, 418, 419, 424, 425, 402, 410<br />3: __ListTransform[381]"):::bucket
+    Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 10, 377, 378, 379, 385, 387, 1430, 1433, 1438, 1443, 46<br /><br />ROOT Connectionᐸ375ᐳ[377]<br />1: PgSelect[380]<br />ᐳ: 398, 400, 401, 405, 406, 408, 409, 413, 414, 417, 418, 419, 424, 425, 402, 410<br />2: __ListTransform[381]"):::bucket
     classDef bucket28 stroke:#00ffff
-    class Bucket28,PgSelect380,__ListTransform381,PgPageInfo398,First400,PgSelectSingle401,PgCursor402,PgClassExpression405,List406,Last408,PgSelectSingle409,PgCursor410,PgClassExpression413,List414,Access417,Object418,Lambda419,Object424,Lambda425,Object1413,Lambda1414,Lambda1419 bucket28
+    class Bucket28,PgSelect380,__ListTransform381,PgPageInfo398,First400,PgSelectSingle401,PgCursor402,PgClassExpression405,List406,Last408,PgSelectSingle409,PgCursor410,PgClassExpression413,List414,Access417,Object418,Lambda419,Object424,Lambda425 bucket28
     Bucket29("Bucket 29 (subroutine)<br /><br />ROOT PgSelectSingle{29}ᐸtable_set_queryᐳ[383]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,__Item382,PgSelectSingle383 bucket29
@@ -1990,9 +2020,9 @@ graph TD
     Bucket32("Bucket 32 (nullableBoundary)<br />Deps: 389<br /><br />ROOT PgSelectSingle{30}ᐸtable_set_queryᐳ[389]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32,PgClassExpression394 bucket32
-    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 10, 432, 378, 379, 385, 387, 1407, 1409, 46, 1424, 1369, 1370, 1786<br /><br />ROOT Connectionᐸ430ᐳ[432]<br />1: <br />ᐳ: 453, 1427, 1433, 1428<br />2: PgSelect[435]<br />ᐳ: 455, 456, 460, 461, 463, 464, 468, 469, 472, 473, 474, 479, 480, 457, 465<br />3: __ListTransform[436]"):::bucket
+    Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 10, 432, 378, 379, 385, 387, 1430, 1433, 1453, 1458, 46<br /><br />ROOT Connectionᐸ430ᐳ[432]<br />1: PgSelect[435]<br />ᐳ: 453, 455, 456, 460, 461, 463, 464, 468, 469, 472, 473, 474, 479, 480, 457, 465<br />2: __ListTransform[436]"):::bucket
     classDef bucket33 stroke:#f5deb3
-    class Bucket33,PgSelect435,__ListTransform436,PgPageInfo453,First455,PgSelectSingle456,PgCursor457,PgClassExpression460,List461,Last463,PgSelectSingle464,PgCursor465,PgClassExpression468,List469,Access472,Object473,Lambda474,Object479,Lambda480,Object1427,Lambda1428,Lambda1433 bucket33
+    class Bucket33,PgSelect435,__ListTransform436,PgPageInfo453,First455,PgSelectSingle456,PgCursor457,PgClassExpression460,List461,Last463,PgSelectSingle464,PgCursor465,PgClassExpression468,List469,Access472,Object473,Lambda474,Object479,Lambda480 bucket33
     Bucket34("Bucket 34 (subroutine)<br /><br />ROOT PgSelectSingle{34}ᐸtable_set_queryᐳ[438]"):::bucket
     classDef bucket34 stroke:#696969
     class Bucket34,__Item437,PgSelectSingle438 bucket34
@@ -2005,9 +2035,9 @@ graph TD
     Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 444<br /><br />ROOT PgSelectSingle{35}ᐸtable_set_queryᐳ[444]"):::bucket
     classDef bucket37 stroke:#ffa500
     class Bucket37,PgClassExpression449 bucket37
-    Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 10, 487, 378, 1734, 385, 46, 48, 1323, 1438, 1369, 1370, 1787<br /><br />ROOT Connectionᐸ485ᐳ[487]<br />1: <br />ᐳ: 504, 1434, 1436, 1447, 1435, 1437, 1441, 1442<br />2: PgSelect[489]<br />ᐳ: 506, 507, 510, 511, 513, 514, 517, 518, 521, 522, 523, 527, 528, 508, 515<br />3: __ListTransform[490]"):::bucket
+    Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 10, 487, 378, 1780, 385, 1460, 1463, 1468, 1473, 46<br /><br />ROOT Connectionᐸ485ᐳ[487]<br />1: PgSelect[489]<br />ᐳ: 504, 506, 507, 510, 511, 513, 514, 517, 518, 521, 522, 523, 527, 528, 508, 515<br />2: __ListTransform[490]"):::bucket
     classDef bucket38 stroke:#0000ff
-    class Bucket38,PgSelect489,__ListTransform490,PgPageInfo504,First506,PgSelectSingle507,PgCursor508,PgClassExpression510,List511,Last513,PgSelectSingle514,PgCursor515,PgClassExpression517,List518,Access521,Object522,Lambda523,Object527,Lambda528,Object1434,Lambda1435,Object1436,Lambda1437,Object1441,Lambda1442,Lambda1447 bucket38
+    class Bucket38,PgSelect489,__ListTransform490,PgPageInfo504,First506,PgSelectSingle507,PgCursor508,PgClassExpression510,List511,Last513,PgSelectSingle514,PgCursor515,PgClassExpression517,List518,Access521,Object522,Lambda523,Object527,Lambda528 bucket38
     Bucket39("Bucket 39 (subroutine)<br /><br />ROOT PgSelectSingle{39}ᐸtable_set_queryᐳ[492]"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,__Item491,PgSelectSingle492 bucket39
@@ -2020,9 +2050,9 @@ graph TD
     Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 496<br /><br />ROOT PgSelectSingle{40}ᐸtable_set_queryᐳ[496]"):::bucket
     classDef bucket42 stroke:#dda0dd
     class Bucket42,PgClassExpression501 bucket42
-    Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 10, 534, 378, 1734, 385, 46, 48, 1323, 1452, 1369, 1370, 1788<br /><br />ROOT Connectionᐸ532ᐳ[534]<br />1: <br />ᐳ: 551, 1448, 1450, 1461, 1449, 1451, 1455, 1456<br />2: PgSelect[536]<br />ᐳ: 553, 554, 557, 558, 560, 561, 564, 565, 568, 569, 570, 574, 575, 555, 562<br />3: __ListTransform[537]"):::bucket
+    Bucket43("Bucket 43 (nullableBoundary)<br />Deps: 10, 534, 378, 1780, 385, 1475, 1478, 1483, 1488, 46<br /><br />ROOT Connectionᐸ532ᐳ[534]<br />1: PgSelect[536]<br />ᐳ: 551, 553, 554, 557, 558, 560, 561, 564, 565, 568, 569, 570, 574, 575, 555, 562<br />2: __ListTransform[537]"):::bucket
     classDef bucket43 stroke:#ff0000
-    class Bucket43,PgSelect536,__ListTransform537,PgPageInfo551,First553,PgSelectSingle554,PgCursor555,PgClassExpression557,List558,Last560,PgSelectSingle561,PgCursor562,PgClassExpression564,List565,Access568,Object569,Lambda570,Object574,Lambda575,Object1448,Lambda1449,Object1450,Lambda1451,Object1455,Lambda1456,Lambda1461 bucket43
+    class Bucket43,PgSelect536,__ListTransform537,PgPageInfo551,First553,PgSelectSingle554,PgCursor555,PgClassExpression557,List558,Last560,PgSelectSingle561,PgCursor562,PgClassExpression564,List565,Access568,Object569,Lambda570,Object574,Lambda575 bucket43
     Bucket44("Bucket 44 (subroutine)<br /><br />ROOT PgSelectSingle{44}ᐸtable_set_queryᐳ[539]"):::bucket
     classDef bucket44 stroke:#ffff00
     class Bucket44,__Item538,PgSelectSingle539 bucket44
@@ -2035,9 +2065,9 @@ graph TD
     Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 543<br /><br />ROOT PgSelectSingle{45}ᐸtable_set_queryᐳ[543]"):::bucket
     classDef bucket47 stroke:#3cb371
     class Bucket47,PgClassExpression548 bucket47
-    Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 10, 581, 379, 1734, 387, 46, 48, 1323, 1466, 1369, 1370, 1789<br /><br />ROOT Connectionᐸ579ᐳ[581]<br />1: <br />ᐳ: 598, 1462, 1464, 1475, 1463, 1465, 1469, 1470<br />2: PgSelect[583]<br />ᐳ: 600, 601, 604, 605, 607, 608, 611, 612, 615, 616, 617, 621, 622, 602, 609<br />3: __ListTransform[584]"):::bucket
+    Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 10, 581, 379, 1780, 387, 1490, 1493, 1498, 1503, 46<br /><br />ROOT Connectionᐸ579ᐳ[581]<br />1: PgSelect[583]<br />ᐳ: 598, 600, 601, 604, 605, 607, 608, 611, 612, 615, 616, 617, 621, 622, 602, 609<br />2: __ListTransform[584]"):::bucket
     classDef bucket48 stroke:#a52a2a
-    class Bucket48,PgSelect583,__ListTransform584,PgPageInfo598,First600,PgSelectSingle601,PgCursor602,PgClassExpression604,List605,Last607,PgSelectSingle608,PgCursor609,PgClassExpression611,List612,Access615,Object616,Lambda617,Object621,Lambda622,Object1462,Lambda1463,Object1464,Lambda1465,Object1469,Lambda1470,Lambda1475 bucket48
+    class Bucket48,PgSelect583,__ListTransform584,PgPageInfo598,First600,PgSelectSingle601,PgCursor602,PgClassExpression604,List605,Last607,PgSelectSingle608,PgCursor609,PgClassExpression611,List612,Access615,Object616,Lambda617,Object621,Lambda622 bucket48
     Bucket49("Bucket 49 (subroutine)<br /><br />ROOT PgSelectSingle{49}ᐸtable_set_queryᐳ[586]"):::bucket
     classDef bucket49 stroke:#ff00ff
     class Bucket49,__Item585,PgSelectSingle586 bucket49
@@ -2050,9 +2080,9 @@ graph TD
     Bucket52("Bucket 52 (nullableBoundary)<br />Deps: 590<br /><br />ROOT PgSelectSingle{50}ᐸtable_set_queryᐳ[590]"):::bucket
     classDef bucket52 stroke:#00bfff
     class Bucket52,PgClassExpression595 bucket52
-    Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 10, 628, 1734, 1477, 46, 1813, 1480, 1369, 1370, 1790<br /><br />ROOT Connectionᐸ626ᐳ[628]<br />1: <br />ᐳ: 641, 1479, 1483, 1489, 1484<br />2: PgSelect[629]<br />ᐳ: 643, 644, 646, 647, 649, 650, 652, 653, 656, 657, 658, 661, 662, 645, 651<br />3: __ListTransform[630]"):::bucket
+    Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 10, 628, 1780, 1505, 1508, 1513, 1518, 46<br /><br />ROOT Connectionᐸ626ᐳ[628]<br />1: PgSelect[629]<br />ᐳ: 641, 643, 644, 646, 647, 649, 650, 652, 653, 656, 657, 658, 661, 662, 645, 651<br />2: __ListTransform[630]"):::bucket
     classDef bucket53 stroke:#7f007f
-    class Bucket53,PgSelect629,__ListTransform630,PgPageInfo641,First643,PgSelectSingle644,PgCursor645,PgClassExpression646,List647,Last649,PgSelectSingle650,PgCursor651,PgClassExpression652,List653,Access656,Object657,Lambda658,Object661,Lambda662,Lambda1479,Object1483,Lambda1484,Lambda1489 bucket53
+    class Bucket53,PgSelect629,__ListTransform630,PgPageInfo641,First643,PgSelectSingle644,PgCursor645,PgClassExpression646,List647,Last649,PgSelectSingle650,PgCursor651,PgClassExpression652,List653,Access656,Object657,Lambda658,Object661,Lambda662 bucket53
     Bucket54("Bucket 54 (subroutine)<br /><br />ROOT PgSelectSingle{54}ᐸtable_set_queryᐳ[632]"):::bucket
     classDef bucket54 stroke:#ffa500
     class Bucket54,__Item631,PgSelectSingle632 bucket54
@@ -2065,9 +2095,9 @@ graph TD
     Bucket57("Bucket 57 (nullableBoundary)<br />Deps: 634<br /><br />ROOT PgSelectSingle{55}ᐸtable_set_queryᐳ[634]"):::bucket
     classDef bucket57 stroke:#ff1493
     class Bucket57,PgClassExpression639 bucket57
-    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 10, 667, 1734, 1757, 1477, 46, 1814, 1494, 1369, 1370, 1791<br /><br />ROOT Connectionᐸ665ᐳ[667]<br />1: <br />ᐳ: 680, 1493, 1497, 1503, 1498<br />2: PgSelect[668]<br />ᐳ: 682, 683, 685, 686, 688, 689, 691, 692, 695, 696, 697, 700, 701, 684, 690<br />3: __ListTransform[669]"):::bucket
+    Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 10, 667, 1780, 1803, 1505, 1523, 1528, 1533, 46<br /><br />ROOT Connectionᐸ665ᐳ[667]<br />1: PgSelect[668]<br />ᐳ: 680, 682, 683, 685, 686, 688, 689, 691, 692, 695, 696, 697, 700, 701, 684, 690<br />2: __ListTransform[669]"):::bucket
     classDef bucket58 stroke:#808000
-    class Bucket58,PgSelect668,__ListTransform669,PgPageInfo680,First682,PgSelectSingle683,PgCursor684,PgClassExpression685,List686,Last688,PgSelectSingle689,PgCursor690,PgClassExpression691,List692,Access695,Object696,Lambda697,Object700,Lambda701,Lambda1493,Object1497,Lambda1498,Lambda1503 bucket58
+    class Bucket58,PgSelect668,__ListTransform669,PgPageInfo680,First682,PgSelectSingle683,PgCursor684,PgClassExpression685,List686,Last688,PgSelectSingle689,PgCursor690,PgClassExpression691,List692,Access695,Object696,Lambda697,Object700,Lambda701 bucket58
     Bucket59("Bucket 59 (subroutine)<br /><br />ROOT PgSelectSingle{59}ᐸtable_set_queryᐳ[671]"):::bucket
     classDef bucket59 stroke:#dda0dd
     class Bucket59,__Item670,PgSelectSingle671 bucket59
@@ -2080,9 +2110,9 @@ graph TD
     Bucket62("Bucket 62 (nullableBoundary)<br />Deps: 673<br /><br />ROOT PgSelectSingle{60}ᐸtable_set_queryᐳ[673]"):::bucket
     classDef bucket62 stroke:#00ffff
     class Bucket62,PgClassExpression678 bucket62
-    Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 10, 706, 1734, 1758, 1477, 46, 1815, 1508, 1369, 1370, 1792<br /><br />ROOT Connectionᐸ704ᐳ[706]<br />1: <br />ᐳ: 719, 1507, 1511, 1517, 1512<br />2: PgSelect[707]<br />ᐳ: 721, 722, 724, 725, 727, 728, 730, 731, 734, 735, 736, 739, 740, 723, 729<br />3: __ListTransform[708]"):::bucket
+    Bucket63("Bucket 63 (nullableBoundary)<br />Deps: 10, 706, 1780, 1804, 1505, 1538, 1543, 1548, 46<br /><br />ROOT Connectionᐸ704ᐳ[706]<br />1: PgSelect[707]<br />ᐳ: 719, 721, 722, 724, 725, 727, 728, 730, 731, 734, 735, 736, 739, 740, 723, 729<br />2: __ListTransform[708]"):::bucket
     classDef bucket63 stroke:#4169e1
-    class Bucket63,PgSelect707,__ListTransform708,PgPageInfo719,First721,PgSelectSingle722,PgCursor723,PgClassExpression724,List725,Last727,PgSelectSingle728,PgCursor729,PgClassExpression730,List731,Access734,Object735,Lambda736,Object739,Lambda740,Lambda1507,Object1511,Lambda1512,Lambda1517 bucket63
+    class Bucket63,PgSelect707,__ListTransform708,PgPageInfo719,First721,PgSelectSingle722,PgCursor723,PgClassExpression724,List725,Last727,PgSelectSingle728,PgCursor729,PgClassExpression730,List731,Access734,Object735,Lambda736,Object739,Lambda740 bucket63
     Bucket64("Bucket 64 (subroutine)<br /><br />ROOT PgSelectSingle{64}ᐸtable_set_queryᐳ[710]"):::bucket
     classDef bucket64 stroke:#3cb371
     class Bucket64,__Item709,PgSelectSingle710 bucket64
@@ -2095,9 +2125,9 @@ graph TD
     Bucket67("Bucket 67 (nullableBoundary)<br />Deps: 712<br /><br />ROOT PgSelectSingle{65}ᐸtable_set_queryᐳ[712]"):::bucket
     classDef bucket67 stroke:#f5deb3
     class Bucket67,PgClassExpression717 bucket67
-    Bucket68("Bucket 68 (nullableBoundary)<br />Deps: 10, 745, 1759, 1758, 46, 1816, 1817, 1522, 1369, 1370, 1793<br /><br />ROOT Connectionᐸ743ᐳ[745]<br />1: <br />ᐳ: 758, 1519, 1521, 1531, 1525, 1526<br />2: PgSelect[746]<br />ᐳ: 760, 761, 763, 764, 766, 767, 769, 770, 773, 774, 775, 778, 779, 762, 768<br />3: __ListTransform[747]"):::bucket
+    Bucket68("Bucket 68 (nullableBoundary)<br />Deps: 10, 745, 1805, 1804, 1550, 1553, 1558, 1563, 46<br /><br />ROOT Connectionᐸ743ᐳ[745]<br />1: PgSelect[746]<br />ᐳ: 758, 760, 761, 763, 764, 766, 767, 769, 770, 773, 774, 775, 778, 779, 762, 768<br />2: __ListTransform[747]"):::bucket
     classDef bucket68 stroke:#696969
-    class Bucket68,PgSelect746,__ListTransform747,PgPageInfo758,First760,PgSelectSingle761,PgCursor762,PgClassExpression763,List764,Last766,PgSelectSingle767,PgCursor768,PgClassExpression769,List770,Access773,Object774,Lambda775,Object778,Lambda779,Lambda1519,Lambda1521,Object1525,Lambda1526,Lambda1531 bucket68
+    class Bucket68,PgSelect746,__ListTransform747,PgPageInfo758,First760,PgSelectSingle761,PgCursor762,PgClassExpression763,List764,Last766,PgSelectSingle767,PgCursor768,PgClassExpression769,List770,Access773,Object774,Lambda775,Object778,Lambda779 bucket68
     Bucket69("Bucket 69 (subroutine)<br /><br />ROOT PgSelectSingle{69}ᐸtable_set_queryᐳ[749]"):::bucket
     classDef bucket69 stroke:#00bfff
     class Bucket69,__Item748,PgSelectSingle749 bucket69
@@ -2110,9 +2140,9 @@ graph TD
     Bucket72("Bucket 72 (nullableBoundary)<br />Deps: 751<br /><br />ROOT PgSelectSingle{70}ᐸtable_set_queryᐳ[751]"):::bucket
     classDef bucket72 stroke:#0000ff
     class Bucket72,PgClassExpression756 bucket72
-    Bucket73("Bucket 73 (nullableBoundary)<br />Deps: 10, 784, 785, 1734, 791, 46, 48, 1323, 1536, 1369, 1370, 1794<br /><br />ROOT Connectionᐸ782ᐳ[784]<br />1: <br />ᐳ: 801, 1532, 1534, 1545, 1533, 1535, 1539, 1540<br />2: PgSelect[786]<br />ᐳ: 803, 804, 807, 808, 810, 811, 814, 815, 818, 819, 820, 824, 825, 805, 812<br />3: __ListTransform[787]"):::bucket
+    Bucket73("Bucket 73 (nullableBoundary)<br />Deps: 10, 784, 785, 1780, 791, 1565, 1568, 1573, 1578, 46<br /><br />ROOT Connectionᐸ782ᐳ[784]<br />1: PgSelect[786]<br />ᐳ: 801, 803, 804, 807, 808, 810, 811, 814, 815, 818, 819, 820, 824, 825, 805, 812<br />2: __ListTransform[787]"):::bucket
     classDef bucket73 stroke:#7fff00
-    class Bucket73,PgSelect786,__ListTransform787,PgPageInfo801,First803,PgSelectSingle804,PgCursor805,PgClassExpression807,List808,Last810,PgSelectSingle811,PgCursor812,PgClassExpression814,List815,Access818,Object819,Lambda820,Object824,Lambda825,Object1532,Lambda1533,Object1534,Lambda1535,Object1539,Lambda1540,Lambda1545 bucket73
+    class Bucket73,PgSelect786,__ListTransform787,PgPageInfo801,First803,PgSelectSingle804,PgCursor805,PgClassExpression807,List808,Last810,PgSelectSingle811,PgCursor812,PgClassExpression814,List815,Access818,Object819,Lambda820,Object824,Lambda825 bucket73
     Bucket74("Bucket 74 (subroutine)<br /><br />ROOT PgSelectSingle{74}ᐸtable_set_queryᐳ[789]"):::bucket
     classDef bucket74 stroke:#ff1493
     class Bucket74,__Item788,PgSelectSingle789 bucket74
@@ -2125,9 +2155,9 @@ graph TD
     Bucket77("Bucket 77 (nullableBoundary)<br />Deps: 793<br /><br />ROOT PgSelectSingle{75}ᐸtable_set_queryᐳ[793]"):::bucket
     classDef bucket77 stroke:#ff0000
     class Bucket77,PgClassExpression798 bucket77
-    Bucket78("Bucket 78 (nullableBoundary)<br />Deps: 10, 832, 785, 1734, 1733, 791, 46, 48, 1323, 1550, 1369, 1370, 1795<br /><br />ROOT Connectionᐸ830ᐳ[832]<br />1: <br />ᐳ: 849, 1546, 1548, 1559, 1547, 1549, 1553, 1554<br />2: PgSelect[834]<br />ᐳ: 851, 852, 855, 856, 858, 859, 862, 863, 866, 867, 868, 872, 873, 853, 860<br />3: __ListTransform[835]"):::bucket
+    Bucket78("Bucket 78 (nullableBoundary)<br />Deps: 10, 832, 785, 1780, 1779, 791, 1580, 1583, 1588, 1593, 46<br /><br />ROOT Connectionᐸ830ᐳ[832]<br />1: PgSelect[834]<br />ᐳ: 849, 851, 852, 855, 856, 858, 859, 862, 863, 866, 867, 868, 872, 873, 853, 860<br />2: __ListTransform[835]"):::bucket
     classDef bucket78 stroke:#ffff00
-    class Bucket78,PgSelect834,__ListTransform835,PgPageInfo849,First851,PgSelectSingle852,PgCursor853,PgClassExpression855,List856,Last858,PgSelectSingle859,PgCursor860,PgClassExpression862,List863,Access866,Object867,Lambda868,Object872,Lambda873,Object1546,Lambda1547,Object1548,Lambda1549,Object1553,Lambda1554,Lambda1559 bucket78
+    class Bucket78,PgSelect834,__ListTransform835,PgPageInfo849,First851,PgSelectSingle852,PgCursor853,PgClassExpression855,List856,Last858,PgSelectSingle859,PgCursor860,PgClassExpression862,List863,Access866,Object867,Lambda868,Object872,Lambda873 bucket78
     Bucket79("Bucket 79 (subroutine)<br /><br />ROOT PgSelectSingle{79}ᐸtable_set_queryᐳ[837]"):::bucket
     classDef bucket79 stroke:#00ffff
     class Bucket79,__Item836,PgSelectSingle837 bucket79
@@ -2140,9 +2170,9 @@ graph TD
     Bucket82("Bucket 82 (nullableBoundary)<br />Deps: 841<br /><br />ROOT PgSelectSingle{80}ᐸtable_set_queryᐳ[841]"):::bucket
     classDef bucket82 stroke:#a52a2a
     class Bucket82,PgClassExpression846 bucket82
-    Bucket83("Bucket 83 (nullableBoundary)<br />Deps: 10, 878, 1734, 1477, 46, 1818, 1564, 1565, 1370, 1796<br /><br />ROOT Connectionᐸ876ᐳ[878]<br />1: <br />ᐳ: 891, 1563, 1567, 1573, 1568<br />2: PgSelect[879]<br />ᐳ: 893, 894, 896, 897, 899, 900, 902, 903, 906, 907, 908, 911, 912, 895, 901<br />3: __ListTransform[880]"):::bucket
+    Bucket83("Bucket 83 (nullableBoundary)<br />Deps: 10, 878, 1780, 1505, 1598, 1603, 1608, 46<br /><br />ROOT Connectionᐸ876ᐳ[878]<br />1: PgSelect[879]<br />ᐳ: 891, 893, 894, 896, 897, 899, 900, 902, 903, 906, 907, 908, 911, 912, 895, 901<br />2: __ListTransform[880]"):::bucket
     classDef bucket83 stroke:#ff00ff
-    class Bucket83,PgSelect879,__ListTransform880,PgPageInfo891,First893,PgSelectSingle894,PgCursor895,PgClassExpression896,List897,Last899,PgSelectSingle900,PgCursor901,PgClassExpression902,List903,Access906,Object907,Lambda908,Object911,Lambda912,Lambda1563,Object1567,Lambda1568,Lambda1573 bucket83
+    class Bucket83,PgSelect879,__ListTransform880,PgPageInfo891,First893,PgSelectSingle894,PgCursor895,PgClassExpression896,List897,Last899,PgSelectSingle900,PgCursor901,PgClassExpression902,List903,Access906,Object907,Lambda908,Object911,Lambda912 bucket83
     Bucket84("Bucket 84 (subroutine)<br /><br />ROOT PgSelectSingle{84}ᐸtable_set_query_plpgsqlᐳ[882]"):::bucket
     classDef bucket84 stroke:#f5deb3
     class Bucket84,__Item881,PgSelectSingle882 bucket84
@@ -2155,9 +2185,9 @@ graph TD
     Bucket87("Bucket 87 (nullableBoundary)<br />Deps: 884<br /><br />ROOT PgSelectSingle{85}ᐸtable_set_query_plpgsqlᐳ[884]"):::bucket
     classDef bucket87 stroke:#7f007f
     class Bucket87,PgClassExpression889 bucket87
-    Bucket88("Bucket 88 (nullableBoundary)<br />Deps: 10, 917, 918, 1734, 46, 48, 1323, 1578, 1565, 1370, 1797<br /><br />ROOT Connectionᐸ915ᐳ[917]<br />1: <br />ᐳ: 924, 934, 1587, 1574, 1575, 1576, 1577, 1581, 1582<br />2: PgSelect[919]<br />ᐳ: 936, 937, 940, 941, 943, 944, 947, 948, 951, 952, 953, 957, 958, 938, 945<br />3: __ListTransform[920]"):::bucket
+    Bucket88("Bucket 88 (nullableBoundary)<br />Deps: 10, 917, 918, 1780, 924, 1610, 1613, 1618, 1623, 46<br /><br />ROOT Connectionᐸ915ᐳ[917]<br />1: PgSelect[919]<br />ᐳ: 934, 936, 937, 940, 941, 943, 944, 947, 948, 951, 952, 953, 957, 958, 938, 945<br />2: __ListTransform[920]"):::bucket
     classDef bucket88 stroke:#ffa500
-    class Bucket88,PgSelect919,__ListTransform920,Access924,PgPageInfo934,First936,PgSelectSingle937,PgCursor938,PgClassExpression940,List941,Last943,PgSelectSingle944,PgCursor945,PgClassExpression947,List948,Access951,Object952,Lambda953,Object957,Lambda958,Object1574,Lambda1575,Object1576,Lambda1577,Object1581,Lambda1582,Lambda1587 bucket88
+    class Bucket88,PgSelect919,__ListTransform920,PgPageInfo934,First936,PgSelectSingle937,PgCursor938,PgClassExpression940,List941,Last943,PgSelectSingle944,PgCursor945,PgClassExpression947,List948,Access951,Object952,Lambda953,Object957,Lambda958 bucket88
     Bucket89("Bucket 89 (subroutine)<br /><br />ROOT PgSelectSingle{89}ᐸtable_set_query_plpgsqlᐳ[922]"):::bucket
     classDef bucket89 stroke:#0000ff
     class Bucket89,__Item921,PgSelectSingle922 bucket89
@@ -2170,9 +2200,9 @@ graph TD
     Bucket92("Bucket 92 (nullableBoundary)<br />Deps: 926<br /><br />ROOT PgSelectSingle{90}ᐸtable_set_query_plpgsqlᐳ[926]"):::bucket
     classDef bucket92 stroke:#808000
     class Bucket92,PgClassExpression931 bucket92
-    Bucket93("Bucket 93 (nullableBoundary)<br />Deps: 10, 1736, 48, 1759, 964, 1083, 1086, 1592, 1593, 1145, 1798, 1606, 1799<br /><br />ROOT Connectionᐸ962ᐳ[964]<br />1: <br />ᐳ: 1595, 1601, 1609, 1615, 1596, 1610<br />2: PgSelect[965], PgSelect[977]<br />ᐳ: 978, 979, 980<br />3: __ListTransform[966]"):::bucket
+    Bucket93("Bucket 93 (nullableBoundary)<br />Deps: 10, 1782, 48, 1805, 964, 1083, 1087, 1633, 1638, 1648, 1653<br /><br />ROOT Connectionᐸ962ᐳ[964]<br />1: PgSelect[965], PgSelect[977]<br />ᐳ: 978, 979, 980<br />2: __ListTransform[966]"):::bucket
     classDef bucket93 stroke:#dda0dd
-    class Bucket93,PgSelect965,__ListTransform966,PgSelect977,First978,PgSelectSingle979,PgClassExpression980,Object1595,Lambda1596,Lambda1601,Object1609,Lambda1610,Lambda1615 bucket93
+    class Bucket93,PgSelect965,__ListTransform966,PgSelect977,First978,PgSelectSingle979,PgClassExpression980 bucket93
     Bucket94("Bucket 94 (subroutine)<br /><br />ROOT PgClassExpression{94}ᐸ__int_set_query__.vᐳ[969]"):::bucket
     classDef bucket94 stroke:#ff0000
     class Bucket94,__Item967,PgSelectSingle968,PgClassExpression969 bucket94
@@ -2182,16 +2212,16 @@ graph TD
     Bucket96("Bucket 96 (nullableBoundary)<br />Deps: 973, 974, 972<br /><br />ROOT Edge{95}[973]"):::bucket
     classDef bucket96 stroke:#00ffff
     class Bucket96 bucket96
-    Bucket97("Bucket 97 (nullableBoundary)<br />Deps: 10, 988, 1083, 1086, 1635, 1636, 1637, 1801, 1649, 1802<br /><br />ROOT Connectionᐸ986ᐳ[988]<br />1: <br />ᐳ: 1638, 1644, 1652, 1658, 1639, 1653<br />2: PgSelect[989], PgSelect[1001]<br />ᐳ: 1002, 1003, 1004<br />3: __ListTransform[990]"):::bucket
+    Bucket97("Bucket 97 (nullableBoundary)<br />Deps: 10, 988, 1083, 1087, 1679, 1684, 1694, 1699<br /><br />ROOT Connectionᐸ986ᐳ[988]<br />1: PgSelect[989], PgSelect[1001]<br />ᐳ: 1002, 1003, 1004<br />2: __ListTransform[990]"):::bucket
     classDef bucket97 stroke:#4169e1
-    class Bucket97,PgSelect989,__ListTransform990,PgSelect1001,First1002,PgSelectSingle1003,PgClassExpression1004,Object1638,Lambda1639,Lambda1644,Object1652,Lambda1653,Lambda1658 bucket97
+    class Bucket97,PgSelect989,__ListTransform990,PgSelect1001,First1002,PgSelectSingle1003,PgClassExpression1004 bucket97
     Bucket98("Bucket 98 (subroutine)<br /><br />ROOT PgClassExpression{98}ᐸ__static_b...nteger__.vᐳ[993]"):::bucket
     classDef bucket98 stroke:#3cb371
     class Bucket98,__Item991,PgSelectSingle992,PgClassExpression993 bucket98
     Bucket99("Bucket 99 (listItem)<br />Deps: 988<br /><br />ROOT __Item{99}ᐸ990ᐳ[994]"):::bucket
     classDef bucket99 stroke:#a52a2a
-    class Bucket99,__Item994,PgSelectSingle995,PgClassExpression996,Edge1630 bucket99
-    Bucket100("Bucket 100 (nullableBoundary)<br />Deps: 1630, 996<br /><br />ROOT Edge{99}[1630]"):::bucket
+    class Bucket99,__Item994,PgSelectSingle995,PgClassExpression996,Edge1669 bucket99
+    Bucket100("Bucket 100 (nullableBoundary)<br />Deps: 1669, 996<br /><br />ROOT Edge{99}[1669]"):::bucket
     classDef bucket100 stroke:#ff00ff
     class Bucket100 bucket100
     Bucket101("Bucket 101 (listItem)<br /><br />ROOT __Item{101}ᐸ1016ᐳ[1018]"):::bucket
@@ -2212,9 +2242,9 @@ graph TD
     Bucket106("Bucket 106 (nullableBoundary)<br />Deps: 1042<br /><br />ROOT __Item{105}ᐸ1041ᐳ[1042]"):::bucket
     classDef bucket106 stroke:#0000ff
     class Bucket106 bucket106
-    Bucket107("Bucket 107 (nullableBoundary)<br />Deps: 10, 1051, 1083, 1086, 1705, 1706, 1707, 1806, 1719, 1807<br /><br />ROOT Connectionᐸ1049ᐳ[1051]<br />1: <br />ᐳ: 1708, 1714, 1722, 1728, 1709, 1723<br />2: PgSelect[1052], PgSelect[1077]<br />ᐳ: 1078, 1079, 1080<br />3: __ListTransform[1063]"):::bucket
+    Bucket107("Bucket 107 (nullableBoundary)<br />Deps: 10, 1051, 1083, 1087, 1754, 1759, 1769, 1774<br /><br />ROOT Connectionᐸ1049ᐳ[1051]<br />1: PgSelect[1052], PgSelect[1077]<br />ᐳ: 1078, 1079, 1080<br />2: __ListTransform[1063]"):::bucket
     classDef bucket107 stroke:#7fff00
-    class Bucket107,PgSelect1052,__ListTransform1063,PgSelect1077,First1078,PgSelectSingle1079,PgClassExpression1080,Object1708,Lambda1709,Lambda1714,Object1722,Lambda1723,Lambda1728 bucket107
+    class Bucket107,PgSelect1052,__ListTransform1063,PgSelect1077,First1078,PgSelectSingle1079,PgClassExpression1080 bucket107
     Bucket108("Bucket 108 (listItem)<br /><br />ROOT __Item{108}ᐸ1052ᐳ[1053]"):::bucket
     classDef bucket108 stroke:#ff1493
     class Bucket108,__Item1053,PgSelectSingle1054,PgClassExpression1055 bucket108

--- a/postgraphile/postgraphile/__tests__/queries/v4/query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/query.mermaid
@@ -9,946 +9,946 @@ graph TD
 
 
     %% plan dependencies
-    Object2228{{"Object[2228∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object2229{{"Object[2229∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda2221{{"Lambda[2221∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant2225{{"Constant[2225∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2226{{"Constant[2226∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Constant2227{{"Constant[2227∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
-    Lambda2221 & Constant2225 & Constant2226 & Constant2227 --> Object2228
-    Object2242{{"Object[2242∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2239{{"Constant[2239∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2240{{"Constant[2240∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Constant2241{{"Constant[2241∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
-    Lambda2221 & Constant2239 & Constant2240 & Constant2241 --> Object2242
-    Object2256{{"Object[2256∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2253{{"Constant[2253∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2254{{"Constant[2254∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Constant2255{{"Constant[2255∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
-    Lambda2221 & Constant2253 & Constant2254 & Constant2255 --> Object2256
-    Object2270{{"Object[2270∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2267{{"Constant[2267∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2268{{"Constant[2268∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Constant2269{{"Constant[2269∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
-    Lambda2221 & Constant2267 & Constant2268 & Constant2269 --> Object2270
-    Object2284{{"Object[2284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2281{{"Constant[2281∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2282{{"Constant[2282∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Constant2283{{"Constant[2283∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
-    Lambda2221 & Constant2281 & Constant2282 & Constant2283 --> Object2284
-    Object2298{{"Object[2298∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2295{{"Constant[2295∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2296{{"Constant[2296∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Constant2297{{"Constant[2297∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
-    Lambda2221 & Constant2295 & Constant2296 & Constant2297 --> Object2298
-    Object2312{{"Object[2312∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2309{{"Constant[2309∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2310{{"Constant[2310∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant2311{{"Constant[2311∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda2221 & Constant2309 & Constant2310 & Constant2311 --> Object2312
-    Object2326{{"Object[2326∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2323{{"Constant[2323∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2324{{"Constant[2324∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant2325{{"Constant[2325∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda2221 & Constant2323 & Constant2324 & Constant2325 --> Object2326
-    Object2340{{"Object[2340∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2337{{"Constant[2337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2338{{"Constant[2338∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant2339{{"Constant[2339∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda2221 & Constant2337 & Constant2338 & Constant2339 --> Object2340
-    Object2354{{"Object[2354∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2351{{"Constant[2351∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2352{{"Constant[2352∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant2353{{"Constant[2353∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Lambda2221 & Constant2351 & Constant2352 & Constant2353 --> Object2354
-    Object2368{{"Object[2368∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2365{{"Constant[2365∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2366{{"Constant[2366∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant2367{{"Constant[2367∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Lambda2221 & Constant2365 & Constant2366 & Constant2367 --> Object2368
-    Object2382{{"Object[2382∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2379{{"Constant[2379∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2380{{"Constant[2380∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant2381{{"Constant[2381∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda2221 & Constant2379 & Constant2380 & Constant2381 --> Object2382
-    Object2396{{"Object[2396∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2393{{"Constant[2393∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2394{{"Constant[2394∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant2395{{"Constant[2395∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
-    Lambda2221 & Constant2393 & Constant2394 & Constant2395 --> Object2396
-    Object2410{{"Object[2410∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2407{{"Constant[2407∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2408{{"Constant[2408∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Constant2409{{"Constant[2409∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
-    Lambda2221 & Constant2407 & Constant2408 & Constant2409 --> Object2410
+    Constant2226{{"Constant[2226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2227{{"Constant[2227∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Constant2228{{"Constant[2228∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
+    Lambda2221 & Constant2226 & Constant2227 & Constant2228 --> Object2229
+    Object2244{{"Object[2244∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2241{{"Constant[2241∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2242{{"Constant[2242∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Constant2243{{"Constant[2243∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
+    Lambda2221 & Constant2241 & Constant2242 & Constant2243 --> Object2244
+    Object2259{{"Object[2259∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2256{{"Constant[2256∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2257{{"Constant[2257∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Constant2258{{"Constant[2258∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
+    Lambda2221 & Constant2256 & Constant2257 & Constant2258 --> Object2259
+    Object2274{{"Object[2274∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2271{{"Constant[2271∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2272{{"Constant[2272∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Constant2273{{"Constant[2273∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
+    Lambda2221 & Constant2271 & Constant2272 & Constant2273 --> Object2274
+    Object2289{{"Object[2289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2286{{"Constant[2286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2287{{"Constant[2287∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Constant2288{{"Constant[2288∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
+    Lambda2221 & Constant2286 & Constant2287 & Constant2288 --> Object2289
+    Object2304{{"Object[2304∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2301{{"Constant[2301∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2302{{"Constant[2302∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Constant2303{{"Constant[2303∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
+    Lambda2221 & Constant2301 & Constant2302 & Constant2303 --> Object2304
+    Object2319{{"Object[2319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2316{{"Constant[2316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2317{{"Constant[2317∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant2318{{"Constant[2318∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda2221 & Constant2316 & Constant2317 & Constant2318 --> Object2319
+    Object2334{{"Object[2334∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2331{{"Constant[2331∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2332{{"Constant[2332∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant2333{{"Constant[2333∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda2221 & Constant2331 & Constant2332 & Constant2333 --> Object2334
+    Object2349{{"Object[2349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2346{{"Constant[2346∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2347{{"Constant[2347∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant2348{{"Constant[2348∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda2221 & Constant2346 & Constant2347 & Constant2348 --> Object2349
+    Object2364{{"Object[2364∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2361{{"Constant[2361∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2362{{"Constant[2362∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant2363{{"Constant[2363∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda2221 & Constant2361 & Constant2362 & Constant2363 --> Object2364
+    Object2379{{"Object[2379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2376{{"Constant[2376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2377{{"Constant[2377∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant2378{{"Constant[2378∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda2221 & Constant2376 & Constant2377 & Constant2378 --> Object2379
+    Object2394{{"Object[2394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2391{{"Constant[2391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2392{{"Constant[2392∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant2393{{"Constant[2393∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda2221 & Constant2391 & Constant2392 & Constant2393 --> Object2394
+    Object2409{{"Object[2409∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2406{{"Constant[2406∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2407{{"Constant[2407∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Constant2408{{"Constant[2408∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
+    Lambda2221 & Constant2406 & Constant2407 & Constant2408 --> Object2409
     Object2424{{"Object[2424∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2421{{"Constant[2421∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2422{{"Constant[2422∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Constant2423{{"Constant[2423∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Constant2422{{"Constant[2422∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Constant2423{{"Constant[2423∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
     Lambda2221 & Constant2421 & Constant2422 & Constant2423 --> Object2424
-    Object2438{{"Object[2438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2435{{"Constant[2435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2436{{"Constant[2436∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Constant2437{{"Constant[2437∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
-    Lambda2221 & Constant2435 & Constant2436 & Constant2437 --> Object2438
-    Object2452{{"Object[2452∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2449{{"Constant[2449∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2450{{"Constant[2450∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Constant2451{{"Constant[2451∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
-    Lambda2221 & Constant2449 & Constant2450 & Constant2451 --> Object2452
-    Object2466{{"Object[2466∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2463{{"Constant[2463∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2464{{"Constant[2464∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Constant2465{{"Constant[2465∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
-    Lambda2221 & Constant2463 & Constant2464 & Constant2465 --> Object2466
-    Object2480{{"Object[2480∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2477{{"Constant[2477∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2478{{"Constant[2478∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Constant2479{{"Constant[2479∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
-    Lambda2221 & Constant2477 & Constant2478 & Constant2479 --> Object2480
-    Object2494{{"Object[2494∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2491{{"Constant[2491∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2492{{"Constant[2492∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant2491 & Constant2492 & Constant2227 --> Object2494
-    Object2508{{"Object[2508∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2505{{"Constant[2505∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2506{{"Constant[2506∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant2505 & Constant2506 & Constant2241 --> Object2508
-    Object2522{{"Object[2522∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2519{{"Constant[2519∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2520{{"Constant[2520∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant2519 & Constant2520 & Constant2255 --> Object2522
-    Object2536{{"Object[2536∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2533{{"Constant[2533∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2534{{"Constant[2534∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant2533 & Constant2534 & Constant2269 --> Object2536
-    Object2550{{"Object[2550∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2547{{"Constant[2547∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2548{{"Constant[2548∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant2547 & Constant2548 & Constant2283 --> Object2550
-    Object2564{{"Object[2564∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2561{{"Constant[2561∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2562{{"Constant[2562∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant2561 & Constant2562 & Constant2297 --> Object2564
-    Object2578{{"Object[2578∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2575{{"Constant[2575∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2576{{"Constant[2576∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant2575 & Constant2576 & Constant2311 --> Object2578
-    Object2592{{"Object[2592∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2589{{"Constant[2589∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2590{{"Constant[2590∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant2589 & Constant2590 & Constant2325 --> Object2592
-    Object2606{{"Object[2606∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2603{{"Constant[2603∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2604{{"Constant[2604∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant2603 & Constant2604 & Constant2339 --> Object2606
-    Object2620{{"Object[2620∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2617{{"Constant[2617∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2618{{"Constant[2618∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant2617 & Constant2618 & Constant2353 --> Object2620
+    Object2439{{"Object[2439∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2436{{"Constant[2436∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2437{{"Constant[2437∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Constant2438{{"Constant[2438∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Lambda2221 & Constant2436 & Constant2437 & Constant2438 --> Object2439
+    Object2454{{"Object[2454∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2451{{"Constant[2451∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2452{{"Constant[2452∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Constant2453{{"Constant[2453∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
+    Lambda2221 & Constant2451 & Constant2452 & Constant2453 --> Object2454
+    Object2469{{"Object[2469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2466{{"Constant[2466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2467{{"Constant[2467∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Constant2468{{"Constant[2468∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
+    Lambda2221 & Constant2466 & Constant2467 & Constant2468 --> Object2469
+    Object2484{{"Object[2484∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2481{{"Constant[2481∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2482{{"Constant[2482∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Constant2483{{"Constant[2483∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
+    Lambda2221 & Constant2481 & Constant2482 & Constant2483 --> Object2484
+    Object2499{{"Object[2499∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2496{{"Constant[2496∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2497{{"Constant[2497∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Constant2498{{"Constant[2498∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
+    Lambda2221 & Constant2496 & Constant2497 & Constant2498 --> Object2499
+    Object2514{{"Object[2514∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2511{{"Constant[2511∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2512{{"Constant[2512∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant2511 & Constant2512 & Constant2228 --> Object2514
+    Object2529{{"Object[2529∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2526{{"Constant[2526∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2527{{"Constant[2527∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant2526 & Constant2527 & Constant2243 --> Object2529
+    Object2544{{"Object[2544∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2541{{"Constant[2541∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2542{{"Constant[2542∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant2541 & Constant2542 & Constant2258 --> Object2544
+    Object2559{{"Object[2559∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2556{{"Constant[2556∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2557{{"Constant[2557∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant2556 & Constant2557 & Constant2273 --> Object2559
+    Object2574{{"Object[2574∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2571{{"Constant[2571∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2572{{"Constant[2572∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant2571 & Constant2572 & Constant2288 --> Object2574
+    Object2589{{"Object[2589∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2586{{"Constant[2586∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2587{{"Constant[2587∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant2586 & Constant2587 & Constant2303 --> Object2589
+    Object2604{{"Object[2604∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2601{{"Constant[2601∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2602{{"Constant[2602∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant2601 & Constant2602 & Constant2318 --> Object2604
+    Object2619{{"Object[2619∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2616{{"Constant[2616∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2617{{"Constant[2617∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant2616 & Constant2617 & Constant2333 --> Object2619
     Object2634{{"Object[2634∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2631{{"Constant[2631∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2632{{"Constant[2632∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant2631 & Constant2632 & Constant2367 --> Object2634
-    Object2648{{"Object[2648∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2645{{"Constant[2645∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2646{{"Constant[2646∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant2645 & Constant2646 & Constant2381 --> Object2648
-    Object2662{{"Object[2662∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2659{{"Constant[2659∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2660{{"Constant[2660∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant2659 & Constant2660 & Constant2395 --> Object2662
-    Object2676{{"Object[2676∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2673{{"Constant[2673∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2674{{"Constant[2674∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant2673 & Constant2674 & Constant2409 --> Object2676
-    Object2690{{"Object[2690∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2687{{"Constant[2687∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2688{{"Constant[2688∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant2687 & Constant2688 & Constant2423 --> Object2690
-    Object2704{{"Object[2704∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2701{{"Constant[2701∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2702{{"Constant[2702∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant2701 & Constant2702 & Constant2437 --> Object2704
-    Object2718{{"Object[2718∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2715{{"Constant[2715∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2716{{"Constant[2716∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant2715 & Constant2716 & Constant2451 --> Object2718
-    Object2732{{"Object[2732∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2729{{"Constant[2729∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2730{{"Constant[2730∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant2729 & Constant2730 & Constant2465 --> Object2732
-    Object2746{{"Object[2746∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2743{{"Constant[2743∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2744{{"Constant[2744∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant2743 & Constant2744 & Constant2479 --> Object2746
-    Object2760{{"Object[2760∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2757{{"Constant[2757∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2758{{"Constant[2758∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant2757 & Constant2758 & Constant2227 --> Object2760
-    Object2774{{"Object[2774∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2771{{"Constant[2771∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2772{{"Constant[2772∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant2771 & Constant2772 & Constant2241 --> Object2774
-    Object2788{{"Object[2788∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2785{{"Constant[2785∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2786{{"Constant[2786∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant2785 & Constant2786 & Constant2255 --> Object2788
-    Object2802{{"Object[2802∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2799{{"Constant[2799∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2800{{"Constant[2800∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant2799 & Constant2800 & Constant2269 --> Object2802
-    Object2816{{"Object[2816∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2813{{"Constant[2813∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2814{{"Constant[2814∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant2813 & Constant2814 & Constant2283 --> Object2816
-    Object2830{{"Object[2830∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2827{{"Constant[2827∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2828{{"Constant[2828∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant2827 & Constant2828 & Constant2297 --> Object2830
+    Constant2632{{"Constant[2632∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant2631 & Constant2632 & Constant2348 --> Object2634
+    Object2649{{"Object[2649∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2646{{"Constant[2646∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2647{{"Constant[2647∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant2646 & Constant2647 & Constant2363 --> Object2649
+    Object2664{{"Object[2664∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2661{{"Constant[2661∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2662{{"Constant[2662∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant2661 & Constant2662 & Constant2378 --> Object2664
+    Object2679{{"Object[2679∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2676{{"Constant[2676∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2677{{"Constant[2677∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant2676 & Constant2677 & Constant2393 --> Object2679
+    Object2694{{"Object[2694∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2691{{"Constant[2691∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2692{{"Constant[2692∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant2691 & Constant2692 & Constant2408 --> Object2694
+    Object2709{{"Object[2709∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2706{{"Constant[2706∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2707{{"Constant[2707∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant2706 & Constant2707 & Constant2423 --> Object2709
+    Object2724{{"Object[2724∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2721{{"Constant[2721∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2722{{"Constant[2722∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant2721 & Constant2722 & Constant2438 --> Object2724
+    Object2739{{"Object[2739∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2736{{"Constant[2736∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2737{{"Constant[2737∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant2736 & Constant2737 & Constant2453 --> Object2739
+    Object2754{{"Object[2754∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2751{{"Constant[2751∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2752{{"Constant[2752∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant2751 & Constant2752 & Constant2468 --> Object2754
+    Object2769{{"Object[2769∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2766{{"Constant[2766∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2767{{"Constant[2767∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant2766 & Constant2767 & Constant2483 --> Object2769
+    Object2784{{"Object[2784∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2781{{"Constant[2781∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2782{{"Constant[2782∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant2781 & Constant2782 & Constant2498 --> Object2784
+    Object2799{{"Object[2799∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2796{{"Constant[2796∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2797{{"Constant[2797∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant2796 & Constant2797 & Constant2228 --> Object2799
+    Object2814{{"Object[2814∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2811{{"Constant[2811∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2812{{"Constant[2812∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant2811 & Constant2812 & Constant2243 --> Object2814
+    Object2829{{"Object[2829∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2826{{"Constant[2826∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2827{{"Constant[2827∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant2826 & Constant2827 & Constant2258 --> Object2829
     Object2844{{"Object[2844∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant2841{{"Constant[2841∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2842{{"Constant[2842∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant2841 & Constant2842 & Constant2311 --> Object2844
-    Object2858{{"Object[2858∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2855{{"Constant[2855∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2856{{"Constant[2856∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant2855 & Constant2856 & Constant2325 --> Object2858
-    Object2872{{"Object[2872∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2869{{"Constant[2869∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2870{{"Constant[2870∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant2869 & Constant2870 & Constant2339 --> Object2872
-    Object2886{{"Object[2886∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2883{{"Constant[2883∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2884{{"Constant[2884∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant2883 & Constant2884 & Constant2353 --> Object2886
-    Object2900{{"Object[2900∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2897{{"Constant[2897∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2898{{"Constant[2898∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant2897 & Constant2898 & Constant2367 --> Object2900
-    Object2914{{"Object[2914∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2911{{"Constant[2911∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2912{{"Constant[2912∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant2911 & Constant2912 & Constant2381 --> Object2914
-    Object2928{{"Object[2928∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2925{{"Constant[2925∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2926{{"Constant[2926∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant2925 & Constant2926 & Constant2395 --> Object2928
-    Object2942{{"Object[2942∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2939{{"Constant[2939∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2940{{"Constant[2940∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant2939 & Constant2940 & Constant2409 --> Object2942
-    Object2956{{"Object[2956∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2953{{"Constant[2953∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2954{{"Constant[2954∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant2953 & Constant2954 & Constant2423 --> Object2956
-    Object2970{{"Object[2970∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2967{{"Constant[2967∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2968{{"Constant[2968∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant2967 & Constant2968 & Constant2437 --> Object2970
-    Object2984{{"Object[2984∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2981{{"Constant[2981∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2982{{"Constant[2982∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant2981 & Constant2982 & Constant2451 --> Object2984
-    Object2998{{"Object[2998∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant2995{{"Constant[2995∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant2996{{"Constant[2996∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant2995 & Constant2996 & Constant2465 --> Object2998
-    Object3012{{"Object[3012∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3009{{"Constant[3009∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3010{{"Constant[3010∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant3009 & Constant3010 & Constant2479 --> Object3012
-    Object3026{{"Object[3026∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3023{{"Constant[3023∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3024{{"Constant[3024∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3023 & Constant3024 & Constant2227 --> Object3026
-    Object3040{{"Object[3040∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3037{{"Constant[3037∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3038{{"Constant[3038∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3037 & Constant3038 & Constant2241 --> Object3040
+    Constant2842{{"Constant[2842∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant2841 & Constant2842 & Constant2273 --> Object2844
+    Object2859{{"Object[2859∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2856{{"Constant[2856∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2857{{"Constant[2857∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant2856 & Constant2857 & Constant2288 --> Object2859
+    Object2874{{"Object[2874∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2871{{"Constant[2871∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2872{{"Constant[2872∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant2871 & Constant2872 & Constant2303 --> Object2874
+    Object2889{{"Object[2889∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2886{{"Constant[2886∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2887{{"Constant[2887∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant2886 & Constant2887 & Constant2318 --> Object2889
+    Object2904{{"Object[2904∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2901{{"Constant[2901∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2902{{"Constant[2902∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant2901 & Constant2902 & Constant2333 --> Object2904
+    Object2919{{"Object[2919∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2916{{"Constant[2916∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2917{{"Constant[2917∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant2916 & Constant2917 & Constant2348 --> Object2919
+    Object2934{{"Object[2934∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2931{{"Constant[2931∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2932{{"Constant[2932∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant2931 & Constant2932 & Constant2363 --> Object2934
+    Object2949{{"Object[2949∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2946{{"Constant[2946∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2947{{"Constant[2947∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant2946 & Constant2947 & Constant2378 --> Object2949
+    Object2964{{"Object[2964∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2961{{"Constant[2961∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2962{{"Constant[2962∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant2961 & Constant2962 & Constant2393 --> Object2964
+    Object2979{{"Object[2979∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2976{{"Constant[2976∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2977{{"Constant[2977∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant2976 & Constant2977 & Constant2408 --> Object2979
+    Object2994{{"Object[2994∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant2991{{"Constant[2991∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant2992{{"Constant[2992∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant2991 & Constant2992 & Constant2423 --> Object2994
+    Object3009{{"Object[3009∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3006{{"Constant[3006∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3007{{"Constant[3007∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant3006 & Constant3007 & Constant2438 --> Object3009
+    Object3024{{"Object[3024∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3021{{"Constant[3021∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3022{{"Constant[3022∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant3021 & Constant3022 & Constant2453 --> Object3024
+    Object3039{{"Object[3039∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3036{{"Constant[3036∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3037{{"Constant[3037∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant3036 & Constant3037 & Constant2468 --> Object3039
     Object3054{{"Object[3054∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3051{{"Constant[3051∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3052{{"Constant[3052∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant3051 & Constant3052 & Constant2255 --> Object3054
-    Object3068{{"Object[3068∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3065{{"Constant[3065∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3066{{"Constant[3066∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3065 & Constant3066 & Constant2269 --> Object3068
-    Object3082{{"Object[3082∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3079{{"Constant[3079∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3080{{"Constant[3080∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant3079 & Constant3080 & Constant2283 --> Object3082
-    Object3096{{"Object[3096∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3093{{"Constant[3093∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3094{{"Constant[3094∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant3093 & Constant3094 & Constant2297 --> Object3096
-    Object3110{{"Object[3110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3107{{"Constant[3107∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3108{{"Constant[3108∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant3107 & Constant3108 & Constant2311 --> Object3110
-    Object3124{{"Object[3124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3121{{"Constant[3121∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3122{{"Constant[3122∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant3121 & Constant3122 & Constant2325 --> Object3124
-    Object3138{{"Object[3138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3135{{"Constant[3135∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3136{{"Constant[3136∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant3135 & Constant3136 & Constant2339 --> Object3138
-    Object3152{{"Object[3152∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3149{{"Constant[3149∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3150{{"Constant[3150∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant3149 & Constant3150 & Constant2353 --> Object3152
-    Object3166{{"Object[3166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3163{{"Constant[3163∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3164{{"Constant[3164∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant3163 & Constant3164 & Constant2367 --> Object3166
-    Object3180{{"Object[3180∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3177{{"Constant[3177∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3178{{"Constant[3178∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant3177 & Constant3178 & Constant2381 --> Object3180
-    Object3194{{"Object[3194∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3191{{"Constant[3191∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3192{{"Constant[3192∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3191 & Constant3192 & Constant2395 --> Object3194
-    Object3208{{"Object[3208∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3205{{"Constant[3205∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3206{{"Constant[3206∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3205 & Constant3206 & Constant2409 --> Object3208
-    Object3222{{"Object[3222∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3219{{"Constant[3219∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3220{{"Constant[3220∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant3219 & Constant3220 & Constant2423 --> Object3222
-    Object3236{{"Object[3236∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3233{{"Constant[3233∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3234{{"Constant[3234∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant3233 & Constant3234 & Constant2437 --> Object3236
-    Object3250{{"Object[3250∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3247{{"Constant[3247∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3248{{"Constant[3248∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant3247 & Constant3248 & Constant2451 --> Object3250
+    Constant3052{{"Constant[3052∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant3051 & Constant3052 & Constant2483 --> Object3054
+    Object3069{{"Object[3069∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3066{{"Constant[3066∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3067{{"Constant[3067∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant3066 & Constant3067 & Constant2498 --> Object3069
+    Object3084{{"Object[3084∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3081{{"Constant[3081∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3082{{"Constant[3082∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3081 & Constant3082 & Constant2228 --> Object3084
+    Object3099{{"Object[3099∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3096{{"Constant[3096∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3097{{"Constant[3097∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3096 & Constant3097 & Constant2243 --> Object3099
+    Object3114{{"Object[3114∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3111{{"Constant[3111∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3112{{"Constant[3112∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant3111 & Constant3112 & Constant2258 --> Object3114
+    Object3129{{"Object[3129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3126{{"Constant[3126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3127{{"Constant[3127∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3126 & Constant3127 & Constant2273 --> Object3129
+    Object3144{{"Object[3144∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3141{{"Constant[3141∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3142{{"Constant[3142∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant3141 & Constant3142 & Constant2288 --> Object3144
+    Object3159{{"Object[3159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3156{{"Constant[3156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3157{{"Constant[3157∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant3156 & Constant3157 & Constant2303 --> Object3159
+    Object3174{{"Object[3174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3171{{"Constant[3171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3172{{"Constant[3172∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant3171 & Constant3172 & Constant2318 --> Object3174
+    Object3189{{"Object[3189∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3186{{"Constant[3186∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3187{{"Constant[3187∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant3186 & Constant3187 & Constant2333 --> Object3189
+    Object3204{{"Object[3204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3201{{"Constant[3201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3202{{"Constant[3202∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant3201 & Constant3202 & Constant2348 --> Object3204
+    Object3219{{"Object[3219∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3216{{"Constant[3216∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3217{{"Constant[3217∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant3216 & Constant3217 & Constant2363 --> Object3219
+    Object3234{{"Object[3234∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3231{{"Constant[3231∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3232{{"Constant[3232∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant3231 & Constant3232 & Constant2378 --> Object3234
+    Object3249{{"Object[3249∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3246{{"Constant[3246∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3247{{"Constant[3247∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant3246 & Constant3247 & Constant2393 --> Object3249
     Object3264{{"Object[3264∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3261{{"Constant[3261∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3262{{"Constant[3262∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant3261 & Constant3262 & Constant2465 --> Object3264
-    Object3278{{"Object[3278∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3275{{"Constant[3275∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3276{{"Constant[3276∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant3275 & Constant3276 & Constant2479 --> Object3278
-    Object3292{{"Object[3292∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3289{{"Constant[3289∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3290{{"Constant[3290∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3289 & Constant3290 & Constant2227 --> Object3292
-    Object3306{{"Object[3306∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3303{{"Constant[3303∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3304{{"Constant[3304∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3303 & Constant3304 & Constant2241 --> Object3306
-    Object3320{{"Object[3320∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3317{{"Constant[3317∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3318{{"Constant[3318∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant3317 & Constant3318 & Constant2255 --> Object3320
-    Object3334{{"Object[3334∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3331{{"Constant[3331∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3332{{"Constant[3332∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3331 & Constant3332 & Constant2269 --> Object3334
-    Object3348{{"Object[3348∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3345{{"Constant[3345∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3346{{"Constant[3346∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant3345 & Constant3346 & Constant2283 --> Object3348
-    Object3362{{"Object[3362∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3359{{"Constant[3359∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3360{{"Constant[3360∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant3359 & Constant3360 & Constant2297 --> Object3362
-    Object3376{{"Object[3376∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3373{{"Constant[3373∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3374{{"Constant[3374∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant3373 & Constant3374 & Constant2311 --> Object3376
-    Object3390{{"Object[3390∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3387{{"Constant[3387∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3388{{"Constant[3388∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant3387 & Constant3388 & Constant2325 --> Object3390
-    Object3404{{"Object[3404∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3401{{"Constant[3401∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3402{{"Constant[3402∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant3401 & Constant3402 & Constant2339 --> Object3404
-    Object3418{{"Object[3418∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3415{{"Constant[3415∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3416{{"Constant[3416∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant3415 & Constant3416 & Constant2353 --> Object3418
-    Object3432{{"Object[3432∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3429{{"Constant[3429∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3430{{"Constant[3430∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant3429 & Constant3430 & Constant2367 --> Object3432
-    Object3446{{"Object[3446∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3443{{"Constant[3443∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3444{{"Constant[3444∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant3443 & Constant3444 & Constant2381 --> Object3446
-    Object3460{{"Object[3460∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3457{{"Constant[3457∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3458{{"Constant[3458∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3457 & Constant3458 & Constant2395 --> Object3460
+    Constant3262{{"Constant[3262∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant3261 & Constant3262 & Constant2408 --> Object3264
+    Object3279{{"Object[3279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3276{{"Constant[3276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3277{{"Constant[3277∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant3276 & Constant3277 & Constant2423 --> Object3279
+    Object3294{{"Object[3294∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3291{{"Constant[3291∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3292{{"Constant[3292∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant3291 & Constant3292 & Constant2438 --> Object3294
+    Object3309{{"Object[3309∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3306{{"Constant[3306∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3307{{"Constant[3307∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant3306 & Constant3307 & Constant2453 --> Object3309
+    Object3324{{"Object[3324∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3321{{"Constant[3321∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3322{{"Constant[3322∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant3321 & Constant3322 & Constant2468 --> Object3324
+    Object3339{{"Object[3339∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3336{{"Constant[3336∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3337{{"Constant[3337∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant3336 & Constant3337 & Constant2483 --> Object3339
+    Object3354{{"Object[3354∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3351{{"Constant[3351∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3352{{"Constant[3352∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant3351 & Constant3352 & Constant2498 --> Object3354
+    Object3369{{"Object[3369∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3366{{"Constant[3366∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3367{{"Constant[3367∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3366 & Constant3367 & Constant2228 --> Object3369
+    Object3384{{"Object[3384∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3381{{"Constant[3381∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3382{{"Constant[3382∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3381 & Constant3382 & Constant2243 --> Object3384
+    Object3399{{"Object[3399∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3396{{"Constant[3396∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3397{{"Constant[3397∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant3396 & Constant3397 & Constant2258 --> Object3399
+    Object3414{{"Object[3414∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3411{{"Constant[3411∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3412{{"Constant[3412∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3411 & Constant3412 & Constant2273 --> Object3414
+    Object3429{{"Object[3429∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3426{{"Constant[3426∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3427{{"Constant[3427∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant3426 & Constant3427 & Constant2288 --> Object3429
+    Object3444{{"Object[3444∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3441{{"Constant[3441∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3442{{"Constant[3442∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant3441 & Constant3442 & Constant2303 --> Object3444
+    Object3459{{"Object[3459∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3456{{"Constant[3456∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3457{{"Constant[3457∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant3456 & Constant3457 & Constant2318 --> Object3459
     Object3474{{"Object[3474∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3471{{"Constant[3471∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3472{{"Constant[3472∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3471 & Constant3472 & Constant2409 --> Object3474
-    Object3488{{"Object[3488∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3485{{"Constant[3485∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3486{{"Constant[3486∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant3485 & Constant3486 & Constant2423 --> Object3488
-    Object3502{{"Object[3502∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3499{{"Constant[3499∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3500{{"Constant[3500∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant3499 & Constant3500 & Constant2437 --> Object3502
-    Object3516{{"Object[3516∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3513{{"Constant[3513∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3514{{"Constant[3514∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant3513 & Constant3514 & Constant2451 --> Object3516
-    Object3530{{"Object[3530∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3527{{"Constant[3527∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3528{{"Constant[3528∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant3527 & Constant3528 & Constant2465 --> Object3530
-    Object3544{{"Object[3544∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3541{{"Constant[3541∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3542{{"Constant[3542∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant3541 & Constant3542 & Constant2479 --> Object3544
-    Object3558{{"Object[3558∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3555{{"Constant[3555∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3556{{"Constant[3556∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3555 & Constant3556 & Constant2227 --> Object3558
-    Object3572{{"Object[3572∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3569{{"Constant[3569∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3570{{"Constant[3570∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3569 & Constant3570 & Constant2241 --> Object3572
-    Object3586{{"Object[3586∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3583{{"Constant[3583∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3584{{"Constant[3584∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant3583 & Constant3584 & Constant2255 --> Object3586
-    Object3600{{"Object[3600∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3597{{"Constant[3597∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3598{{"Constant[3598∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3597 & Constant3598 & Constant2269 --> Object3600
-    Object3614{{"Object[3614∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3611{{"Constant[3611∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3612{{"Constant[3612∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant3611 & Constant3612 & Constant2283 --> Object3614
-    Object3628{{"Object[3628∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3625{{"Constant[3625∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3626{{"Constant[3626∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant3625 & Constant3626 & Constant2297 --> Object3628
-    Object3642{{"Object[3642∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3639{{"Constant[3639∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3640{{"Constant[3640∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant3639 & Constant3640 & Constant2311 --> Object3642
-    Object3656{{"Object[3656∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3653{{"Constant[3653∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3654{{"Constant[3654∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant3653 & Constant3654 & Constant2325 --> Object3656
-    Object3670{{"Object[3670∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3667{{"Constant[3667∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3668{{"Constant[3668∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant3667 & Constant3668 & Constant2339 --> Object3670
+    Constant3472{{"Constant[3472∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant3471 & Constant3472 & Constant2333 --> Object3474
+    Object3489{{"Object[3489∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3486{{"Constant[3486∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3487{{"Constant[3487∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant3486 & Constant3487 & Constant2348 --> Object3489
+    Object3504{{"Object[3504∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3501{{"Constant[3501∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3502{{"Constant[3502∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant3501 & Constant3502 & Constant2363 --> Object3504
+    Object3519{{"Object[3519∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3516{{"Constant[3516∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3517{{"Constant[3517∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant3516 & Constant3517 & Constant2378 --> Object3519
+    Object3534{{"Object[3534∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3531{{"Constant[3531∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3532{{"Constant[3532∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant3531 & Constant3532 & Constant2393 --> Object3534
+    Object3549{{"Object[3549∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3546{{"Constant[3546∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3547{{"Constant[3547∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant3546 & Constant3547 & Constant2408 --> Object3549
+    Object3564{{"Object[3564∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3561{{"Constant[3561∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3562{{"Constant[3562∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant3561 & Constant3562 & Constant2423 --> Object3564
+    Object3579{{"Object[3579∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3576{{"Constant[3576∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3577{{"Constant[3577∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant3576 & Constant3577 & Constant2438 --> Object3579
+    Object3594{{"Object[3594∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3591{{"Constant[3591∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3592{{"Constant[3592∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant3591 & Constant3592 & Constant2453 --> Object3594
+    Object3609{{"Object[3609∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3606{{"Constant[3606∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3607{{"Constant[3607∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant3606 & Constant3607 & Constant2468 --> Object3609
+    Object3624{{"Object[3624∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3621{{"Constant[3621∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3622{{"Constant[3622∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant3621 & Constant3622 & Constant2483 --> Object3624
+    Object3639{{"Object[3639∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3636{{"Constant[3636∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3637{{"Constant[3637∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant3636 & Constant3637 & Constant2498 --> Object3639
+    Object3654{{"Object[3654∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3651{{"Constant[3651∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3652{{"Constant[3652∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3651 & Constant3652 & Constant2228 --> Object3654
+    Object3669{{"Object[3669∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3666{{"Constant[3666∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3667{{"Constant[3667∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3666 & Constant3667 & Constant2243 --> Object3669
     Object3684{{"Object[3684∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3681{{"Constant[3681∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3682{{"Constant[3682∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant3681 & Constant3682 & Constant2353 --> Object3684
-    Object3698{{"Object[3698∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3695{{"Constant[3695∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3696{{"Constant[3696∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant3695 & Constant3696 & Constant2367 --> Object3698
-    Object3712{{"Object[3712∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3709{{"Constant[3709∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3710{{"Constant[3710∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant3709 & Constant3710 & Constant2381 --> Object3712
-    Object3726{{"Object[3726∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3723{{"Constant[3723∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3724{{"Constant[3724∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3723 & Constant3724 & Constant2395 --> Object3726
-    Object3740{{"Object[3740∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3737{{"Constant[3737∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3738{{"Constant[3738∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3737 & Constant3738 & Constant2409 --> Object3740
-    Object3754{{"Object[3754∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3751{{"Constant[3751∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3752{{"Constant[3752∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant3751 & Constant3752 & Constant2423 --> Object3754
-    Object3768{{"Object[3768∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3765{{"Constant[3765∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3766{{"Constant[3766∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant3765 & Constant3766 & Constant2437 --> Object3768
-    Object3782{{"Object[3782∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3779{{"Constant[3779∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3780{{"Constant[3780∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant3779 & Constant3780 & Constant2451 --> Object3782
-    Object3796{{"Object[3796∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3793{{"Constant[3793∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3794{{"Constant[3794∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant3793 & Constant3794 & Constant2465 --> Object3796
-    Object3810{{"Object[3810∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3807{{"Constant[3807∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3808{{"Constant[3808∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant3807 & Constant3808 & Constant2479 --> Object3810
-    Object3824{{"Object[3824∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3821{{"Constant[3821∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3822{{"Constant[3822∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3821 & Constant3822 & Constant2227 --> Object3824
-    Object3838{{"Object[3838∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3835{{"Constant[3835∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3836{{"Constant[3836∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3835 & Constant3836 & Constant2241 --> Object3838
-    Object3852{{"Object[3852∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3849{{"Constant[3849∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3850{{"Constant[3850∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant3849 & Constant3850 & Constant2255 --> Object3852
-    Object3866{{"Object[3866∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3863{{"Constant[3863∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3864{{"Constant[3864∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant3863 & Constant3864 & Constant2269 --> Object3866
-    Object3880{{"Object[3880∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3877{{"Constant[3877∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3878{{"Constant[3878∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant3877 & Constant3878 & Constant2283 --> Object3880
+    Constant3682{{"Constant[3682∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant3681 & Constant3682 & Constant2258 --> Object3684
+    Object3699{{"Object[3699∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3696{{"Constant[3696∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3697{{"Constant[3697∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3696 & Constant3697 & Constant2273 --> Object3699
+    Object3714{{"Object[3714∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3711{{"Constant[3711∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3712{{"Constant[3712∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant3711 & Constant3712 & Constant2288 --> Object3714
+    Object3729{{"Object[3729∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3726{{"Constant[3726∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3727{{"Constant[3727∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant3726 & Constant3727 & Constant2303 --> Object3729
+    Object3744{{"Object[3744∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3741{{"Constant[3741∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3742{{"Constant[3742∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant3741 & Constant3742 & Constant2318 --> Object3744
+    Object3759{{"Object[3759∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3756{{"Constant[3756∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3757{{"Constant[3757∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant3756 & Constant3757 & Constant2333 --> Object3759
+    Object3774{{"Object[3774∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3771{{"Constant[3771∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3772{{"Constant[3772∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant3771 & Constant3772 & Constant2348 --> Object3774
+    Object3789{{"Object[3789∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3786{{"Constant[3786∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3787{{"Constant[3787∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant3786 & Constant3787 & Constant2363 --> Object3789
+    Object3804{{"Object[3804∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3801{{"Constant[3801∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3802{{"Constant[3802∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant3801 & Constant3802 & Constant2378 --> Object3804
+    Object3819{{"Object[3819∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3816{{"Constant[3816∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3817{{"Constant[3817∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant3816 & Constant3817 & Constant2393 --> Object3819
+    Object3834{{"Object[3834∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3831{{"Constant[3831∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3832{{"Constant[3832∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant3831 & Constant3832 & Constant2408 --> Object3834
+    Object3849{{"Object[3849∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3846{{"Constant[3846∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3847{{"Constant[3847∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant3846 & Constant3847 & Constant2423 --> Object3849
+    Object3864{{"Object[3864∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3861{{"Constant[3861∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3862{{"Constant[3862∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant3861 & Constant3862 & Constant2438 --> Object3864
+    Object3879{{"Object[3879∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3876{{"Constant[3876∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3877{{"Constant[3877∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant3876 & Constant3877 & Constant2453 --> Object3879
     Object3894{{"Object[3894∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant3891{{"Constant[3891∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3892{{"Constant[3892∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant3891 & Constant3892 & Constant2297 --> Object3894
-    Object3908{{"Object[3908∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3905{{"Constant[3905∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3906{{"Constant[3906∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant3905 & Constant3906 & Constant2311 --> Object3908
-    Object3922{{"Object[3922∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3919{{"Constant[3919∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3920{{"Constant[3920∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant3919 & Constant3920 & Constant2325 --> Object3922
-    Object3936{{"Object[3936∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3933{{"Constant[3933∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3934{{"Constant[3934∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant3933 & Constant3934 & Constant2339 --> Object3936
-    Object3950{{"Object[3950∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3947{{"Constant[3947∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3948{{"Constant[3948∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant3947 & Constant3948 & Constant2353 --> Object3950
-    Object3964{{"Object[3964∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3961{{"Constant[3961∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3962{{"Constant[3962∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant3961 & Constant3962 & Constant2367 --> Object3964
-    Object3978{{"Object[3978∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3975{{"Constant[3975∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3976{{"Constant[3976∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant3975 & Constant3976 & Constant2381 --> Object3978
-    Object3992{{"Object[3992∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3989{{"Constant[3989∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3990{{"Constant[3990∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant3989 & Constant3990 & Constant2395 --> Object3992
-    Object4006{{"Object[4006∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4003{{"Constant[4003∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4004{{"Constant[4004∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4003 & Constant4004 & Constant2409 --> Object4006
-    Object4020{{"Object[4020∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4017{{"Constant[4017∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4018{{"Constant[4018∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant4017 & Constant4018 & Constant2423 --> Object4020
-    Object4034{{"Object[4034∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4031{{"Constant[4031∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4032{{"Constant[4032∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant4031 & Constant4032 & Constant2437 --> Object4034
-    Object4048{{"Object[4048∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4045{{"Constant[4045∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4046{{"Constant[4046∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant4045 & Constant4046 & Constant2451 --> Object4048
-    Object4062{{"Object[4062∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4059{{"Constant[4059∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4060{{"Constant[4060∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant4059 & Constant4060 & Constant2465 --> Object4062
-    Object4076{{"Object[4076∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4073{{"Constant[4073∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4074{{"Constant[4074∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant4073 & Constant4074 & Constant2479 --> Object4076
-    Object4090{{"Object[4090∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4087{{"Constant[4087∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4088{{"Constant[4088∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4087 & Constant4088 & Constant2227 --> Object4090
+    Constant3892{{"Constant[3892∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant3891 & Constant3892 & Constant2468 --> Object3894
+    Object3909{{"Object[3909∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3906{{"Constant[3906∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3907{{"Constant[3907∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant3906 & Constant3907 & Constant2483 --> Object3909
+    Object3924{{"Object[3924∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3921{{"Constant[3921∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3922{{"Constant[3922∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant3921 & Constant3922 & Constant2498 --> Object3924
+    Object3939{{"Object[3939∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3936{{"Constant[3936∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3937{{"Constant[3937∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3936 & Constant3937 & Constant2228 --> Object3939
+    Object3954{{"Object[3954∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3951{{"Constant[3951∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3952{{"Constant[3952∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3951 & Constant3952 & Constant2243 --> Object3954
+    Object3969{{"Object[3969∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3966{{"Constant[3966∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3967{{"Constant[3967∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant3966 & Constant3967 & Constant2258 --> Object3969
+    Object3984{{"Object[3984∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3981{{"Constant[3981∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3982{{"Constant[3982∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant3981 & Constant3982 & Constant2273 --> Object3984
+    Object3999{{"Object[3999∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3996{{"Constant[3996∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3997{{"Constant[3997∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant3996 & Constant3997 & Constant2288 --> Object3999
+    Object4014{{"Object[4014∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4011{{"Constant[4011∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4012{{"Constant[4012∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant4011 & Constant4012 & Constant2303 --> Object4014
+    Object4029{{"Object[4029∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4026{{"Constant[4026∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4027{{"Constant[4027∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant4026 & Constant4027 & Constant2318 --> Object4029
+    Object4044{{"Object[4044∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4041{{"Constant[4041∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4042{{"Constant[4042∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant4041 & Constant4042 & Constant2333 --> Object4044
+    Object4059{{"Object[4059∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4056{{"Constant[4056∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4057{{"Constant[4057∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant4056 & Constant4057 & Constant2348 --> Object4059
+    Object4074{{"Object[4074∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4071{{"Constant[4071∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4072{{"Constant[4072∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant4071 & Constant4072 & Constant2363 --> Object4074
+    Object4089{{"Object[4089∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4086{{"Constant[4086∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4087{{"Constant[4087∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant4086 & Constant4087 & Constant2378 --> Object4089
     Object4104{{"Object[4104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4101{{"Constant[4101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4102{{"Constant[4102∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4101 & Constant4102 & Constant2241 --> Object4104
-    Object4118{{"Object[4118∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4115{{"Constant[4115∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4116{{"Constant[4116∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant4115 & Constant4116 & Constant2255 --> Object4118
-    Object4132{{"Object[4132∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4129{{"Constant[4129∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4130{{"Constant[4130∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4129 & Constant4130 & Constant2269 --> Object4132
-    Object4146{{"Object[4146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4143{{"Constant[4143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4144{{"Constant[4144∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant4143 & Constant4144 & Constant2283 --> Object4146
-    Object4160{{"Object[4160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4157{{"Constant[4157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4158{{"Constant[4158∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant4157 & Constant4158 & Constant2297 --> Object4160
-    Object4174{{"Object[4174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4171{{"Constant[4171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4172{{"Constant[4172∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant4171 & Constant4172 & Constant2311 --> Object4174
-    Object4188{{"Object[4188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4185{{"Constant[4185∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4186{{"Constant[4186∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant4185 & Constant4186 & Constant2325 --> Object4188
-    Object4202{{"Object[4202∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4199{{"Constant[4199∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4200{{"Constant[4200∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant4199 & Constant4200 & Constant2339 --> Object4202
-    Object4216{{"Object[4216∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4213{{"Constant[4213∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4214{{"Constant[4214∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant4213 & Constant4214 & Constant2353 --> Object4216
-    Object4230{{"Object[4230∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4227{{"Constant[4227∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4228{{"Constant[4228∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant4227 & Constant4228 & Constant2367 --> Object4230
-    Object4244{{"Object[4244∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4241{{"Constant[4241∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4242{{"Constant[4242∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant4241 & Constant4242 & Constant2381 --> Object4244
-    Object4258{{"Object[4258∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4255{{"Constant[4255∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4256{{"Constant[4256∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4255 & Constant4256 & Constant2395 --> Object4258
-    Object4272{{"Object[4272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4269{{"Constant[4269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4270{{"Constant[4270∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4269 & Constant4270 & Constant2409 --> Object4272
-    Object4286{{"Object[4286∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4283{{"Constant[4283∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4284{{"Constant[4284∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant4283 & Constant4284 & Constant2423 --> Object4286
-    Object4300{{"Object[4300∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4297{{"Constant[4297∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4298{{"Constant[4298∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant4297 & Constant4298 & Constant2437 --> Object4300
+    Constant4102{{"Constant[4102∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant4101 & Constant4102 & Constant2393 --> Object4104
+    Object4119{{"Object[4119∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4116{{"Constant[4116∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4117{{"Constant[4117∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4116 & Constant4117 & Constant2408 --> Object4119
+    Object4134{{"Object[4134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4131{{"Constant[4131∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4132{{"Constant[4132∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4131 & Constant4132 & Constant2423 --> Object4134
+    Object4149{{"Object[4149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4146{{"Constant[4146∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4147{{"Constant[4147∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant4146 & Constant4147 & Constant2438 --> Object4149
+    Object4164{{"Object[4164∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4161{{"Constant[4161∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4162{{"Constant[4162∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant4161 & Constant4162 & Constant2453 --> Object4164
+    Object4179{{"Object[4179∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4176{{"Constant[4176∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4177{{"Constant[4177∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant4176 & Constant4177 & Constant2468 --> Object4179
+    Object4194{{"Object[4194∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4191{{"Constant[4191∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4192{{"Constant[4192∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant4191 & Constant4192 & Constant2483 --> Object4194
+    Object4209{{"Object[4209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4206{{"Constant[4206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4207{{"Constant[4207∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant4206 & Constant4207 & Constant2498 --> Object4209
+    Object4224{{"Object[4224∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4221{{"Constant[4221∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4222{{"Constant[4222∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4221 & Constant4222 & Constant2228 --> Object4224
+    Object4239{{"Object[4239∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4236{{"Constant[4236∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4237{{"Constant[4237∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4236 & Constant4237 & Constant2243 --> Object4239
+    Object4254{{"Object[4254∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4251{{"Constant[4251∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4252{{"Constant[4252∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant4251 & Constant4252 & Constant2258 --> Object4254
+    Object4269{{"Object[4269∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4266{{"Constant[4266∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4267{{"Constant[4267∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4266 & Constant4267 & Constant2273 --> Object4269
+    Object4284{{"Object[4284∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4281{{"Constant[4281∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4282{{"Constant[4282∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant4281 & Constant4282 & Constant2288 --> Object4284
+    Object4299{{"Object[4299∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4296{{"Constant[4296∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4297{{"Constant[4297∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant4296 & Constant4297 & Constant2303 --> Object4299
     Object4314{{"Object[4314∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4311{{"Constant[4311∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4312{{"Constant[4312∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant4311 & Constant4312 & Constant2451 --> Object4314
-    Object4328{{"Object[4328∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4325{{"Constant[4325∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4326{{"Constant[4326∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant4325 & Constant4326 & Constant2465 --> Object4328
-    Object4342{{"Object[4342∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4339{{"Constant[4339∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4340{{"Constant[4340∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant4339 & Constant4340 & Constant2479 --> Object4342
-    Object4356{{"Object[4356∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4353{{"Constant[4353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4354{{"Constant[4354∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4353 & Constant4354 & Constant2227 --> Object4356
-    Object4370{{"Object[4370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4367{{"Constant[4367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4368{{"Constant[4368∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4367 & Constant4368 & Constant2241 --> Object4370
-    Object4384{{"Object[4384∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4381{{"Constant[4381∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4382{{"Constant[4382∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant4381 & Constant4382 & Constant2255 --> Object4384
-    Object4398{{"Object[4398∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4395{{"Constant[4395∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4396{{"Constant[4396∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4395 & Constant4396 & Constant2269 --> Object4398
-    Object4412{{"Object[4412∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4409{{"Constant[4409∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4410{{"Constant[4410∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant4409 & Constant4410 & Constant2283 --> Object4412
-    Object4426{{"Object[4426∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4423{{"Constant[4423∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4424{{"Constant[4424∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant4423 & Constant4424 & Constant2297 --> Object4426
-    Object4440{{"Object[4440∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4437{{"Constant[4437∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4438{{"Constant[4438∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant4437 & Constant4438 & Constant2311 --> Object4440
-    Object4454{{"Object[4454∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4451{{"Constant[4451∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4452{{"Constant[4452∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant4451 & Constant4452 & Constant2325 --> Object4454
-    Object4468{{"Object[4468∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4465{{"Constant[4465∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4466{{"Constant[4466∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant4465 & Constant4466 & Constant2339 --> Object4468
-    Object4482{{"Object[4482∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4479{{"Constant[4479∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4480{{"Constant[4480∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant4479 & Constant4480 & Constant2353 --> Object4482
-    Object4496{{"Object[4496∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4493{{"Constant[4493∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4494{{"Constant[4494∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant4493 & Constant4494 & Constant2367 --> Object4496
-    Object4510{{"Object[4510∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4507{{"Constant[4507∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4508{{"Constant[4508∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant4507 & Constant4508 & Constant2381 --> Object4510
+    Constant4312{{"Constant[4312∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant4311 & Constant4312 & Constant2318 --> Object4314
+    Object4329{{"Object[4329∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4326{{"Constant[4326∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4327{{"Constant[4327∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant4326 & Constant4327 & Constant2333 --> Object4329
+    Object4344{{"Object[4344∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4341{{"Constant[4341∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4342{{"Constant[4342∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant4341 & Constant4342 & Constant2348 --> Object4344
+    Object4359{{"Object[4359∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4356{{"Constant[4356∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4357{{"Constant[4357∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant4356 & Constant4357 & Constant2363 --> Object4359
+    Object4374{{"Object[4374∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4371{{"Constant[4371∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4372{{"Constant[4372∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant4371 & Constant4372 & Constant2378 --> Object4374
+    Object4389{{"Object[4389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4386{{"Constant[4386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4387{{"Constant[4387∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant4386 & Constant4387 & Constant2393 --> Object4389
+    Object4404{{"Object[4404∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4401{{"Constant[4401∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4402{{"Constant[4402∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4401 & Constant4402 & Constant2408 --> Object4404
+    Object4419{{"Object[4419∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4416{{"Constant[4416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4417{{"Constant[4417∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4416 & Constant4417 & Constant2423 --> Object4419
+    Object4434{{"Object[4434∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4431{{"Constant[4431∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4432{{"Constant[4432∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant4431 & Constant4432 & Constant2438 --> Object4434
+    Object4449{{"Object[4449∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4446{{"Constant[4446∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4447{{"Constant[4447∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant4446 & Constant4447 & Constant2453 --> Object4449
+    Object4464{{"Object[4464∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4461{{"Constant[4461∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4462{{"Constant[4462∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant4461 & Constant4462 & Constant2468 --> Object4464
+    Object4479{{"Object[4479∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4476{{"Constant[4476∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4477{{"Constant[4477∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant4476 & Constant4477 & Constant2483 --> Object4479
+    Object4494{{"Object[4494∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4491{{"Constant[4491∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4492{{"Constant[4492∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant4491 & Constant4492 & Constant2498 --> Object4494
+    Object4509{{"Object[4509∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4506{{"Constant[4506∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4507{{"Constant[4507∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4506 & Constant4507 & Constant2228 --> Object4509
     Object4524{{"Object[4524∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4521{{"Constant[4521∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4522{{"Constant[4522∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4521 & Constant4522 & Constant2395 --> Object4524
-    Object4538{{"Object[4538∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4535{{"Constant[4535∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4536{{"Constant[4536∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4535 & Constant4536 & Constant2409 --> Object4538
-    Object4552{{"Object[4552∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4549{{"Constant[4549∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4550{{"Constant[4550∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant4549 & Constant4550 & Constant2423 --> Object4552
-    Object4566{{"Object[4566∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4563{{"Constant[4563∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4564{{"Constant[4564∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant4563 & Constant4564 & Constant2437 --> Object4566
-    Object4580{{"Object[4580∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4577{{"Constant[4577∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4578{{"Constant[4578∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant4577 & Constant4578 & Constant2451 --> Object4580
-    Object4594{{"Object[4594∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4591{{"Constant[4591∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4592{{"Constant[4592∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant4591 & Constant4592 & Constant2465 --> Object4594
-    Object4608{{"Object[4608∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4605{{"Constant[4605∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4606{{"Constant[4606∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant4605 & Constant4606 & Constant2479 --> Object4608
-    Object4622{{"Object[4622∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4619{{"Constant[4619∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4620{{"Constant[4620∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4619 & Constant4620 & Constant2227 --> Object4622
-    Object4636{{"Object[4636∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4633{{"Constant[4633∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4634{{"Constant[4634∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4633 & Constant4634 & Constant2241 --> Object4636
-    Object4650{{"Object[4650∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4647{{"Constant[4647∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4648{{"Constant[4648∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant4647 & Constant4648 & Constant2255 --> Object4650
-    Object4664{{"Object[4664∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4661{{"Constant[4661∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4662{{"Constant[4662∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4661 & Constant4662 & Constant2269 --> Object4664
-    Object4678{{"Object[4678∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4675{{"Constant[4675∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4676{{"Constant[4676∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant4675 & Constant4676 & Constant2283 --> Object4678
-    Object4692{{"Object[4692∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4689{{"Constant[4689∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4690{{"Constant[4690∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant4689 & Constant4690 & Constant2297 --> Object4692
-    Object4706{{"Object[4706∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4703{{"Constant[4703∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4704{{"Constant[4704∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant4703 & Constant4704 & Constant2311 --> Object4706
-    Object4720{{"Object[4720∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4717{{"Constant[4717∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4718{{"Constant[4718∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant4717 & Constant4718 & Constant2325 --> Object4720
+    Constant4522{{"Constant[4522∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4521 & Constant4522 & Constant2243 --> Object4524
+    Object4539{{"Object[4539∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4536{{"Constant[4536∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4537{{"Constant[4537∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant4536 & Constant4537 & Constant2258 --> Object4539
+    Object4554{{"Object[4554∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4551{{"Constant[4551∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4552{{"Constant[4552∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4551 & Constant4552 & Constant2273 --> Object4554
+    Object4569{{"Object[4569∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4566{{"Constant[4566∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4567{{"Constant[4567∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant4566 & Constant4567 & Constant2288 --> Object4569
+    Object4584{{"Object[4584∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4581{{"Constant[4581∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4582{{"Constant[4582∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant4581 & Constant4582 & Constant2303 --> Object4584
+    Object4599{{"Object[4599∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4596{{"Constant[4596∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4597{{"Constant[4597∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant4596 & Constant4597 & Constant2318 --> Object4599
+    Object4614{{"Object[4614∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4611{{"Constant[4611∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4612{{"Constant[4612∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant4611 & Constant4612 & Constant2333 --> Object4614
+    Object4629{{"Object[4629∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4626{{"Constant[4626∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4627{{"Constant[4627∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant4626 & Constant4627 & Constant2348 --> Object4629
+    Object4644{{"Object[4644∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4641{{"Constant[4641∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4642{{"Constant[4642∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant4641 & Constant4642 & Constant2363 --> Object4644
+    Object4659{{"Object[4659∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4656{{"Constant[4656∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4657{{"Constant[4657∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant4656 & Constant4657 & Constant2378 --> Object4659
+    Object4674{{"Object[4674∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4671{{"Constant[4671∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4672{{"Constant[4672∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant4671 & Constant4672 & Constant2393 --> Object4674
+    Object4689{{"Object[4689∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4686{{"Constant[4686∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4687{{"Constant[4687∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4686 & Constant4687 & Constant2408 --> Object4689
+    Object4704{{"Object[4704∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4701{{"Constant[4701∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4702{{"Constant[4702∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4701 & Constant4702 & Constant2423 --> Object4704
+    Object4719{{"Object[4719∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4716{{"Constant[4716∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4717{{"Constant[4717∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant4716 & Constant4717 & Constant2438 --> Object4719
     Object4734{{"Object[4734∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4731{{"Constant[4731∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4732{{"Constant[4732∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant4731 & Constant4732 & Constant2339 --> Object4734
-    Object4748{{"Object[4748∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4745{{"Constant[4745∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4746{{"Constant[4746∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant4745 & Constant4746 & Constant2353 --> Object4748
-    Object4762{{"Object[4762∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4759{{"Constant[4759∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4760{{"Constant[4760∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant4759 & Constant4760 & Constant2367 --> Object4762
-    Object4776{{"Object[4776∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4773{{"Constant[4773∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4774{{"Constant[4774∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant4773 & Constant4774 & Constant2381 --> Object4776
-    Object4790{{"Object[4790∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4787{{"Constant[4787∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4788{{"Constant[4788∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4787 & Constant4788 & Constant2395 --> Object4790
-    Object4804{{"Object[4804∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4801{{"Constant[4801∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4802{{"Constant[4802∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant4801 & Constant4802 & Constant2409 --> Object4804
-    Object4818{{"Object[4818∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4815{{"Constant[4815∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4816{{"Constant[4816∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant4815 & Constant4816 & Constant2423 --> Object4818
-    Object4832{{"Object[4832∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4829{{"Constant[4829∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4830{{"Constant[4830∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant4829 & Constant4830 & Constant2437 --> Object4832
-    Object4846{{"Object[4846∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4843{{"Constant[4843∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4844{{"Constant[4844∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant4843 & Constant4844 & Constant2451 --> Object4846
-    Object4860{{"Object[4860∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4857{{"Constant[4857∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4858{{"Constant[4858∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant4857 & Constant4858 & Constant2465 --> Object4860
-    Object4874{{"Object[4874∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4871{{"Constant[4871∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4872{{"Constant[4872∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant4871 & Constant4872 & Constant2479 --> Object4874
-    Object4888{{"Object[4888∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4885{{"Constant[4885∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4886{{"Constant[4886∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4885 & Constant4886 & Constant2227 --> Object4888
-    Object4902{{"Object[4902∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4899{{"Constant[4899∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4900{{"Constant[4900∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4899 & Constant4900 & Constant2241 --> Object4902
-    Object4916{{"Object[4916∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4913{{"Constant[4913∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4914{{"Constant[4914∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant4913 & Constant4914 & Constant2255 --> Object4916
-    Object4930{{"Object[4930∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4927{{"Constant[4927∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4928{{"Constant[4928∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant4927 & Constant4928 & Constant2269 --> Object4930
+    Constant4732{{"Constant[4732∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant4731 & Constant4732 & Constant2453 --> Object4734
+    Object4749{{"Object[4749∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4746{{"Constant[4746∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4747{{"Constant[4747∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant4746 & Constant4747 & Constant2468 --> Object4749
+    Object4764{{"Object[4764∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4761{{"Constant[4761∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4762{{"Constant[4762∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant4761 & Constant4762 & Constant2483 --> Object4764
+    Object4779{{"Object[4779∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4776{{"Constant[4776∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4777{{"Constant[4777∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant4776 & Constant4777 & Constant2498 --> Object4779
+    Object4794{{"Object[4794∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4791{{"Constant[4791∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4792{{"Constant[4792∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4791 & Constant4792 & Constant2228 --> Object4794
+    Object4809{{"Object[4809∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4806{{"Constant[4806∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4807{{"Constant[4807∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4806 & Constant4807 & Constant2243 --> Object4809
+    Object4824{{"Object[4824∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4821{{"Constant[4821∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4822{{"Constant[4822∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant4821 & Constant4822 & Constant2258 --> Object4824
+    Object4839{{"Object[4839∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4836{{"Constant[4836∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4837{{"Constant[4837∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant4836 & Constant4837 & Constant2273 --> Object4839
+    Object4854{{"Object[4854∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4851{{"Constant[4851∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4852{{"Constant[4852∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant4851 & Constant4852 & Constant2288 --> Object4854
+    Object4869{{"Object[4869∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4866{{"Constant[4866∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4867{{"Constant[4867∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant4866 & Constant4867 & Constant2303 --> Object4869
+    Object4884{{"Object[4884∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4881{{"Constant[4881∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4882{{"Constant[4882∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant4881 & Constant4882 & Constant2318 --> Object4884
+    Object4899{{"Object[4899∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4896{{"Constant[4896∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4897{{"Constant[4897∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant4896 & Constant4897 & Constant2333 --> Object4899
+    Object4914{{"Object[4914∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4911{{"Constant[4911∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4912{{"Constant[4912∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant4911 & Constant4912 & Constant2348 --> Object4914
+    Object4929{{"Object[4929∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4926{{"Constant[4926∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4927{{"Constant[4927∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant4926 & Constant4927 & Constant2363 --> Object4929
     Object4944{{"Object[4944∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4941{{"Constant[4941∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4942{{"Constant[4942∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant4941 & Constant4942 & Constant2283 --> Object4944
-    Object4958{{"Object[4958∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4955{{"Constant[4955∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4956{{"Constant[4956∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant4955 & Constant4956 & Constant2297 --> Object4958
-    Object4972{{"Object[4972∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4969{{"Constant[4969∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4970{{"Constant[4970∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant4969 & Constant4970 & Constant2311 --> Object4972
-    Object4986{{"Object[4986∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4983{{"Constant[4983∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4984{{"Constant[4984∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant4983 & Constant4984 & Constant2325 --> Object4986
-    Object5000{{"Object[5000∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4997{{"Constant[4997∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4998{{"Constant[4998∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant4997 & Constant4998 & Constant2339 --> Object5000
-    Object5014{{"Object[5014∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5011{{"Constant[5011∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5012{{"Constant[5012∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant5011 & Constant5012 & Constant2353 --> Object5014
-    Object5028{{"Object[5028∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5025{{"Constant[5025∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5026{{"Constant[5026∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant5025 & Constant5026 & Constant2367 --> Object5028
-    Object5042{{"Object[5042∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5039{{"Constant[5039∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5040{{"Constant[5040∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant5039 & Constant5040 & Constant2381 --> Object5042
-    Object5056{{"Object[5056∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5053{{"Constant[5053∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5054{{"Constant[5054∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant5053 & Constant5054 & Constant2395 --> Object5056
-    Object5070{{"Object[5070∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5067{{"Constant[5067∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5068{{"Constant[5068∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant5067 & Constant5068 & Constant2409 --> Object5070
-    Object5084{{"Object[5084∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5081{{"Constant[5081∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5082{{"Constant[5082∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant5081 & Constant5082 & Constant2423 --> Object5084
-    Object5098{{"Object[5098∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5095{{"Constant[5095∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5096{{"Constant[5096∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant5095 & Constant5096 & Constant2437 --> Object5098
-    Object5112{{"Object[5112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5109{{"Constant[5109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5110{{"Constant[5110∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant5109 & Constant5110 & Constant2451 --> Object5112
-    Object5126{{"Object[5126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5123{{"Constant[5123∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5124{{"Constant[5124∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant5123 & Constant5124 & Constant2465 --> Object5126
-    Object5140{{"Object[5140∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5137{{"Constant[5137∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5138{{"Constant[5138∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant5137 & Constant5138 & Constant2479 --> Object5140
+    Constant4942{{"Constant[4942∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant4941 & Constant4942 & Constant2378 --> Object4944
+    Object4959{{"Object[4959∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4956{{"Constant[4956∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4957{{"Constant[4957∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant4956 & Constant4957 & Constant2393 --> Object4959
+    Object4974{{"Object[4974∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4971{{"Constant[4971∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4972{{"Constant[4972∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4971 & Constant4972 & Constant2408 --> Object4974
+    Object4989{{"Object[4989∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4986{{"Constant[4986∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4987{{"Constant[4987∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant4986 & Constant4987 & Constant2423 --> Object4989
+    Object5004{{"Object[5004∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5001{{"Constant[5001∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5002{{"Constant[5002∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant5001 & Constant5002 & Constant2438 --> Object5004
+    Object5019{{"Object[5019∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5016{{"Constant[5016∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5017{{"Constant[5017∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant5016 & Constant5017 & Constant2453 --> Object5019
+    Object5034{{"Object[5034∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5031{{"Constant[5031∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5032{{"Constant[5032∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant5031 & Constant5032 & Constant2468 --> Object5034
+    Object5049{{"Object[5049∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5046{{"Constant[5046∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5047{{"Constant[5047∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant5046 & Constant5047 & Constant2483 --> Object5049
+    Object5064{{"Object[5064∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5061{{"Constant[5061∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5062{{"Constant[5062∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant5061 & Constant5062 & Constant2498 --> Object5064
+    Object5079{{"Object[5079∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5076{{"Constant[5076∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5077{{"Constant[5077∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant5076 & Constant5077 & Constant2228 --> Object5079
+    Object5094{{"Object[5094∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5091{{"Constant[5091∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5092{{"Constant[5092∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant5091 & Constant5092 & Constant2243 --> Object5094
+    Object5109{{"Object[5109∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5106{{"Constant[5106∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5107{{"Constant[5107∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant5106 & Constant5107 & Constant2258 --> Object5109
+    Object5124{{"Object[5124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5121{{"Constant[5121∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5122{{"Constant[5122∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant5121 & Constant5122 & Constant2273 --> Object5124
+    Object5139{{"Object[5139∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5136{{"Constant[5136∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5137{{"Constant[5137∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant5136 & Constant5137 & Constant2288 --> Object5139
     Object5154{{"Object[5154∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant5151{{"Constant[5151∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5152{{"Constant[5152∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Lambda2221 & Constant5151 & Constant5152 & Constant2227 --> Object5154
-    Object5168{{"Object[5168∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5165{{"Constant[5165∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5166{{"Constant[5166∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant5165 & Constant5166 & Constant2241 --> Object5168
-    Object5182{{"Object[5182∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5179{{"Constant[5179∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5180{{"Constant[5180∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Lambda2221 & Constant5179 & Constant5180 & Constant2255 --> Object5182
-    Object5196{{"Object[5196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5193{{"Constant[5193∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5194{{"Constant[5194∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Lambda2221 & Constant5193 & Constant5194 & Constant2269 --> Object5196
-    Object5210{{"Object[5210∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5207{{"Constant[5207∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5208{{"Constant[5208∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Lambda2221 & Constant5207 & Constant5208 & Constant2283 --> Object5210
-    Object5224{{"Object[5224∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5221{{"Constant[5221∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5222{{"Constant[5222∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Lambda2221 & Constant5221 & Constant5222 & Constant2297 --> Object5224
-    Object5238{{"Object[5238∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5235{{"Constant[5235∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5236{{"Constant[5236∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda2221 & Constant5235 & Constant5236 & Constant2311 --> Object5238
-    Object5252{{"Object[5252∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5249{{"Constant[5249∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5250{{"Constant[5250∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda2221 & Constant5249 & Constant5250 & Constant2325 --> Object5252
-    Object5266{{"Object[5266∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5263{{"Constant[5263∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5264{{"Constant[5264∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda2221 & Constant5263 & Constant5264 & Constant2339 --> Object5266
-    Object5280{{"Object[5280∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5277{{"Constant[5277∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5278{{"Constant[5278∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda2221 & Constant5277 & Constant5278 & Constant2353 --> Object5280
-    Object5294{{"Object[5294∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5291{{"Constant[5291∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5292{{"Constant[5292∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda2221 & Constant5291 & Constant5292 & Constant2367 --> Object5294
-    Object5308{{"Object[5308∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5305{{"Constant[5305∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5306{{"Constant[5306∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda2221 & Constant5305 & Constant5306 & Constant2381 --> Object5308
-    Object5322{{"Object[5322∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5319{{"Constant[5319∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5320{{"Constant[5320∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant5319 & Constant5320 & Constant2395 --> Object5322
-    Object5336{{"Object[5336∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5333{{"Constant[5333∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5334{{"Constant[5334∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Lambda2221 & Constant5333 & Constant5334 & Constant2409 --> Object5336
-    Object5350{{"Object[5350∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5347{{"Constant[5347∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5348{{"Constant[5348∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Lambda2221 & Constant5347 & Constant5348 & Constant2423 --> Object5350
+    Constant5152{{"Constant[5152∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant5151 & Constant5152 & Constant2303 --> Object5154
+    Object5169{{"Object[5169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5166{{"Constant[5166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5167{{"Constant[5167∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant5166 & Constant5167 & Constant2318 --> Object5169
+    Object5184{{"Object[5184∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5181{{"Constant[5181∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5182{{"Constant[5182∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant5181 & Constant5182 & Constant2333 --> Object5184
+    Object5199{{"Object[5199∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5196{{"Constant[5196∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5197{{"Constant[5197∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant5196 & Constant5197 & Constant2348 --> Object5199
+    Object5214{{"Object[5214∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5211{{"Constant[5211∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5212{{"Constant[5212∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant5211 & Constant5212 & Constant2363 --> Object5214
+    Object5229{{"Object[5229∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5226{{"Constant[5226∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5227{{"Constant[5227∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant5226 & Constant5227 & Constant2378 --> Object5229
+    Object5244{{"Object[5244∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5241{{"Constant[5241∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5242{{"Constant[5242∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant5241 & Constant5242 & Constant2393 --> Object5244
+    Object5259{{"Object[5259∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5256{{"Constant[5256∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5257{{"Constant[5257∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant5256 & Constant5257 & Constant2408 --> Object5259
+    Object5274{{"Object[5274∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5271{{"Constant[5271∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5272{{"Constant[5272∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant5271 & Constant5272 & Constant2423 --> Object5274
+    Object5289{{"Object[5289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5286{{"Constant[5286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5287{{"Constant[5287∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant5286 & Constant5287 & Constant2438 --> Object5289
+    Object5304{{"Object[5304∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5301{{"Constant[5301∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5302{{"Constant[5302∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant5301 & Constant5302 & Constant2453 --> Object5304
+    Object5319{{"Object[5319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5316{{"Constant[5316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5317{{"Constant[5317∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant5316 & Constant5317 & Constant2468 --> Object5319
+    Object5334{{"Object[5334∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5331{{"Constant[5331∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5332{{"Constant[5332∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant5331 & Constant5332 & Constant2483 --> Object5334
+    Object5349{{"Object[5349∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5346{{"Constant[5346∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5347{{"Constant[5347∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant5346 & Constant5347 & Constant2498 --> Object5349
     Object5364{{"Object[5364∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant5361{{"Constant[5361∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5362{{"Constant[5362∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Lambda2221 & Constant5361 & Constant5362 & Constant2437 --> Object5364
-    Object5378{{"Object[5378∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5375{{"Constant[5375∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5376{{"Constant[5376∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Lambda2221 & Constant5375 & Constant5376 & Constant2451 --> Object5378
-    Object5392{{"Object[5392∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5389{{"Constant[5389∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5390{{"Constant[5390∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Lambda2221 & Constant5389 & Constant5390 & Constant2465 --> Object5392
-    Object5406{{"Object[5406∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5403{{"Constant[5403∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5404{{"Constant[5404∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Lambda2221 & Constant5403 & Constant5404 & Constant2479 --> Object5406
+    Constant5362{{"Constant[5362∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Lambda2221 & Constant5361 & Constant5362 & Constant2228 --> Object5364
+    Object5379{{"Object[5379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5376{{"Constant[5376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5377{{"Constant[5377∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant5376 & Constant5377 & Constant2243 --> Object5379
+    Object5394{{"Object[5394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5391{{"Constant[5391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5392{{"Constant[5392∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Lambda2221 & Constant5391 & Constant5392 & Constant2258 --> Object5394
+    Object5409{{"Object[5409∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5406{{"Constant[5406∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5407{{"Constant[5407∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Lambda2221 & Constant5406 & Constant5407 & Constant2273 --> Object5409
+    Object5424{{"Object[5424∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5421{{"Constant[5421∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5422{{"Constant[5422∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Lambda2221 & Constant5421 & Constant5422 & Constant2288 --> Object5424
+    Object5439{{"Object[5439∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5436{{"Constant[5436∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5437{{"Constant[5437∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Lambda2221 & Constant5436 & Constant5437 & Constant2303 --> Object5439
+    Object5454{{"Object[5454∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5451{{"Constant[5451∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5452{{"Constant[5452∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda2221 & Constant5451 & Constant5452 & Constant2318 --> Object5454
+    Object5469{{"Object[5469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5466{{"Constant[5466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5467{{"Constant[5467∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda2221 & Constant5466 & Constant5467 & Constant2333 --> Object5469
+    Object5484{{"Object[5484∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5481{{"Constant[5481∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5482{{"Constant[5482∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda2221 & Constant5481 & Constant5482 & Constant2348 --> Object5484
+    Object5499{{"Object[5499∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5496{{"Constant[5496∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5497{{"Constant[5497∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda2221 & Constant5496 & Constant5497 & Constant2363 --> Object5499
+    Object5514{{"Object[5514∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5511{{"Constant[5511∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5512{{"Constant[5512∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda2221 & Constant5511 & Constant5512 & Constant2378 --> Object5514
+    Object5529{{"Object[5529∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5526{{"Constant[5526∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5527{{"Constant[5527∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda2221 & Constant5526 & Constant5527 & Constant2393 --> Object5529
+    Object5544{{"Object[5544∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5541{{"Constant[5541∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5542{{"Constant[5542∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant5541 & Constant5542 & Constant2408 --> Object5544
+    Object5559{{"Object[5559∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5556{{"Constant[5556∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5557{{"Constant[5557∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Lambda2221 & Constant5556 & Constant5557 & Constant2423 --> Object5559
+    Object5574{{"Object[5574∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5571{{"Constant[5571∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5572{{"Constant[5572∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Lambda2221 & Constant5571 & Constant5572 & Constant2438 --> Object5574
+    Object5589{{"Object[5589∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5586{{"Constant[5586∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5587{{"Constant[5587∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Lambda2221 & Constant5586 & Constant5587 & Constant2453 --> Object5589
+    Object5604{{"Object[5604∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5601{{"Constant[5601∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5602{{"Constant[5602∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Lambda2221 & Constant5601 & Constant5602 & Constant2468 --> Object5604
+    Object5619{{"Object[5619∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5616{{"Constant[5616∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5617{{"Constant[5617∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Lambda2221 & Constant5616 & Constant5617 & Constant2483 --> Object5619
+    Object5634{{"Object[5634∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5631{{"Constant[5631∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5632{{"Constant[5632∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Lambda2221 & Constant5631 & Constant5632 & Constant2498 --> Object5634
     Lambda7{{"Lambda[7∈0] ➊<br />ᐸrawEncodeᐳ"}}:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸ'query'ᐳ"}}:::plan
     Constant6 --> Lambda7
     Node9{{"Node[9∈0] ➊"}}:::plan
     Lambda10{{"Lambda[10∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda10 --> Node9
-    Constant5415{{"Constant[5415∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
-    Constant5415 --> Lambda10
+    Constant5643{{"Constant[5643∈0] ➊<br />ᐸ'hello'ᐳ"}}:::plan
+    Constant5643 --> Lambda10
     Node561{{"Node[561∈0] ➊"}}:::plan
     Lambda562{{"Lambda[562∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda562 --> Node561
@@ -956,7 +956,7 @@ graph TD
     Node1114{{"Node[1114∈0] ➊"}}:::plan
     Lambda1115{{"Lambda[1115∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1115 --> Node1114
-    Constant5415 --> Lambda1115
+    Constant5643 --> Lambda1115
     Node1298{{"Node[1298∈0] ➊"}}:::plan
     Lambda1299{{"Lambda[1299∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1299 --> Node1298
@@ -964,7 +964,7 @@ graph TD
     Node1483{{"Node[1483∈0] ➊"}}:::plan
     Lambda1484{{"Lambda[1484∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1484 --> Node1483
-    Constant5415 --> Lambda1484
+    Constant5643 --> Lambda1484
     Node1667{{"Node[1667∈0] ➊"}}:::plan
     Lambda1668{{"Lambda[1668∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1668 --> Node1667
@@ -972,1156 +972,1158 @@ graph TD
     Node1852{{"Node[1852∈0] ➊"}}:::plan
     Lambda1853{{"Lambda[1853∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1853 --> Node1852
-    Constant5415 --> Lambda1853
+    Constant5643 --> Lambda1853
     Node2036{{"Node[2036∈0] ➊"}}:::plan
     Lambda2037{{"Lambda[2037∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda2037 --> Node2036
     Constant6 --> Lambda2037
-    Constant5439{{"Constant[5439∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant5439 --> Lambda2221
+    Constant5667{{"Constant[5667∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant5667 --> Lambda2221
     Lambda2224{{"Lambda[2224∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant5440{{"Constant[5440∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant5440 --> Lambda2224
-    Lambda2229{{"Lambda[2229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2228 --> Lambda2229
-    Lambda2234{{"Lambda[2234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5441{{"Constant[5441∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5441 --> Lambda2234
-    Lambda2243{{"Lambda[2243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2242 --> Lambda2243
-    Lambda2248{{"Lambda[2248∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5442{{"Constant[5442∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5442 --> Lambda2248
-    Lambda2257{{"Lambda[2257∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2256 --> Lambda2257
-    Lambda2262{{"Lambda[2262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5443{{"Constant[5443∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5443 --> Lambda2262
-    Lambda2271{{"Lambda[2271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2270 --> Lambda2271
-    Lambda2276{{"Lambda[2276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5444{{"Constant[5444∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5444 --> Lambda2276
-    Lambda2285{{"Lambda[2285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2284 --> Lambda2285
+    Constant5668{{"Constant[5668∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant5668 --> Lambda2224
+    Access2225{{"Access[2225∈0] ➊<br />ᐸ2224.0ᐳ"}}:::plan
+    Lambda2224 --> Access2225
+    Lambda2230{{"Lambda[2230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2229 --> Lambda2230
+    Lambda2235{{"Lambda[2235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5669{{"Constant[5669∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5669 --> Lambda2235
+    Lambda2245{{"Lambda[2245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2244 --> Lambda2245
+    Lambda2250{{"Lambda[2250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5670{{"Constant[5670∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5670 --> Lambda2250
+    Lambda2260{{"Lambda[2260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2259 --> Lambda2260
+    Lambda2265{{"Lambda[2265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5671{{"Constant[5671∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5671 --> Lambda2265
+    Lambda2275{{"Lambda[2275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2274 --> Lambda2275
+    Lambda2280{{"Lambda[2280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5672{{"Constant[5672∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5672 --> Lambda2280
     Lambda2290{{"Lambda[2290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5445{{"Constant[5445∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5445 --> Lambda2290
-    Lambda2299{{"Lambda[2299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2298 --> Lambda2299
-    Lambda2304{{"Lambda[2304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5446{{"Constant[5446∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5446 --> Lambda2304
-    Lambda2313{{"Lambda[2313∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2312 --> Lambda2313
-    Lambda2318{{"Lambda[2318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5447{{"Constant[5447∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5447 --> Lambda2318
-    Lambda2327{{"Lambda[2327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2326 --> Lambda2327
-    Lambda2332{{"Lambda[2332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5448{{"Constant[5448∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5448 --> Lambda2332
-    Lambda2341{{"Lambda[2341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2340 --> Lambda2341
-    Lambda2346{{"Lambda[2346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5449{{"Constant[5449∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5449 --> Lambda2346
+    Object2289 --> Lambda2290
+    Lambda2295{{"Lambda[2295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5673{{"Constant[5673∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5673 --> Lambda2295
+    Lambda2305{{"Lambda[2305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2304 --> Lambda2305
+    Lambda2310{{"Lambda[2310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5674{{"Constant[5674∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5674 --> Lambda2310
+    Lambda2320{{"Lambda[2320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2319 --> Lambda2320
+    Lambda2325{{"Lambda[2325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5675{{"Constant[5675∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5675 --> Lambda2325
+    Lambda2335{{"Lambda[2335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2334 --> Lambda2335
+    Lambda2340{{"Lambda[2340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5676{{"Constant[5676∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5676 --> Lambda2340
+    Lambda2350{{"Lambda[2350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2349 --> Lambda2350
     Lambda2355{{"Lambda[2355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2354 --> Lambda2355
-    Lambda2360{{"Lambda[2360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5450{{"Constant[5450∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5450 --> Lambda2360
-    Lambda2369{{"Lambda[2369∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2368 --> Lambda2369
-    Lambda2374{{"Lambda[2374∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5451{{"Constant[5451∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5451 --> Lambda2374
-    Lambda2383{{"Lambda[2383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2382 --> Lambda2383
-    Lambda2388{{"Lambda[2388∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5452{{"Constant[5452∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5452 --> Lambda2388
-    Lambda2397{{"Lambda[2397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2396 --> Lambda2397
-    Lambda2402{{"Lambda[2402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5453{{"Constant[5453∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5453 --> Lambda2402
-    Lambda2411{{"Lambda[2411∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2410 --> Lambda2411
-    Lambda2416{{"Lambda[2416∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5454{{"Constant[5454∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5454 --> Lambda2416
+    Constant5677{{"Constant[5677∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5677 --> Lambda2355
+    Lambda2365{{"Lambda[2365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2364 --> Lambda2365
+    Lambda2370{{"Lambda[2370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5678{{"Constant[5678∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5678 --> Lambda2370
+    Lambda2380{{"Lambda[2380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2379 --> Lambda2380
+    Lambda2385{{"Lambda[2385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5679{{"Constant[5679∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5679 --> Lambda2385
+    Lambda2395{{"Lambda[2395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2394 --> Lambda2395
+    Lambda2400{{"Lambda[2400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5680{{"Constant[5680∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5680 --> Lambda2400
+    Lambda2410{{"Lambda[2410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2409 --> Lambda2410
+    Lambda2415{{"Lambda[2415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5681{{"Constant[5681∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5681 --> Lambda2415
     Lambda2425{{"Lambda[2425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2424 --> Lambda2425
     Lambda2430{{"Lambda[2430∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5455{{"Constant[5455∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5455 --> Lambda2430
-    Lambda2439{{"Lambda[2439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2438 --> Lambda2439
-    Lambda2444{{"Lambda[2444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5456{{"Constant[5456∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5456 --> Lambda2444
-    Lambda2453{{"Lambda[2453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2452 --> Lambda2453
-    Lambda2458{{"Lambda[2458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5457{{"Constant[5457∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5457 --> Lambda2458
-    Lambda2467{{"Lambda[2467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2466 --> Lambda2467
-    Lambda2472{{"Lambda[2472∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5458{{"Constant[5458∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5458 --> Lambda2472
-    Lambda2481{{"Lambda[2481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2480 --> Lambda2481
-    Lambda2486{{"Lambda[2486∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5459{{"Constant[5459∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5459 --> Lambda2486
-    Lambda2495{{"Lambda[2495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2494 --> Lambda2495
+    Constant5682{{"Constant[5682∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5682 --> Lambda2430
+    Lambda2440{{"Lambda[2440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2439 --> Lambda2440
+    Lambda2445{{"Lambda[2445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5683{{"Constant[5683∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5683 --> Lambda2445
+    Lambda2455{{"Lambda[2455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2454 --> Lambda2455
+    Lambda2460{{"Lambda[2460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5684{{"Constant[5684∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5684 --> Lambda2460
+    Lambda2470{{"Lambda[2470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2469 --> Lambda2470
+    Lambda2475{{"Lambda[2475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5685{{"Constant[5685∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5685 --> Lambda2475
+    Lambda2485{{"Lambda[2485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2484 --> Lambda2485
+    Lambda2490{{"Lambda[2490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5686{{"Constant[5686∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5686 --> Lambda2490
     Lambda2500{{"Lambda[2500∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5460{{"Constant[5460∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5460 --> Lambda2500
-    Lambda2509{{"Lambda[2509∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2508 --> Lambda2509
-    Lambda2514{{"Lambda[2514∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5461{{"Constant[5461∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5461 --> Lambda2514
-    Lambda2523{{"Lambda[2523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2522 --> Lambda2523
-    Lambda2528{{"Lambda[2528∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5462{{"Constant[5462∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5462 --> Lambda2528
-    Lambda2537{{"Lambda[2537∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2536 --> Lambda2537
-    Lambda2542{{"Lambda[2542∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5463{{"Constant[5463∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5463 --> Lambda2542
-    Lambda2551{{"Lambda[2551∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2550 --> Lambda2551
-    Lambda2556{{"Lambda[2556∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5464{{"Constant[5464∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5464 --> Lambda2556
+    Object2499 --> Lambda2500
+    Lambda2505{{"Lambda[2505∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5687{{"Constant[5687∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5687 --> Lambda2505
+    Lambda2515{{"Lambda[2515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2514 --> Lambda2515
+    Lambda2520{{"Lambda[2520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5688{{"Constant[5688∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5688 --> Lambda2520
+    Lambda2530{{"Lambda[2530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2529 --> Lambda2530
+    Lambda2535{{"Lambda[2535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5689{{"Constant[5689∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5689 --> Lambda2535
+    Lambda2545{{"Lambda[2545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2544 --> Lambda2545
+    Lambda2550{{"Lambda[2550∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5690{{"Constant[5690∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5690 --> Lambda2550
+    Lambda2560{{"Lambda[2560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2559 --> Lambda2560
     Lambda2565{{"Lambda[2565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2564 --> Lambda2565
-    Lambda2570{{"Lambda[2570∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5465{{"Constant[5465∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5465 --> Lambda2570
-    Lambda2579{{"Lambda[2579∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2578 --> Lambda2579
-    Lambda2584{{"Lambda[2584∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5466{{"Constant[5466∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5466 --> Lambda2584
-    Lambda2593{{"Lambda[2593∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2592 --> Lambda2593
-    Lambda2598{{"Lambda[2598∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5467{{"Constant[5467∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5467 --> Lambda2598
-    Lambda2607{{"Lambda[2607∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2606 --> Lambda2607
-    Lambda2612{{"Lambda[2612∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5468{{"Constant[5468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5468 --> Lambda2612
-    Lambda2621{{"Lambda[2621∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2620 --> Lambda2621
-    Lambda2626{{"Lambda[2626∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5469{{"Constant[5469∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5469 --> Lambda2626
+    Constant5691{{"Constant[5691∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5691 --> Lambda2565
+    Lambda2575{{"Lambda[2575∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2574 --> Lambda2575
+    Lambda2580{{"Lambda[2580∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5692{{"Constant[5692∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5692 --> Lambda2580
+    Lambda2590{{"Lambda[2590∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2589 --> Lambda2590
+    Lambda2595{{"Lambda[2595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5693{{"Constant[5693∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5693 --> Lambda2595
+    Lambda2605{{"Lambda[2605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2604 --> Lambda2605
+    Lambda2610{{"Lambda[2610∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5694{{"Constant[5694∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5694 --> Lambda2610
+    Lambda2620{{"Lambda[2620∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2619 --> Lambda2620
+    Lambda2625{{"Lambda[2625∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5695{{"Constant[5695∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5695 --> Lambda2625
     Lambda2635{{"Lambda[2635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2634 --> Lambda2635
     Lambda2640{{"Lambda[2640∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5470{{"Constant[5470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5470 --> Lambda2640
-    Lambda2649{{"Lambda[2649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2648 --> Lambda2649
-    Lambda2654{{"Lambda[2654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5471{{"Constant[5471∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5471 --> Lambda2654
-    Lambda2663{{"Lambda[2663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2662 --> Lambda2663
-    Lambda2668{{"Lambda[2668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5472{{"Constant[5472∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5472 --> Lambda2668
-    Lambda2677{{"Lambda[2677∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2676 --> Lambda2677
-    Lambda2682{{"Lambda[2682∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5473{{"Constant[5473∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5473 --> Lambda2682
-    Lambda2691{{"Lambda[2691∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2690 --> Lambda2691
-    Lambda2696{{"Lambda[2696∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5474{{"Constant[5474∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5474 --> Lambda2696
-    Lambda2705{{"Lambda[2705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2704 --> Lambda2705
+    Constant5696{{"Constant[5696∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5696 --> Lambda2640
+    Lambda2650{{"Lambda[2650∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2649 --> Lambda2650
+    Lambda2655{{"Lambda[2655∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5697{{"Constant[5697∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5697 --> Lambda2655
+    Lambda2665{{"Lambda[2665∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2664 --> Lambda2665
+    Lambda2670{{"Lambda[2670∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5698{{"Constant[5698∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5698 --> Lambda2670
+    Lambda2680{{"Lambda[2680∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2679 --> Lambda2680
+    Lambda2685{{"Lambda[2685∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5699{{"Constant[5699∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5699 --> Lambda2685
+    Lambda2695{{"Lambda[2695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2694 --> Lambda2695
+    Lambda2700{{"Lambda[2700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5700{{"Constant[5700∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5700 --> Lambda2700
     Lambda2710{{"Lambda[2710∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5475{{"Constant[5475∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5475 --> Lambda2710
-    Lambda2719{{"Lambda[2719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2718 --> Lambda2719
-    Lambda2724{{"Lambda[2724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5476{{"Constant[5476∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5476 --> Lambda2724
-    Lambda2733{{"Lambda[2733∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2732 --> Lambda2733
-    Lambda2738{{"Lambda[2738∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5477{{"Constant[5477∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5477 --> Lambda2738
-    Lambda2747{{"Lambda[2747∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2746 --> Lambda2747
-    Lambda2752{{"Lambda[2752∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5478{{"Constant[5478∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5478 --> Lambda2752
-    Lambda2761{{"Lambda[2761∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2760 --> Lambda2761
-    Lambda2766{{"Lambda[2766∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5479{{"Constant[5479∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5479 --> Lambda2766
+    Object2709 --> Lambda2710
+    Lambda2715{{"Lambda[2715∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5701{{"Constant[5701∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5701 --> Lambda2715
+    Lambda2725{{"Lambda[2725∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2724 --> Lambda2725
+    Lambda2730{{"Lambda[2730∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5702{{"Constant[5702∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5702 --> Lambda2730
+    Lambda2740{{"Lambda[2740∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2739 --> Lambda2740
+    Lambda2745{{"Lambda[2745∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5703{{"Constant[5703∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5703 --> Lambda2745
+    Lambda2755{{"Lambda[2755∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2754 --> Lambda2755
+    Lambda2760{{"Lambda[2760∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5704{{"Constant[5704∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5704 --> Lambda2760
+    Lambda2770{{"Lambda[2770∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2769 --> Lambda2770
     Lambda2775{{"Lambda[2775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2774 --> Lambda2775
-    Lambda2780{{"Lambda[2780∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5480{{"Constant[5480∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5480 --> Lambda2780
-    Lambda2789{{"Lambda[2789∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2788 --> Lambda2789
-    Lambda2794{{"Lambda[2794∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5481{{"Constant[5481∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5481 --> Lambda2794
-    Lambda2803{{"Lambda[2803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2802 --> Lambda2803
-    Lambda2808{{"Lambda[2808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5482{{"Constant[5482∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5482 --> Lambda2808
-    Lambda2817{{"Lambda[2817∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2816 --> Lambda2817
-    Lambda2822{{"Lambda[2822∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5483{{"Constant[5483∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5483 --> Lambda2822
-    Lambda2831{{"Lambda[2831∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2830 --> Lambda2831
-    Lambda2836{{"Lambda[2836∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5484{{"Constant[5484∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5484 --> Lambda2836
+    Constant5705{{"Constant[5705∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5705 --> Lambda2775
+    Lambda2785{{"Lambda[2785∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2784 --> Lambda2785
+    Lambda2790{{"Lambda[2790∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5706{{"Constant[5706∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5706 --> Lambda2790
+    Lambda2800{{"Lambda[2800∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2799 --> Lambda2800
+    Lambda2805{{"Lambda[2805∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5707{{"Constant[5707∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5707 --> Lambda2805
+    Lambda2815{{"Lambda[2815∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2814 --> Lambda2815
+    Lambda2820{{"Lambda[2820∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5708{{"Constant[5708∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5708 --> Lambda2820
+    Lambda2830{{"Lambda[2830∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2829 --> Lambda2830
+    Lambda2835{{"Lambda[2835∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5709{{"Constant[5709∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5709 --> Lambda2835
     Lambda2845{{"Lambda[2845∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object2844 --> Lambda2845
     Lambda2850{{"Lambda[2850∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5485{{"Constant[5485∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5485 --> Lambda2850
-    Lambda2859{{"Lambda[2859∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2858 --> Lambda2859
-    Lambda2864{{"Lambda[2864∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5486{{"Constant[5486∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5486 --> Lambda2864
-    Lambda2873{{"Lambda[2873∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2872 --> Lambda2873
-    Lambda2878{{"Lambda[2878∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5487{{"Constant[5487∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5487 --> Lambda2878
-    Lambda2887{{"Lambda[2887∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2886 --> Lambda2887
-    Lambda2892{{"Lambda[2892∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5488{{"Constant[5488∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5488 --> Lambda2892
-    Lambda2901{{"Lambda[2901∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2900 --> Lambda2901
-    Lambda2906{{"Lambda[2906∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5489{{"Constant[5489∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5489 --> Lambda2906
-    Lambda2915{{"Lambda[2915∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2914 --> Lambda2915
+    Constant5710{{"Constant[5710∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5710 --> Lambda2850
+    Lambda2860{{"Lambda[2860∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2859 --> Lambda2860
+    Lambda2865{{"Lambda[2865∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5711{{"Constant[5711∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5711 --> Lambda2865
+    Lambda2875{{"Lambda[2875∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2874 --> Lambda2875
+    Lambda2880{{"Lambda[2880∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5712{{"Constant[5712∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5712 --> Lambda2880
+    Lambda2890{{"Lambda[2890∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2889 --> Lambda2890
+    Lambda2895{{"Lambda[2895∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5713{{"Constant[5713∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5713 --> Lambda2895
+    Lambda2905{{"Lambda[2905∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2904 --> Lambda2905
+    Lambda2910{{"Lambda[2910∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5714{{"Constant[5714∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5714 --> Lambda2910
     Lambda2920{{"Lambda[2920∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5490{{"Constant[5490∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5490 --> Lambda2920
-    Lambda2929{{"Lambda[2929∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2928 --> Lambda2929
-    Lambda2934{{"Lambda[2934∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5491{{"Constant[5491∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5491 --> Lambda2934
-    Lambda2943{{"Lambda[2943∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2942 --> Lambda2943
-    Lambda2948{{"Lambda[2948∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5492{{"Constant[5492∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5492 --> Lambda2948
-    Lambda2957{{"Lambda[2957∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2956 --> Lambda2957
-    Lambda2962{{"Lambda[2962∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5493{{"Constant[5493∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5493 --> Lambda2962
-    Lambda2971{{"Lambda[2971∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2970 --> Lambda2971
-    Lambda2976{{"Lambda[2976∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5494{{"Constant[5494∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5494 --> Lambda2976
+    Object2919 --> Lambda2920
+    Lambda2925{{"Lambda[2925∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5715{{"Constant[5715∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5715 --> Lambda2925
+    Lambda2935{{"Lambda[2935∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2934 --> Lambda2935
+    Lambda2940{{"Lambda[2940∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5716{{"Constant[5716∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5716 --> Lambda2940
+    Lambda2950{{"Lambda[2950∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2949 --> Lambda2950
+    Lambda2955{{"Lambda[2955∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5717{{"Constant[5717∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5717 --> Lambda2955
+    Lambda2965{{"Lambda[2965∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2964 --> Lambda2965
+    Lambda2970{{"Lambda[2970∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5718{{"Constant[5718∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5718 --> Lambda2970
+    Lambda2980{{"Lambda[2980∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2979 --> Lambda2980
     Lambda2985{{"Lambda[2985∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2984 --> Lambda2985
-    Lambda2990{{"Lambda[2990∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5495{{"Constant[5495∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5495 --> Lambda2990
-    Lambda2999{{"Lambda[2999∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object2998 --> Lambda2999
-    Lambda3004{{"Lambda[3004∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5496{{"Constant[5496∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5496 --> Lambda3004
-    Lambda3013{{"Lambda[3013∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3012 --> Lambda3013
-    Lambda3018{{"Lambda[3018∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5497{{"Constant[5497∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5497 --> Lambda3018
-    Lambda3027{{"Lambda[3027∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3026 --> Lambda3027
-    Lambda3032{{"Lambda[3032∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5498{{"Constant[5498∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5498 --> Lambda3032
-    Lambda3041{{"Lambda[3041∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3040 --> Lambda3041
-    Lambda3046{{"Lambda[3046∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5499{{"Constant[5499∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5499 --> Lambda3046
+    Constant5719{{"Constant[5719∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5719 --> Lambda2985
+    Lambda2995{{"Lambda[2995∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object2994 --> Lambda2995
+    Lambda3000{{"Lambda[3000∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5720{{"Constant[5720∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5720 --> Lambda3000
+    Lambda3010{{"Lambda[3010∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3009 --> Lambda3010
+    Lambda3015{{"Lambda[3015∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5721{{"Constant[5721∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5721 --> Lambda3015
+    Lambda3025{{"Lambda[3025∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3024 --> Lambda3025
+    Lambda3030{{"Lambda[3030∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5722{{"Constant[5722∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5722 --> Lambda3030
+    Lambda3040{{"Lambda[3040∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3039 --> Lambda3040
+    Lambda3045{{"Lambda[3045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5723{{"Constant[5723∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5723 --> Lambda3045
     Lambda3055{{"Lambda[3055∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3054 --> Lambda3055
     Lambda3060{{"Lambda[3060∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5500{{"Constant[5500∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5500 --> Lambda3060
-    Lambda3069{{"Lambda[3069∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3068 --> Lambda3069
-    Lambda3074{{"Lambda[3074∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5501{{"Constant[5501∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5501 --> Lambda3074
-    Lambda3083{{"Lambda[3083∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3082 --> Lambda3083
-    Lambda3088{{"Lambda[3088∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5502{{"Constant[5502∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5502 --> Lambda3088
-    Lambda3097{{"Lambda[3097∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3096 --> Lambda3097
-    Lambda3102{{"Lambda[3102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5503{{"Constant[5503∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5503 --> Lambda3102
-    Lambda3111{{"Lambda[3111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3110 --> Lambda3111
-    Lambda3116{{"Lambda[3116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5504{{"Constant[5504∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5504 --> Lambda3116
-    Lambda3125{{"Lambda[3125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3124 --> Lambda3125
+    Constant5724{{"Constant[5724∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5724 --> Lambda3060
+    Lambda3070{{"Lambda[3070∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3069 --> Lambda3070
+    Lambda3075{{"Lambda[3075∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5725{{"Constant[5725∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5725 --> Lambda3075
+    Lambda3085{{"Lambda[3085∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3084 --> Lambda3085
+    Lambda3090{{"Lambda[3090∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5726{{"Constant[5726∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5726 --> Lambda3090
+    Lambda3100{{"Lambda[3100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3099 --> Lambda3100
+    Lambda3105{{"Lambda[3105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5727{{"Constant[5727∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5727 --> Lambda3105
+    Lambda3115{{"Lambda[3115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3114 --> Lambda3115
+    Lambda3120{{"Lambda[3120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5728{{"Constant[5728∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5728 --> Lambda3120
     Lambda3130{{"Lambda[3130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5505{{"Constant[5505∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5505 --> Lambda3130
-    Lambda3139{{"Lambda[3139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3138 --> Lambda3139
-    Lambda3144{{"Lambda[3144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5506{{"Constant[5506∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5506 --> Lambda3144
-    Lambda3153{{"Lambda[3153∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3152 --> Lambda3153
-    Lambda3158{{"Lambda[3158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5507{{"Constant[5507∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5507 --> Lambda3158
-    Lambda3167{{"Lambda[3167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3166 --> Lambda3167
-    Lambda3172{{"Lambda[3172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5508{{"Constant[5508∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5508 --> Lambda3172
-    Lambda3181{{"Lambda[3181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3180 --> Lambda3181
-    Lambda3186{{"Lambda[3186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5509{{"Constant[5509∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5509 --> Lambda3186
+    Object3129 --> Lambda3130
+    Lambda3135{{"Lambda[3135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5729{{"Constant[5729∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5729 --> Lambda3135
+    Lambda3145{{"Lambda[3145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3144 --> Lambda3145
+    Lambda3150{{"Lambda[3150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5730{{"Constant[5730∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5730 --> Lambda3150
+    Lambda3160{{"Lambda[3160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3159 --> Lambda3160
+    Lambda3165{{"Lambda[3165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5731{{"Constant[5731∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5731 --> Lambda3165
+    Lambda3175{{"Lambda[3175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3174 --> Lambda3175
+    Lambda3180{{"Lambda[3180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5732{{"Constant[5732∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5732 --> Lambda3180
+    Lambda3190{{"Lambda[3190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3189 --> Lambda3190
     Lambda3195{{"Lambda[3195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3194 --> Lambda3195
-    Lambda3200{{"Lambda[3200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5510{{"Constant[5510∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5510 --> Lambda3200
-    Lambda3209{{"Lambda[3209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3208 --> Lambda3209
-    Lambda3214{{"Lambda[3214∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5511{{"Constant[5511∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5511 --> Lambda3214
-    Lambda3223{{"Lambda[3223∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3222 --> Lambda3223
-    Lambda3228{{"Lambda[3228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5512{{"Constant[5512∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5512 --> Lambda3228
-    Lambda3237{{"Lambda[3237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3236 --> Lambda3237
-    Lambda3242{{"Lambda[3242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5513{{"Constant[5513∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5513 --> Lambda3242
-    Lambda3251{{"Lambda[3251∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3250 --> Lambda3251
-    Lambda3256{{"Lambda[3256∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5514{{"Constant[5514∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5514 --> Lambda3256
+    Constant5733{{"Constant[5733∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5733 --> Lambda3195
+    Lambda3205{{"Lambda[3205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3204 --> Lambda3205
+    Lambda3210{{"Lambda[3210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5734{{"Constant[5734∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5734 --> Lambda3210
+    Lambda3220{{"Lambda[3220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3219 --> Lambda3220
+    Lambda3225{{"Lambda[3225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5735{{"Constant[5735∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5735 --> Lambda3225
+    Lambda3235{{"Lambda[3235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3234 --> Lambda3235
+    Lambda3240{{"Lambda[3240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5736{{"Constant[5736∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5736 --> Lambda3240
+    Lambda3250{{"Lambda[3250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3249 --> Lambda3250
+    Lambda3255{{"Lambda[3255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5737{{"Constant[5737∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5737 --> Lambda3255
     Lambda3265{{"Lambda[3265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3264 --> Lambda3265
     Lambda3270{{"Lambda[3270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5515{{"Constant[5515∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5515 --> Lambda3270
-    Lambda3279{{"Lambda[3279∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3278 --> Lambda3279
-    Lambda3284{{"Lambda[3284∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5516{{"Constant[5516∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5516 --> Lambda3284
-    Lambda3293{{"Lambda[3293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3292 --> Lambda3293
-    Lambda3298{{"Lambda[3298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5517{{"Constant[5517∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5517 --> Lambda3298
-    Lambda3307{{"Lambda[3307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3306 --> Lambda3307
-    Lambda3312{{"Lambda[3312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5518{{"Constant[5518∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5518 --> Lambda3312
-    Lambda3321{{"Lambda[3321∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3320 --> Lambda3321
-    Lambda3326{{"Lambda[3326∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5519{{"Constant[5519∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5519 --> Lambda3326
-    Lambda3335{{"Lambda[3335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3334 --> Lambda3335
+    Constant5738{{"Constant[5738∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5738 --> Lambda3270
+    Lambda3280{{"Lambda[3280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3279 --> Lambda3280
+    Lambda3285{{"Lambda[3285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5739{{"Constant[5739∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5739 --> Lambda3285
+    Lambda3295{{"Lambda[3295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3294 --> Lambda3295
+    Lambda3300{{"Lambda[3300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5740{{"Constant[5740∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5740 --> Lambda3300
+    Lambda3310{{"Lambda[3310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3309 --> Lambda3310
+    Lambda3315{{"Lambda[3315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5741{{"Constant[5741∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5741 --> Lambda3315
+    Lambda3325{{"Lambda[3325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3324 --> Lambda3325
+    Lambda3330{{"Lambda[3330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5742{{"Constant[5742∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5742 --> Lambda3330
     Lambda3340{{"Lambda[3340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5520{{"Constant[5520∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5520 --> Lambda3340
-    Lambda3349{{"Lambda[3349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3348 --> Lambda3349
-    Lambda3354{{"Lambda[3354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5521{{"Constant[5521∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5521 --> Lambda3354
-    Lambda3363{{"Lambda[3363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3362 --> Lambda3363
-    Lambda3368{{"Lambda[3368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5522{{"Constant[5522∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5522 --> Lambda3368
-    Lambda3377{{"Lambda[3377∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3376 --> Lambda3377
-    Lambda3382{{"Lambda[3382∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5523{{"Constant[5523∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5523 --> Lambda3382
-    Lambda3391{{"Lambda[3391∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3390 --> Lambda3391
-    Lambda3396{{"Lambda[3396∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5524{{"Constant[5524∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5524 --> Lambda3396
+    Object3339 --> Lambda3340
+    Lambda3345{{"Lambda[3345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5743{{"Constant[5743∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5743 --> Lambda3345
+    Lambda3355{{"Lambda[3355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3354 --> Lambda3355
+    Lambda3360{{"Lambda[3360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5744{{"Constant[5744∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5744 --> Lambda3360
+    Lambda3370{{"Lambda[3370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3369 --> Lambda3370
+    Lambda3375{{"Lambda[3375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5745{{"Constant[5745∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5745 --> Lambda3375
+    Lambda3385{{"Lambda[3385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3384 --> Lambda3385
+    Lambda3390{{"Lambda[3390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5746{{"Constant[5746∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5746 --> Lambda3390
+    Lambda3400{{"Lambda[3400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3399 --> Lambda3400
     Lambda3405{{"Lambda[3405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3404 --> Lambda3405
-    Lambda3410{{"Lambda[3410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5525{{"Constant[5525∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5525 --> Lambda3410
-    Lambda3419{{"Lambda[3419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3418 --> Lambda3419
-    Lambda3424{{"Lambda[3424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5526{{"Constant[5526∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5526 --> Lambda3424
-    Lambda3433{{"Lambda[3433∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3432 --> Lambda3433
-    Lambda3438{{"Lambda[3438∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5527{{"Constant[5527∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5527 --> Lambda3438
-    Lambda3447{{"Lambda[3447∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3446 --> Lambda3447
-    Lambda3452{{"Lambda[3452∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5528{{"Constant[5528∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5528 --> Lambda3452
-    Lambda3461{{"Lambda[3461∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3460 --> Lambda3461
-    Lambda3466{{"Lambda[3466∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5529{{"Constant[5529∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5529 --> Lambda3466
+    Constant5747{{"Constant[5747∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5747 --> Lambda3405
+    Lambda3415{{"Lambda[3415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3414 --> Lambda3415
+    Lambda3420{{"Lambda[3420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5748{{"Constant[5748∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5748 --> Lambda3420
+    Lambda3430{{"Lambda[3430∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3429 --> Lambda3430
+    Lambda3435{{"Lambda[3435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5749{{"Constant[5749∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5749 --> Lambda3435
+    Lambda3445{{"Lambda[3445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3444 --> Lambda3445
+    Lambda3450{{"Lambda[3450∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5750{{"Constant[5750∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5750 --> Lambda3450
+    Lambda3460{{"Lambda[3460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3459 --> Lambda3460
+    Lambda3465{{"Lambda[3465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5751{{"Constant[5751∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5751 --> Lambda3465
     Lambda3475{{"Lambda[3475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3474 --> Lambda3475
     Lambda3480{{"Lambda[3480∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5530{{"Constant[5530∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5530 --> Lambda3480
-    Lambda3489{{"Lambda[3489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3488 --> Lambda3489
-    Lambda3494{{"Lambda[3494∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5531{{"Constant[5531∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5531 --> Lambda3494
-    Lambda3503{{"Lambda[3503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3502 --> Lambda3503
-    Lambda3508{{"Lambda[3508∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5532{{"Constant[5532∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5532 --> Lambda3508
-    Lambda3517{{"Lambda[3517∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3516 --> Lambda3517
-    Lambda3522{{"Lambda[3522∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5533{{"Constant[5533∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5533 --> Lambda3522
-    Lambda3531{{"Lambda[3531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3530 --> Lambda3531
-    Lambda3536{{"Lambda[3536∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5534{{"Constant[5534∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5534 --> Lambda3536
-    Lambda3545{{"Lambda[3545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3544 --> Lambda3545
+    Constant5752{{"Constant[5752∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5752 --> Lambda3480
+    Lambda3490{{"Lambda[3490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3489 --> Lambda3490
+    Lambda3495{{"Lambda[3495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5753{{"Constant[5753∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5753 --> Lambda3495
+    Lambda3505{{"Lambda[3505∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3504 --> Lambda3505
+    Lambda3510{{"Lambda[3510∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5754{{"Constant[5754∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5754 --> Lambda3510
+    Lambda3520{{"Lambda[3520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3519 --> Lambda3520
+    Lambda3525{{"Lambda[3525∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5755{{"Constant[5755∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5755 --> Lambda3525
+    Lambda3535{{"Lambda[3535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3534 --> Lambda3535
+    Lambda3540{{"Lambda[3540∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5756{{"Constant[5756∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5756 --> Lambda3540
     Lambda3550{{"Lambda[3550∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5535{{"Constant[5535∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5535 --> Lambda3550
-    Lambda3559{{"Lambda[3559∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3558 --> Lambda3559
-    Lambda3564{{"Lambda[3564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5536{{"Constant[5536∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5536 --> Lambda3564
-    Lambda3573{{"Lambda[3573∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3572 --> Lambda3573
-    Lambda3578{{"Lambda[3578∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5537{{"Constant[5537∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5537 --> Lambda3578
-    Lambda3587{{"Lambda[3587∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3586 --> Lambda3587
-    Lambda3592{{"Lambda[3592∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5538{{"Constant[5538∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5538 --> Lambda3592
-    Lambda3601{{"Lambda[3601∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3600 --> Lambda3601
-    Lambda3606{{"Lambda[3606∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5539{{"Constant[5539∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5539 --> Lambda3606
+    Object3549 --> Lambda3550
+    Lambda3555{{"Lambda[3555∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5757{{"Constant[5757∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5757 --> Lambda3555
+    Lambda3565{{"Lambda[3565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3564 --> Lambda3565
+    Lambda3570{{"Lambda[3570∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5758{{"Constant[5758∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5758 --> Lambda3570
+    Lambda3580{{"Lambda[3580∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3579 --> Lambda3580
+    Lambda3585{{"Lambda[3585∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5759{{"Constant[5759∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5759 --> Lambda3585
+    Lambda3595{{"Lambda[3595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3594 --> Lambda3595
+    Lambda3600{{"Lambda[3600∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5760{{"Constant[5760∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5760 --> Lambda3600
+    Lambda3610{{"Lambda[3610∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3609 --> Lambda3610
     Lambda3615{{"Lambda[3615∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3614 --> Lambda3615
-    Lambda3620{{"Lambda[3620∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5540{{"Constant[5540∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5540 --> Lambda3620
-    Lambda3629{{"Lambda[3629∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3628 --> Lambda3629
-    Lambda3634{{"Lambda[3634∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5541{{"Constant[5541∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5541 --> Lambda3634
-    Lambda3643{{"Lambda[3643∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3642 --> Lambda3643
-    Lambda3648{{"Lambda[3648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5542{{"Constant[5542∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5542 --> Lambda3648
-    Lambda3657{{"Lambda[3657∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3656 --> Lambda3657
-    Lambda3662{{"Lambda[3662∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5543{{"Constant[5543∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5543 --> Lambda3662
-    Lambda3671{{"Lambda[3671∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3670 --> Lambda3671
-    Lambda3676{{"Lambda[3676∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5544{{"Constant[5544∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5544 --> Lambda3676
+    Constant5761{{"Constant[5761∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5761 --> Lambda3615
+    Lambda3625{{"Lambda[3625∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3624 --> Lambda3625
+    Lambda3630{{"Lambda[3630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5762{{"Constant[5762∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5762 --> Lambda3630
+    Lambda3640{{"Lambda[3640∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3639 --> Lambda3640
+    Lambda3645{{"Lambda[3645∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5763{{"Constant[5763∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5763 --> Lambda3645
+    Lambda3655{{"Lambda[3655∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3654 --> Lambda3655
+    Lambda3660{{"Lambda[3660∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5764{{"Constant[5764∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5764 --> Lambda3660
+    Lambda3670{{"Lambda[3670∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3669 --> Lambda3670
+    Lambda3675{{"Lambda[3675∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5765{{"Constant[5765∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5765 --> Lambda3675
     Lambda3685{{"Lambda[3685∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3684 --> Lambda3685
     Lambda3690{{"Lambda[3690∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5545{{"Constant[5545∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5545 --> Lambda3690
-    Lambda3699{{"Lambda[3699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3698 --> Lambda3699
-    Lambda3704{{"Lambda[3704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5546{{"Constant[5546∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5546 --> Lambda3704
-    Lambda3713{{"Lambda[3713∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3712 --> Lambda3713
-    Lambda3718{{"Lambda[3718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5547{{"Constant[5547∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5547 --> Lambda3718
-    Lambda3727{{"Lambda[3727∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3726 --> Lambda3727
-    Lambda3732{{"Lambda[3732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5548{{"Constant[5548∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5548 --> Lambda3732
-    Lambda3741{{"Lambda[3741∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3740 --> Lambda3741
-    Lambda3746{{"Lambda[3746∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5549{{"Constant[5549∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5549 --> Lambda3746
-    Lambda3755{{"Lambda[3755∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3754 --> Lambda3755
+    Constant5766{{"Constant[5766∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5766 --> Lambda3690
+    Lambda3700{{"Lambda[3700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3699 --> Lambda3700
+    Lambda3705{{"Lambda[3705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5767{{"Constant[5767∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5767 --> Lambda3705
+    Lambda3715{{"Lambda[3715∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3714 --> Lambda3715
+    Lambda3720{{"Lambda[3720∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5768{{"Constant[5768∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5768 --> Lambda3720
+    Lambda3730{{"Lambda[3730∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3729 --> Lambda3730
+    Lambda3735{{"Lambda[3735∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5769{{"Constant[5769∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5769 --> Lambda3735
+    Lambda3745{{"Lambda[3745∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3744 --> Lambda3745
+    Lambda3750{{"Lambda[3750∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5770{{"Constant[5770∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5770 --> Lambda3750
     Lambda3760{{"Lambda[3760∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5550{{"Constant[5550∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5550 --> Lambda3760
-    Lambda3769{{"Lambda[3769∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3768 --> Lambda3769
-    Lambda3774{{"Lambda[3774∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5551{{"Constant[5551∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5551 --> Lambda3774
-    Lambda3783{{"Lambda[3783∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3782 --> Lambda3783
-    Lambda3788{{"Lambda[3788∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5552{{"Constant[5552∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5552 --> Lambda3788
-    Lambda3797{{"Lambda[3797∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3796 --> Lambda3797
-    Lambda3802{{"Lambda[3802∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5553{{"Constant[5553∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5553 --> Lambda3802
-    Lambda3811{{"Lambda[3811∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3810 --> Lambda3811
-    Lambda3816{{"Lambda[3816∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5554{{"Constant[5554∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5554 --> Lambda3816
+    Object3759 --> Lambda3760
+    Lambda3765{{"Lambda[3765∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5771{{"Constant[5771∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5771 --> Lambda3765
+    Lambda3775{{"Lambda[3775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3774 --> Lambda3775
+    Lambda3780{{"Lambda[3780∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5772{{"Constant[5772∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5772 --> Lambda3780
+    Lambda3790{{"Lambda[3790∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3789 --> Lambda3790
+    Lambda3795{{"Lambda[3795∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5773{{"Constant[5773∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5773 --> Lambda3795
+    Lambda3805{{"Lambda[3805∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3804 --> Lambda3805
+    Lambda3810{{"Lambda[3810∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5774{{"Constant[5774∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5774 --> Lambda3810
+    Lambda3820{{"Lambda[3820∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3819 --> Lambda3820
     Lambda3825{{"Lambda[3825∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3824 --> Lambda3825
-    Lambda3830{{"Lambda[3830∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5555{{"Constant[5555∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5555 --> Lambda3830
-    Lambda3839{{"Lambda[3839∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3838 --> Lambda3839
-    Lambda3844{{"Lambda[3844∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5556{{"Constant[5556∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5556 --> Lambda3844
-    Lambda3853{{"Lambda[3853∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3852 --> Lambda3853
-    Lambda3858{{"Lambda[3858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5557{{"Constant[5557∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5557 --> Lambda3858
-    Lambda3867{{"Lambda[3867∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3866 --> Lambda3867
-    Lambda3872{{"Lambda[3872∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5558{{"Constant[5558∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5558 --> Lambda3872
-    Lambda3881{{"Lambda[3881∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3880 --> Lambda3881
-    Lambda3886{{"Lambda[3886∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5559{{"Constant[5559∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5559 --> Lambda3886
+    Constant5775{{"Constant[5775∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5775 --> Lambda3825
+    Lambda3835{{"Lambda[3835∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3834 --> Lambda3835
+    Lambda3840{{"Lambda[3840∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5776{{"Constant[5776∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5776 --> Lambda3840
+    Lambda3850{{"Lambda[3850∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3849 --> Lambda3850
+    Lambda3855{{"Lambda[3855∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5777{{"Constant[5777∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5777 --> Lambda3855
+    Lambda3865{{"Lambda[3865∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3864 --> Lambda3865
+    Lambda3870{{"Lambda[3870∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5778{{"Constant[5778∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5778 --> Lambda3870
+    Lambda3880{{"Lambda[3880∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3879 --> Lambda3880
+    Lambda3885{{"Lambda[3885∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5779{{"Constant[5779∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5779 --> Lambda3885
     Lambda3895{{"Lambda[3895∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object3894 --> Lambda3895
     Lambda3900{{"Lambda[3900∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5560{{"Constant[5560∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5560 --> Lambda3900
-    Lambda3909{{"Lambda[3909∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3908 --> Lambda3909
-    Lambda3914{{"Lambda[3914∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5561{{"Constant[5561∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5561 --> Lambda3914
-    Lambda3923{{"Lambda[3923∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3922 --> Lambda3923
-    Lambda3928{{"Lambda[3928∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5562{{"Constant[5562∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5562 --> Lambda3928
-    Lambda3937{{"Lambda[3937∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3936 --> Lambda3937
-    Lambda3942{{"Lambda[3942∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5563{{"Constant[5563∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5563 --> Lambda3942
-    Lambda3951{{"Lambda[3951∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3950 --> Lambda3951
-    Lambda3956{{"Lambda[3956∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5564{{"Constant[5564∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5564 --> Lambda3956
-    Lambda3965{{"Lambda[3965∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3964 --> Lambda3965
+    Constant5780{{"Constant[5780∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5780 --> Lambda3900
+    Lambda3910{{"Lambda[3910∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3909 --> Lambda3910
+    Lambda3915{{"Lambda[3915∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5781{{"Constant[5781∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5781 --> Lambda3915
+    Lambda3925{{"Lambda[3925∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3924 --> Lambda3925
+    Lambda3930{{"Lambda[3930∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5782{{"Constant[5782∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5782 --> Lambda3930
+    Lambda3940{{"Lambda[3940∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3939 --> Lambda3940
+    Lambda3945{{"Lambda[3945∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5783{{"Constant[5783∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5783 --> Lambda3945
+    Lambda3955{{"Lambda[3955∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3954 --> Lambda3955
+    Lambda3960{{"Lambda[3960∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5784{{"Constant[5784∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5784 --> Lambda3960
     Lambda3970{{"Lambda[3970∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5565{{"Constant[5565∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5565 --> Lambda3970
-    Lambda3979{{"Lambda[3979∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3978 --> Lambda3979
-    Lambda3984{{"Lambda[3984∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5566{{"Constant[5566∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5566 --> Lambda3984
-    Lambda3993{{"Lambda[3993∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object3992 --> Lambda3993
-    Lambda3998{{"Lambda[3998∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5567{{"Constant[5567∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5567 --> Lambda3998
-    Lambda4007{{"Lambda[4007∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4006 --> Lambda4007
-    Lambda4012{{"Lambda[4012∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5568{{"Constant[5568∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5568 --> Lambda4012
-    Lambda4021{{"Lambda[4021∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4020 --> Lambda4021
-    Lambda4026{{"Lambda[4026∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5569{{"Constant[5569∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5569 --> Lambda4026
+    Object3969 --> Lambda3970
+    Lambda3975{{"Lambda[3975∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5785{{"Constant[5785∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5785 --> Lambda3975
+    Lambda3985{{"Lambda[3985∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3984 --> Lambda3985
+    Lambda3990{{"Lambda[3990∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5786{{"Constant[5786∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5786 --> Lambda3990
+    Lambda4000{{"Lambda[4000∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3999 --> Lambda4000
+    Lambda4005{{"Lambda[4005∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5787{{"Constant[5787∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5787 --> Lambda4005
+    Lambda4015{{"Lambda[4015∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4014 --> Lambda4015
+    Lambda4020{{"Lambda[4020∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5788{{"Constant[5788∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5788 --> Lambda4020
+    Lambda4030{{"Lambda[4030∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4029 --> Lambda4030
     Lambda4035{{"Lambda[4035∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4034 --> Lambda4035
-    Lambda4040{{"Lambda[4040∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5570{{"Constant[5570∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5570 --> Lambda4040
-    Lambda4049{{"Lambda[4049∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4048 --> Lambda4049
-    Lambda4054{{"Lambda[4054∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5571{{"Constant[5571∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5571 --> Lambda4054
-    Lambda4063{{"Lambda[4063∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4062 --> Lambda4063
-    Lambda4068{{"Lambda[4068∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5572{{"Constant[5572∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5572 --> Lambda4068
-    Lambda4077{{"Lambda[4077∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4076 --> Lambda4077
-    Lambda4082{{"Lambda[4082∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5573{{"Constant[5573∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5573 --> Lambda4082
-    Lambda4091{{"Lambda[4091∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4090 --> Lambda4091
-    Lambda4096{{"Lambda[4096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5574{{"Constant[5574∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5574 --> Lambda4096
+    Constant5789{{"Constant[5789∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5789 --> Lambda4035
+    Lambda4045{{"Lambda[4045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4044 --> Lambda4045
+    Lambda4050{{"Lambda[4050∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5790{{"Constant[5790∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5790 --> Lambda4050
+    Lambda4060{{"Lambda[4060∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4059 --> Lambda4060
+    Lambda4065{{"Lambda[4065∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5791{{"Constant[5791∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5791 --> Lambda4065
+    Lambda4075{{"Lambda[4075∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4074 --> Lambda4075
+    Lambda4080{{"Lambda[4080∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5792{{"Constant[5792∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5792 --> Lambda4080
+    Lambda4090{{"Lambda[4090∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4089 --> Lambda4090
+    Lambda4095{{"Lambda[4095∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5793{{"Constant[5793∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5793 --> Lambda4095
     Lambda4105{{"Lambda[4105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object4104 --> Lambda4105
     Lambda4110{{"Lambda[4110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5575{{"Constant[5575∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5575 --> Lambda4110
-    Lambda4119{{"Lambda[4119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4118 --> Lambda4119
-    Lambda4124{{"Lambda[4124∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5576{{"Constant[5576∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5576 --> Lambda4124
-    Lambda4133{{"Lambda[4133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4132 --> Lambda4133
-    Lambda4138{{"Lambda[4138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5577{{"Constant[5577∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5577 --> Lambda4138
-    Lambda4147{{"Lambda[4147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4146 --> Lambda4147
-    Lambda4152{{"Lambda[4152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5578{{"Constant[5578∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5578 --> Lambda4152
-    Lambda4161{{"Lambda[4161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4160 --> Lambda4161
-    Lambda4166{{"Lambda[4166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5579{{"Constant[5579∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5579 --> Lambda4166
-    Lambda4175{{"Lambda[4175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4174 --> Lambda4175
+    Constant5794{{"Constant[5794∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5794 --> Lambda4110
+    Lambda4120{{"Lambda[4120∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4119 --> Lambda4120
+    Lambda4125{{"Lambda[4125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5795{{"Constant[5795∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5795 --> Lambda4125
+    Lambda4135{{"Lambda[4135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4134 --> Lambda4135
+    Lambda4140{{"Lambda[4140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5796{{"Constant[5796∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5796 --> Lambda4140
+    Lambda4150{{"Lambda[4150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4149 --> Lambda4150
+    Lambda4155{{"Lambda[4155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5797{{"Constant[5797∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5797 --> Lambda4155
+    Lambda4165{{"Lambda[4165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4164 --> Lambda4165
+    Lambda4170{{"Lambda[4170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5798{{"Constant[5798∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5798 --> Lambda4170
     Lambda4180{{"Lambda[4180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5580{{"Constant[5580∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5580 --> Lambda4180
-    Lambda4189{{"Lambda[4189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4188 --> Lambda4189
-    Lambda4194{{"Lambda[4194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5581{{"Constant[5581∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5581 --> Lambda4194
-    Lambda4203{{"Lambda[4203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4202 --> Lambda4203
-    Lambda4208{{"Lambda[4208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5582{{"Constant[5582∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5582 --> Lambda4208
-    Lambda4217{{"Lambda[4217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4216 --> Lambda4217
-    Lambda4222{{"Lambda[4222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5583{{"Constant[5583∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5583 --> Lambda4222
-    Lambda4231{{"Lambda[4231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4230 --> Lambda4231
-    Lambda4236{{"Lambda[4236∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5584{{"Constant[5584∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5584 --> Lambda4236
+    Object4179 --> Lambda4180
+    Lambda4185{{"Lambda[4185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5799{{"Constant[5799∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5799 --> Lambda4185
+    Lambda4195{{"Lambda[4195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4194 --> Lambda4195
+    Lambda4200{{"Lambda[4200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5800{{"Constant[5800∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5800 --> Lambda4200
+    Lambda4210{{"Lambda[4210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4209 --> Lambda4210
+    Lambda4215{{"Lambda[4215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5801{{"Constant[5801∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5801 --> Lambda4215
+    Lambda4225{{"Lambda[4225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4224 --> Lambda4225
+    Lambda4230{{"Lambda[4230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5802{{"Constant[5802∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5802 --> Lambda4230
+    Lambda4240{{"Lambda[4240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4239 --> Lambda4240
     Lambda4245{{"Lambda[4245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4244 --> Lambda4245
-    Lambda4250{{"Lambda[4250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5585{{"Constant[5585∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5585 --> Lambda4250
-    Lambda4259{{"Lambda[4259∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4258 --> Lambda4259
-    Lambda4264{{"Lambda[4264∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5586{{"Constant[5586∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5586 --> Lambda4264
-    Lambda4273{{"Lambda[4273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4272 --> Lambda4273
-    Lambda4278{{"Lambda[4278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5587{{"Constant[5587∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5587 --> Lambda4278
-    Lambda4287{{"Lambda[4287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4286 --> Lambda4287
-    Lambda4292{{"Lambda[4292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5588{{"Constant[5588∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5588 --> Lambda4292
-    Lambda4301{{"Lambda[4301∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4300 --> Lambda4301
-    Lambda4306{{"Lambda[4306∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5589{{"Constant[5589∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5589 --> Lambda4306
+    Constant5803{{"Constant[5803∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5803 --> Lambda4245
+    Lambda4255{{"Lambda[4255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4254 --> Lambda4255
+    Lambda4260{{"Lambda[4260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5804{{"Constant[5804∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5804 --> Lambda4260
+    Lambda4270{{"Lambda[4270∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4269 --> Lambda4270
+    Lambda4275{{"Lambda[4275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5805{{"Constant[5805∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5805 --> Lambda4275
+    Lambda4285{{"Lambda[4285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4284 --> Lambda4285
+    Lambda4290{{"Lambda[4290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5806{{"Constant[5806∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5806 --> Lambda4290
+    Lambda4300{{"Lambda[4300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4299 --> Lambda4300
+    Lambda4305{{"Lambda[4305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5807{{"Constant[5807∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5807 --> Lambda4305
     Lambda4315{{"Lambda[4315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object4314 --> Lambda4315
     Lambda4320{{"Lambda[4320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5590{{"Constant[5590∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5590 --> Lambda4320
-    Lambda4329{{"Lambda[4329∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4328 --> Lambda4329
-    Lambda4334{{"Lambda[4334∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5591{{"Constant[5591∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5591 --> Lambda4334
-    Lambda4343{{"Lambda[4343∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4342 --> Lambda4343
-    Lambda4348{{"Lambda[4348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5592{{"Constant[5592∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5592 --> Lambda4348
-    Lambda4357{{"Lambda[4357∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4356 --> Lambda4357
-    Lambda4362{{"Lambda[4362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5593{{"Constant[5593∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5593 --> Lambda4362
-    Lambda4371{{"Lambda[4371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4370 --> Lambda4371
-    Lambda4376{{"Lambda[4376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5594{{"Constant[5594∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5594 --> Lambda4376
-    Lambda4385{{"Lambda[4385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4384 --> Lambda4385
+    Constant5808{{"Constant[5808∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5808 --> Lambda4320
+    Lambda4330{{"Lambda[4330∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4329 --> Lambda4330
+    Lambda4335{{"Lambda[4335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5809{{"Constant[5809∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5809 --> Lambda4335
+    Lambda4345{{"Lambda[4345∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4344 --> Lambda4345
+    Lambda4350{{"Lambda[4350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5810{{"Constant[5810∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5810 --> Lambda4350
+    Lambda4360{{"Lambda[4360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4359 --> Lambda4360
+    Lambda4365{{"Lambda[4365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5811{{"Constant[5811∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5811 --> Lambda4365
+    Lambda4375{{"Lambda[4375∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4374 --> Lambda4375
+    Lambda4380{{"Lambda[4380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5812{{"Constant[5812∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5812 --> Lambda4380
     Lambda4390{{"Lambda[4390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5595{{"Constant[5595∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5595 --> Lambda4390
-    Lambda4399{{"Lambda[4399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4398 --> Lambda4399
-    Lambda4404{{"Lambda[4404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5596{{"Constant[5596∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5596 --> Lambda4404
-    Lambda4413{{"Lambda[4413∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4412 --> Lambda4413
-    Lambda4418{{"Lambda[4418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5597{{"Constant[5597∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5597 --> Lambda4418
-    Lambda4427{{"Lambda[4427∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4426 --> Lambda4427
-    Lambda4432{{"Lambda[4432∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5598{{"Constant[5598∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5598 --> Lambda4432
-    Lambda4441{{"Lambda[4441∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4440 --> Lambda4441
-    Lambda4446{{"Lambda[4446∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5599{{"Constant[5599∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5599 --> Lambda4446
+    Object4389 --> Lambda4390
+    Lambda4395{{"Lambda[4395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5813{{"Constant[5813∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5813 --> Lambda4395
+    Lambda4405{{"Lambda[4405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4404 --> Lambda4405
+    Lambda4410{{"Lambda[4410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5814{{"Constant[5814∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5814 --> Lambda4410
+    Lambda4420{{"Lambda[4420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4419 --> Lambda4420
+    Lambda4425{{"Lambda[4425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5815{{"Constant[5815∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5815 --> Lambda4425
+    Lambda4435{{"Lambda[4435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4434 --> Lambda4435
+    Lambda4440{{"Lambda[4440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5816{{"Constant[5816∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5816 --> Lambda4440
+    Lambda4450{{"Lambda[4450∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4449 --> Lambda4450
     Lambda4455{{"Lambda[4455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4454 --> Lambda4455
-    Lambda4460{{"Lambda[4460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5600{{"Constant[5600∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5600 --> Lambda4460
-    Lambda4469{{"Lambda[4469∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4468 --> Lambda4469
-    Lambda4474{{"Lambda[4474∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5601{{"Constant[5601∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5601 --> Lambda4474
-    Lambda4483{{"Lambda[4483∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4482 --> Lambda4483
-    Lambda4488{{"Lambda[4488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5602{{"Constant[5602∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5602 --> Lambda4488
-    Lambda4497{{"Lambda[4497∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4496 --> Lambda4497
-    Lambda4502{{"Lambda[4502∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5603{{"Constant[5603∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5603 --> Lambda4502
-    Lambda4511{{"Lambda[4511∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4510 --> Lambda4511
-    Lambda4516{{"Lambda[4516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5604{{"Constant[5604∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5604 --> Lambda4516
+    Constant5817{{"Constant[5817∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5817 --> Lambda4455
+    Lambda4465{{"Lambda[4465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4464 --> Lambda4465
+    Lambda4470{{"Lambda[4470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5818{{"Constant[5818∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5818 --> Lambda4470
+    Lambda4480{{"Lambda[4480∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4479 --> Lambda4480
+    Lambda4485{{"Lambda[4485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5819{{"Constant[5819∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5819 --> Lambda4485
+    Lambda4495{{"Lambda[4495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4494 --> Lambda4495
+    Lambda4500{{"Lambda[4500∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5820{{"Constant[5820∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5820 --> Lambda4500
+    Lambda4510{{"Lambda[4510∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4509 --> Lambda4510
+    Lambda4515{{"Lambda[4515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5821{{"Constant[5821∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5821 --> Lambda4515
     Lambda4525{{"Lambda[4525∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object4524 --> Lambda4525
     Lambda4530{{"Lambda[4530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5605{{"Constant[5605∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5605 --> Lambda4530
-    Lambda4539{{"Lambda[4539∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4538 --> Lambda4539
-    Lambda4544{{"Lambda[4544∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5606{{"Constant[5606∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5606 --> Lambda4544
-    Lambda4553{{"Lambda[4553∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4552 --> Lambda4553
-    Lambda4558{{"Lambda[4558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5607{{"Constant[5607∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5607 --> Lambda4558
-    Lambda4567{{"Lambda[4567∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4566 --> Lambda4567
-    Lambda4572{{"Lambda[4572∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5608{{"Constant[5608∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5608 --> Lambda4572
-    Lambda4581{{"Lambda[4581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4580 --> Lambda4581
-    Lambda4586{{"Lambda[4586∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5609{{"Constant[5609∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5609 --> Lambda4586
-    Lambda4595{{"Lambda[4595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4594 --> Lambda4595
+    Constant5822{{"Constant[5822∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5822 --> Lambda4530
+    Lambda4540{{"Lambda[4540∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4539 --> Lambda4540
+    Lambda4545{{"Lambda[4545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5823{{"Constant[5823∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5823 --> Lambda4545
+    Lambda4555{{"Lambda[4555∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4554 --> Lambda4555
+    Lambda4560{{"Lambda[4560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5824{{"Constant[5824∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5824 --> Lambda4560
+    Lambda4570{{"Lambda[4570∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4569 --> Lambda4570
+    Lambda4575{{"Lambda[4575∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5825{{"Constant[5825∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5825 --> Lambda4575
+    Lambda4585{{"Lambda[4585∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4584 --> Lambda4585
+    Lambda4590{{"Lambda[4590∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5826{{"Constant[5826∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5826 --> Lambda4590
     Lambda4600{{"Lambda[4600∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5610{{"Constant[5610∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5610 --> Lambda4600
-    Lambda4609{{"Lambda[4609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4608 --> Lambda4609
-    Lambda4614{{"Lambda[4614∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5611{{"Constant[5611∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5611 --> Lambda4614
-    Lambda4623{{"Lambda[4623∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4622 --> Lambda4623
-    Lambda4628{{"Lambda[4628∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5612{{"Constant[5612∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5612 --> Lambda4628
-    Lambda4637{{"Lambda[4637∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4636 --> Lambda4637
-    Lambda4642{{"Lambda[4642∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5613{{"Constant[5613∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5613 --> Lambda4642
-    Lambda4651{{"Lambda[4651∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4650 --> Lambda4651
-    Lambda4656{{"Lambda[4656∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5614{{"Constant[5614∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5614 --> Lambda4656
+    Object4599 --> Lambda4600
+    Lambda4605{{"Lambda[4605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5827{{"Constant[5827∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5827 --> Lambda4605
+    Lambda4615{{"Lambda[4615∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4614 --> Lambda4615
+    Lambda4620{{"Lambda[4620∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5828{{"Constant[5828∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5828 --> Lambda4620
+    Lambda4630{{"Lambda[4630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4629 --> Lambda4630
+    Lambda4635{{"Lambda[4635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5829{{"Constant[5829∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5829 --> Lambda4635
+    Lambda4645{{"Lambda[4645∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4644 --> Lambda4645
+    Lambda4650{{"Lambda[4650∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5830{{"Constant[5830∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5830 --> Lambda4650
+    Lambda4660{{"Lambda[4660∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4659 --> Lambda4660
     Lambda4665{{"Lambda[4665∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4664 --> Lambda4665
-    Lambda4670{{"Lambda[4670∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5615{{"Constant[5615∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5615 --> Lambda4670
-    Lambda4679{{"Lambda[4679∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4678 --> Lambda4679
-    Lambda4684{{"Lambda[4684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5616{{"Constant[5616∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5616 --> Lambda4684
-    Lambda4693{{"Lambda[4693∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4692 --> Lambda4693
-    Lambda4698{{"Lambda[4698∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5617{{"Constant[5617∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5617 --> Lambda4698
-    Lambda4707{{"Lambda[4707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4706 --> Lambda4707
-    Lambda4712{{"Lambda[4712∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5618{{"Constant[5618∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5618 --> Lambda4712
-    Lambda4721{{"Lambda[4721∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4720 --> Lambda4721
-    Lambda4726{{"Lambda[4726∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5619{{"Constant[5619∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5619 --> Lambda4726
+    Constant5831{{"Constant[5831∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5831 --> Lambda4665
+    Lambda4675{{"Lambda[4675∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4674 --> Lambda4675
+    Lambda4680{{"Lambda[4680∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5832{{"Constant[5832∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5832 --> Lambda4680
+    Lambda4690{{"Lambda[4690∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4689 --> Lambda4690
+    Lambda4695{{"Lambda[4695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5833{{"Constant[5833∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5833 --> Lambda4695
+    Lambda4705{{"Lambda[4705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4704 --> Lambda4705
+    Lambda4710{{"Lambda[4710∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5834{{"Constant[5834∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5834 --> Lambda4710
+    Lambda4720{{"Lambda[4720∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4719 --> Lambda4720
+    Lambda4725{{"Lambda[4725∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5835{{"Constant[5835∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5835 --> Lambda4725
     Lambda4735{{"Lambda[4735∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object4734 --> Lambda4735
     Lambda4740{{"Lambda[4740∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5620{{"Constant[5620∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5620 --> Lambda4740
-    Lambda4749{{"Lambda[4749∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4748 --> Lambda4749
-    Lambda4754{{"Lambda[4754∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5621{{"Constant[5621∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5621 --> Lambda4754
-    Lambda4763{{"Lambda[4763∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4762 --> Lambda4763
-    Lambda4768{{"Lambda[4768∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5622{{"Constant[5622∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5622 --> Lambda4768
-    Lambda4777{{"Lambda[4777∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4776 --> Lambda4777
-    Lambda4782{{"Lambda[4782∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5623{{"Constant[5623∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5623 --> Lambda4782
-    Lambda4791{{"Lambda[4791∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4790 --> Lambda4791
-    Lambda4796{{"Lambda[4796∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5624{{"Constant[5624∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5624 --> Lambda4796
-    Lambda4805{{"Lambda[4805∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4804 --> Lambda4805
+    Constant5836{{"Constant[5836∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5836 --> Lambda4740
+    Lambda4750{{"Lambda[4750∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4749 --> Lambda4750
+    Lambda4755{{"Lambda[4755∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5837{{"Constant[5837∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5837 --> Lambda4755
+    Lambda4765{{"Lambda[4765∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4764 --> Lambda4765
+    Lambda4770{{"Lambda[4770∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5838{{"Constant[5838∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5838 --> Lambda4770
+    Lambda4780{{"Lambda[4780∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4779 --> Lambda4780
+    Lambda4785{{"Lambda[4785∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5839{{"Constant[5839∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5839 --> Lambda4785
+    Lambda4795{{"Lambda[4795∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4794 --> Lambda4795
+    Lambda4800{{"Lambda[4800∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5840{{"Constant[5840∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5840 --> Lambda4800
     Lambda4810{{"Lambda[4810∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5625{{"Constant[5625∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5625 --> Lambda4810
-    Lambda4819{{"Lambda[4819∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4818 --> Lambda4819
-    Lambda4824{{"Lambda[4824∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5626{{"Constant[5626∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5626 --> Lambda4824
-    Lambda4833{{"Lambda[4833∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4832 --> Lambda4833
-    Lambda4838{{"Lambda[4838∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5627{{"Constant[5627∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5627 --> Lambda4838
-    Lambda4847{{"Lambda[4847∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4846 --> Lambda4847
-    Lambda4852{{"Lambda[4852∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5628{{"Constant[5628∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5628 --> Lambda4852
-    Lambda4861{{"Lambda[4861∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4860 --> Lambda4861
-    Lambda4866{{"Lambda[4866∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5629{{"Constant[5629∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5629 --> Lambda4866
+    Object4809 --> Lambda4810
+    Lambda4815{{"Lambda[4815∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5841{{"Constant[5841∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5841 --> Lambda4815
+    Lambda4825{{"Lambda[4825∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4824 --> Lambda4825
+    Lambda4830{{"Lambda[4830∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5842{{"Constant[5842∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5842 --> Lambda4830
+    Lambda4840{{"Lambda[4840∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4839 --> Lambda4840
+    Lambda4845{{"Lambda[4845∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5843{{"Constant[5843∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5843 --> Lambda4845
+    Lambda4855{{"Lambda[4855∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4854 --> Lambda4855
+    Lambda4860{{"Lambda[4860∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5844{{"Constant[5844∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5844 --> Lambda4860
+    Lambda4870{{"Lambda[4870∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4869 --> Lambda4870
     Lambda4875{{"Lambda[4875∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4874 --> Lambda4875
-    Lambda4880{{"Lambda[4880∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5630{{"Constant[5630∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5630 --> Lambda4880
-    Lambda4889{{"Lambda[4889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4888 --> Lambda4889
-    Lambda4894{{"Lambda[4894∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5631{{"Constant[5631∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5631 --> Lambda4894
-    Lambda4903{{"Lambda[4903∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4902 --> Lambda4903
-    Lambda4908{{"Lambda[4908∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5632{{"Constant[5632∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5632 --> Lambda4908
-    Lambda4917{{"Lambda[4917∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4916 --> Lambda4917
-    Lambda4922{{"Lambda[4922∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5633{{"Constant[5633∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5633 --> Lambda4922
-    Lambda4931{{"Lambda[4931∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4930 --> Lambda4931
-    Lambda4936{{"Lambda[4936∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5634{{"Constant[5634∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5634 --> Lambda4936
+    Constant5845{{"Constant[5845∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5845 --> Lambda4875
+    Lambda4885{{"Lambda[4885∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4884 --> Lambda4885
+    Lambda4890{{"Lambda[4890∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5846{{"Constant[5846∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5846 --> Lambda4890
+    Lambda4900{{"Lambda[4900∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4899 --> Lambda4900
+    Lambda4905{{"Lambda[4905∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5847{{"Constant[5847∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5847 --> Lambda4905
+    Lambda4915{{"Lambda[4915∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4914 --> Lambda4915
+    Lambda4920{{"Lambda[4920∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5848{{"Constant[5848∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5848 --> Lambda4920
+    Lambda4930{{"Lambda[4930∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4929 --> Lambda4930
+    Lambda4935{{"Lambda[4935∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5849{{"Constant[5849∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5849 --> Lambda4935
     Lambda4945{{"Lambda[4945∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object4944 --> Lambda4945
     Lambda4950{{"Lambda[4950∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5635{{"Constant[5635∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5635 --> Lambda4950
-    Lambda4959{{"Lambda[4959∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4958 --> Lambda4959
-    Lambda4964{{"Lambda[4964∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5636{{"Constant[5636∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5636 --> Lambda4964
-    Lambda4973{{"Lambda[4973∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4972 --> Lambda4973
-    Lambda4978{{"Lambda[4978∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5637{{"Constant[5637∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5637 --> Lambda4978
-    Lambda4987{{"Lambda[4987∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4986 --> Lambda4987
-    Lambda4992{{"Lambda[4992∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5638{{"Constant[5638∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5638 --> Lambda4992
-    Lambda5001{{"Lambda[5001∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5000 --> Lambda5001
-    Lambda5006{{"Lambda[5006∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5639{{"Constant[5639∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5639 --> Lambda5006
-    Lambda5015{{"Lambda[5015∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5014 --> Lambda5015
+    Constant5850{{"Constant[5850∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5850 --> Lambda4950
+    Lambda4960{{"Lambda[4960∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4959 --> Lambda4960
+    Lambda4965{{"Lambda[4965∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5851{{"Constant[5851∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5851 --> Lambda4965
+    Lambda4975{{"Lambda[4975∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4974 --> Lambda4975
+    Lambda4980{{"Lambda[4980∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5852{{"Constant[5852∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5852 --> Lambda4980
+    Lambda4990{{"Lambda[4990∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4989 --> Lambda4990
+    Lambda4995{{"Lambda[4995∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5853{{"Constant[5853∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5853 --> Lambda4995
+    Lambda5005{{"Lambda[5005∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5004 --> Lambda5005
+    Lambda5010{{"Lambda[5010∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5854{{"Constant[5854∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5854 --> Lambda5010
     Lambda5020{{"Lambda[5020∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5640{{"Constant[5640∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5640 --> Lambda5020
-    Lambda5029{{"Lambda[5029∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5028 --> Lambda5029
-    Lambda5034{{"Lambda[5034∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5641{{"Constant[5641∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5641 --> Lambda5034
-    Lambda5043{{"Lambda[5043∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5042 --> Lambda5043
-    Lambda5048{{"Lambda[5048∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5642{{"Constant[5642∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5642 --> Lambda5048
-    Lambda5057{{"Lambda[5057∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5056 --> Lambda5057
-    Lambda5062{{"Lambda[5062∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5643{{"Constant[5643∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5643 --> Lambda5062
-    Lambda5071{{"Lambda[5071∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5070 --> Lambda5071
-    Lambda5076{{"Lambda[5076∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5644{{"Constant[5644∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5644 --> Lambda5076
+    Object5019 --> Lambda5020
+    Lambda5025{{"Lambda[5025∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5855{{"Constant[5855∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5855 --> Lambda5025
+    Lambda5035{{"Lambda[5035∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5034 --> Lambda5035
+    Lambda5040{{"Lambda[5040∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5856{{"Constant[5856∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5856 --> Lambda5040
+    Lambda5050{{"Lambda[5050∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5049 --> Lambda5050
+    Lambda5055{{"Lambda[5055∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5857{{"Constant[5857∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5857 --> Lambda5055
+    Lambda5065{{"Lambda[5065∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5064 --> Lambda5065
+    Lambda5070{{"Lambda[5070∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5858{{"Constant[5858∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5858 --> Lambda5070
+    Lambda5080{{"Lambda[5080∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5079 --> Lambda5080
     Lambda5085{{"Lambda[5085∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5084 --> Lambda5085
-    Lambda5090{{"Lambda[5090∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5645{{"Constant[5645∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5645 --> Lambda5090
-    Lambda5099{{"Lambda[5099∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5098 --> Lambda5099
-    Lambda5104{{"Lambda[5104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5646{{"Constant[5646∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5646 --> Lambda5104
-    Lambda5113{{"Lambda[5113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5112 --> Lambda5113
-    Lambda5118{{"Lambda[5118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5647{{"Constant[5647∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5647 --> Lambda5118
-    Lambda5127{{"Lambda[5127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5126 --> Lambda5127
-    Lambda5132{{"Lambda[5132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5648{{"Constant[5648∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5648 --> Lambda5132
-    Lambda5141{{"Lambda[5141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5140 --> Lambda5141
-    Lambda5146{{"Lambda[5146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5649{{"Constant[5649∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5649 --> Lambda5146
+    Constant5859{{"Constant[5859∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5859 --> Lambda5085
+    Lambda5095{{"Lambda[5095∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5094 --> Lambda5095
+    Lambda5100{{"Lambda[5100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5860{{"Constant[5860∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5860 --> Lambda5100
+    Lambda5110{{"Lambda[5110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5109 --> Lambda5110
+    Lambda5115{{"Lambda[5115∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5861{{"Constant[5861∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5861 --> Lambda5115
+    Lambda5125{{"Lambda[5125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5124 --> Lambda5125
+    Lambda5130{{"Lambda[5130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5862{{"Constant[5862∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5862 --> Lambda5130
+    Lambda5140{{"Lambda[5140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5139 --> Lambda5140
+    Lambda5145{{"Lambda[5145∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5863{{"Constant[5863∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5863 --> Lambda5145
     Lambda5155{{"Lambda[5155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object5154 --> Lambda5155
     Lambda5160{{"Lambda[5160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5650{{"Constant[5650∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant5650 --> Lambda5160
-    Lambda5169{{"Lambda[5169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5168 --> Lambda5169
-    Lambda5174{{"Lambda[5174∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5651{{"Constant[5651∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant5651 --> Lambda5174
-    Lambda5183{{"Lambda[5183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5182 --> Lambda5183
-    Lambda5188{{"Lambda[5188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5652{{"Constant[5652∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5652 --> Lambda5188
-    Lambda5197{{"Lambda[5197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5196 --> Lambda5197
-    Lambda5202{{"Lambda[5202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5653{{"Constant[5653∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5653 --> Lambda5202
-    Lambda5211{{"Lambda[5211∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5210 --> Lambda5211
-    Lambda5216{{"Lambda[5216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5654{{"Constant[5654∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant5654 --> Lambda5216
-    Lambda5225{{"Lambda[5225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5224 --> Lambda5225
+    Constant5864{{"Constant[5864∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5864 --> Lambda5160
+    Lambda5170{{"Lambda[5170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5169 --> Lambda5170
+    Lambda5175{{"Lambda[5175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5865{{"Constant[5865∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5865 --> Lambda5175
+    Lambda5185{{"Lambda[5185∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5184 --> Lambda5185
+    Lambda5190{{"Lambda[5190∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5866{{"Constant[5866∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5866 --> Lambda5190
+    Lambda5200{{"Lambda[5200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5199 --> Lambda5200
+    Lambda5205{{"Lambda[5205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5867{{"Constant[5867∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5867 --> Lambda5205
+    Lambda5215{{"Lambda[5215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5214 --> Lambda5215
+    Lambda5220{{"Lambda[5220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5868{{"Constant[5868∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5868 --> Lambda5220
     Lambda5230{{"Lambda[5230∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5655{{"Constant[5655∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant5655 --> Lambda5230
-    Lambda5239{{"Lambda[5239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5238 --> Lambda5239
-    Lambda5244{{"Lambda[5244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5656{{"Constant[5656∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant5656 --> Lambda5244
-    Lambda5253{{"Lambda[5253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5252 --> Lambda5253
-    Lambda5258{{"Lambda[5258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5657{{"Constant[5657∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5657 --> Lambda5258
-    Lambda5267{{"Lambda[5267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5266 --> Lambda5267
-    Lambda5272{{"Lambda[5272∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5658{{"Constant[5658∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant5658 --> Lambda5272
-    Lambda5281{{"Lambda[5281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5280 --> Lambda5281
-    Lambda5286{{"Lambda[5286∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5659{{"Constant[5659∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant5659 --> Lambda5286
+    Object5229 --> Lambda5230
+    Lambda5235{{"Lambda[5235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5869{{"Constant[5869∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5869 --> Lambda5235
+    Lambda5245{{"Lambda[5245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5244 --> Lambda5245
+    Lambda5250{{"Lambda[5250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5870{{"Constant[5870∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5870 --> Lambda5250
+    Lambda5260{{"Lambda[5260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5259 --> Lambda5260
+    Lambda5265{{"Lambda[5265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5871{{"Constant[5871∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5871 --> Lambda5265
+    Lambda5275{{"Lambda[5275∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5274 --> Lambda5275
+    Lambda5280{{"Lambda[5280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5872{{"Constant[5872∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5872 --> Lambda5280
+    Lambda5290{{"Lambda[5290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5289 --> Lambda5290
     Lambda5295{{"Lambda[5295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5294 --> Lambda5295
-    Lambda5300{{"Lambda[5300∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5660{{"Constant[5660∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant5660 --> Lambda5300
-    Lambda5309{{"Lambda[5309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5308 --> Lambda5309
-    Lambda5314{{"Lambda[5314∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5661{{"Constant[5661∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant5661 --> Lambda5314
-    Lambda5323{{"Lambda[5323∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5322 --> Lambda5323
-    Lambda5328{{"Lambda[5328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5662{{"Constant[5662∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant5662 --> Lambda5328
-    Lambda5337{{"Lambda[5337∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5336 --> Lambda5337
-    Lambda5342{{"Lambda[5342∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5663{{"Constant[5663∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant5663 --> Lambda5342
-    Lambda5351{{"Lambda[5351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5350 --> Lambda5351
-    Lambda5356{{"Lambda[5356∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5664{{"Constant[5664∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5664 --> Lambda5356
+    Constant5873{{"Constant[5873∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5873 --> Lambda5295
+    Lambda5305{{"Lambda[5305∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5304 --> Lambda5305
+    Lambda5310{{"Lambda[5310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5874{{"Constant[5874∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5874 --> Lambda5310
+    Lambda5320{{"Lambda[5320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5319 --> Lambda5320
+    Lambda5325{{"Lambda[5325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5875{{"Constant[5875∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5875 --> Lambda5325
+    Lambda5335{{"Lambda[5335∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5334 --> Lambda5335
+    Lambda5340{{"Lambda[5340∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5876{{"Constant[5876∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5876 --> Lambda5340
+    Lambda5350{{"Lambda[5350∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5349 --> Lambda5350
+    Lambda5355{{"Lambda[5355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5877{{"Constant[5877∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5877 --> Lambda5355
     Lambda5365{{"Lambda[5365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object5364 --> Lambda5365
     Lambda5370{{"Lambda[5370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5665{{"Constant[5665∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant5665 --> Lambda5370
-    Lambda5379{{"Lambda[5379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5378 --> Lambda5379
-    Lambda5384{{"Lambda[5384∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5666{{"Constant[5666∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant5666 --> Lambda5384
-    Lambda5393{{"Lambda[5393∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5392 --> Lambda5393
-    Lambda5398{{"Lambda[5398∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5667{{"Constant[5667∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant5667 --> Lambda5398
-    Lambda5407{{"Lambda[5407∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5406 --> Lambda5407
-    Lambda5412{{"Lambda[5412∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant5668{{"Constant[5668∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant5668 --> Lambda5412
+    Constant5878{{"Constant[5878∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant5878 --> Lambda5370
+    Lambda5380{{"Lambda[5380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5379 --> Lambda5380
+    Lambda5385{{"Lambda[5385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5879{{"Constant[5879∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant5879 --> Lambda5385
+    Lambda5395{{"Lambda[5395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5394 --> Lambda5395
+    Lambda5400{{"Lambda[5400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5880{{"Constant[5880∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5880 --> Lambda5400
+    Lambda5410{{"Lambda[5410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5409 --> Lambda5410
+    Lambda5415{{"Lambda[5415∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5881{{"Constant[5881∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5881 --> Lambda5415
+    Lambda5425{{"Lambda[5425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5424 --> Lambda5425
+    Lambda5430{{"Lambda[5430∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5882{{"Constant[5882∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant5882 --> Lambda5430
+    Lambda5440{{"Lambda[5440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5439 --> Lambda5440
+    Lambda5445{{"Lambda[5445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5883{{"Constant[5883∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant5883 --> Lambda5445
+    Lambda5455{{"Lambda[5455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5454 --> Lambda5455
+    Lambda5460{{"Lambda[5460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5884{{"Constant[5884∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant5884 --> Lambda5460
+    Lambda5470{{"Lambda[5470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5469 --> Lambda5470
+    Lambda5475{{"Lambda[5475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5885{{"Constant[5885∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5885 --> Lambda5475
+    Lambda5485{{"Lambda[5485∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5484 --> Lambda5485
+    Lambda5490{{"Lambda[5490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5886{{"Constant[5886∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant5886 --> Lambda5490
+    Lambda5500{{"Lambda[5500∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5499 --> Lambda5500
+    Lambda5505{{"Lambda[5505∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5887{{"Constant[5887∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant5887 --> Lambda5505
+    Lambda5515{{"Lambda[5515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5514 --> Lambda5515
+    Lambda5520{{"Lambda[5520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5888{{"Constant[5888∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant5888 --> Lambda5520
+    Lambda5530{{"Lambda[5530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5529 --> Lambda5530
+    Lambda5535{{"Lambda[5535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5889{{"Constant[5889∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant5889 --> Lambda5535
+    Lambda5545{{"Lambda[5545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5544 --> Lambda5545
+    Lambda5550{{"Lambda[5550∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5890{{"Constant[5890∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant5890 --> Lambda5550
+    Lambda5560{{"Lambda[5560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5559 --> Lambda5560
+    Lambda5565{{"Lambda[5565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5891{{"Constant[5891∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant5891 --> Lambda5565
+    Lambda5575{{"Lambda[5575∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5574 --> Lambda5575
+    Lambda5580{{"Lambda[5580∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5892{{"Constant[5892∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5892 --> Lambda5580
+    Lambda5590{{"Lambda[5590∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5589 --> Lambda5590
+    Lambda5595{{"Lambda[5595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5893{{"Constant[5893∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant5893 --> Lambda5595
+    Lambda5605{{"Lambda[5605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5604 --> Lambda5605
+    Lambda5610{{"Lambda[5610∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5894{{"Constant[5894∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant5894 --> Lambda5610
+    Lambda5620{{"Lambda[5620∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5619 --> Lambda5620
+    Lambda5625{{"Lambda[5625∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5895{{"Constant[5895∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant5895 --> Lambda5625
+    Lambda5635{{"Lambda[5635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5634 --> Lambda5635
+    Lambda5640{{"Lambda[5640∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant5896{{"Constant[5896∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant5896 --> Lambda5640
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant29{{"Constant[29∈0] ➊<br />ᐸ'inputs'ᐳ"}}:::plan
@@ -2145,65 +2147,65 @@ graph TD
     Constant194{{"Constant[194∈0] ➊<br />ᐸ'lists'ᐳ"}}:::plan
     PgSelect443[["PgSelect[443∈1] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object388{{"Object[388∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5413{{"Access[5413∈1] ➊<br />ᐸ10.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5414{{"Access[5414∈1] ➊<br />ᐸ10.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5641{{"Access[5641∈1] ➊<br />ᐸ10.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5642{{"Access[5642∈1] ➊<br />ᐸ10.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object388 -->|rejectNull| PgSelect443
-    Access5413 -->|rejectNull| PgSelect443
-    Access5414 & Lambda2221 & Lambda2224 & Lambda2313 & Lambda2318 --> PgSelect443
+    Access5641 -->|rejectNull| PgSelect443
+    Access5642 & Lambda2221 & Access2225 & Lambda2320 & Lambda2325 --> PgSelect443
     PgSelect385[["PgSelect[385∈1] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object388 -->|rejectNull| PgSelect385
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2229 & Lambda2234 --> PgSelect385
+    Access5641 & Lambda2221 & Access2225 & Lambda2230 & Lambda2235 --> PgSelect385
     PgSelect396[["PgSelect[396∈1] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object388 -->|rejectNull| PgSelect396
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2243 & Lambda2248 --> PgSelect396
+    Access5641 & Lambda2221 & Access2225 & Lambda2245 & Lambda2250 --> PgSelect396
     PgSelect405[["PgSelect[405∈1] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object388 -->|rejectNull| PgSelect405
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2257 & Lambda2262 --> PgSelect405
+    Access5641 & Lambda2221 & Access2225 & Lambda2260 & Lambda2265 --> PgSelect405
     PgSelect414[["PgSelect[414∈1] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect414
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2271 & Lambda2276 --> PgSelect414
+    Access5641 & Lambda2221 & Access2225 & Lambda2275 & Lambda2280 --> PgSelect414
     PgSelect423[["PgSelect[423∈1] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect423
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2285 & Lambda2290 --> PgSelect423
+    Access5641 & Lambda2221 & Access2225 & Lambda2290 & Lambda2295 --> PgSelect423
     PgSelect432[["PgSelect[432∈1] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object388 -->|rejectNull| PgSelect432
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2299 & Lambda2304 --> PgSelect432
+    Access5641 & Lambda2221 & Access2225 & Lambda2305 & Lambda2310 --> PgSelect432
     PgSelect453[["PgSelect[453∈1] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object388 -->|rejectNull| PgSelect453
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2327 & Lambda2332 --> PgSelect453
+    Access5641 & Lambda2221 & Access2225 & Lambda2335 & Lambda2340 --> PgSelect453
     PgSelect462[["PgSelect[462∈1] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object388 -->|rejectNull| PgSelect462
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2341 & Lambda2346 --> PgSelect462
+    Access5641 & Lambda2221 & Access2225 & Lambda2350 & Lambda2355 --> PgSelect462
     PgSelect471[["PgSelect[471∈1] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object388 -->|rejectNull| PgSelect471
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2355 & Lambda2360 --> PgSelect471
+    Access5641 & Lambda2221 & Access2225 & Lambda2365 & Lambda2370 --> PgSelect471
     PgSelect480[["PgSelect[480∈1] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object388 -->|rejectNull| PgSelect480
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2369 & Lambda2374 --> PgSelect480
+    Access5641 & Lambda2221 & Access2225 & Lambda2380 & Lambda2385 --> PgSelect480
     PgSelect489[["PgSelect[489∈1] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object388 -->|rejectNull| PgSelect489
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2383 & Lambda2388 --> PgSelect489
+    Access5641 & Lambda2221 & Access2225 & Lambda2395 & Lambda2400 --> PgSelect489
     PgSelect498[["PgSelect[498∈1] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object388 -->|rejectNull| PgSelect498
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2397 & Lambda2402 --> PgSelect498
+    Access5641 & Lambda2221 & Access2225 & Lambda2410 & Lambda2415 --> PgSelect498
     PgSelect507[["PgSelect[507∈1] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object388 -->|rejectNull| PgSelect507
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2411 & Lambda2416 --> PgSelect507
+    Access5641 & Lambda2221 & Access2225 & Lambda2425 & Lambda2430 --> PgSelect507
     PgSelect516[["PgSelect[516∈1] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object388 -->|rejectNull| PgSelect516
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2425 & Lambda2430 --> PgSelect516
+    Access5641 & Lambda2221 & Access2225 & Lambda2440 & Lambda2445 --> PgSelect516
     PgSelect525[["PgSelect[525∈1] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object388 -->|rejectNull| PgSelect525
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2439 & Lambda2444 --> PgSelect525
+    Access5641 & Lambda2221 & Access2225 & Lambda2455 & Lambda2460 --> PgSelect525
     PgSelect534[["PgSelect[534∈1] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect534
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2453 & Lambda2458 --> PgSelect534
+    Access5641 & Lambda2221 & Access2225 & Lambda2470 & Lambda2475 --> PgSelect534
     PgSelect543[["PgSelect[543∈1] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object388 -->|rejectNull| PgSelect543
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2467 & Lambda2472 --> PgSelect543
+    Access5641 & Lambda2221 & Access2225 & Lambda2485 & Lambda2490 --> PgSelect543
     PgSelect552[["PgSelect[552∈1] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object388 -->|rejectNull| PgSelect552
-    Access5413 & Lambda2221 & Lambda2224 & Lambda2481 & Lambda2486 --> PgSelect552
+    Access5641 & Lambda2221 & Access2225 & Lambda2500 & Lambda2505 --> PgSelect552
     List450{{"List[450∈1] ➊<br />ᐸ85,448,449ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression448{{"PgClassExpression[448∈1] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression449{{"PgClassExpression[449∈1] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -2268,7 +2270,7 @@ graph TD
     Node15{{"Node[15∈1] ➊"}}:::plan
     Lambda16{{"Lambda[16∈1] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ<br />ᐳQuery"}}:::plan
     Lambda16 --> Node15
-    Constant5415 --> Lambda16
+    Constant5643 --> Lambda16
     Node199{{"Node[199∈1] ➊"}}:::plan
     Lambda200{{"Lambda[200∈1] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ<br />ᐳQuery"}}:::plan
     Lambda200 --> Node199
@@ -2409,68 +2411,68 @@ graph TD
     PgSelectSingle555 --> PgClassExpression557
     Lambda559{{"Lambda[559∈1] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List558 --> Lambda559
-    Lambda10 --> Access5413
-    Lambda10 --> Access5414
+    Lambda10 --> Access5641
+    Lambda10 --> Access5642
     PgSelect81[["PgSelect[81∈2] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access5416{{"Access[5416∈2] ➊<br />ᐸ16.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
-    Access5417{{"Access[5417∈2] ➊<br />ᐸ16.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
+    Access5644{{"Access[5644∈2] ➊<br />ᐸ16.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access5645{{"Access[5645∈2] ➊<br />ᐸ16.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object388 -->|rejectNull| PgSelect81
-    Access5416 -->|rejectNull| PgSelect81
-    Access5417 & Lambda2221 & Lambda2224 & Lambda2579 & Lambda2584 --> PgSelect81
+    Access5644 -->|rejectNull| PgSelect81
+    Access5645 & Lambda2221 & Access2225 & Lambda2605 & Lambda2610 --> PgSelect81
     PgSelect23[["PgSelect[23∈2] ➊<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
     Object388 -->|rejectNull| PgSelect23
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2495 & Lambda2500 --> PgSelect23
+    Access5644 & Lambda2221 & Access2225 & Lambda2515 & Lambda2520 --> PgSelect23
     PgSelect34[["PgSelect[34∈2] ➊<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
     Object388 -->|rejectNull| PgSelect34
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2509 & Lambda2514 --> PgSelect34
+    Access5644 & Lambda2221 & Access2225 & Lambda2530 & Lambda2535 --> PgSelect34
     PgSelect43[["PgSelect[43∈2] ➊<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
     Object388 -->|rejectNull| PgSelect43
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2523 & Lambda2528 --> PgSelect43
+    Access5644 & Lambda2221 & Access2225 & Lambda2545 & Lambda2550 --> PgSelect43
     PgSelect52[["PgSelect[52∈2] ➊<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect52
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2537 & Lambda2542 --> PgSelect52
+    Access5644 & Lambda2221 & Access2225 & Lambda2560 & Lambda2565 --> PgSelect52
     PgSelect61[["PgSelect[61∈2] ➊<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect61
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2551 & Lambda2556 --> PgSelect61
+    Access5644 & Lambda2221 & Access2225 & Lambda2575 & Lambda2580 --> PgSelect61
     PgSelect70[["PgSelect[70∈2] ➊<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
     Object388 -->|rejectNull| PgSelect70
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2565 & Lambda2570 --> PgSelect70
+    Access5644 & Lambda2221 & Access2225 & Lambda2590 & Lambda2595 --> PgSelect70
     PgSelect91[["PgSelect[91∈2] ➊<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
     Object388 -->|rejectNull| PgSelect91
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2593 & Lambda2598 --> PgSelect91
+    Access5644 & Lambda2221 & Access2225 & Lambda2620 & Lambda2625 --> PgSelect91
     PgSelect100[["PgSelect[100∈2] ➊<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
     Object388 -->|rejectNull| PgSelect100
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2607 & Lambda2612 --> PgSelect100
+    Access5644 & Lambda2221 & Access2225 & Lambda2635 & Lambda2640 --> PgSelect100
     PgSelect109[["PgSelect[109∈2] ➊<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
     Object388 -->|rejectNull| PgSelect109
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2621 & Lambda2626 --> PgSelect109
+    Access5644 & Lambda2221 & Access2225 & Lambda2650 & Lambda2655 --> PgSelect109
     PgSelect118[["PgSelect[118∈2] ➊<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
     Object388 -->|rejectNull| PgSelect118
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2635 & Lambda2640 --> PgSelect118
+    Access5644 & Lambda2221 & Access2225 & Lambda2665 & Lambda2670 --> PgSelect118
     PgSelect127[["PgSelect[127∈2] ➊<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
     Object388 -->|rejectNull| PgSelect127
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2649 & Lambda2654 --> PgSelect127
+    Access5644 & Lambda2221 & Access2225 & Lambda2680 & Lambda2685 --> PgSelect127
     PgSelect136[["PgSelect[136∈2] ➊<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
     Object388 -->|rejectNull| PgSelect136
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2663 & Lambda2668 --> PgSelect136
+    Access5644 & Lambda2221 & Access2225 & Lambda2695 & Lambda2700 --> PgSelect136
     PgSelect145[["PgSelect[145∈2] ➊<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
     Object388 -->|rejectNull| PgSelect145
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2677 & Lambda2682 --> PgSelect145
+    Access5644 & Lambda2221 & Access2225 & Lambda2710 & Lambda2715 --> PgSelect145
     PgSelect154[["PgSelect[154∈2] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
     Object388 -->|rejectNull| PgSelect154
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2691 & Lambda2696 --> PgSelect154
+    Access5644 & Lambda2221 & Access2225 & Lambda2725 & Lambda2730 --> PgSelect154
     PgSelect163[["PgSelect[163∈2] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
     Object388 -->|rejectNull| PgSelect163
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2705 & Lambda2710 --> PgSelect163
+    Access5644 & Lambda2221 & Access2225 & Lambda2740 & Lambda2745 --> PgSelect163
     PgSelect172[["PgSelect[172∈2] ➊<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect172
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2719 & Lambda2724 --> PgSelect172
+    Access5644 & Lambda2221 & Access2225 & Lambda2755 & Lambda2760 --> PgSelect172
     PgSelect181[["PgSelect[181∈2] ➊<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
     Object388 -->|rejectNull| PgSelect181
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2733 & Lambda2738 --> PgSelect181
+    Access5644 & Lambda2221 & Access2225 & Lambda2770 & Lambda2775 --> PgSelect181
     PgSelect190[["PgSelect[190∈2] ➊<br />ᐸlistsᐳ<br />ᐳQueryᐳList"]]:::plan
     Object388 -->|rejectNull| PgSelect190
-    Access5416 & Lambda2221 & Lambda2224 & Lambda2747 & Lambda2752 --> PgSelect190
+    Access5644 & Lambda2221 & Access2225 & Lambda2785 & Lambda2790 --> PgSelect190
     List88{{"List[88∈2] ➊<br />ᐸ85,86,87ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression86{{"PgClassExpression[86∈2] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression87{{"PgClassExpression[87∈2] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -2663,68 +2665,68 @@ graph TD
     PgSelectSingle193 --> PgClassExpression195
     Lambda197{{"Lambda[197∈2] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List196 --> Lambda197
-    Lambda16 --> Access5416
-    Lambda16 --> Access5417
+    Lambda16 --> Access5644
+    Lambda16 --> Access5645
     PgSelect265[["PgSelect[265∈3] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access5418{{"Access[5418∈3] ➊<br />ᐸ200.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
-    Access5419{{"Access[5419∈3] ➊<br />ᐸ200.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
+    Access5646{{"Access[5646∈3] ➊<br />ᐸ200.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access5647{{"Access[5647∈3] ➊<br />ᐸ200.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object388 -->|rejectNull| PgSelect265
-    Access5418 -->|rejectNull| PgSelect265
-    Access5419 & Lambda2221 & Lambda2224 & Lambda2845 & Lambda2850 --> PgSelect265
+    Access5646 -->|rejectNull| PgSelect265
+    Access5647 & Lambda2221 & Access2225 & Lambda2890 & Lambda2895 --> PgSelect265
     PgSelect207[["PgSelect[207∈3] ➊<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
     Object388 -->|rejectNull| PgSelect207
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2761 & Lambda2766 --> PgSelect207
+    Access5646 & Lambda2221 & Access2225 & Lambda2800 & Lambda2805 --> PgSelect207
     PgSelect218[["PgSelect[218∈3] ➊<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
     Object388 -->|rejectNull| PgSelect218
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2775 & Lambda2780 --> PgSelect218
+    Access5646 & Lambda2221 & Access2225 & Lambda2815 & Lambda2820 --> PgSelect218
     PgSelect227[["PgSelect[227∈3] ➊<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
     Object388 -->|rejectNull| PgSelect227
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2789 & Lambda2794 --> PgSelect227
+    Access5646 & Lambda2221 & Access2225 & Lambda2830 & Lambda2835 --> PgSelect227
     PgSelect236[["PgSelect[236∈3] ➊<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect236
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2803 & Lambda2808 --> PgSelect236
+    Access5646 & Lambda2221 & Access2225 & Lambda2845 & Lambda2850 --> PgSelect236
     PgSelect245[["PgSelect[245∈3] ➊<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect245
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2817 & Lambda2822 --> PgSelect245
+    Access5646 & Lambda2221 & Access2225 & Lambda2860 & Lambda2865 --> PgSelect245
     PgSelect254[["PgSelect[254∈3] ➊<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
     Object388 -->|rejectNull| PgSelect254
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2831 & Lambda2836 --> PgSelect254
+    Access5646 & Lambda2221 & Access2225 & Lambda2875 & Lambda2880 --> PgSelect254
     PgSelect275[["PgSelect[275∈3] ➊<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
     Object388 -->|rejectNull| PgSelect275
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2859 & Lambda2864 --> PgSelect275
+    Access5646 & Lambda2221 & Access2225 & Lambda2905 & Lambda2910 --> PgSelect275
     PgSelect284[["PgSelect[284∈3] ➊<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
     Object388 -->|rejectNull| PgSelect284
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2873 & Lambda2878 --> PgSelect284
+    Access5646 & Lambda2221 & Access2225 & Lambda2920 & Lambda2925 --> PgSelect284
     PgSelect293[["PgSelect[293∈3] ➊<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
     Object388 -->|rejectNull| PgSelect293
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2887 & Lambda2892 --> PgSelect293
+    Access5646 & Lambda2221 & Access2225 & Lambda2935 & Lambda2940 --> PgSelect293
     PgSelect302[["PgSelect[302∈3] ➊<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
     Object388 -->|rejectNull| PgSelect302
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2901 & Lambda2906 --> PgSelect302
+    Access5646 & Lambda2221 & Access2225 & Lambda2950 & Lambda2955 --> PgSelect302
     PgSelect311[["PgSelect[311∈3] ➊<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
     Object388 -->|rejectNull| PgSelect311
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2915 & Lambda2920 --> PgSelect311
+    Access5646 & Lambda2221 & Access2225 & Lambda2965 & Lambda2970 --> PgSelect311
     PgSelect320[["PgSelect[320∈3] ➊<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
     Object388 -->|rejectNull| PgSelect320
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2929 & Lambda2934 --> PgSelect320
+    Access5646 & Lambda2221 & Access2225 & Lambda2980 & Lambda2985 --> PgSelect320
     PgSelect329[["PgSelect[329∈3] ➊<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
     Object388 -->|rejectNull| PgSelect329
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2943 & Lambda2948 --> PgSelect329
+    Access5646 & Lambda2221 & Access2225 & Lambda2995 & Lambda3000 --> PgSelect329
     PgSelect338[["PgSelect[338∈3] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
     Object388 -->|rejectNull| PgSelect338
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2957 & Lambda2962 --> PgSelect338
+    Access5646 & Lambda2221 & Access2225 & Lambda3010 & Lambda3015 --> PgSelect338
     PgSelect347[["PgSelect[347∈3] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
     Object388 -->|rejectNull| PgSelect347
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2971 & Lambda2976 --> PgSelect347
+    Access5646 & Lambda2221 & Access2225 & Lambda3025 & Lambda3030 --> PgSelect347
     PgSelect356[["PgSelect[356∈3] ➊<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
     Object388 -->|rejectNull| PgSelect356
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2985 & Lambda2990 --> PgSelect356
+    Access5646 & Lambda2221 & Access2225 & Lambda3040 & Lambda3045 --> PgSelect356
     PgSelect365[["PgSelect[365∈3] ➊<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
     Object388 -->|rejectNull| PgSelect365
-    Access5418 & Lambda2221 & Lambda2224 & Lambda2999 & Lambda3004 --> PgSelect365
+    Access5646 & Lambda2221 & Access2225 & Lambda3055 & Lambda3060 --> PgSelect365
     PgSelect374[["PgSelect[374∈3] ➊<br />ᐸlistsᐳ<br />ᐳQueryᐳList"]]:::plan
     Object388 -->|rejectNull| PgSelect374
-    Access5418 & Lambda2221 & Lambda2224 & Lambda3013 & Lambda3018 --> PgSelect374
+    Access5646 & Lambda2221 & Access2225 & Lambda3070 & Lambda3075 --> PgSelect374
     List272{{"List[272∈3] ➊<br />ᐸ85,270,271ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression270{{"PgClassExpression[270∈3] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression271{{"PgClassExpression[271∈3] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -2917,69 +2919,69 @@ graph TD
     PgSelectSingle377 --> PgClassExpression379
     Lambda381{{"Lambda[381∈3] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List380 --> Lambda381
-    Lambda200 --> Access5418
-    Lambda200 --> Access5419
+    Lambda200 --> Access5646
+    Lambda200 --> Access5647
     PgSelect995[["PgSelect[995∈4] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object940{{"Object[940∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5421{{"Access[5421∈4] ➊<br />ᐸ562.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5422{{"Access[5422∈4] ➊<br />ᐸ562.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5649{{"Access[5649∈4] ➊<br />ᐸ562.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5650{{"Access[5650∈4] ➊<br />ᐸ562.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object940 -->|rejectNull| PgSelect995
-    Access5421 -->|rejectNull| PgSelect995
-    Access5422 & Lambda2221 & Lambda2224 & Lambda3111 & Lambda3116 --> PgSelect995
+    Access5649 -->|rejectNull| PgSelect995
+    Access5650 & Lambda2221 & Access2225 & Lambda3175 & Lambda3180 --> PgSelect995
     PgSelect937[["PgSelect[937∈4] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object940 -->|rejectNull| PgSelect937
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3027 & Lambda3032 --> PgSelect937
+    Access5649 & Lambda2221 & Access2225 & Lambda3085 & Lambda3090 --> PgSelect937
     PgSelect948[["PgSelect[948∈4] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object940 -->|rejectNull| PgSelect948
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3041 & Lambda3046 --> PgSelect948
+    Access5649 & Lambda2221 & Access2225 & Lambda3100 & Lambda3105 --> PgSelect948
     PgSelect957[["PgSelect[957∈4] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object940 -->|rejectNull| PgSelect957
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3055 & Lambda3060 --> PgSelect957
+    Access5649 & Lambda2221 & Access2225 & Lambda3115 & Lambda3120 --> PgSelect957
     PgSelect966[["PgSelect[966∈4] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect966
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3069 & Lambda3074 --> PgSelect966
+    Access5649 & Lambda2221 & Access2225 & Lambda3130 & Lambda3135 --> PgSelect966
     PgSelect975[["PgSelect[975∈4] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect975
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3083 & Lambda3088 --> PgSelect975
+    Access5649 & Lambda2221 & Access2225 & Lambda3145 & Lambda3150 --> PgSelect975
     PgSelect984[["PgSelect[984∈4] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object940 -->|rejectNull| PgSelect984
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3097 & Lambda3102 --> PgSelect984
+    Access5649 & Lambda2221 & Access2225 & Lambda3160 & Lambda3165 --> PgSelect984
     PgSelect1005[["PgSelect[1005∈4] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object940 -->|rejectNull| PgSelect1005
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3125 & Lambda3130 --> PgSelect1005
+    Access5649 & Lambda2221 & Access2225 & Lambda3190 & Lambda3195 --> PgSelect1005
     PgSelect1014[["PgSelect[1014∈4] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object940 -->|rejectNull| PgSelect1014
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3139 & Lambda3144 --> PgSelect1014
+    Access5649 & Lambda2221 & Access2225 & Lambda3205 & Lambda3210 --> PgSelect1014
     PgSelect1023[["PgSelect[1023∈4] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object940 -->|rejectNull| PgSelect1023
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3153 & Lambda3158 --> PgSelect1023
+    Access5649 & Lambda2221 & Access2225 & Lambda3220 & Lambda3225 --> PgSelect1023
     PgSelect1032[["PgSelect[1032∈4] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object940 -->|rejectNull| PgSelect1032
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3167 & Lambda3172 --> PgSelect1032
+    Access5649 & Lambda2221 & Access2225 & Lambda3235 & Lambda3240 --> PgSelect1032
     PgSelect1041[["PgSelect[1041∈4] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object940 -->|rejectNull| PgSelect1041
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3181 & Lambda3186 --> PgSelect1041
+    Access5649 & Lambda2221 & Access2225 & Lambda3250 & Lambda3255 --> PgSelect1041
     PgSelect1050[["PgSelect[1050∈4] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object940 -->|rejectNull| PgSelect1050
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3195 & Lambda3200 --> PgSelect1050
+    Access5649 & Lambda2221 & Access2225 & Lambda3265 & Lambda3270 --> PgSelect1050
     PgSelect1059[["PgSelect[1059∈4] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object940 -->|rejectNull| PgSelect1059
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3209 & Lambda3214 --> PgSelect1059
+    Access5649 & Lambda2221 & Access2225 & Lambda3280 & Lambda3285 --> PgSelect1059
     PgSelect1068[["PgSelect[1068∈4] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object940 -->|rejectNull| PgSelect1068
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3223 & Lambda3228 --> PgSelect1068
+    Access5649 & Lambda2221 & Access2225 & Lambda3295 & Lambda3300 --> PgSelect1068
     PgSelect1077[["PgSelect[1077∈4] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object940 -->|rejectNull| PgSelect1077
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3237 & Lambda3242 --> PgSelect1077
+    Access5649 & Lambda2221 & Access2225 & Lambda3310 & Lambda3315 --> PgSelect1077
     PgSelect1086[["PgSelect[1086∈4] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect1086
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3251 & Lambda3256 --> PgSelect1086
+    Access5649 & Lambda2221 & Access2225 & Lambda3325 & Lambda3330 --> PgSelect1086
     PgSelect1095[["PgSelect[1095∈4] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object940 -->|rejectNull| PgSelect1095
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3265 & Lambda3270 --> PgSelect1095
+    Access5649 & Lambda2221 & Access2225 & Lambda3340 & Lambda3345 --> PgSelect1095
     PgSelect1104[["PgSelect[1104∈4] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object940 -->|rejectNull| PgSelect1104
-    Access5421 & Lambda2221 & Lambda2224 & Lambda3279 & Lambda3284 --> PgSelect1104
+    Access5649 & Lambda2221 & Access2225 & Lambda3355 & Lambda3360 --> PgSelect1104
     List1002{{"List[1002∈4] ➊<br />ᐸ85,1000,1001ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1000{{"PgClassExpression[1000∈4] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1001{{"PgClassExpression[1001∈4] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3044,7 +3046,7 @@ graph TD
     Node567{{"Node[567∈4] ➊"}}:::plan
     Lambda568{{"Lambda[568∈4] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ<br />ᐳQuery"}}:::plan
     Lambda568 --> Node567
-    Constant5415 --> Lambda568
+    Constant5643 --> Lambda568
     Node751{{"Node[751∈4] ➊"}}:::plan
     Lambda752{{"Lambda[752∈4] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ<br />ᐳQuery"}}:::plan
     Lambda752 --> Node751
@@ -3185,68 +3187,68 @@ graph TD
     PgSelectSingle1107 --> PgClassExpression1109
     Lambda1111{{"Lambda[1111∈4] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1110 --> Lambda1111
-    Lambda562 --> Access5421
-    Lambda562 --> Access5422
+    Lambda562 --> Access5649
+    Lambda562 --> Access5650
     PgSelect633[["PgSelect[633∈5] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access5423{{"Access[5423∈5] ➊<br />ᐸ568.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
-    Access5424{{"Access[5424∈5] ➊<br />ᐸ568.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
+    Access5651{{"Access[5651∈5] ➊<br />ᐸ568.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access5652{{"Access[5652∈5] ➊<br />ᐸ568.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object940 -->|rejectNull| PgSelect633
-    Access5423 -->|rejectNull| PgSelect633
-    Access5424 & Lambda2221 & Lambda2224 & Lambda3377 & Lambda3382 --> PgSelect633
+    Access5651 -->|rejectNull| PgSelect633
+    Access5652 & Lambda2221 & Access2225 & Lambda3460 & Lambda3465 --> PgSelect633
     PgSelect575[["PgSelect[575∈5] ➊<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
     Object940 -->|rejectNull| PgSelect575
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3293 & Lambda3298 --> PgSelect575
+    Access5651 & Lambda2221 & Access2225 & Lambda3370 & Lambda3375 --> PgSelect575
     PgSelect586[["PgSelect[586∈5] ➊<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
     Object940 -->|rejectNull| PgSelect586
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3307 & Lambda3312 --> PgSelect586
+    Access5651 & Lambda2221 & Access2225 & Lambda3385 & Lambda3390 --> PgSelect586
     PgSelect595[["PgSelect[595∈5] ➊<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
     Object940 -->|rejectNull| PgSelect595
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3321 & Lambda3326 --> PgSelect595
+    Access5651 & Lambda2221 & Access2225 & Lambda3400 & Lambda3405 --> PgSelect595
     PgSelect604[["PgSelect[604∈5] ➊<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect604
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3335 & Lambda3340 --> PgSelect604
+    Access5651 & Lambda2221 & Access2225 & Lambda3415 & Lambda3420 --> PgSelect604
     PgSelect613[["PgSelect[613∈5] ➊<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect613
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3349 & Lambda3354 --> PgSelect613
+    Access5651 & Lambda2221 & Access2225 & Lambda3430 & Lambda3435 --> PgSelect613
     PgSelect622[["PgSelect[622∈5] ➊<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
     Object940 -->|rejectNull| PgSelect622
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3363 & Lambda3368 --> PgSelect622
+    Access5651 & Lambda2221 & Access2225 & Lambda3445 & Lambda3450 --> PgSelect622
     PgSelect643[["PgSelect[643∈5] ➊<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
     Object940 -->|rejectNull| PgSelect643
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3391 & Lambda3396 --> PgSelect643
+    Access5651 & Lambda2221 & Access2225 & Lambda3475 & Lambda3480 --> PgSelect643
     PgSelect652[["PgSelect[652∈5] ➊<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
     Object940 -->|rejectNull| PgSelect652
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3405 & Lambda3410 --> PgSelect652
+    Access5651 & Lambda2221 & Access2225 & Lambda3490 & Lambda3495 --> PgSelect652
     PgSelect661[["PgSelect[661∈5] ➊<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
     Object940 -->|rejectNull| PgSelect661
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3419 & Lambda3424 --> PgSelect661
+    Access5651 & Lambda2221 & Access2225 & Lambda3505 & Lambda3510 --> PgSelect661
     PgSelect670[["PgSelect[670∈5] ➊<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
     Object940 -->|rejectNull| PgSelect670
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3433 & Lambda3438 --> PgSelect670
+    Access5651 & Lambda2221 & Access2225 & Lambda3520 & Lambda3525 --> PgSelect670
     PgSelect679[["PgSelect[679∈5] ➊<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
     Object940 -->|rejectNull| PgSelect679
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3447 & Lambda3452 --> PgSelect679
+    Access5651 & Lambda2221 & Access2225 & Lambda3535 & Lambda3540 --> PgSelect679
     PgSelect688[["PgSelect[688∈5] ➊<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
     Object940 -->|rejectNull| PgSelect688
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3461 & Lambda3466 --> PgSelect688
+    Access5651 & Lambda2221 & Access2225 & Lambda3550 & Lambda3555 --> PgSelect688
     PgSelect697[["PgSelect[697∈5] ➊<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
     Object940 -->|rejectNull| PgSelect697
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3475 & Lambda3480 --> PgSelect697
+    Access5651 & Lambda2221 & Access2225 & Lambda3565 & Lambda3570 --> PgSelect697
     PgSelect706[["PgSelect[706∈5] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
     Object940 -->|rejectNull| PgSelect706
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3489 & Lambda3494 --> PgSelect706
+    Access5651 & Lambda2221 & Access2225 & Lambda3580 & Lambda3585 --> PgSelect706
     PgSelect715[["PgSelect[715∈5] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
     Object940 -->|rejectNull| PgSelect715
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3503 & Lambda3508 --> PgSelect715
+    Access5651 & Lambda2221 & Access2225 & Lambda3595 & Lambda3600 --> PgSelect715
     PgSelect724[["PgSelect[724∈5] ➊<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect724
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3517 & Lambda3522 --> PgSelect724
+    Access5651 & Lambda2221 & Access2225 & Lambda3610 & Lambda3615 --> PgSelect724
     PgSelect733[["PgSelect[733∈5] ➊<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
     Object940 -->|rejectNull| PgSelect733
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3531 & Lambda3536 --> PgSelect733
+    Access5651 & Lambda2221 & Access2225 & Lambda3625 & Lambda3630 --> PgSelect733
     PgSelect742[["PgSelect[742∈5] ➊<br />ᐸlistsᐳ<br />ᐳQueryᐳList"]]:::plan
     Object940 -->|rejectNull| PgSelect742
-    Access5423 & Lambda2221 & Lambda2224 & Lambda3545 & Lambda3550 --> PgSelect742
+    Access5651 & Lambda2221 & Access2225 & Lambda3640 & Lambda3645 --> PgSelect742
     List640{{"List[640∈5] ➊<br />ᐸ85,638,639ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression638{{"PgClassExpression[638∈5] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression639{{"PgClassExpression[639∈5] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3439,68 +3441,68 @@ graph TD
     PgSelectSingle745 --> PgClassExpression747
     Lambda749{{"Lambda[749∈5] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List748 --> Lambda749
-    Lambda568 --> Access5423
-    Lambda568 --> Access5424
+    Lambda568 --> Access5651
+    Lambda568 --> Access5652
     PgSelect817[["PgSelect[817∈6] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access5425{{"Access[5425∈6] ➊<br />ᐸ752.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
-    Access5426{{"Access[5426∈6] ➊<br />ᐸ752.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
+    Access5653{{"Access[5653∈6] ➊<br />ᐸ752.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access5654{{"Access[5654∈6] ➊<br />ᐸ752.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object940 -->|rejectNull| PgSelect817
-    Access5425 -->|rejectNull| PgSelect817
-    Access5426 & Lambda2221 & Lambda2224 & Lambda3643 & Lambda3648 --> PgSelect817
+    Access5653 -->|rejectNull| PgSelect817
+    Access5654 & Lambda2221 & Access2225 & Lambda3745 & Lambda3750 --> PgSelect817
     PgSelect759[["PgSelect[759∈6] ➊<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
     Object940 -->|rejectNull| PgSelect759
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3559 & Lambda3564 --> PgSelect759
+    Access5653 & Lambda2221 & Access2225 & Lambda3655 & Lambda3660 --> PgSelect759
     PgSelect770[["PgSelect[770∈6] ➊<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
     Object940 -->|rejectNull| PgSelect770
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3573 & Lambda3578 --> PgSelect770
+    Access5653 & Lambda2221 & Access2225 & Lambda3670 & Lambda3675 --> PgSelect770
     PgSelect779[["PgSelect[779∈6] ➊<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
     Object940 -->|rejectNull| PgSelect779
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3587 & Lambda3592 --> PgSelect779
+    Access5653 & Lambda2221 & Access2225 & Lambda3685 & Lambda3690 --> PgSelect779
     PgSelect788[["PgSelect[788∈6] ➊<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect788
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3601 & Lambda3606 --> PgSelect788
+    Access5653 & Lambda2221 & Access2225 & Lambda3700 & Lambda3705 --> PgSelect788
     PgSelect797[["PgSelect[797∈6] ➊<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect797
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3615 & Lambda3620 --> PgSelect797
+    Access5653 & Lambda2221 & Access2225 & Lambda3715 & Lambda3720 --> PgSelect797
     PgSelect806[["PgSelect[806∈6] ➊<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
     Object940 -->|rejectNull| PgSelect806
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3629 & Lambda3634 --> PgSelect806
+    Access5653 & Lambda2221 & Access2225 & Lambda3730 & Lambda3735 --> PgSelect806
     PgSelect827[["PgSelect[827∈6] ➊<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
     Object940 -->|rejectNull| PgSelect827
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3657 & Lambda3662 --> PgSelect827
+    Access5653 & Lambda2221 & Access2225 & Lambda3760 & Lambda3765 --> PgSelect827
     PgSelect836[["PgSelect[836∈6] ➊<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
     Object940 -->|rejectNull| PgSelect836
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3671 & Lambda3676 --> PgSelect836
+    Access5653 & Lambda2221 & Access2225 & Lambda3775 & Lambda3780 --> PgSelect836
     PgSelect845[["PgSelect[845∈6] ➊<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
     Object940 -->|rejectNull| PgSelect845
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3685 & Lambda3690 --> PgSelect845
+    Access5653 & Lambda2221 & Access2225 & Lambda3790 & Lambda3795 --> PgSelect845
     PgSelect854[["PgSelect[854∈6] ➊<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
     Object940 -->|rejectNull| PgSelect854
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3699 & Lambda3704 --> PgSelect854
+    Access5653 & Lambda2221 & Access2225 & Lambda3805 & Lambda3810 --> PgSelect854
     PgSelect863[["PgSelect[863∈6] ➊<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
     Object940 -->|rejectNull| PgSelect863
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3713 & Lambda3718 --> PgSelect863
+    Access5653 & Lambda2221 & Access2225 & Lambda3820 & Lambda3825 --> PgSelect863
     PgSelect872[["PgSelect[872∈6] ➊<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
     Object940 -->|rejectNull| PgSelect872
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3727 & Lambda3732 --> PgSelect872
+    Access5653 & Lambda2221 & Access2225 & Lambda3835 & Lambda3840 --> PgSelect872
     PgSelect881[["PgSelect[881∈6] ➊<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
     Object940 -->|rejectNull| PgSelect881
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3741 & Lambda3746 --> PgSelect881
+    Access5653 & Lambda2221 & Access2225 & Lambda3850 & Lambda3855 --> PgSelect881
     PgSelect890[["PgSelect[890∈6] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
     Object940 -->|rejectNull| PgSelect890
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3755 & Lambda3760 --> PgSelect890
+    Access5653 & Lambda2221 & Access2225 & Lambda3865 & Lambda3870 --> PgSelect890
     PgSelect899[["PgSelect[899∈6] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
     Object940 -->|rejectNull| PgSelect899
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3769 & Lambda3774 --> PgSelect899
+    Access5653 & Lambda2221 & Access2225 & Lambda3880 & Lambda3885 --> PgSelect899
     PgSelect908[["PgSelect[908∈6] ➊<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
     Object940 -->|rejectNull| PgSelect908
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3783 & Lambda3788 --> PgSelect908
+    Access5653 & Lambda2221 & Access2225 & Lambda3895 & Lambda3900 --> PgSelect908
     PgSelect917[["PgSelect[917∈6] ➊<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
     Object940 -->|rejectNull| PgSelect917
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3797 & Lambda3802 --> PgSelect917
+    Access5653 & Lambda2221 & Access2225 & Lambda3910 & Lambda3915 --> PgSelect917
     PgSelect926[["PgSelect[926∈6] ➊<br />ᐸlistsᐳ<br />ᐳQueryᐳList"]]:::plan
     Object940 -->|rejectNull| PgSelect926
-    Access5425 & Lambda2221 & Lambda2224 & Lambda3811 & Lambda3816 --> PgSelect926
+    Access5653 & Lambda2221 & Access2225 & Lambda3925 & Lambda3930 --> PgSelect926
     List824{{"List[824∈6] ➊<br />ᐸ85,822,823ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression822{{"PgClassExpression[822∈6] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression823{{"PgClassExpression[823∈6] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3693,69 +3695,69 @@ graph TD
     PgSelectSingle929 --> PgClassExpression931
     Lambda933{{"Lambda[933∈6] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List932 --> Lambda933
-    Lambda752 --> Access5425
-    Lambda752 --> Access5426
+    Lambda752 --> Access5653
+    Lambda752 --> Access5654
     PgSelect1180[["PgSelect[1180∈7] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1125{{"Object[1125∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5427{{"Access[5427∈7] ➊<br />ᐸ1115.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5428{{"Access[5428∈7] ➊<br />ᐸ1115.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5655{{"Access[5655∈7] ➊<br />ᐸ1115.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5656{{"Access[5656∈7] ➊<br />ᐸ1115.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1125 -->|rejectNull| PgSelect1180
-    Access5427 -->|rejectNull| PgSelect1180
-    Access5428 & Lambda2221 & Lambda2224 & Lambda3909 & Lambda3914 --> PgSelect1180
+    Access5655 -->|rejectNull| PgSelect1180
+    Access5656 & Lambda2221 & Access2225 & Lambda4030 & Lambda4035 --> PgSelect1180
     PgSelect1122[["PgSelect[1122∈7] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1125 -->|rejectNull| PgSelect1122
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3825 & Lambda3830 --> PgSelect1122
+    Access5655 & Lambda2221 & Access2225 & Lambda3940 & Lambda3945 --> PgSelect1122
     PgSelect1133[["PgSelect[1133∈7] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object1125 -->|rejectNull| PgSelect1133
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3839 & Lambda3844 --> PgSelect1133
+    Access5655 & Lambda2221 & Access2225 & Lambda3955 & Lambda3960 --> PgSelect1133
     PgSelect1142[["PgSelect[1142∈7] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object1125 -->|rejectNull| PgSelect1142
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3853 & Lambda3858 --> PgSelect1142
+    Access5655 & Lambda2221 & Access2225 & Lambda3970 & Lambda3975 --> PgSelect1142
     PgSelect1151[["PgSelect[1151∈7] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object1125 -->|rejectNull| PgSelect1151
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3867 & Lambda3872 --> PgSelect1151
+    Access5655 & Lambda2221 & Access2225 & Lambda3985 & Lambda3990 --> PgSelect1151
     PgSelect1160[["PgSelect[1160∈7] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object1125 -->|rejectNull| PgSelect1160
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3881 & Lambda3886 --> PgSelect1160
+    Access5655 & Lambda2221 & Access2225 & Lambda4000 & Lambda4005 --> PgSelect1160
     PgSelect1169[["PgSelect[1169∈7] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object1125 -->|rejectNull| PgSelect1169
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3895 & Lambda3900 --> PgSelect1169
+    Access5655 & Lambda2221 & Access2225 & Lambda4015 & Lambda4020 --> PgSelect1169
     PgSelect1190[["PgSelect[1190∈7] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object1125 -->|rejectNull| PgSelect1190
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3923 & Lambda3928 --> PgSelect1190
+    Access5655 & Lambda2221 & Access2225 & Lambda4045 & Lambda4050 --> PgSelect1190
     PgSelect1199[["PgSelect[1199∈7] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object1125 -->|rejectNull| PgSelect1199
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3937 & Lambda3942 --> PgSelect1199
+    Access5655 & Lambda2221 & Access2225 & Lambda4060 & Lambda4065 --> PgSelect1199
     PgSelect1208[["PgSelect[1208∈7] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object1125 -->|rejectNull| PgSelect1208
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3951 & Lambda3956 --> PgSelect1208
+    Access5655 & Lambda2221 & Access2225 & Lambda4075 & Lambda4080 --> PgSelect1208
     PgSelect1217[["PgSelect[1217∈7] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object1125 -->|rejectNull| PgSelect1217
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3965 & Lambda3970 --> PgSelect1217
+    Access5655 & Lambda2221 & Access2225 & Lambda4090 & Lambda4095 --> PgSelect1217
     PgSelect1226[["PgSelect[1226∈7] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object1125 -->|rejectNull| PgSelect1226
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3979 & Lambda3984 --> PgSelect1226
+    Access5655 & Lambda2221 & Access2225 & Lambda4105 & Lambda4110 --> PgSelect1226
     PgSelect1235[["PgSelect[1235∈7] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object1125 -->|rejectNull| PgSelect1235
-    Access5427 & Lambda2221 & Lambda2224 & Lambda3993 & Lambda3998 --> PgSelect1235
+    Access5655 & Lambda2221 & Access2225 & Lambda4120 & Lambda4125 --> PgSelect1235
     PgSelect1244[["PgSelect[1244∈7] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object1125 -->|rejectNull| PgSelect1244
-    Access5427 & Lambda2221 & Lambda2224 & Lambda4007 & Lambda4012 --> PgSelect1244
+    Access5655 & Lambda2221 & Access2225 & Lambda4135 & Lambda4140 --> PgSelect1244
     PgSelect1253[["PgSelect[1253∈7] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object1125 -->|rejectNull| PgSelect1253
-    Access5427 & Lambda2221 & Lambda2224 & Lambda4021 & Lambda4026 --> PgSelect1253
+    Access5655 & Lambda2221 & Access2225 & Lambda4150 & Lambda4155 --> PgSelect1253
     PgSelect1262[["PgSelect[1262∈7] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object1125 -->|rejectNull| PgSelect1262
-    Access5427 & Lambda2221 & Lambda2224 & Lambda4035 & Lambda4040 --> PgSelect1262
+    Access5655 & Lambda2221 & Access2225 & Lambda4165 & Lambda4170 --> PgSelect1262
     PgSelect1271[["PgSelect[1271∈7] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object1125 -->|rejectNull| PgSelect1271
-    Access5427 & Lambda2221 & Lambda2224 & Lambda4049 & Lambda4054 --> PgSelect1271
+    Access5655 & Lambda2221 & Access2225 & Lambda4180 & Lambda4185 --> PgSelect1271
     PgSelect1280[["PgSelect[1280∈7] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object1125 -->|rejectNull| PgSelect1280
-    Access5427 & Lambda2221 & Lambda2224 & Lambda4063 & Lambda4068 --> PgSelect1280
+    Access5655 & Lambda2221 & Access2225 & Lambda4195 & Lambda4200 --> PgSelect1280
     PgSelect1289[["PgSelect[1289∈7] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object1125 -->|rejectNull| PgSelect1289
-    Access5427 & Lambda2221 & Lambda2224 & Lambda4077 & Lambda4082 --> PgSelect1289
+    Access5655 & Lambda2221 & Access2225 & Lambda4210 & Lambda4215 --> PgSelect1289
     List1187{{"List[1187∈7] ➊<br />ᐸ85,1185,1186ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1185{{"PgClassExpression[1185∈7] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1186{{"PgClassExpression[1186∈7] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -3953,69 +3955,69 @@ graph TD
     PgSelectSingle1292 --> PgClassExpression1294
     Lambda1296{{"Lambda[1296∈7] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1295 --> Lambda1296
-    Lambda1115 --> Access5427
-    Lambda1115 --> Access5428
+    Lambda1115 --> Access5655
+    Lambda1115 --> Access5656
     PgSelect1364[["PgSelect[1364∈8] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1309{{"Object[1309∈8] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5429{{"Access[5429∈8] ➊<br />ᐸ1299.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5430{{"Access[5430∈8] ➊<br />ᐸ1299.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5657{{"Access[5657∈8] ➊<br />ᐸ1299.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5658{{"Access[5658∈8] ➊<br />ᐸ1299.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1309 -->|rejectNull| PgSelect1364
-    Access5429 -->|rejectNull| PgSelect1364
-    Access5430 & Lambda2221 & Lambda2224 & Lambda4175 & Lambda4180 --> PgSelect1364
+    Access5657 -->|rejectNull| PgSelect1364
+    Access5658 & Lambda2221 & Access2225 & Lambda4315 & Lambda4320 --> PgSelect1364
     PgSelect1306[["PgSelect[1306∈8] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1309 -->|rejectNull| PgSelect1306
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4091 & Lambda4096 --> PgSelect1306
+    Access5657 & Lambda2221 & Access2225 & Lambda4225 & Lambda4230 --> PgSelect1306
     PgSelect1317[["PgSelect[1317∈8] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object1309 -->|rejectNull| PgSelect1317
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4105 & Lambda4110 --> PgSelect1317
+    Access5657 & Lambda2221 & Access2225 & Lambda4240 & Lambda4245 --> PgSelect1317
     PgSelect1326[["PgSelect[1326∈8] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object1309 -->|rejectNull| PgSelect1326
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4119 & Lambda4124 --> PgSelect1326
+    Access5657 & Lambda2221 & Access2225 & Lambda4255 & Lambda4260 --> PgSelect1326
     PgSelect1335[["PgSelect[1335∈8] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object1309 -->|rejectNull| PgSelect1335
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4133 & Lambda4138 --> PgSelect1335
+    Access5657 & Lambda2221 & Access2225 & Lambda4270 & Lambda4275 --> PgSelect1335
     PgSelect1344[["PgSelect[1344∈8] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object1309 -->|rejectNull| PgSelect1344
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4147 & Lambda4152 --> PgSelect1344
+    Access5657 & Lambda2221 & Access2225 & Lambda4285 & Lambda4290 --> PgSelect1344
     PgSelect1353[["PgSelect[1353∈8] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object1309 -->|rejectNull| PgSelect1353
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4161 & Lambda4166 --> PgSelect1353
+    Access5657 & Lambda2221 & Access2225 & Lambda4300 & Lambda4305 --> PgSelect1353
     PgSelect1374[["PgSelect[1374∈8] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object1309 -->|rejectNull| PgSelect1374
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4189 & Lambda4194 --> PgSelect1374
+    Access5657 & Lambda2221 & Access2225 & Lambda4330 & Lambda4335 --> PgSelect1374
     PgSelect1383[["PgSelect[1383∈8] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object1309 -->|rejectNull| PgSelect1383
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4203 & Lambda4208 --> PgSelect1383
+    Access5657 & Lambda2221 & Access2225 & Lambda4345 & Lambda4350 --> PgSelect1383
     PgSelect1392[["PgSelect[1392∈8] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object1309 -->|rejectNull| PgSelect1392
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4217 & Lambda4222 --> PgSelect1392
+    Access5657 & Lambda2221 & Access2225 & Lambda4360 & Lambda4365 --> PgSelect1392
     PgSelect1401[["PgSelect[1401∈8] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object1309 -->|rejectNull| PgSelect1401
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4231 & Lambda4236 --> PgSelect1401
+    Access5657 & Lambda2221 & Access2225 & Lambda4375 & Lambda4380 --> PgSelect1401
     PgSelect1410[["PgSelect[1410∈8] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object1309 -->|rejectNull| PgSelect1410
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4245 & Lambda4250 --> PgSelect1410
+    Access5657 & Lambda2221 & Access2225 & Lambda4390 & Lambda4395 --> PgSelect1410
     PgSelect1419[["PgSelect[1419∈8] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object1309 -->|rejectNull| PgSelect1419
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4259 & Lambda4264 --> PgSelect1419
+    Access5657 & Lambda2221 & Access2225 & Lambda4405 & Lambda4410 --> PgSelect1419
     PgSelect1428[["PgSelect[1428∈8] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object1309 -->|rejectNull| PgSelect1428
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4273 & Lambda4278 --> PgSelect1428
+    Access5657 & Lambda2221 & Access2225 & Lambda4420 & Lambda4425 --> PgSelect1428
     PgSelect1437[["PgSelect[1437∈8] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object1309 -->|rejectNull| PgSelect1437
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4287 & Lambda4292 --> PgSelect1437
+    Access5657 & Lambda2221 & Access2225 & Lambda4435 & Lambda4440 --> PgSelect1437
     PgSelect1446[["PgSelect[1446∈8] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object1309 -->|rejectNull| PgSelect1446
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4301 & Lambda4306 --> PgSelect1446
+    Access5657 & Lambda2221 & Access2225 & Lambda4450 & Lambda4455 --> PgSelect1446
     PgSelect1455[["PgSelect[1455∈8] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object1309 -->|rejectNull| PgSelect1455
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4315 & Lambda4320 --> PgSelect1455
+    Access5657 & Lambda2221 & Access2225 & Lambda4465 & Lambda4470 --> PgSelect1455
     PgSelect1464[["PgSelect[1464∈8] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object1309 -->|rejectNull| PgSelect1464
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4329 & Lambda4334 --> PgSelect1464
+    Access5657 & Lambda2221 & Access2225 & Lambda4480 & Lambda4485 --> PgSelect1464
     PgSelect1473[["PgSelect[1473∈8] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object1309 -->|rejectNull| PgSelect1473
-    Access5429 & Lambda2221 & Lambda2224 & Lambda4343 & Lambda4348 --> PgSelect1473
+    Access5657 & Lambda2221 & Access2225 & Lambda4495 & Lambda4500 --> PgSelect1473
     List1371{{"List[1371∈8] ➊<br />ᐸ85,1369,1370ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1369{{"PgClassExpression[1369∈8] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1370{{"PgClassExpression[1370∈8] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -4213,69 +4215,69 @@ graph TD
     PgSelectSingle1476 --> PgClassExpression1478
     Lambda1480{{"Lambda[1480∈8] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1479 --> Lambda1480
-    Lambda1299 --> Access5429
-    Lambda1299 --> Access5430
+    Lambda1299 --> Access5657
+    Lambda1299 --> Access5658
     PgSelect1549[["PgSelect[1549∈9] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1494{{"Object[1494∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5431{{"Access[5431∈9] ➊<br />ᐸ1484.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5432{{"Access[5432∈9] ➊<br />ᐸ1484.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5659{{"Access[5659∈9] ➊<br />ᐸ1484.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5660{{"Access[5660∈9] ➊<br />ᐸ1484.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1494 -->|rejectNull| PgSelect1549
-    Access5431 -->|rejectNull| PgSelect1549
-    Access5432 & Lambda2221 & Lambda2224 & Lambda4441 & Lambda4446 --> PgSelect1549
+    Access5659 -->|rejectNull| PgSelect1549
+    Access5660 & Lambda2221 & Access2225 & Lambda4600 & Lambda4605 --> PgSelect1549
     PgSelect1491[["PgSelect[1491∈9] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1494 -->|rejectNull| PgSelect1491
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4357 & Lambda4362 --> PgSelect1491
+    Access5659 & Lambda2221 & Access2225 & Lambda4510 & Lambda4515 --> PgSelect1491
     PgSelect1502[["PgSelect[1502∈9] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object1494 -->|rejectNull| PgSelect1502
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4371 & Lambda4376 --> PgSelect1502
+    Access5659 & Lambda2221 & Access2225 & Lambda4525 & Lambda4530 --> PgSelect1502
     PgSelect1511[["PgSelect[1511∈9] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object1494 -->|rejectNull| PgSelect1511
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4385 & Lambda4390 --> PgSelect1511
+    Access5659 & Lambda2221 & Access2225 & Lambda4540 & Lambda4545 --> PgSelect1511
     PgSelect1520[["PgSelect[1520∈9] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object1494 -->|rejectNull| PgSelect1520
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4399 & Lambda4404 --> PgSelect1520
+    Access5659 & Lambda2221 & Access2225 & Lambda4555 & Lambda4560 --> PgSelect1520
     PgSelect1529[["PgSelect[1529∈9] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object1494 -->|rejectNull| PgSelect1529
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4413 & Lambda4418 --> PgSelect1529
+    Access5659 & Lambda2221 & Access2225 & Lambda4570 & Lambda4575 --> PgSelect1529
     PgSelect1538[["PgSelect[1538∈9] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object1494 -->|rejectNull| PgSelect1538
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4427 & Lambda4432 --> PgSelect1538
+    Access5659 & Lambda2221 & Access2225 & Lambda4585 & Lambda4590 --> PgSelect1538
     PgSelect1559[["PgSelect[1559∈9] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object1494 -->|rejectNull| PgSelect1559
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4455 & Lambda4460 --> PgSelect1559
+    Access5659 & Lambda2221 & Access2225 & Lambda4615 & Lambda4620 --> PgSelect1559
     PgSelect1568[["PgSelect[1568∈9] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object1494 -->|rejectNull| PgSelect1568
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4469 & Lambda4474 --> PgSelect1568
+    Access5659 & Lambda2221 & Access2225 & Lambda4630 & Lambda4635 --> PgSelect1568
     PgSelect1577[["PgSelect[1577∈9] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object1494 -->|rejectNull| PgSelect1577
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4483 & Lambda4488 --> PgSelect1577
+    Access5659 & Lambda2221 & Access2225 & Lambda4645 & Lambda4650 --> PgSelect1577
     PgSelect1586[["PgSelect[1586∈9] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object1494 -->|rejectNull| PgSelect1586
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4497 & Lambda4502 --> PgSelect1586
+    Access5659 & Lambda2221 & Access2225 & Lambda4660 & Lambda4665 --> PgSelect1586
     PgSelect1595[["PgSelect[1595∈9] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object1494 -->|rejectNull| PgSelect1595
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4511 & Lambda4516 --> PgSelect1595
+    Access5659 & Lambda2221 & Access2225 & Lambda4675 & Lambda4680 --> PgSelect1595
     PgSelect1604[["PgSelect[1604∈9] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object1494 -->|rejectNull| PgSelect1604
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4525 & Lambda4530 --> PgSelect1604
+    Access5659 & Lambda2221 & Access2225 & Lambda4690 & Lambda4695 --> PgSelect1604
     PgSelect1613[["PgSelect[1613∈9] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object1494 -->|rejectNull| PgSelect1613
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4539 & Lambda4544 --> PgSelect1613
+    Access5659 & Lambda2221 & Access2225 & Lambda4705 & Lambda4710 --> PgSelect1613
     PgSelect1622[["PgSelect[1622∈9] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object1494 -->|rejectNull| PgSelect1622
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4553 & Lambda4558 --> PgSelect1622
+    Access5659 & Lambda2221 & Access2225 & Lambda4720 & Lambda4725 --> PgSelect1622
     PgSelect1631[["PgSelect[1631∈9] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object1494 -->|rejectNull| PgSelect1631
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4567 & Lambda4572 --> PgSelect1631
+    Access5659 & Lambda2221 & Access2225 & Lambda4735 & Lambda4740 --> PgSelect1631
     PgSelect1640[["PgSelect[1640∈9] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object1494 -->|rejectNull| PgSelect1640
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4581 & Lambda4586 --> PgSelect1640
+    Access5659 & Lambda2221 & Access2225 & Lambda4750 & Lambda4755 --> PgSelect1640
     PgSelect1649[["PgSelect[1649∈9] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object1494 -->|rejectNull| PgSelect1649
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4595 & Lambda4600 --> PgSelect1649
+    Access5659 & Lambda2221 & Access2225 & Lambda4765 & Lambda4770 --> PgSelect1649
     PgSelect1658[["PgSelect[1658∈9] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object1494 -->|rejectNull| PgSelect1658
-    Access5431 & Lambda2221 & Lambda2224 & Lambda4609 & Lambda4614 --> PgSelect1658
+    Access5659 & Lambda2221 & Access2225 & Lambda4780 & Lambda4785 --> PgSelect1658
     List1556{{"List[1556∈9] ➊<br />ᐸ85,1554,1555ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1554{{"PgClassExpression[1554∈9] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1555{{"PgClassExpression[1555∈9] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -4473,69 +4475,69 @@ graph TD
     PgSelectSingle1661 --> PgClassExpression1663
     Lambda1665{{"Lambda[1665∈9] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1664 --> Lambda1665
-    Lambda1484 --> Access5431
-    Lambda1484 --> Access5432
+    Lambda1484 --> Access5659
+    Lambda1484 --> Access5660
     PgSelect1733[["PgSelect[1733∈10] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1678{{"Object[1678∈10] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5433{{"Access[5433∈10] ➊<br />ᐸ1668.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5434{{"Access[5434∈10] ➊<br />ᐸ1668.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5661{{"Access[5661∈10] ➊<br />ᐸ1668.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5662{{"Access[5662∈10] ➊<br />ᐸ1668.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1678 -->|rejectNull| PgSelect1733
-    Access5433 -->|rejectNull| PgSelect1733
-    Access5434 & Lambda2221 & Lambda2224 & Lambda4707 & Lambda4712 --> PgSelect1733
+    Access5661 -->|rejectNull| PgSelect1733
+    Access5662 & Lambda2221 & Access2225 & Lambda4885 & Lambda4890 --> PgSelect1733
     PgSelect1675[["PgSelect[1675∈10] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1678 -->|rejectNull| PgSelect1675
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4623 & Lambda4628 --> PgSelect1675
+    Access5661 & Lambda2221 & Access2225 & Lambda4795 & Lambda4800 --> PgSelect1675
     PgSelect1686[["PgSelect[1686∈10] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object1678 -->|rejectNull| PgSelect1686
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4637 & Lambda4642 --> PgSelect1686
+    Access5661 & Lambda2221 & Access2225 & Lambda4810 & Lambda4815 --> PgSelect1686
     PgSelect1695[["PgSelect[1695∈10] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object1678 -->|rejectNull| PgSelect1695
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4651 & Lambda4656 --> PgSelect1695
+    Access5661 & Lambda2221 & Access2225 & Lambda4825 & Lambda4830 --> PgSelect1695
     PgSelect1704[["PgSelect[1704∈10] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object1678 -->|rejectNull| PgSelect1704
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4665 & Lambda4670 --> PgSelect1704
+    Access5661 & Lambda2221 & Access2225 & Lambda4840 & Lambda4845 --> PgSelect1704
     PgSelect1713[["PgSelect[1713∈10] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object1678 -->|rejectNull| PgSelect1713
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4679 & Lambda4684 --> PgSelect1713
+    Access5661 & Lambda2221 & Access2225 & Lambda4855 & Lambda4860 --> PgSelect1713
     PgSelect1722[["PgSelect[1722∈10] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object1678 -->|rejectNull| PgSelect1722
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4693 & Lambda4698 --> PgSelect1722
+    Access5661 & Lambda2221 & Access2225 & Lambda4870 & Lambda4875 --> PgSelect1722
     PgSelect1743[["PgSelect[1743∈10] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object1678 -->|rejectNull| PgSelect1743
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4721 & Lambda4726 --> PgSelect1743
+    Access5661 & Lambda2221 & Access2225 & Lambda4900 & Lambda4905 --> PgSelect1743
     PgSelect1752[["PgSelect[1752∈10] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object1678 -->|rejectNull| PgSelect1752
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4735 & Lambda4740 --> PgSelect1752
+    Access5661 & Lambda2221 & Access2225 & Lambda4915 & Lambda4920 --> PgSelect1752
     PgSelect1761[["PgSelect[1761∈10] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object1678 -->|rejectNull| PgSelect1761
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4749 & Lambda4754 --> PgSelect1761
+    Access5661 & Lambda2221 & Access2225 & Lambda4930 & Lambda4935 --> PgSelect1761
     PgSelect1770[["PgSelect[1770∈10] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object1678 -->|rejectNull| PgSelect1770
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4763 & Lambda4768 --> PgSelect1770
+    Access5661 & Lambda2221 & Access2225 & Lambda4945 & Lambda4950 --> PgSelect1770
     PgSelect1779[["PgSelect[1779∈10] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object1678 -->|rejectNull| PgSelect1779
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4777 & Lambda4782 --> PgSelect1779
+    Access5661 & Lambda2221 & Access2225 & Lambda4960 & Lambda4965 --> PgSelect1779
     PgSelect1788[["PgSelect[1788∈10] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object1678 -->|rejectNull| PgSelect1788
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4791 & Lambda4796 --> PgSelect1788
+    Access5661 & Lambda2221 & Access2225 & Lambda4975 & Lambda4980 --> PgSelect1788
     PgSelect1797[["PgSelect[1797∈10] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object1678 -->|rejectNull| PgSelect1797
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4805 & Lambda4810 --> PgSelect1797
+    Access5661 & Lambda2221 & Access2225 & Lambda4990 & Lambda4995 --> PgSelect1797
     PgSelect1806[["PgSelect[1806∈10] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object1678 -->|rejectNull| PgSelect1806
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4819 & Lambda4824 --> PgSelect1806
+    Access5661 & Lambda2221 & Access2225 & Lambda5005 & Lambda5010 --> PgSelect1806
     PgSelect1815[["PgSelect[1815∈10] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object1678 -->|rejectNull| PgSelect1815
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4833 & Lambda4838 --> PgSelect1815
+    Access5661 & Lambda2221 & Access2225 & Lambda5020 & Lambda5025 --> PgSelect1815
     PgSelect1824[["PgSelect[1824∈10] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object1678 -->|rejectNull| PgSelect1824
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4847 & Lambda4852 --> PgSelect1824
+    Access5661 & Lambda2221 & Access2225 & Lambda5035 & Lambda5040 --> PgSelect1824
     PgSelect1833[["PgSelect[1833∈10] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object1678 -->|rejectNull| PgSelect1833
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4861 & Lambda4866 --> PgSelect1833
+    Access5661 & Lambda2221 & Access2225 & Lambda5050 & Lambda5055 --> PgSelect1833
     PgSelect1842[["PgSelect[1842∈10] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object1678 -->|rejectNull| PgSelect1842
-    Access5433 & Lambda2221 & Lambda2224 & Lambda4875 & Lambda4880 --> PgSelect1842
+    Access5661 & Lambda2221 & Access2225 & Lambda5065 & Lambda5070 --> PgSelect1842
     List1740{{"List[1740∈10] ➊<br />ᐸ85,1738,1739ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1738{{"PgClassExpression[1738∈10] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1739{{"PgClassExpression[1739∈10] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -4733,69 +4735,69 @@ graph TD
     PgSelectSingle1845 --> PgClassExpression1847
     Lambda1849{{"Lambda[1849∈10] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1848 --> Lambda1849
-    Lambda1668 --> Access5433
-    Lambda1668 --> Access5434
+    Lambda1668 --> Access5661
+    Lambda1668 --> Access5662
     PgSelect1918[["PgSelect[1918∈11] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1863{{"Object[1863∈11] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5435{{"Access[5435∈11] ➊<br />ᐸ1853.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5436{{"Access[5436∈11] ➊<br />ᐸ1853.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5663{{"Access[5663∈11] ➊<br />ᐸ1853.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5664{{"Access[5664∈11] ➊<br />ᐸ1853.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1863 -->|rejectNull| PgSelect1918
-    Access5435 -->|rejectNull| PgSelect1918
-    Access5436 & Lambda2221 & Lambda2224 & Lambda4973 & Lambda4978 --> PgSelect1918
+    Access5663 -->|rejectNull| PgSelect1918
+    Access5664 & Lambda2221 & Access2225 & Lambda5170 & Lambda5175 --> PgSelect1918
     PgSelect1860[["PgSelect[1860∈11] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1863 -->|rejectNull| PgSelect1860
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4889 & Lambda4894 --> PgSelect1860
+    Access5663 & Lambda2221 & Access2225 & Lambda5080 & Lambda5085 --> PgSelect1860
     PgSelect1871[["PgSelect[1871∈11] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object1863 -->|rejectNull| PgSelect1871
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4903 & Lambda4908 --> PgSelect1871
+    Access5663 & Lambda2221 & Access2225 & Lambda5095 & Lambda5100 --> PgSelect1871
     PgSelect1880[["PgSelect[1880∈11] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object1863 -->|rejectNull| PgSelect1880
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4917 & Lambda4922 --> PgSelect1880
+    Access5663 & Lambda2221 & Access2225 & Lambda5110 & Lambda5115 --> PgSelect1880
     PgSelect1889[["PgSelect[1889∈11] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object1863 -->|rejectNull| PgSelect1889
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4931 & Lambda4936 --> PgSelect1889
+    Access5663 & Lambda2221 & Access2225 & Lambda5125 & Lambda5130 --> PgSelect1889
     PgSelect1898[["PgSelect[1898∈11] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object1863 -->|rejectNull| PgSelect1898
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4945 & Lambda4950 --> PgSelect1898
+    Access5663 & Lambda2221 & Access2225 & Lambda5140 & Lambda5145 --> PgSelect1898
     PgSelect1907[["PgSelect[1907∈11] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object1863 -->|rejectNull| PgSelect1907
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4959 & Lambda4964 --> PgSelect1907
+    Access5663 & Lambda2221 & Access2225 & Lambda5155 & Lambda5160 --> PgSelect1907
     PgSelect1928[["PgSelect[1928∈11] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object1863 -->|rejectNull| PgSelect1928
-    Access5435 & Lambda2221 & Lambda2224 & Lambda4987 & Lambda4992 --> PgSelect1928
+    Access5663 & Lambda2221 & Access2225 & Lambda5185 & Lambda5190 --> PgSelect1928
     PgSelect1937[["PgSelect[1937∈11] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object1863 -->|rejectNull| PgSelect1937
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5001 & Lambda5006 --> PgSelect1937
+    Access5663 & Lambda2221 & Access2225 & Lambda5200 & Lambda5205 --> PgSelect1937
     PgSelect1946[["PgSelect[1946∈11] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object1863 -->|rejectNull| PgSelect1946
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5015 & Lambda5020 --> PgSelect1946
+    Access5663 & Lambda2221 & Access2225 & Lambda5215 & Lambda5220 --> PgSelect1946
     PgSelect1955[["PgSelect[1955∈11] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object1863 -->|rejectNull| PgSelect1955
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5029 & Lambda5034 --> PgSelect1955
+    Access5663 & Lambda2221 & Access2225 & Lambda5230 & Lambda5235 --> PgSelect1955
     PgSelect1964[["PgSelect[1964∈11] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object1863 -->|rejectNull| PgSelect1964
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5043 & Lambda5048 --> PgSelect1964
+    Access5663 & Lambda2221 & Access2225 & Lambda5245 & Lambda5250 --> PgSelect1964
     PgSelect1973[["PgSelect[1973∈11] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object1863 -->|rejectNull| PgSelect1973
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5057 & Lambda5062 --> PgSelect1973
+    Access5663 & Lambda2221 & Access2225 & Lambda5260 & Lambda5265 --> PgSelect1973
     PgSelect1982[["PgSelect[1982∈11] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object1863 -->|rejectNull| PgSelect1982
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5071 & Lambda5076 --> PgSelect1982
+    Access5663 & Lambda2221 & Access2225 & Lambda5275 & Lambda5280 --> PgSelect1982
     PgSelect1991[["PgSelect[1991∈11] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object1863 -->|rejectNull| PgSelect1991
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5085 & Lambda5090 --> PgSelect1991
+    Access5663 & Lambda2221 & Access2225 & Lambda5290 & Lambda5295 --> PgSelect1991
     PgSelect2000[["PgSelect[2000∈11] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object1863 -->|rejectNull| PgSelect2000
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5099 & Lambda5104 --> PgSelect2000
+    Access5663 & Lambda2221 & Access2225 & Lambda5305 & Lambda5310 --> PgSelect2000
     PgSelect2009[["PgSelect[2009∈11] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object1863 -->|rejectNull| PgSelect2009
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5113 & Lambda5118 --> PgSelect2009
+    Access5663 & Lambda2221 & Access2225 & Lambda5320 & Lambda5325 --> PgSelect2009
     PgSelect2018[["PgSelect[2018∈11] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object1863 -->|rejectNull| PgSelect2018
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5127 & Lambda5132 --> PgSelect2018
+    Access5663 & Lambda2221 & Access2225 & Lambda5335 & Lambda5340 --> PgSelect2018
     PgSelect2027[["PgSelect[2027∈11] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object1863 -->|rejectNull| PgSelect2027
-    Access5435 & Lambda2221 & Lambda2224 & Lambda5141 & Lambda5146 --> PgSelect2027
+    Access5663 & Lambda2221 & Access2225 & Lambda5350 & Lambda5355 --> PgSelect2027
     List1925{{"List[1925∈11] ➊<br />ᐸ85,1923,1924ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1923{{"PgClassExpression[1923∈11] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1924{{"PgClassExpression[1924∈11] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -4993,69 +4995,69 @@ graph TD
     PgSelectSingle2030 --> PgClassExpression2032
     Lambda2034{{"Lambda[2034∈11] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List2033 --> Lambda2034
-    Lambda1853 --> Access5435
-    Lambda1853 --> Access5436
+    Lambda1853 --> Access5663
+    Lambda1853 --> Access5664
     PgSelect2102[["PgSelect[2102∈12] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object2047{{"Object[2047∈12] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access5437{{"Access[5437∈12] ➊<br />ᐸ2037.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access5438{{"Access[5438∈12] ➊<br />ᐸ2037.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access5665{{"Access[5665∈12] ➊<br />ᐸ2037.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access5666{{"Access[5666∈12] ➊<br />ᐸ2037.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object2047 -->|rejectNull| PgSelect2102
-    Access5437 -->|rejectNull| PgSelect2102
-    Access5438 & Lambda2221 & Lambda2224 & Lambda5239 & Lambda5244 --> PgSelect2102
+    Access5665 -->|rejectNull| PgSelect2102
+    Access5666 & Lambda2221 & Access2225 & Lambda5455 & Lambda5460 --> PgSelect2102
     PgSelect2044[["PgSelect[2044∈12] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object2047 -->|rejectNull| PgSelect2044
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5155 & Lambda5160 --> PgSelect2044
+    Access5665 & Lambda2221 & Access2225 & Lambda5365 & Lambda5370 --> PgSelect2044
     PgSelect2055[["PgSelect[2055∈12] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object2047 -->|rejectNull| PgSelect2055
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5169 & Lambda5174 --> PgSelect2055
+    Access5665 & Lambda2221 & Access2225 & Lambda5380 & Lambda5385 --> PgSelect2055
     PgSelect2064[["PgSelect[2064∈12] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object2047 -->|rejectNull| PgSelect2064
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5183 & Lambda5188 --> PgSelect2064
+    Access5665 & Lambda2221 & Access2225 & Lambda5395 & Lambda5400 --> PgSelect2064
     PgSelect2073[["PgSelect[2073∈12] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object2047 -->|rejectNull| PgSelect2073
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5197 & Lambda5202 --> PgSelect2073
+    Access5665 & Lambda2221 & Access2225 & Lambda5410 & Lambda5415 --> PgSelect2073
     PgSelect2082[["PgSelect[2082∈12] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object2047 -->|rejectNull| PgSelect2082
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5211 & Lambda5216 --> PgSelect2082
+    Access5665 & Lambda2221 & Access2225 & Lambda5425 & Lambda5430 --> PgSelect2082
     PgSelect2091[["PgSelect[2091∈12] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object2047 -->|rejectNull| PgSelect2091
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5225 & Lambda5230 --> PgSelect2091
+    Access5665 & Lambda2221 & Access2225 & Lambda5440 & Lambda5445 --> PgSelect2091
     PgSelect2112[["PgSelect[2112∈12] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object2047 -->|rejectNull| PgSelect2112
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5253 & Lambda5258 --> PgSelect2112
+    Access5665 & Lambda2221 & Access2225 & Lambda5470 & Lambda5475 --> PgSelect2112
     PgSelect2121[["PgSelect[2121∈12] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object2047 -->|rejectNull| PgSelect2121
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5267 & Lambda5272 --> PgSelect2121
+    Access5665 & Lambda2221 & Access2225 & Lambda5485 & Lambda5490 --> PgSelect2121
     PgSelect2130[["PgSelect[2130∈12] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object2047 -->|rejectNull| PgSelect2130
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5281 & Lambda5286 --> PgSelect2130
+    Access5665 & Lambda2221 & Access2225 & Lambda5500 & Lambda5505 --> PgSelect2130
     PgSelect2139[["PgSelect[2139∈12] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object2047 -->|rejectNull| PgSelect2139
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5295 & Lambda5300 --> PgSelect2139
+    Access5665 & Lambda2221 & Access2225 & Lambda5515 & Lambda5520 --> PgSelect2139
     PgSelect2148[["PgSelect[2148∈12] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object2047 -->|rejectNull| PgSelect2148
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5309 & Lambda5314 --> PgSelect2148
+    Access5665 & Lambda2221 & Access2225 & Lambda5530 & Lambda5535 --> PgSelect2148
     PgSelect2157[["PgSelect[2157∈12] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object2047 -->|rejectNull| PgSelect2157
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5323 & Lambda5328 --> PgSelect2157
+    Access5665 & Lambda2221 & Access2225 & Lambda5545 & Lambda5550 --> PgSelect2157
     PgSelect2166[["PgSelect[2166∈12] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object2047 -->|rejectNull| PgSelect2166
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5337 & Lambda5342 --> PgSelect2166
+    Access5665 & Lambda2221 & Access2225 & Lambda5560 & Lambda5565 --> PgSelect2166
     PgSelect2175[["PgSelect[2175∈12] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object2047 -->|rejectNull| PgSelect2175
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5351 & Lambda5356 --> PgSelect2175
+    Access5665 & Lambda2221 & Access2225 & Lambda5575 & Lambda5580 --> PgSelect2175
     PgSelect2184[["PgSelect[2184∈12] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object2047 -->|rejectNull| PgSelect2184
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5365 & Lambda5370 --> PgSelect2184
+    Access5665 & Lambda2221 & Access2225 & Lambda5590 & Lambda5595 --> PgSelect2184
     PgSelect2193[["PgSelect[2193∈12] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object2047 -->|rejectNull| PgSelect2193
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5379 & Lambda5384 --> PgSelect2193
+    Access5665 & Lambda2221 & Access2225 & Lambda5605 & Lambda5610 --> PgSelect2193
     PgSelect2202[["PgSelect[2202∈12] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object2047 -->|rejectNull| PgSelect2202
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5393 & Lambda5398 --> PgSelect2202
+    Access5665 & Lambda2221 & Access2225 & Lambda5620 & Lambda5625 --> PgSelect2202
     PgSelect2211[["PgSelect[2211∈12] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object2047 -->|rejectNull| PgSelect2211
-    Access5437 & Lambda2221 & Lambda2224 & Lambda5407 & Lambda5412 --> PgSelect2211
+    Access5665 & Lambda2221 & Access2225 & Lambda5635 & Lambda5640 --> PgSelect2211
     List2109{{"List[2109∈12] ➊<br />ᐸ85,2107,2108ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression2107{{"PgClassExpression[2107∈12] ➊<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression2108{{"PgClassExpression[2108∈12] ➊<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
@@ -5253,51 +5255,51 @@ graph TD
     PgSelectSingle2214 --> PgClassExpression2216
     Lambda2218{{"Lambda[2218∈12] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List2217 --> Lambda2218
-    Lambda2037 --> Access5437
-    Lambda2037 --> Access5438
+    Lambda2037 --> Access5665
+    Lambda2037 --> Access5666
 
     %% define steps
 
     subgraph "Buckets for queries/v4/query"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,Lambda7,Node9,Lambda10,Constant29,Constant38,Constant47,Constant56,Constant65,Constant74,Constant85,Constant95,Constant104,Constant113,Constant122,Constant131,Constant140,Constant149,Constant158,Constant167,Constant176,Constant185,Constant194,Node561,Lambda562,Node1114,Lambda1115,Node1298,Lambda1299,Node1483,Lambda1484,Node1667,Lambda1668,Node1852,Lambda1853,Node2036,Lambda2037,Lambda2221,Lambda2224,Constant2225,Constant2226,Constant2227,Object2228,Lambda2229,Lambda2234,Constant2239,Constant2240,Constant2241,Object2242,Lambda2243,Lambda2248,Constant2253,Constant2254,Constant2255,Object2256,Lambda2257,Lambda2262,Constant2267,Constant2268,Constant2269,Object2270,Lambda2271,Lambda2276,Constant2281,Constant2282,Constant2283,Object2284,Lambda2285,Lambda2290,Constant2295,Constant2296,Constant2297,Object2298,Lambda2299,Lambda2304,Constant2309,Constant2310,Constant2311,Object2312,Lambda2313,Lambda2318,Constant2323,Constant2324,Constant2325,Object2326,Lambda2327,Lambda2332,Constant2337,Constant2338,Constant2339,Object2340,Lambda2341,Lambda2346,Constant2351,Constant2352,Constant2353,Object2354,Lambda2355,Lambda2360,Constant2365,Constant2366,Constant2367,Object2368,Lambda2369,Lambda2374,Constant2379,Constant2380,Constant2381,Object2382,Lambda2383,Lambda2388,Constant2393,Constant2394,Constant2395,Object2396,Lambda2397,Lambda2402,Constant2407,Constant2408,Constant2409,Object2410,Lambda2411,Lambda2416,Constant2421,Constant2422,Constant2423,Object2424,Lambda2425,Lambda2430,Constant2435,Constant2436,Constant2437,Object2438,Lambda2439,Lambda2444,Constant2449,Constant2450,Constant2451,Object2452,Lambda2453,Lambda2458,Constant2463,Constant2464,Constant2465,Object2466,Lambda2467,Lambda2472,Constant2477,Constant2478,Constant2479,Object2480,Lambda2481,Lambda2486,Constant2491,Constant2492,Object2494,Lambda2495,Lambda2500,Constant2505,Constant2506,Object2508,Lambda2509,Lambda2514,Constant2519,Constant2520,Object2522,Lambda2523,Lambda2528,Constant2533,Constant2534,Object2536,Lambda2537,Lambda2542,Constant2547,Constant2548,Object2550,Lambda2551,Lambda2556,Constant2561,Constant2562,Object2564,Lambda2565,Lambda2570,Constant2575,Constant2576,Object2578,Lambda2579,Lambda2584,Constant2589,Constant2590,Object2592,Lambda2593,Lambda2598,Constant2603,Constant2604,Object2606,Lambda2607,Lambda2612,Constant2617,Constant2618,Object2620,Lambda2621,Lambda2626,Constant2631,Constant2632,Object2634,Lambda2635,Lambda2640,Constant2645,Constant2646,Object2648,Lambda2649,Lambda2654,Constant2659,Constant2660,Object2662,Lambda2663,Lambda2668,Constant2673,Constant2674,Object2676,Lambda2677,Lambda2682,Constant2687,Constant2688,Object2690,Lambda2691,Lambda2696,Constant2701,Constant2702,Object2704,Lambda2705,Lambda2710,Constant2715,Constant2716,Object2718,Lambda2719,Lambda2724,Constant2729,Constant2730,Object2732,Lambda2733,Lambda2738,Constant2743,Constant2744,Object2746,Lambda2747,Lambda2752,Constant2757,Constant2758,Object2760,Lambda2761,Lambda2766,Constant2771,Constant2772,Object2774,Lambda2775,Lambda2780,Constant2785,Constant2786,Object2788,Lambda2789,Lambda2794,Constant2799,Constant2800,Object2802,Lambda2803,Lambda2808,Constant2813,Constant2814,Object2816,Lambda2817,Lambda2822,Constant2827,Constant2828,Object2830,Lambda2831,Lambda2836,Constant2841,Constant2842,Object2844,Lambda2845,Lambda2850,Constant2855,Constant2856,Object2858,Lambda2859,Lambda2864,Constant2869,Constant2870,Object2872,Lambda2873,Lambda2878,Constant2883,Constant2884,Object2886,Lambda2887,Lambda2892,Constant2897,Constant2898,Object2900,Lambda2901,Lambda2906,Constant2911,Constant2912,Object2914,Lambda2915,Lambda2920,Constant2925,Constant2926,Object2928,Lambda2929,Lambda2934,Constant2939,Constant2940,Object2942,Lambda2943,Lambda2948,Constant2953,Constant2954,Object2956,Lambda2957,Lambda2962,Constant2967,Constant2968,Object2970,Lambda2971,Lambda2976,Constant2981,Constant2982,Object2984,Lambda2985,Lambda2990,Constant2995,Constant2996,Object2998,Lambda2999,Lambda3004,Constant3009,Constant3010,Object3012,Lambda3013,Lambda3018,Constant3023,Constant3024,Object3026,Lambda3027,Lambda3032,Constant3037,Constant3038,Object3040,Lambda3041,Lambda3046,Constant3051,Constant3052,Object3054,Lambda3055,Lambda3060,Constant3065,Constant3066,Object3068,Lambda3069,Lambda3074,Constant3079,Constant3080,Object3082,Lambda3083,Lambda3088,Constant3093,Constant3094,Object3096,Lambda3097,Lambda3102,Constant3107,Constant3108,Object3110,Lambda3111,Lambda3116,Constant3121,Constant3122,Object3124,Lambda3125,Lambda3130,Constant3135,Constant3136,Object3138,Lambda3139,Lambda3144,Constant3149,Constant3150,Object3152,Lambda3153,Lambda3158,Constant3163,Constant3164,Object3166,Lambda3167,Lambda3172,Constant3177,Constant3178,Object3180,Lambda3181,Lambda3186,Constant3191,Constant3192,Object3194,Lambda3195,Lambda3200,Constant3205,Constant3206,Object3208,Lambda3209,Lambda3214,Constant3219,Constant3220,Object3222,Lambda3223,Lambda3228,Constant3233,Constant3234,Object3236,Lambda3237,Lambda3242,Constant3247,Constant3248,Object3250,Lambda3251,Lambda3256,Constant3261,Constant3262,Object3264,Lambda3265,Lambda3270,Constant3275,Constant3276,Object3278,Lambda3279,Lambda3284,Constant3289,Constant3290,Object3292,Lambda3293,Lambda3298,Constant3303,Constant3304,Object3306,Lambda3307,Lambda3312,Constant3317,Constant3318,Object3320,Lambda3321,Lambda3326,Constant3331,Constant3332,Object3334,Lambda3335,Lambda3340,Constant3345,Constant3346,Object3348,Lambda3349,Lambda3354,Constant3359,Constant3360,Object3362,Lambda3363,Lambda3368,Constant3373,Constant3374,Object3376,Lambda3377,Lambda3382,Constant3387,Constant3388,Object3390,Lambda3391,Lambda3396,Constant3401,Constant3402,Object3404,Lambda3405,Lambda3410,Constant3415,Constant3416,Object3418,Lambda3419,Lambda3424,Constant3429,Constant3430,Object3432,Lambda3433,Lambda3438,Constant3443,Constant3444,Object3446,Lambda3447,Lambda3452,Constant3457,Constant3458,Object3460,Lambda3461,Lambda3466,Constant3471,Constant3472,Object3474,Lambda3475,Lambda3480,Constant3485,Constant3486,Object3488,Lambda3489,Lambda3494,Constant3499,Constant3500,Object3502,Lambda3503,Lambda3508,Constant3513,Constant3514,Object3516,Lambda3517,Lambda3522,Constant3527,Constant3528,Object3530,Lambda3531,Lambda3536,Constant3541,Constant3542,Object3544,Lambda3545,Lambda3550,Constant3555,Constant3556,Object3558,Lambda3559,Lambda3564,Constant3569,Constant3570,Object3572,Lambda3573,Lambda3578,Constant3583,Constant3584,Object3586,Lambda3587,Lambda3592,Constant3597,Constant3598,Object3600,Lambda3601,Lambda3606,Constant3611,Constant3612,Object3614,Lambda3615,Lambda3620,Constant3625,Constant3626,Object3628,Lambda3629,Lambda3634,Constant3639,Constant3640,Object3642,Lambda3643,Lambda3648,Constant3653,Constant3654,Object3656,Lambda3657,Lambda3662,Constant3667,Constant3668,Object3670,Lambda3671,Lambda3676,Constant3681,Constant3682,Object3684,Lambda3685,Lambda3690,Constant3695,Constant3696,Object3698,Lambda3699,Lambda3704,Constant3709,Constant3710,Object3712,Lambda3713,Lambda3718,Constant3723,Constant3724,Object3726,Lambda3727,Lambda3732,Constant3737,Constant3738,Object3740,Lambda3741,Lambda3746,Constant3751,Constant3752,Object3754,Lambda3755,Lambda3760,Constant3765,Constant3766,Object3768,Lambda3769,Lambda3774,Constant3779,Constant3780,Object3782,Lambda3783,Lambda3788,Constant3793,Constant3794,Object3796,Lambda3797,Lambda3802,Constant3807,Constant3808,Object3810,Lambda3811,Lambda3816,Constant3821,Constant3822,Object3824,Lambda3825,Lambda3830,Constant3835,Constant3836,Object3838,Lambda3839,Lambda3844,Constant3849,Constant3850,Object3852,Lambda3853,Lambda3858,Constant3863,Constant3864,Object3866,Lambda3867,Lambda3872,Constant3877,Constant3878,Object3880,Lambda3881,Lambda3886,Constant3891,Constant3892,Object3894,Lambda3895,Lambda3900,Constant3905,Constant3906,Object3908,Lambda3909,Lambda3914,Constant3919,Constant3920,Object3922,Lambda3923,Lambda3928,Constant3933,Constant3934,Object3936,Lambda3937,Lambda3942,Constant3947,Constant3948,Object3950,Lambda3951,Lambda3956,Constant3961,Constant3962,Object3964,Lambda3965,Lambda3970,Constant3975,Constant3976,Object3978,Lambda3979,Lambda3984,Constant3989,Constant3990,Object3992,Lambda3993,Lambda3998,Constant4003,Constant4004,Object4006,Lambda4007,Lambda4012,Constant4017,Constant4018,Object4020,Lambda4021,Lambda4026,Constant4031,Constant4032,Object4034,Lambda4035,Lambda4040,Constant4045,Constant4046,Object4048,Lambda4049,Lambda4054,Constant4059,Constant4060,Object4062,Lambda4063,Lambda4068,Constant4073,Constant4074,Object4076,Lambda4077,Lambda4082,Constant4087,Constant4088,Object4090,Lambda4091,Lambda4096,Constant4101,Constant4102,Object4104,Lambda4105,Lambda4110,Constant4115,Constant4116,Object4118,Lambda4119,Lambda4124,Constant4129,Constant4130,Object4132,Lambda4133,Lambda4138,Constant4143,Constant4144,Object4146,Lambda4147,Lambda4152,Constant4157,Constant4158,Object4160,Lambda4161,Lambda4166,Constant4171,Constant4172,Object4174,Lambda4175,Lambda4180,Constant4185,Constant4186,Object4188,Lambda4189,Lambda4194,Constant4199,Constant4200,Object4202,Lambda4203,Lambda4208,Constant4213,Constant4214,Object4216,Lambda4217,Lambda4222,Constant4227,Constant4228,Object4230,Lambda4231,Lambda4236,Constant4241,Constant4242,Object4244,Lambda4245,Lambda4250,Constant4255,Constant4256,Object4258,Lambda4259,Lambda4264,Constant4269,Constant4270,Object4272,Lambda4273,Lambda4278,Constant4283,Constant4284,Object4286,Lambda4287,Lambda4292,Constant4297,Constant4298,Object4300,Lambda4301,Lambda4306,Constant4311,Constant4312,Object4314,Lambda4315,Lambda4320,Constant4325,Constant4326,Object4328,Lambda4329,Lambda4334,Constant4339,Constant4340,Object4342,Lambda4343,Lambda4348,Constant4353,Constant4354,Object4356,Lambda4357,Lambda4362,Constant4367,Constant4368,Object4370,Lambda4371,Lambda4376,Constant4381,Constant4382,Object4384,Lambda4385,Lambda4390,Constant4395,Constant4396,Object4398,Lambda4399,Lambda4404,Constant4409,Constant4410,Object4412,Lambda4413,Lambda4418,Constant4423,Constant4424,Object4426,Lambda4427,Lambda4432,Constant4437,Constant4438,Object4440,Lambda4441,Lambda4446,Constant4451,Constant4452,Object4454,Lambda4455,Lambda4460,Constant4465,Constant4466,Object4468,Lambda4469,Lambda4474,Constant4479,Constant4480,Object4482,Lambda4483,Lambda4488,Constant4493,Constant4494,Object4496,Lambda4497,Lambda4502,Constant4507,Constant4508,Object4510,Lambda4511,Lambda4516,Constant4521,Constant4522,Object4524,Lambda4525,Lambda4530,Constant4535,Constant4536,Object4538,Lambda4539,Lambda4544,Constant4549,Constant4550,Object4552,Lambda4553,Lambda4558,Constant4563,Constant4564,Object4566,Lambda4567,Lambda4572,Constant4577,Constant4578,Object4580,Lambda4581,Lambda4586,Constant4591,Constant4592,Object4594,Lambda4595,Lambda4600,Constant4605,Constant4606,Object4608,Lambda4609,Lambda4614,Constant4619,Constant4620,Object4622,Lambda4623,Lambda4628,Constant4633,Constant4634,Object4636,Lambda4637,Lambda4642,Constant4647,Constant4648,Object4650,Lambda4651,Lambda4656,Constant4661,Constant4662,Object4664,Lambda4665,Lambda4670,Constant4675,Constant4676,Object4678,Lambda4679,Lambda4684,Constant4689,Constant4690,Object4692,Lambda4693,Lambda4698,Constant4703,Constant4704,Object4706,Lambda4707,Lambda4712,Constant4717,Constant4718,Object4720,Lambda4721,Lambda4726,Constant4731,Constant4732,Object4734,Lambda4735,Lambda4740,Constant4745,Constant4746,Object4748,Lambda4749,Lambda4754,Constant4759,Constant4760,Object4762,Lambda4763,Lambda4768,Constant4773,Constant4774,Object4776,Lambda4777,Lambda4782,Constant4787,Constant4788,Object4790,Lambda4791,Lambda4796,Constant4801,Constant4802,Object4804,Lambda4805,Lambda4810,Constant4815,Constant4816,Object4818,Lambda4819,Lambda4824,Constant4829,Constant4830,Object4832,Lambda4833,Lambda4838,Constant4843,Constant4844,Object4846,Lambda4847,Lambda4852,Constant4857,Constant4858,Object4860,Lambda4861,Lambda4866,Constant4871,Constant4872,Object4874,Lambda4875,Lambda4880,Constant4885,Constant4886,Object4888,Lambda4889,Lambda4894,Constant4899,Constant4900,Object4902,Lambda4903,Lambda4908,Constant4913,Constant4914,Object4916,Lambda4917,Lambda4922,Constant4927,Constant4928,Object4930,Lambda4931,Lambda4936,Constant4941,Constant4942,Object4944,Lambda4945,Lambda4950,Constant4955,Constant4956,Object4958,Lambda4959,Lambda4964,Constant4969,Constant4970,Object4972,Lambda4973,Lambda4978,Constant4983,Constant4984,Object4986,Lambda4987,Lambda4992,Constant4997,Constant4998,Object5000,Lambda5001,Lambda5006,Constant5011,Constant5012,Object5014,Lambda5015,Lambda5020,Constant5025,Constant5026,Object5028,Lambda5029,Lambda5034,Constant5039,Constant5040,Object5042,Lambda5043,Lambda5048,Constant5053,Constant5054,Object5056,Lambda5057,Lambda5062,Constant5067,Constant5068,Object5070,Lambda5071,Lambda5076,Constant5081,Constant5082,Object5084,Lambda5085,Lambda5090,Constant5095,Constant5096,Object5098,Lambda5099,Lambda5104,Constant5109,Constant5110,Object5112,Lambda5113,Lambda5118,Constant5123,Constant5124,Object5126,Lambda5127,Lambda5132,Constant5137,Constant5138,Object5140,Lambda5141,Lambda5146,Constant5151,Constant5152,Object5154,Lambda5155,Lambda5160,Constant5165,Constant5166,Object5168,Lambda5169,Lambda5174,Constant5179,Constant5180,Object5182,Lambda5183,Lambda5188,Constant5193,Constant5194,Object5196,Lambda5197,Lambda5202,Constant5207,Constant5208,Object5210,Lambda5211,Lambda5216,Constant5221,Constant5222,Object5224,Lambda5225,Lambda5230,Constant5235,Constant5236,Object5238,Lambda5239,Lambda5244,Constant5249,Constant5250,Object5252,Lambda5253,Lambda5258,Constant5263,Constant5264,Object5266,Lambda5267,Lambda5272,Constant5277,Constant5278,Object5280,Lambda5281,Lambda5286,Constant5291,Constant5292,Object5294,Lambda5295,Lambda5300,Constant5305,Constant5306,Object5308,Lambda5309,Lambda5314,Constant5319,Constant5320,Object5322,Lambda5323,Lambda5328,Constant5333,Constant5334,Object5336,Lambda5337,Lambda5342,Constant5347,Constant5348,Object5350,Lambda5351,Lambda5356,Constant5361,Constant5362,Object5364,Lambda5365,Lambda5370,Constant5375,Constant5376,Object5378,Lambda5379,Lambda5384,Constant5389,Constant5390,Object5392,Lambda5393,Lambda5398,Constant5403,Constant5404,Object5406,Lambda5407,Lambda5412,Constant5415,Constant5439,Constant5440,Constant5441,Constant5442,Constant5443,Constant5444,Constant5445,Constant5446,Constant5447,Constant5448,Constant5449,Constant5450,Constant5451,Constant5452,Constant5453,Constant5454,Constant5455,Constant5456,Constant5457,Constant5458,Constant5459,Constant5460,Constant5461,Constant5462,Constant5463,Constant5464,Constant5465,Constant5466,Constant5467,Constant5468,Constant5469,Constant5470,Constant5471,Constant5472,Constant5473,Constant5474,Constant5475,Constant5476,Constant5477,Constant5478,Constant5479,Constant5480,Constant5481,Constant5482,Constant5483,Constant5484,Constant5485,Constant5486,Constant5487,Constant5488,Constant5489,Constant5490,Constant5491,Constant5492,Constant5493,Constant5494,Constant5495,Constant5496,Constant5497,Constant5498,Constant5499,Constant5500,Constant5501,Constant5502,Constant5503,Constant5504,Constant5505,Constant5506,Constant5507,Constant5508,Constant5509,Constant5510,Constant5511,Constant5512,Constant5513,Constant5514,Constant5515,Constant5516,Constant5517,Constant5518,Constant5519,Constant5520,Constant5521,Constant5522,Constant5523,Constant5524,Constant5525,Constant5526,Constant5527,Constant5528,Constant5529,Constant5530,Constant5531,Constant5532,Constant5533,Constant5534,Constant5535,Constant5536,Constant5537,Constant5538,Constant5539,Constant5540,Constant5541,Constant5542,Constant5543,Constant5544,Constant5545,Constant5546,Constant5547,Constant5548,Constant5549,Constant5550,Constant5551,Constant5552,Constant5553,Constant5554,Constant5555,Constant5556,Constant5557,Constant5558,Constant5559,Constant5560,Constant5561,Constant5562,Constant5563,Constant5564,Constant5565,Constant5566,Constant5567,Constant5568,Constant5569,Constant5570,Constant5571,Constant5572,Constant5573,Constant5574,Constant5575,Constant5576,Constant5577,Constant5578,Constant5579,Constant5580,Constant5581,Constant5582,Constant5583,Constant5584,Constant5585,Constant5586,Constant5587,Constant5588,Constant5589,Constant5590,Constant5591,Constant5592,Constant5593,Constant5594,Constant5595,Constant5596,Constant5597,Constant5598,Constant5599,Constant5600,Constant5601,Constant5602,Constant5603,Constant5604,Constant5605,Constant5606,Constant5607,Constant5608,Constant5609,Constant5610,Constant5611,Constant5612,Constant5613,Constant5614,Constant5615,Constant5616,Constant5617,Constant5618,Constant5619,Constant5620,Constant5621,Constant5622,Constant5623,Constant5624,Constant5625,Constant5626,Constant5627,Constant5628,Constant5629,Constant5630,Constant5631,Constant5632,Constant5633,Constant5634,Constant5635,Constant5636,Constant5637,Constant5638,Constant5639,Constant5640,Constant5641,Constant5642,Constant5643,Constant5644,Constant5645,Constant5646,Constant5647,Constant5648,Constant5649,Constant5650,Constant5651,Constant5652,Constant5653,Constant5654,Constant5655,Constant5656,Constant5657,Constant5658,Constant5659,Constant5660,Constant5661,Constant5662,Constant5663,Constant5664,Constant5665,Constant5666,Constant5667,Constant5668 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 5415, 6, 2221, 2224, 2229, 2234, 2, 29, 2243, 2248, 38, 2257, 2262, 47, 2271, 2276, 56, 2285, 2290, 65, 2299, 2304, 74, 2313, 2318, 85, 2327, 2332, 95, 2341, 2346, 104, 2355, 2360, 113, 2369, 2374, 122, 2383, 2388, 131, 2397, 2402, 140, 2411, 2416, 149, 2425, 2430, 158, 2439, 2444, 167, 2453, 2458, 176, 2467, 2472, 185, 2481, 2486, 194, 10, 9, 2495, 2500, 2509, 2514, 2523, 2528, 2537, 2542, 2551, 2556, 2565, 2570, 2579, 2584, 2593, 2598, 2607, 2612, 2621, 2626, 2635, 2640, 2649, 2654, 2663, 2668, 2677, 2682, 2691, 2696, 2705, 2710, 2719, 2724, 2733, 2738, 2747, 2752, 2761, 2766, 2775, 2780, 2789, 2794, 2803, 2808, 2817, 2822, 2831, 2836, 2845, 2850, 2859, 2864, 2873, 2878, 2887, 2892, 2901, 2906, 2915, 2920, 2929, 2934, 2943, 2948, 2957, 2962, 2971, 2976, 2985, 2990, 2999, 3004, 3013, 3018, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 16, 200, 386, 387, 5413, 5414, 15, 199, 388<br />2: 385, 396, 405, 414, 423, 432, 443, 453, 462, 471, 480, 489, 498, 507, 516, 525, 534, 543, 552<br />ᐳ: 389, 390, 392, 393, 394, 398, 399, 401, 402, 403, 407, 408, 410, 411, 412, 416, 417, 419, 420, 421, 425, 426, 428, 429, 430, 434, 435, 437, 438, 439, 445, 446, 448, 449, 450, 451, 455, 456, 458, 459, 460, 464, 465, 467, 468, 469, 473, 474, 476, 477, 478, 482, 483, 485, 486, 487, 491, 492, 494, 495, 496, 500, 501, 503, 504, 505, 509, 510, 512, 513, 514, 518, 519, 521, 522, 523, 527, 528, 530, 531, 532, 536, 537, 539, 540, 541, 545, 546, 548, 549, 550, 554, 555, 557, 558, 559"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,Lambda7,Node9,Lambda10,Constant29,Constant38,Constant47,Constant56,Constant65,Constant74,Constant85,Constant95,Constant104,Constant113,Constant122,Constant131,Constant140,Constant149,Constant158,Constant167,Constant176,Constant185,Constant194,Node561,Lambda562,Node1114,Lambda1115,Node1298,Lambda1299,Node1483,Lambda1484,Node1667,Lambda1668,Node1852,Lambda1853,Node2036,Lambda2037,Lambda2221,Lambda2224,Access2225,Constant2226,Constant2227,Constant2228,Object2229,Lambda2230,Lambda2235,Constant2241,Constant2242,Constant2243,Object2244,Lambda2245,Lambda2250,Constant2256,Constant2257,Constant2258,Object2259,Lambda2260,Lambda2265,Constant2271,Constant2272,Constant2273,Object2274,Lambda2275,Lambda2280,Constant2286,Constant2287,Constant2288,Object2289,Lambda2290,Lambda2295,Constant2301,Constant2302,Constant2303,Object2304,Lambda2305,Lambda2310,Constant2316,Constant2317,Constant2318,Object2319,Lambda2320,Lambda2325,Constant2331,Constant2332,Constant2333,Object2334,Lambda2335,Lambda2340,Constant2346,Constant2347,Constant2348,Object2349,Lambda2350,Lambda2355,Constant2361,Constant2362,Constant2363,Object2364,Lambda2365,Lambda2370,Constant2376,Constant2377,Constant2378,Object2379,Lambda2380,Lambda2385,Constant2391,Constant2392,Constant2393,Object2394,Lambda2395,Lambda2400,Constant2406,Constant2407,Constant2408,Object2409,Lambda2410,Lambda2415,Constant2421,Constant2422,Constant2423,Object2424,Lambda2425,Lambda2430,Constant2436,Constant2437,Constant2438,Object2439,Lambda2440,Lambda2445,Constant2451,Constant2452,Constant2453,Object2454,Lambda2455,Lambda2460,Constant2466,Constant2467,Constant2468,Object2469,Lambda2470,Lambda2475,Constant2481,Constant2482,Constant2483,Object2484,Lambda2485,Lambda2490,Constant2496,Constant2497,Constant2498,Object2499,Lambda2500,Lambda2505,Constant2511,Constant2512,Object2514,Lambda2515,Lambda2520,Constant2526,Constant2527,Object2529,Lambda2530,Lambda2535,Constant2541,Constant2542,Object2544,Lambda2545,Lambda2550,Constant2556,Constant2557,Object2559,Lambda2560,Lambda2565,Constant2571,Constant2572,Object2574,Lambda2575,Lambda2580,Constant2586,Constant2587,Object2589,Lambda2590,Lambda2595,Constant2601,Constant2602,Object2604,Lambda2605,Lambda2610,Constant2616,Constant2617,Object2619,Lambda2620,Lambda2625,Constant2631,Constant2632,Object2634,Lambda2635,Lambda2640,Constant2646,Constant2647,Object2649,Lambda2650,Lambda2655,Constant2661,Constant2662,Object2664,Lambda2665,Lambda2670,Constant2676,Constant2677,Object2679,Lambda2680,Lambda2685,Constant2691,Constant2692,Object2694,Lambda2695,Lambda2700,Constant2706,Constant2707,Object2709,Lambda2710,Lambda2715,Constant2721,Constant2722,Object2724,Lambda2725,Lambda2730,Constant2736,Constant2737,Object2739,Lambda2740,Lambda2745,Constant2751,Constant2752,Object2754,Lambda2755,Lambda2760,Constant2766,Constant2767,Object2769,Lambda2770,Lambda2775,Constant2781,Constant2782,Object2784,Lambda2785,Lambda2790,Constant2796,Constant2797,Object2799,Lambda2800,Lambda2805,Constant2811,Constant2812,Object2814,Lambda2815,Lambda2820,Constant2826,Constant2827,Object2829,Lambda2830,Lambda2835,Constant2841,Constant2842,Object2844,Lambda2845,Lambda2850,Constant2856,Constant2857,Object2859,Lambda2860,Lambda2865,Constant2871,Constant2872,Object2874,Lambda2875,Lambda2880,Constant2886,Constant2887,Object2889,Lambda2890,Lambda2895,Constant2901,Constant2902,Object2904,Lambda2905,Lambda2910,Constant2916,Constant2917,Object2919,Lambda2920,Lambda2925,Constant2931,Constant2932,Object2934,Lambda2935,Lambda2940,Constant2946,Constant2947,Object2949,Lambda2950,Lambda2955,Constant2961,Constant2962,Object2964,Lambda2965,Lambda2970,Constant2976,Constant2977,Object2979,Lambda2980,Lambda2985,Constant2991,Constant2992,Object2994,Lambda2995,Lambda3000,Constant3006,Constant3007,Object3009,Lambda3010,Lambda3015,Constant3021,Constant3022,Object3024,Lambda3025,Lambda3030,Constant3036,Constant3037,Object3039,Lambda3040,Lambda3045,Constant3051,Constant3052,Object3054,Lambda3055,Lambda3060,Constant3066,Constant3067,Object3069,Lambda3070,Lambda3075,Constant3081,Constant3082,Object3084,Lambda3085,Lambda3090,Constant3096,Constant3097,Object3099,Lambda3100,Lambda3105,Constant3111,Constant3112,Object3114,Lambda3115,Lambda3120,Constant3126,Constant3127,Object3129,Lambda3130,Lambda3135,Constant3141,Constant3142,Object3144,Lambda3145,Lambda3150,Constant3156,Constant3157,Object3159,Lambda3160,Lambda3165,Constant3171,Constant3172,Object3174,Lambda3175,Lambda3180,Constant3186,Constant3187,Object3189,Lambda3190,Lambda3195,Constant3201,Constant3202,Object3204,Lambda3205,Lambda3210,Constant3216,Constant3217,Object3219,Lambda3220,Lambda3225,Constant3231,Constant3232,Object3234,Lambda3235,Lambda3240,Constant3246,Constant3247,Object3249,Lambda3250,Lambda3255,Constant3261,Constant3262,Object3264,Lambda3265,Lambda3270,Constant3276,Constant3277,Object3279,Lambda3280,Lambda3285,Constant3291,Constant3292,Object3294,Lambda3295,Lambda3300,Constant3306,Constant3307,Object3309,Lambda3310,Lambda3315,Constant3321,Constant3322,Object3324,Lambda3325,Lambda3330,Constant3336,Constant3337,Object3339,Lambda3340,Lambda3345,Constant3351,Constant3352,Object3354,Lambda3355,Lambda3360,Constant3366,Constant3367,Object3369,Lambda3370,Lambda3375,Constant3381,Constant3382,Object3384,Lambda3385,Lambda3390,Constant3396,Constant3397,Object3399,Lambda3400,Lambda3405,Constant3411,Constant3412,Object3414,Lambda3415,Lambda3420,Constant3426,Constant3427,Object3429,Lambda3430,Lambda3435,Constant3441,Constant3442,Object3444,Lambda3445,Lambda3450,Constant3456,Constant3457,Object3459,Lambda3460,Lambda3465,Constant3471,Constant3472,Object3474,Lambda3475,Lambda3480,Constant3486,Constant3487,Object3489,Lambda3490,Lambda3495,Constant3501,Constant3502,Object3504,Lambda3505,Lambda3510,Constant3516,Constant3517,Object3519,Lambda3520,Lambda3525,Constant3531,Constant3532,Object3534,Lambda3535,Lambda3540,Constant3546,Constant3547,Object3549,Lambda3550,Lambda3555,Constant3561,Constant3562,Object3564,Lambda3565,Lambda3570,Constant3576,Constant3577,Object3579,Lambda3580,Lambda3585,Constant3591,Constant3592,Object3594,Lambda3595,Lambda3600,Constant3606,Constant3607,Object3609,Lambda3610,Lambda3615,Constant3621,Constant3622,Object3624,Lambda3625,Lambda3630,Constant3636,Constant3637,Object3639,Lambda3640,Lambda3645,Constant3651,Constant3652,Object3654,Lambda3655,Lambda3660,Constant3666,Constant3667,Object3669,Lambda3670,Lambda3675,Constant3681,Constant3682,Object3684,Lambda3685,Lambda3690,Constant3696,Constant3697,Object3699,Lambda3700,Lambda3705,Constant3711,Constant3712,Object3714,Lambda3715,Lambda3720,Constant3726,Constant3727,Object3729,Lambda3730,Lambda3735,Constant3741,Constant3742,Object3744,Lambda3745,Lambda3750,Constant3756,Constant3757,Object3759,Lambda3760,Lambda3765,Constant3771,Constant3772,Object3774,Lambda3775,Lambda3780,Constant3786,Constant3787,Object3789,Lambda3790,Lambda3795,Constant3801,Constant3802,Object3804,Lambda3805,Lambda3810,Constant3816,Constant3817,Object3819,Lambda3820,Lambda3825,Constant3831,Constant3832,Object3834,Lambda3835,Lambda3840,Constant3846,Constant3847,Object3849,Lambda3850,Lambda3855,Constant3861,Constant3862,Object3864,Lambda3865,Lambda3870,Constant3876,Constant3877,Object3879,Lambda3880,Lambda3885,Constant3891,Constant3892,Object3894,Lambda3895,Lambda3900,Constant3906,Constant3907,Object3909,Lambda3910,Lambda3915,Constant3921,Constant3922,Object3924,Lambda3925,Lambda3930,Constant3936,Constant3937,Object3939,Lambda3940,Lambda3945,Constant3951,Constant3952,Object3954,Lambda3955,Lambda3960,Constant3966,Constant3967,Object3969,Lambda3970,Lambda3975,Constant3981,Constant3982,Object3984,Lambda3985,Lambda3990,Constant3996,Constant3997,Object3999,Lambda4000,Lambda4005,Constant4011,Constant4012,Object4014,Lambda4015,Lambda4020,Constant4026,Constant4027,Object4029,Lambda4030,Lambda4035,Constant4041,Constant4042,Object4044,Lambda4045,Lambda4050,Constant4056,Constant4057,Object4059,Lambda4060,Lambda4065,Constant4071,Constant4072,Object4074,Lambda4075,Lambda4080,Constant4086,Constant4087,Object4089,Lambda4090,Lambda4095,Constant4101,Constant4102,Object4104,Lambda4105,Lambda4110,Constant4116,Constant4117,Object4119,Lambda4120,Lambda4125,Constant4131,Constant4132,Object4134,Lambda4135,Lambda4140,Constant4146,Constant4147,Object4149,Lambda4150,Lambda4155,Constant4161,Constant4162,Object4164,Lambda4165,Lambda4170,Constant4176,Constant4177,Object4179,Lambda4180,Lambda4185,Constant4191,Constant4192,Object4194,Lambda4195,Lambda4200,Constant4206,Constant4207,Object4209,Lambda4210,Lambda4215,Constant4221,Constant4222,Object4224,Lambda4225,Lambda4230,Constant4236,Constant4237,Object4239,Lambda4240,Lambda4245,Constant4251,Constant4252,Object4254,Lambda4255,Lambda4260,Constant4266,Constant4267,Object4269,Lambda4270,Lambda4275,Constant4281,Constant4282,Object4284,Lambda4285,Lambda4290,Constant4296,Constant4297,Object4299,Lambda4300,Lambda4305,Constant4311,Constant4312,Object4314,Lambda4315,Lambda4320,Constant4326,Constant4327,Object4329,Lambda4330,Lambda4335,Constant4341,Constant4342,Object4344,Lambda4345,Lambda4350,Constant4356,Constant4357,Object4359,Lambda4360,Lambda4365,Constant4371,Constant4372,Object4374,Lambda4375,Lambda4380,Constant4386,Constant4387,Object4389,Lambda4390,Lambda4395,Constant4401,Constant4402,Object4404,Lambda4405,Lambda4410,Constant4416,Constant4417,Object4419,Lambda4420,Lambda4425,Constant4431,Constant4432,Object4434,Lambda4435,Lambda4440,Constant4446,Constant4447,Object4449,Lambda4450,Lambda4455,Constant4461,Constant4462,Object4464,Lambda4465,Lambda4470,Constant4476,Constant4477,Object4479,Lambda4480,Lambda4485,Constant4491,Constant4492,Object4494,Lambda4495,Lambda4500,Constant4506,Constant4507,Object4509,Lambda4510,Lambda4515,Constant4521,Constant4522,Object4524,Lambda4525,Lambda4530,Constant4536,Constant4537,Object4539,Lambda4540,Lambda4545,Constant4551,Constant4552,Object4554,Lambda4555,Lambda4560,Constant4566,Constant4567,Object4569,Lambda4570,Lambda4575,Constant4581,Constant4582,Object4584,Lambda4585,Lambda4590,Constant4596,Constant4597,Object4599,Lambda4600,Lambda4605,Constant4611,Constant4612,Object4614,Lambda4615,Lambda4620,Constant4626,Constant4627,Object4629,Lambda4630,Lambda4635,Constant4641,Constant4642,Object4644,Lambda4645,Lambda4650,Constant4656,Constant4657,Object4659,Lambda4660,Lambda4665,Constant4671,Constant4672,Object4674,Lambda4675,Lambda4680,Constant4686,Constant4687,Object4689,Lambda4690,Lambda4695,Constant4701,Constant4702,Object4704,Lambda4705,Lambda4710,Constant4716,Constant4717,Object4719,Lambda4720,Lambda4725,Constant4731,Constant4732,Object4734,Lambda4735,Lambda4740,Constant4746,Constant4747,Object4749,Lambda4750,Lambda4755,Constant4761,Constant4762,Object4764,Lambda4765,Lambda4770,Constant4776,Constant4777,Object4779,Lambda4780,Lambda4785,Constant4791,Constant4792,Object4794,Lambda4795,Lambda4800,Constant4806,Constant4807,Object4809,Lambda4810,Lambda4815,Constant4821,Constant4822,Object4824,Lambda4825,Lambda4830,Constant4836,Constant4837,Object4839,Lambda4840,Lambda4845,Constant4851,Constant4852,Object4854,Lambda4855,Lambda4860,Constant4866,Constant4867,Object4869,Lambda4870,Lambda4875,Constant4881,Constant4882,Object4884,Lambda4885,Lambda4890,Constant4896,Constant4897,Object4899,Lambda4900,Lambda4905,Constant4911,Constant4912,Object4914,Lambda4915,Lambda4920,Constant4926,Constant4927,Object4929,Lambda4930,Lambda4935,Constant4941,Constant4942,Object4944,Lambda4945,Lambda4950,Constant4956,Constant4957,Object4959,Lambda4960,Lambda4965,Constant4971,Constant4972,Object4974,Lambda4975,Lambda4980,Constant4986,Constant4987,Object4989,Lambda4990,Lambda4995,Constant5001,Constant5002,Object5004,Lambda5005,Lambda5010,Constant5016,Constant5017,Object5019,Lambda5020,Lambda5025,Constant5031,Constant5032,Object5034,Lambda5035,Lambda5040,Constant5046,Constant5047,Object5049,Lambda5050,Lambda5055,Constant5061,Constant5062,Object5064,Lambda5065,Lambda5070,Constant5076,Constant5077,Object5079,Lambda5080,Lambda5085,Constant5091,Constant5092,Object5094,Lambda5095,Lambda5100,Constant5106,Constant5107,Object5109,Lambda5110,Lambda5115,Constant5121,Constant5122,Object5124,Lambda5125,Lambda5130,Constant5136,Constant5137,Object5139,Lambda5140,Lambda5145,Constant5151,Constant5152,Object5154,Lambda5155,Lambda5160,Constant5166,Constant5167,Object5169,Lambda5170,Lambda5175,Constant5181,Constant5182,Object5184,Lambda5185,Lambda5190,Constant5196,Constant5197,Object5199,Lambda5200,Lambda5205,Constant5211,Constant5212,Object5214,Lambda5215,Lambda5220,Constant5226,Constant5227,Object5229,Lambda5230,Lambda5235,Constant5241,Constant5242,Object5244,Lambda5245,Lambda5250,Constant5256,Constant5257,Object5259,Lambda5260,Lambda5265,Constant5271,Constant5272,Object5274,Lambda5275,Lambda5280,Constant5286,Constant5287,Object5289,Lambda5290,Lambda5295,Constant5301,Constant5302,Object5304,Lambda5305,Lambda5310,Constant5316,Constant5317,Object5319,Lambda5320,Lambda5325,Constant5331,Constant5332,Object5334,Lambda5335,Lambda5340,Constant5346,Constant5347,Object5349,Lambda5350,Lambda5355,Constant5361,Constant5362,Object5364,Lambda5365,Lambda5370,Constant5376,Constant5377,Object5379,Lambda5380,Lambda5385,Constant5391,Constant5392,Object5394,Lambda5395,Lambda5400,Constant5406,Constant5407,Object5409,Lambda5410,Lambda5415,Constant5421,Constant5422,Object5424,Lambda5425,Lambda5430,Constant5436,Constant5437,Object5439,Lambda5440,Lambda5445,Constant5451,Constant5452,Object5454,Lambda5455,Lambda5460,Constant5466,Constant5467,Object5469,Lambda5470,Lambda5475,Constant5481,Constant5482,Object5484,Lambda5485,Lambda5490,Constant5496,Constant5497,Object5499,Lambda5500,Lambda5505,Constant5511,Constant5512,Object5514,Lambda5515,Lambda5520,Constant5526,Constant5527,Object5529,Lambda5530,Lambda5535,Constant5541,Constant5542,Object5544,Lambda5545,Lambda5550,Constant5556,Constant5557,Object5559,Lambda5560,Lambda5565,Constant5571,Constant5572,Object5574,Lambda5575,Lambda5580,Constant5586,Constant5587,Object5589,Lambda5590,Lambda5595,Constant5601,Constant5602,Object5604,Lambda5605,Lambda5610,Constant5616,Constant5617,Object5619,Lambda5620,Lambda5625,Constant5631,Constant5632,Object5634,Lambda5635,Lambda5640,Constant5643,Constant5667,Constant5668,Constant5669,Constant5670,Constant5671,Constant5672,Constant5673,Constant5674,Constant5675,Constant5676,Constant5677,Constant5678,Constant5679,Constant5680,Constant5681,Constant5682,Constant5683,Constant5684,Constant5685,Constant5686,Constant5687,Constant5688,Constant5689,Constant5690,Constant5691,Constant5692,Constant5693,Constant5694,Constant5695,Constant5696,Constant5697,Constant5698,Constant5699,Constant5700,Constant5701,Constant5702,Constant5703,Constant5704,Constant5705,Constant5706,Constant5707,Constant5708,Constant5709,Constant5710,Constant5711,Constant5712,Constant5713,Constant5714,Constant5715,Constant5716,Constant5717,Constant5718,Constant5719,Constant5720,Constant5721,Constant5722,Constant5723,Constant5724,Constant5725,Constant5726,Constant5727,Constant5728,Constant5729,Constant5730,Constant5731,Constant5732,Constant5733,Constant5734,Constant5735,Constant5736,Constant5737,Constant5738,Constant5739,Constant5740,Constant5741,Constant5742,Constant5743,Constant5744,Constant5745,Constant5746,Constant5747,Constant5748,Constant5749,Constant5750,Constant5751,Constant5752,Constant5753,Constant5754,Constant5755,Constant5756,Constant5757,Constant5758,Constant5759,Constant5760,Constant5761,Constant5762,Constant5763,Constant5764,Constant5765,Constant5766,Constant5767,Constant5768,Constant5769,Constant5770,Constant5771,Constant5772,Constant5773,Constant5774,Constant5775,Constant5776,Constant5777,Constant5778,Constant5779,Constant5780,Constant5781,Constant5782,Constant5783,Constant5784,Constant5785,Constant5786,Constant5787,Constant5788,Constant5789,Constant5790,Constant5791,Constant5792,Constant5793,Constant5794,Constant5795,Constant5796,Constant5797,Constant5798,Constant5799,Constant5800,Constant5801,Constant5802,Constant5803,Constant5804,Constant5805,Constant5806,Constant5807,Constant5808,Constant5809,Constant5810,Constant5811,Constant5812,Constant5813,Constant5814,Constant5815,Constant5816,Constant5817,Constant5818,Constant5819,Constant5820,Constant5821,Constant5822,Constant5823,Constant5824,Constant5825,Constant5826,Constant5827,Constant5828,Constant5829,Constant5830,Constant5831,Constant5832,Constant5833,Constant5834,Constant5835,Constant5836,Constant5837,Constant5838,Constant5839,Constant5840,Constant5841,Constant5842,Constant5843,Constant5844,Constant5845,Constant5846,Constant5847,Constant5848,Constant5849,Constant5850,Constant5851,Constant5852,Constant5853,Constant5854,Constant5855,Constant5856,Constant5857,Constant5858,Constant5859,Constant5860,Constant5861,Constant5862,Constant5863,Constant5864,Constant5865,Constant5866,Constant5867,Constant5868,Constant5869,Constant5870,Constant5871,Constant5872,Constant5873,Constant5874,Constant5875,Constant5876,Constant5877,Constant5878,Constant5879,Constant5880,Constant5881,Constant5882,Constant5883,Constant5884,Constant5885,Constant5886,Constant5887,Constant5888,Constant5889,Constant5890,Constant5891,Constant5892,Constant5893,Constant5894,Constant5895,Constant5896 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 5643, 6, 2221, 2225, 2230, 2235, 2, 29, 2245, 2250, 38, 2260, 2265, 47, 2275, 2280, 56, 2290, 2295, 65, 2305, 2310, 74, 2320, 2325, 85, 2335, 2340, 95, 2350, 2355, 104, 2365, 2370, 113, 2380, 2385, 122, 2395, 2400, 131, 2410, 2415, 140, 2425, 2430, 149, 2440, 2445, 158, 2455, 2460, 167, 2470, 2475, 176, 2485, 2490, 185, 2500, 2505, 194, 10, 9, 2515, 2520, 2530, 2535, 2545, 2550, 2560, 2565, 2575, 2580, 2590, 2595, 2605, 2610, 2620, 2625, 2635, 2640, 2650, 2655, 2665, 2670, 2680, 2685, 2695, 2700, 2710, 2715, 2725, 2730, 2740, 2745, 2755, 2760, 2770, 2775, 2785, 2790, 2800, 2805, 2815, 2820, 2830, 2835, 2845, 2850, 2860, 2865, 2875, 2880, 2890, 2895, 2905, 2910, 2920, 2925, 2935, 2940, 2950, 2955, 2965, 2970, 2980, 2985, 2995, 3000, 3010, 3015, 3025, 3030, 3040, 3045, 3055, 3060, 3070, 3075, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 16, 200, 386, 387, 5641, 5642, 15, 199, 388<br />2: 385, 396, 405, 414, 423, 432, 443, 453, 462, 471, 480, 489, 498, 507, 516, 525, 534, 543, 552<br />ᐳ: 389, 390, 392, 393, 394, 398, 399, 401, 402, 403, 407, 408, 410, 411, 412, 416, 417, 419, 420, 421, 425, 426, 428, 429, 430, 434, 435, 437, 438, 439, 445, 446, 448, 449, 450, 451, 455, 456, 458, 459, 460, 464, 465, 467, 468, 469, 473, 474, 476, 477, 478, 482, 483, 485, 486, 487, 491, 492, 494, 495, 496, 500, 501, 503, 504, 505, 509, 510, 512, 513, 514, 518, 519, 521, 522, 523, 527, 528, 530, 531, 532, 536, 537, 539, 540, 541, 545, 546, 548, 549, 550, 554, 555, 557, 558, 559"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Node15,Lambda16,Node199,Lambda200,PgSelect385,Access386,Access387,Object388,First389,PgSelectSingle390,PgClassExpression392,List393,Lambda394,PgSelect396,First398,PgSelectSingle399,PgClassExpression401,List402,Lambda403,PgSelect405,First407,PgSelectSingle408,PgClassExpression410,List411,Lambda412,PgSelect414,First416,PgSelectSingle417,PgClassExpression419,List420,Lambda421,PgSelect423,First425,PgSelectSingle426,PgClassExpression428,List429,Lambda430,PgSelect432,First434,PgSelectSingle435,PgClassExpression437,List438,Lambda439,PgSelect443,First445,PgSelectSingle446,PgClassExpression448,PgClassExpression449,List450,Lambda451,PgSelect453,First455,PgSelectSingle456,PgClassExpression458,List459,Lambda460,PgSelect462,First464,PgSelectSingle465,PgClassExpression467,List468,Lambda469,PgSelect471,First473,PgSelectSingle474,PgClassExpression476,List477,Lambda478,PgSelect480,First482,PgSelectSingle483,PgClassExpression485,List486,Lambda487,PgSelect489,First491,PgSelectSingle492,PgClassExpression494,List495,Lambda496,PgSelect498,First500,PgSelectSingle501,PgClassExpression503,List504,Lambda505,PgSelect507,First509,PgSelectSingle510,PgClassExpression512,List513,Lambda514,PgSelect516,First518,PgSelectSingle519,PgClassExpression521,List522,Lambda523,PgSelect525,First527,PgSelectSingle528,PgClassExpression530,List531,Lambda532,PgSelect534,First536,PgSelectSingle537,PgClassExpression539,List540,Lambda541,PgSelect543,First545,PgSelectSingle546,PgClassExpression548,List549,Lambda550,PgSelect552,First554,PgSelectSingle555,PgClassExpression557,List558,Lambda559,Access5413,Access5414 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 388, 2221, 2224, 2495, 2500, 29, 2509, 2514, 38, 2523, 2528, 47, 2537, 2542, 56, 2551, 2556, 65, 2565, 2570, 74, 2579, 2584, 85, 2593, 2598, 95, 2607, 2612, 104, 2621, 2626, 113, 2635, 2640, 122, 2649, 2654, 131, 2663, 2668, 140, 2677, 2682, 149, 2691, 2696, 158, 2705, 2710, 167, 2719, 2724, 176, 2733, 2738, 185, 2747, 2752, 194, 16, 15, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5416], Access[5417]<br />2: 23, 34, 43, 52, 61, 70, 81, 91, 100, 109, 118, 127, 136, 145, 154, 163, 172, 181, 190<br />ᐳ: 27, 28, 30, 31, 32, 36, 37, 39, 40, 41, 45, 46, 48, 49, 50, 54, 55, 57, 58, 59, 63, 64, 66, 67, 68, 72, 73, 75, 76, 77, 83, 84, 86, 87, 88, 89, 93, 94, 96, 97, 98, 102, 103, 105, 106, 107, 111, 112, 114, 115, 116, 120, 121, 123, 124, 125, 129, 130, 132, 133, 134, 138, 139, 141, 142, 143, 147, 148, 150, 151, 152, 156, 157, 159, 160, 161, 165, 166, 168, 169, 170, 174, 175, 177, 178, 179, 183, 184, 186, 187, 188, 192, 193, 195, 196, 197"):::bucket
+    class Bucket1,Node15,Lambda16,Node199,Lambda200,PgSelect385,Access386,Access387,Object388,First389,PgSelectSingle390,PgClassExpression392,List393,Lambda394,PgSelect396,First398,PgSelectSingle399,PgClassExpression401,List402,Lambda403,PgSelect405,First407,PgSelectSingle408,PgClassExpression410,List411,Lambda412,PgSelect414,First416,PgSelectSingle417,PgClassExpression419,List420,Lambda421,PgSelect423,First425,PgSelectSingle426,PgClassExpression428,List429,Lambda430,PgSelect432,First434,PgSelectSingle435,PgClassExpression437,List438,Lambda439,PgSelect443,First445,PgSelectSingle446,PgClassExpression448,PgClassExpression449,List450,Lambda451,PgSelect453,First455,PgSelectSingle456,PgClassExpression458,List459,Lambda460,PgSelect462,First464,PgSelectSingle465,PgClassExpression467,List468,Lambda469,PgSelect471,First473,PgSelectSingle474,PgClassExpression476,List477,Lambda478,PgSelect480,First482,PgSelectSingle483,PgClassExpression485,List486,Lambda487,PgSelect489,First491,PgSelectSingle492,PgClassExpression494,List495,Lambda496,PgSelect498,First500,PgSelectSingle501,PgClassExpression503,List504,Lambda505,PgSelect507,First509,PgSelectSingle510,PgClassExpression512,List513,Lambda514,PgSelect516,First518,PgSelectSingle519,PgClassExpression521,List522,Lambda523,PgSelect525,First527,PgSelectSingle528,PgClassExpression530,List531,Lambda532,PgSelect534,First536,PgSelectSingle537,PgClassExpression539,List540,Lambda541,PgSelect543,First545,PgSelectSingle546,PgClassExpression548,List549,Lambda550,PgSelect552,First554,PgSelectSingle555,PgClassExpression557,List558,Lambda559,Access5641,Access5642 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 388, 2221, 2225, 2515, 2520, 29, 2530, 2535, 38, 2545, 2550, 47, 2560, 2565, 56, 2575, 2580, 65, 2590, 2595, 74, 2605, 2610, 85, 2620, 2625, 95, 2635, 2640, 104, 2650, 2655, 113, 2665, 2670, 122, 2680, 2685, 131, 2695, 2700, 140, 2710, 2715, 149, 2725, 2730, 158, 2740, 2745, 167, 2755, 2760, 176, 2770, 2775, 185, 2785, 2790, 194, 16, 15, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5644], Access[5645]<br />2: 23, 34, 43, 52, 61, 70, 81, 91, 100, 109, 118, 127, 136, 145, 154, 163, 172, 181, 190<br />ᐳ: 27, 28, 30, 31, 32, 36, 37, 39, 40, 41, 45, 46, 48, 49, 50, 54, 55, 57, 58, 59, 63, 64, 66, 67, 68, 72, 73, 75, 76, 77, 83, 84, 86, 87, 88, 89, 93, 94, 96, 97, 98, 102, 103, 105, 106, 107, 111, 112, 114, 115, 116, 120, 121, 123, 124, 125, 129, 130, 132, 133, 134, 138, 139, 141, 142, 143, 147, 148, 150, 151, 152, 156, 157, 159, 160, 161, 165, 166, 168, 169, 170, 174, 175, 177, 178, 179, 183, 184, 186, 187, 188, 192, 193, 195, 196, 197"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect23,First27,PgSelectSingle28,PgClassExpression30,List31,Lambda32,PgSelect34,First36,PgSelectSingle37,PgClassExpression39,List40,Lambda41,PgSelect43,First45,PgSelectSingle46,PgClassExpression48,List49,Lambda50,PgSelect52,First54,PgSelectSingle55,PgClassExpression57,List58,Lambda59,PgSelect61,First63,PgSelectSingle64,PgClassExpression66,List67,Lambda68,PgSelect70,First72,PgSelectSingle73,PgClassExpression75,List76,Lambda77,PgSelect81,First83,PgSelectSingle84,PgClassExpression86,PgClassExpression87,List88,Lambda89,PgSelect91,First93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgSelect100,First102,PgSelectSingle103,PgClassExpression105,List106,Lambda107,PgSelect109,First111,PgSelectSingle112,PgClassExpression114,List115,Lambda116,PgSelect118,First120,PgSelectSingle121,PgClassExpression123,List124,Lambda125,PgSelect127,First129,PgSelectSingle130,PgClassExpression132,List133,Lambda134,PgSelect136,First138,PgSelectSingle139,PgClassExpression141,List142,Lambda143,PgSelect145,First147,PgSelectSingle148,PgClassExpression150,List151,Lambda152,PgSelect154,First156,PgSelectSingle157,PgClassExpression159,List160,Lambda161,PgSelect163,First165,PgSelectSingle166,PgClassExpression168,List169,Lambda170,PgSelect172,First174,PgSelectSingle175,PgClassExpression177,List178,Lambda179,PgSelect181,First183,PgSelectSingle184,PgClassExpression186,List187,Lambda188,PgSelect190,First192,PgSelectSingle193,PgClassExpression195,List196,Lambda197,Access5416,Access5417 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 388, 2221, 2224, 2761, 2766, 29, 2775, 2780, 38, 2789, 2794, 47, 2803, 2808, 56, 2817, 2822, 65, 2831, 2836, 74, 2845, 2850, 85, 2859, 2864, 95, 2873, 2878, 104, 2887, 2892, 113, 2901, 2906, 122, 2915, 2920, 131, 2929, 2934, 140, 2943, 2948, 149, 2957, 2962, 158, 2971, 2976, 167, 2985, 2990, 176, 2999, 3004, 185, 3013, 3018, 194, 200, 199, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5418], Access[5419]<br />2: 207, 218, 227, 236, 245, 254, 265, 275, 284, 293, 302, 311, 320, 329, 338, 347, 356, 365, 374<br />ᐳ: 211, 212, 214, 215, 216, 220, 221, 223, 224, 225, 229, 230, 232, 233, 234, 238, 239, 241, 242, 243, 247, 248, 250, 251, 252, 256, 257, 259, 260, 261, 267, 268, 270, 271, 272, 273, 277, 278, 280, 281, 282, 286, 287, 289, 290, 291, 295, 296, 298, 299, 300, 304, 305, 307, 308, 309, 313, 314, 316, 317, 318, 322, 323, 325, 326, 327, 331, 332, 334, 335, 336, 340, 341, 343, 344, 345, 349, 350, 352, 353, 354, 358, 359, 361, 362, 363, 367, 368, 370, 371, 372, 376, 377, 379, 380, 381"):::bucket
+    class Bucket2,PgSelect23,First27,PgSelectSingle28,PgClassExpression30,List31,Lambda32,PgSelect34,First36,PgSelectSingle37,PgClassExpression39,List40,Lambda41,PgSelect43,First45,PgSelectSingle46,PgClassExpression48,List49,Lambda50,PgSelect52,First54,PgSelectSingle55,PgClassExpression57,List58,Lambda59,PgSelect61,First63,PgSelectSingle64,PgClassExpression66,List67,Lambda68,PgSelect70,First72,PgSelectSingle73,PgClassExpression75,List76,Lambda77,PgSelect81,First83,PgSelectSingle84,PgClassExpression86,PgClassExpression87,List88,Lambda89,PgSelect91,First93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgSelect100,First102,PgSelectSingle103,PgClassExpression105,List106,Lambda107,PgSelect109,First111,PgSelectSingle112,PgClassExpression114,List115,Lambda116,PgSelect118,First120,PgSelectSingle121,PgClassExpression123,List124,Lambda125,PgSelect127,First129,PgSelectSingle130,PgClassExpression132,List133,Lambda134,PgSelect136,First138,PgSelectSingle139,PgClassExpression141,List142,Lambda143,PgSelect145,First147,PgSelectSingle148,PgClassExpression150,List151,Lambda152,PgSelect154,First156,PgSelectSingle157,PgClassExpression159,List160,Lambda161,PgSelect163,First165,PgSelectSingle166,PgClassExpression168,List169,Lambda170,PgSelect172,First174,PgSelectSingle175,PgClassExpression177,List178,Lambda179,PgSelect181,First183,PgSelectSingle184,PgClassExpression186,List187,Lambda188,PgSelect190,First192,PgSelectSingle193,PgClassExpression195,List196,Lambda197,Access5644,Access5645 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 388, 2221, 2225, 2800, 2805, 29, 2815, 2820, 38, 2830, 2835, 47, 2845, 2850, 56, 2860, 2865, 65, 2875, 2880, 74, 2890, 2895, 85, 2905, 2910, 95, 2920, 2925, 104, 2935, 2940, 113, 2950, 2955, 122, 2965, 2970, 131, 2980, 2985, 140, 2995, 3000, 149, 3010, 3015, 158, 3025, 3030, 167, 3040, 3045, 176, 3055, 3060, 185, 3070, 3075, 194, 200, 199, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5646], Access[5647]<br />2: 207, 218, 227, 236, 245, 254, 265, 275, 284, 293, 302, 311, 320, 329, 338, 347, 356, 365, 374<br />ᐳ: 211, 212, 214, 215, 216, 220, 221, 223, 224, 225, 229, 230, 232, 233, 234, 238, 239, 241, 242, 243, 247, 248, 250, 251, 252, 256, 257, 259, 260, 261, 267, 268, 270, 271, 272, 273, 277, 278, 280, 281, 282, 286, 287, 289, 290, 291, 295, 296, 298, 299, 300, 304, 305, 307, 308, 309, 313, 314, 316, 317, 318, 322, 323, 325, 326, 327, 331, 332, 334, 335, 336, 340, 341, 343, 344, 345, 349, 350, 352, 353, 354, 358, 359, 361, 362, 363, 367, 368, 370, 371, 372, 376, 377, 379, 380, 381"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect207,First211,PgSelectSingle212,PgClassExpression214,List215,Lambda216,PgSelect218,First220,PgSelectSingle221,PgClassExpression223,List224,Lambda225,PgSelect227,First229,PgSelectSingle230,PgClassExpression232,List233,Lambda234,PgSelect236,First238,PgSelectSingle239,PgClassExpression241,List242,Lambda243,PgSelect245,First247,PgSelectSingle248,PgClassExpression250,List251,Lambda252,PgSelect254,First256,PgSelectSingle257,PgClassExpression259,List260,Lambda261,PgSelect265,First267,PgSelectSingle268,PgClassExpression270,PgClassExpression271,List272,Lambda273,PgSelect275,First277,PgSelectSingle278,PgClassExpression280,List281,Lambda282,PgSelect284,First286,PgSelectSingle287,PgClassExpression289,List290,Lambda291,PgSelect293,First295,PgSelectSingle296,PgClassExpression298,List299,Lambda300,PgSelect302,First304,PgSelectSingle305,PgClassExpression307,List308,Lambda309,PgSelect311,First313,PgSelectSingle314,PgClassExpression316,List317,Lambda318,PgSelect320,First322,PgSelectSingle323,PgClassExpression325,List326,Lambda327,PgSelect329,First331,PgSelectSingle332,PgClassExpression334,List335,Lambda336,PgSelect338,First340,PgSelectSingle341,PgClassExpression343,List344,Lambda345,PgSelect347,First349,PgSelectSingle350,PgClassExpression352,List353,Lambda354,PgSelect356,First358,PgSelectSingle359,PgClassExpression361,List362,Lambda363,PgSelect365,First367,PgSelectSingle368,PgClassExpression370,List371,Lambda372,PgSelect374,First376,PgSelectSingle377,PgClassExpression379,List380,Lambda381,Access5418,Access5419 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 5415, 6, 2221, 2224, 3027, 3032, 2, 29, 3041, 3046, 38, 3055, 3060, 47, 3069, 3074, 56, 3083, 3088, 65, 3097, 3102, 74, 3111, 3116, 85, 3125, 3130, 95, 3139, 3144, 104, 3153, 3158, 113, 3167, 3172, 122, 3181, 3186, 131, 3195, 3200, 140, 3209, 3214, 149, 3223, 3228, 158, 3237, 3242, 167, 3251, 3256, 176, 3265, 3270, 185, 3279, 3284, 194, 562, 561, 3293, 3298, 3307, 3312, 3321, 3326, 3335, 3340, 3349, 3354, 3363, 3368, 3377, 3382, 3391, 3396, 3405, 3410, 3419, 3424, 3433, 3438, 3447, 3452, 3461, 3466, 3475, 3480, 3489, 3494, 3503, 3508, 3517, 3522, 3531, 3536, 3545, 3550, 3559, 3564, 3573, 3578, 3587, 3592, 3601, 3606, 3615, 3620, 3629, 3634, 3643, 3648, 3657, 3662, 3671, 3676, 3685, 3690, 3699, 3704, 3713, 3718, 3727, 3732, 3741, 3746, 3755, 3760, 3769, 3774, 3783, 3788, 3797, 3802, 3811, 3816, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 568, 752, 938, 939, 5421, 5422, 567, 751, 940<br />2: 937, 948, 957, 966, 975, 984, 995, 1005, 1014, 1023, 1032, 1041, 1050, 1059, 1068, 1077, 1086, 1095, 1104<br />ᐳ: 941, 942, 944, 945, 946, 950, 951, 953, 954, 955, 959, 960, 962, 963, 964, 968, 969, 971, 972, 973, 977, 978, 980, 981, 982, 986, 987, 989, 990, 991, 997, 998, 1000, 1001, 1002, 1003, 1007, 1008, 1010, 1011, 1012, 1016, 1017, 1019, 1020, 1021, 1025, 1026, 1028, 1029, 1030, 1034, 1035, 1037, 1038, 1039, 1043, 1044, 1046, 1047, 1048, 1052, 1053, 1055, 1056, 1057, 1061, 1062, 1064, 1065, 1066, 1070, 1071, 1073, 1074, 1075, 1079, 1080, 1082, 1083, 1084, 1088, 1089, 1091, 1092, 1093, 1097, 1098, 1100, 1101, 1102, 1106, 1107, 1109, 1110, 1111"):::bucket
+    class Bucket3,PgSelect207,First211,PgSelectSingle212,PgClassExpression214,List215,Lambda216,PgSelect218,First220,PgSelectSingle221,PgClassExpression223,List224,Lambda225,PgSelect227,First229,PgSelectSingle230,PgClassExpression232,List233,Lambda234,PgSelect236,First238,PgSelectSingle239,PgClassExpression241,List242,Lambda243,PgSelect245,First247,PgSelectSingle248,PgClassExpression250,List251,Lambda252,PgSelect254,First256,PgSelectSingle257,PgClassExpression259,List260,Lambda261,PgSelect265,First267,PgSelectSingle268,PgClassExpression270,PgClassExpression271,List272,Lambda273,PgSelect275,First277,PgSelectSingle278,PgClassExpression280,List281,Lambda282,PgSelect284,First286,PgSelectSingle287,PgClassExpression289,List290,Lambda291,PgSelect293,First295,PgSelectSingle296,PgClassExpression298,List299,Lambda300,PgSelect302,First304,PgSelectSingle305,PgClassExpression307,List308,Lambda309,PgSelect311,First313,PgSelectSingle314,PgClassExpression316,List317,Lambda318,PgSelect320,First322,PgSelectSingle323,PgClassExpression325,List326,Lambda327,PgSelect329,First331,PgSelectSingle332,PgClassExpression334,List335,Lambda336,PgSelect338,First340,PgSelectSingle341,PgClassExpression343,List344,Lambda345,PgSelect347,First349,PgSelectSingle350,PgClassExpression352,List353,Lambda354,PgSelect356,First358,PgSelectSingle359,PgClassExpression361,List362,Lambda363,PgSelect365,First367,PgSelectSingle368,PgClassExpression370,List371,Lambda372,PgSelect374,First376,PgSelectSingle377,PgClassExpression379,List380,Lambda381,Access5646,Access5647 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 5643, 6, 2221, 2225, 3085, 3090, 2, 29, 3100, 3105, 38, 3115, 3120, 47, 3130, 3135, 56, 3145, 3150, 65, 3160, 3165, 74, 3175, 3180, 85, 3190, 3195, 95, 3205, 3210, 104, 3220, 3225, 113, 3235, 3240, 122, 3250, 3255, 131, 3265, 3270, 140, 3280, 3285, 149, 3295, 3300, 158, 3310, 3315, 167, 3325, 3330, 176, 3340, 3345, 185, 3355, 3360, 194, 562, 561, 3370, 3375, 3385, 3390, 3400, 3405, 3415, 3420, 3430, 3435, 3445, 3450, 3460, 3465, 3475, 3480, 3490, 3495, 3505, 3510, 3520, 3525, 3535, 3540, 3550, 3555, 3565, 3570, 3580, 3585, 3595, 3600, 3610, 3615, 3625, 3630, 3640, 3645, 3655, 3660, 3670, 3675, 3685, 3690, 3700, 3705, 3715, 3720, 3730, 3735, 3745, 3750, 3760, 3765, 3775, 3780, 3790, 3795, 3805, 3810, 3820, 3825, 3835, 3840, 3850, 3855, 3865, 3870, 3880, 3885, 3895, 3900, 3910, 3915, 3925, 3930, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 568, 752, 938, 939, 5649, 5650, 567, 751, 940<br />2: 937, 948, 957, 966, 975, 984, 995, 1005, 1014, 1023, 1032, 1041, 1050, 1059, 1068, 1077, 1086, 1095, 1104<br />ᐳ: 941, 942, 944, 945, 946, 950, 951, 953, 954, 955, 959, 960, 962, 963, 964, 968, 969, 971, 972, 973, 977, 978, 980, 981, 982, 986, 987, 989, 990, 991, 997, 998, 1000, 1001, 1002, 1003, 1007, 1008, 1010, 1011, 1012, 1016, 1017, 1019, 1020, 1021, 1025, 1026, 1028, 1029, 1030, 1034, 1035, 1037, 1038, 1039, 1043, 1044, 1046, 1047, 1048, 1052, 1053, 1055, 1056, 1057, 1061, 1062, 1064, 1065, 1066, 1070, 1071, 1073, 1074, 1075, 1079, 1080, 1082, 1083, 1084, 1088, 1089, 1091, 1092, 1093, 1097, 1098, 1100, 1101, 1102, 1106, 1107, 1109, 1110, 1111"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Node567,Lambda568,Node751,Lambda752,PgSelect937,Access938,Access939,Object940,First941,PgSelectSingle942,PgClassExpression944,List945,Lambda946,PgSelect948,First950,PgSelectSingle951,PgClassExpression953,List954,Lambda955,PgSelect957,First959,PgSelectSingle960,PgClassExpression962,List963,Lambda964,PgSelect966,First968,PgSelectSingle969,PgClassExpression971,List972,Lambda973,PgSelect975,First977,PgSelectSingle978,PgClassExpression980,List981,Lambda982,PgSelect984,First986,PgSelectSingle987,PgClassExpression989,List990,Lambda991,PgSelect995,First997,PgSelectSingle998,PgClassExpression1000,PgClassExpression1001,List1002,Lambda1003,PgSelect1005,First1007,PgSelectSingle1008,PgClassExpression1010,List1011,Lambda1012,PgSelect1014,First1016,PgSelectSingle1017,PgClassExpression1019,List1020,Lambda1021,PgSelect1023,First1025,PgSelectSingle1026,PgClassExpression1028,List1029,Lambda1030,PgSelect1032,First1034,PgSelectSingle1035,PgClassExpression1037,List1038,Lambda1039,PgSelect1041,First1043,PgSelectSingle1044,PgClassExpression1046,List1047,Lambda1048,PgSelect1050,First1052,PgSelectSingle1053,PgClassExpression1055,List1056,Lambda1057,PgSelect1059,First1061,PgSelectSingle1062,PgClassExpression1064,List1065,Lambda1066,PgSelect1068,First1070,PgSelectSingle1071,PgClassExpression1073,List1074,Lambda1075,PgSelect1077,First1079,PgSelectSingle1080,PgClassExpression1082,List1083,Lambda1084,PgSelect1086,First1088,PgSelectSingle1089,PgClassExpression1091,List1092,Lambda1093,PgSelect1095,First1097,PgSelectSingle1098,PgClassExpression1100,List1101,Lambda1102,PgSelect1104,First1106,PgSelectSingle1107,PgClassExpression1109,List1110,Lambda1111,Access5421,Access5422 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 940, 2221, 2224, 3293, 3298, 29, 3307, 3312, 38, 3321, 3326, 47, 3335, 3340, 56, 3349, 3354, 65, 3363, 3368, 74, 3377, 3382, 85, 3391, 3396, 95, 3405, 3410, 104, 3419, 3424, 113, 3433, 3438, 122, 3447, 3452, 131, 3461, 3466, 140, 3475, 3480, 149, 3489, 3494, 158, 3503, 3508, 167, 3517, 3522, 176, 3531, 3536, 185, 3545, 3550, 194, 568, 567, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5423], Access[5424]<br />2: 575, 586, 595, 604, 613, 622, 633, 643, 652, 661, 670, 679, 688, 697, 706, 715, 724, 733, 742<br />ᐳ: 579, 580, 582, 583, 584, 588, 589, 591, 592, 593, 597, 598, 600, 601, 602, 606, 607, 609, 610, 611, 615, 616, 618, 619, 620, 624, 625, 627, 628, 629, 635, 636, 638, 639, 640, 641, 645, 646, 648, 649, 650, 654, 655, 657, 658, 659, 663, 664, 666, 667, 668, 672, 673, 675, 676, 677, 681, 682, 684, 685, 686, 690, 691, 693, 694, 695, 699, 700, 702, 703, 704, 708, 709, 711, 712, 713, 717, 718, 720, 721, 722, 726, 727, 729, 730, 731, 735, 736, 738, 739, 740, 744, 745, 747, 748, 749"):::bucket
+    class Bucket4,Node567,Lambda568,Node751,Lambda752,PgSelect937,Access938,Access939,Object940,First941,PgSelectSingle942,PgClassExpression944,List945,Lambda946,PgSelect948,First950,PgSelectSingle951,PgClassExpression953,List954,Lambda955,PgSelect957,First959,PgSelectSingle960,PgClassExpression962,List963,Lambda964,PgSelect966,First968,PgSelectSingle969,PgClassExpression971,List972,Lambda973,PgSelect975,First977,PgSelectSingle978,PgClassExpression980,List981,Lambda982,PgSelect984,First986,PgSelectSingle987,PgClassExpression989,List990,Lambda991,PgSelect995,First997,PgSelectSingle998,PgClassExpression1000,PgClassExpression1001,List1002,Lambda1003,PgSelect1005,First1007,PgSelectSingle1008,PgClassExpression1010,List1011,Lambda1012,PgSelect1014,First1016,PgSelectSingle1017,PgClassExpression1019,List1020,Lambda1021,PgSelect1023,First1025,PgSelectSingle1026,PgClassExpression1028,List1029,Lambda1030,PgSelect1032,First1034,PgSelectSingle1035,PgClassExpression1037,List1038,Lambda1039,PgSelect1041,First1043,PgSelectSingle1044,PgClassExpression1046,List1047,Lambda1048,PgSelect1050,First1052,PgSelectSingle1053,PgClassExpression1055,List1056,Lambda1057,PgSelect1059,First1061,PgSelectSingle1062,PgClassExpression1064,List1065,Lambda1066,PgSelect1068,First1070,PgSelectSingle1071,PgClassExpression1073,List1074,Lambda1075,PgSelect1077,First1079,PgSelectSingle1080,PgClassExpression1082,List1083,Lambda1084,PgSelect1086,First1088,PgSelectSingle1089,PgClassExpression1091,List1092,Lambda1093,PgSelect1095,First1097,PgSelectSingle1098,PgClassExpression1100,List1101,Lambda1102,PgSelect1104,First1106,PgSelectSingle1107,PgClassExpression1109,List1110,Lambda1111,Access5649,Access5650 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 940, 2221, 2225, 3370, 3375, 29, 3385, 3390, 38, 3400, 3405, 47, 3415, 3420, 56, 3430, 3435, 65, 3445, 3450, 74, 3460, 3465, 85, 3475, 3480, 95, 3490, 3495, 104, 3505, 3510, 113, 3520, 3525, 122, 3535, 3540, 131, 3550, 3555, 140, 3565, 3570, 149, 3580, 3585, 158, 3595, 3600, 167, 3610, 3615, 176, 3625, 3630, 185, 3640, 3645, 194, 568, 567, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5651], Access[5652]<br />2: 575, 586, 595, 604, 613, 622, 633, 643, 652, 661, 670, 679, 688, 697, 706, 715, 724, 733, 742<br />ᐳ: 579, 580, 582, 583, 584, 588, 589, 591, 592, 593, 597, 598, 600, 601, 602, 606, 607, 609, 610, 611, 615, 616, 618, 619, 620, 624, 625, 627, 628, 629, 635, 636, 638, 639, 640, 641, 645, 646, 648, 649, 650, 654, 655, 657, 658, 659, 663, 664, 666, 667, 668, 672, 673, 675, 676, 677, 681, 682, 684, 685, 686, 690, 691, 693, 694, 695, 699, 700, 702, 703, 704, 708, 709, 711, 712, 713, 717, 718, 720, 721, 722, 726, 727, 729, 730, 731, 735, 736, 738, 739, 740, 744, 745, 747, 748, 749"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgSelect575,First579,PgSelectSingle580,PgClassExpression582,List583,Lambda584,PgSelect586,First588,PgSelectSingle589,PgClassExpression591,List592,Lambda593,PgSelect595,First597,PgSelectSingle598,PgClassExpression600,List601,Lambda602,PgSelect604,First606,PgSelectSingle607,PgClassExpression609,List610,Lambda611,PgSelect613,First615,PgSelectSingle616,PgClassExpression618,List619,Lambda620,PgSelect622,First624,PgSelectSingle625,PgClassExpression627,List628,Lambda629,PgSelect633,First635,PgSelectSingle636,PgClassExpression638,PgClassExpression639,List640,Lambda641,PgSelect643,First645,PgSelectSingle646,PgClassExpression648,List649,Lambda650,PgSelect652,First654,PgSelectSingle655,PgClassExpression657,List658,Lambda659,PgSelect661,First663,PgSelectSingle664,PgClassExpression666,List667,Lambda668,PgSelect670,First672,PgSelectSingle673,PgClassExpression675,List676,Lambda677,PgSelect679,First681,PgSelectSingle682,PgClassExpression684,List685,Lambda686,PgSelect688,First690,PgSelectSingle691,PgClassExpression693,List694,Lambda695,PgSelect697,First699,PgSelectSingle700,PgClassExpression702,List703,Lambda704,PgSelect706,First708,PgSelectSingle709,PgClassExpression711,List712,Lambda713,PgSelect715,First717,PgSelectSingle718,PgClassExpression720,List721,Lambda722,PgSelect724,First726,PgSelectSingle727,PgClassExpression729,List730,Lambda731,PgSelect733,First735,PgSelectSingle736,PgClassExpression738,List739,Lambda740,PgSelect742,First744,PgSelectSingle745,PgClassExpression747,List748,Lambda749,Access5423,Access5424 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 940, 2221, 2224, 3559, 3564, 29, 3573, 3578, 38, 3587, 3592, 47, 3601, 3606, 56, 3615, 3620, 65, 3629, 3634, 74, 3643, 3648, 85, 3657, 3662, 95, 3671, 3676, 104, 3685, 3690, 113, 3699, 3704, 122, 3713, 3718, 131, 3727, 3732, 140, 3741, 3746, 149, 3755, 3760, 158, 3769, 3774, 167, 3783, 3788, 176, 3797, 3802, 185, 3811, 3816, 194, 752, 751, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5425], Access[5426]<br />2: 759, 770, 779, 788, 797, 806, 817, 827, 836, 845, 854, 863, 872, 881, 890, 899, 908, 917, 926<br />ᐳ: 763, 764, 766, 767, 768, 772, 773, 775, 776, 777, 781, 782, 784, 785, 786, 790, 791, 793, 794, 795, 799, 800, 802, 803, 804, 808, 809, 811, 812, 813, 819, 820, 822, 823, 824, 825, 829, 830, 832, 833, 834, 838, 839, 841, 842, 843, 847, 848, 850, 851, 852, 856, 857, 859, 860, 861, 865, 866, 868, 869, 870, 874, 875, 877, 878, 879, 883, 884, 886, 887, 888, 892, 893, 895, 896, 897, 901, 902, 904, 905, 906, 910, 911, 913, 914, 915, 919, 920, 922, 923, 924, 928, 929, 931, 932, 933"):::bucket
+    class Bucket5,PgSelect575,First579,PgSelectSingle580,PgClassExpression582,List583,Lambda584,PgSelect586,First588,PgSelectSingle589,PgClassExpression591,List592,Lambda593,PgSelect595,First597,PgSelectSingle598,PgClassExpression600,List601,Lambda602,PgSelect604,First606,PgSelectSingle607,PgClassExpression609,List610,Lambda611,PgSelect613,First615,PgSelectSingle616,PgClassExpression618,List619,Lambda620,PgSelect622,First624,PgSelectSingle625,PgClassExpression627,List628,Lambda629,PgSelect633,First635,PgSelectSingle636,PgClassExpression638,PgClassExpression639,List640,Lambda641,PgSelect643,First645,PgSelectSingle646,PgClassExpression648,List649,Lambda650,PgSelect652,First654,PgSelectSingle655,PgClassExpression657,List658,Lambda659,PgSelect661,First663,PgSelectSingle664,PgClassExpression666,List667,Lambda668,PgSelect670,First672,PgSelectSingle673,PgClassExpression675,List676,Lambda677,PgSelect679,First681,PgSelectSingle682,PgClassExpression684,List685,Lambda686,PgSelect688,First690,PgSelectSingle691,PgClassExpression693,List694,Lambda695,PgSelect697,First699,PgSelectSingle700,PgClassExpression702,List703,Lambda704,PgSelect706,First708,PgSelectSingle709,PgClassExpression711,List712,Lambda713,PgSelect715,First717,PgSelectSingle718,PgClassExpression720,List721,Lambda722,PgSelect724,First726,PgSelectSingle727,PgClassExpression729,List730,Lambda731,PgSelect733,First735,PgSelectSingle736,PgClassExpression738,List739,Lambda740,PgSelect742,First744,PgSelectSingle745,PgClassExpression747,List748,Lambda749,Access5651,Access5652 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 940, 2221, 2225, 3655, 3660, 29, 3670, 3675, 38, 3685, 3690, 47, 3700, 3705, 56, 3715, 3720, 65, 3730, 3735, 74, 3745, 3750, 85, 3760, 3765, 95, 3775, 3780, 104, 3790, 3795, 113, 3805, 3810, 122, 3820, 3825, 131, 3835, 3840, 140, 3850, 3855, 149, 3865, 3870, 158, 3880, 3885, 167, 3895, 3900, 176, 3910, 3915, 185, 3925, 3930, 194, 752, 751, 4, 7<br />ᐳQueryᐳQuery<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList<br /><br />1: <br />ᐳ: Access[5653], Access[5654]<br />2: 759, 770, 779, 788, 797, 806, 817, 827, 836, 845, 854, 863, 872, 881, 890, 899, 908, 917, 926<br />ᐳ: 763, 764, 766, 767, 768, 772, 773, 775, 776, 777, 781, 782, 784, 785, 786, 790, 791, 793, 794, 795, 799, 800, 802, 803, 804, 808, 809, 811, 812, 813, 819, 820, 822, 823, 824, 825, 829, 830, 832, 833, 834, 838, 839, 841, 842, 843, 847, 848, 850, 851, 852, 856, 857, 859, 860, 861, 865, 866, 868, 869, 870, 874, 875, 877, 878, 879, 883, 884, 886, 887, 888, 892, 893, 895, 896, 897, 901, 902, 904, 905, 906, 910, 911, 913, 914, 915, 919, 920, 922, 923, 924, 928, 929, 931, 932, 933"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgSelect759,First763,PgSelectSingle764,PgClassExpression766,List767,Lambda768,PgSelect770,First772,PgSelectSingle773,PgClassExpression775,List776,Lambda777,PgSelect779,First781,PgSelectSingle782,PgClassExpression784,List785,Lambda786,PgSelect788,First790,PgSelectSingle791,PgClassExpression793,List794,Lambda795,PgSelect797,First799,PgSelectSingle800,PgClassExpression802,List803,Lambda804,PgSelect806,First808,PgSelectSingle809,PgClassExpression811,List812,Lambda813,PgSelect817,First819,PgSelectSingle820,PgClassExpression822,PgClassExpression823,List824,Lambda825,PgSelect827,First829,PgSelectSingle830,PgClassExpression832,List833,Lambda834,PgSelect836,First838,PgSelectSingle839,PgClassExpression841,List842,Lambda843,PgSelect845,First847,PgSelectSingle848,PgClassExpression850,List851,Lambda852,PgSelect854,First856,PgSelectSingle857,PgClassExpression859,List860,Lambda861,PgSelect863,First865,PgSelectSingle866,PgClassExpression868,List869,Lambda870,PgSelect872,First874,PgSelectSingle875,PgClassExpression877,List878,Lambda879,PgSelect881,First883,PgSelectSingle884,PgClassExpression886,List887,Lambda888,PgSelect890,First892,PgSelectSingle893,PgClassExpression895,List896,Lambda897,PgSelect899,First901,PgSelectSingle902,PgClassExpression904,List905,Lambda906,PgSelect908,First910,PgSelectSingle911,PgClassExpression913,List914,Lambda915,PgSelect917,First919,PgSelectSingle920,PgClassExpression922,List923,Lambda924,PgSelect926,First928,PgSelectSingle929,PgClassExpression931,List932,Lambda933,Access5425,Access5426 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2224, 3825, 3830, 2, 29, 3839, 3844, 38, 3853, 3858, 47, 3867, 3872, 56, 3881, 3886, 65, 3895, 3900, 74, 3909, 3914, 85, 3923, 3928, 95, 3937, 3942, 104, 3951, 3956, 113, 3965, 3970, 122, 3979, 3984, 131, 3993, 3998, 140, 4007, 4012, 149, 4021, 4026, 158, 4035, 4040, 167, 4049, 4054, 176, 4063, 4068, 185, 4077, 4082, 194, 1115, 1114, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1123, 1124, 5427, 5428, 1125<br />2: 1122, 1133, 1142, 1151, 1160, 1169, 1180, 1190, 1199, 1208, 1217, 1226, 1235, 1244, 1253, 1262, 1271, 1280, 1289<br />ᐳ: 1126, 1127, 1129, 1130, 1131, 1135, 1136, 1138, 1139, 1140, 1144, 1145, 1147, 1148, 1149, 1153, 1154, 1156, 1157, 1158, 1162, 1163, 1165, 1166, 1167, 1171, 1172, 1174, 1175, 1176, 1182, 1183, 1185, 1186, 1187, 1188, 1192, 1193, 1195, 1196, 1197, 1201, 1202, 1204, 1205, 1206, 1210, 1211, 1213, 1214, 1215, 1219, 1220, 1222, 1223, 1224, 1228, 1229, 1231, 1232, 1233, 1237, 1238, 1240, 1241, 1242, 1246, 1247, 1249, 1250, 1251, 1255, 1256, 1258, 1259, 1260, 1264, 1265, 1267, 1268, 1269, 1273, 1274, 1276, 1277, 1278, 1282, 1283, 1285, 1286, 1287, 1291, 1292, 1294, 1295, 1296"):::bucket
+    class Bucket6,PgSelect759,First763,PgSelectSingle764,PgClassExpression766,List767,Lambda768,PgSelect770,First772,PgSelectSingle773,PgClassExpression775,List776,Lambda777,PgSelect779,First781,PgSelectSingle782,PgClassExpression784,List785,Lambda786,PgSelect788,First790,PgSelectSingle791,PgClassExpression793,List794,Lambda795,PgSelect797,First799,PgSelectSingle800,PgClassExpression802,List803,Lambda804,PgSelect806,First808,PgSelectSingle809,PgClassExpression811,List812,Lambda813,PgSelect817,First819,PgSelectSingle820,PgClassExpression822,PgClassExpression823,List824,Lambda825,PgSelect827,First829,PgSelectSingle830,PgClassExpression832,List833,Lambda834,PgSelect836,First838,PgSelectSingle839,PgClassExpression841,List842,Lambda843,PgSelect845,First847,PgSelectSingle848,PgClassExpression850,List851,Lambda852,PgSelect854,First856,PgSelectSingle857,PgClassExpression859,List860,Lambda861,PgSelect863,First865,PgSelectSingle866,PgClassExpression868,List869,Lambda870,PgSelect872,First874,PgSelectSingle875,PgClassExpression877,List878,Lambda879,PgSelect881,First883,PgSelectSingle884,PgClassExpression886,List887,Lambda888,PgSelect890,First892,PgSelectSingle893,PgClassExpression895,List896,Lambda897,PgSelect899,First901,PgSelectSingle902,PgClassExpression904,List905,Lambda906,PgSelect908,First910,PgSelectSingle911,PgClassExpression913,List914,Lambda915,PgSelect917,First919,PgSelectSingle920,PgClassExpression922,List923,Lambda924,PgSelect926,First928,PgSelectSingle929,PgClassExpression931,List932,Lambda933,Access5653,Access5654 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2225, 3940, 3945, 2, 29, 3955, 3960, 38, 3970, 3975, 47, 3985, 3990, 56, 4000, 4005, 65, 4015, 4020, 74, 4030, 4035, 85, 4045, 4050, 95, 4060, 4065, 104, 4075, 4080, 113, 4090, 4095, 122, 4105, 4110, 131, 4120, 4125, 140, 4135, 4140, 149, 4150, 4155, 158, 4165, 4170, 167, 4180, 4185, 176, 4195, 4200, 185, 4210, 4215, 194, 1115, 1114, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1123, 1124, 5655, 5656, 1125<br />2: 1122, 1133, 1142, 1151, 1160, 1169, 1180, 1190, 1199, 1208, 1217, 1226, 1235, 1244, 1253, 1262, 1271, 1280, 1289<br />ᐳ: 1126, 1127, 1129, 1130, 1131, 1135, 1136, 1138, 1139, 1140, 1144, 1145, 1147, 1148, 1149, 1153, 1154, 1156, 1157, 1158, 1162, 1163, 1165, 1166, 1167, 1171, 1172, 1174, 1175, 1176, 1182, 1183, 1185, 1186, 1187, 1188, 1192, 1193, 1195, 1196, 1197, 1201, 1202, 1204, 1205, 1206, 1210, 1211, 1213, 1214, 1215, 1219, 1220, 1222, 1223, 1224, 1228, 1229, 1231, 1232, 1233, 1237, 1238, 1240, 1241, 1242, 1246, 1247, 1249, 1250, 1251, 1255, 1256, 1258, 1259, 1260, 1264, 1265, 1267, 1268, 1269, 1273, 1274, 1276, 1277, 1278, 1282, 1283, 1285, 1286, 1287, 1291, 1292, 1294, 1295, 1296"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelect1122,Access1123,Access1124,Object1125,First1126,PgSelectSingle1127,PgClassExpression1129,List1130,Lambda1131,PgSelect1133,First1135,PgSelectSingle1136,PgClassExpression1138,List1139,Lambda1140,PgSelect1142,First1144,PgSelectSingle1145,PgClassExpression1147,List1148,Lambda1149,PgSelect1151,First1153,PgSelectSingle1154,PgClassExpression1156,List1157,Lambda1158,PgSelect1160,First1162,PgSelectSingle1163,PgClassExpression1165,List1166,Lambda1167,PgSelect1169,First1171,PgSelectSingle1172,PgClassExpression1174,List1175,Lambda1176,PgSelect1180,First1182,PgSelectSingle1183,PgClassExpression1185,PgClassExpression1186,List1187,Lambda1188,PgSelect1190,First1192,PgSelectSingle1193,PgClassExpression1195,List1196,Lambda1197,PgSelect1199,First1201,PgSelectSingle1202,PgClassExpression1204,List1205,Lambda1206,PgSelect1208,First1210,PgSelectSingle1211,PgClassExpression1213,List1214,Lambda1215,PgSelect1217,First1219,PgSelectSingle1220,PgClassExpression1222,List1223,Lambda1224,PgSelect1226,First1228,PgSelectSingle1229,PgClassExpression1231,List1232,Lambda1233,PgSelect1235,First1237,PgSelectSingle1238,PgClassExpression1240,List1241,Lambda1242,PgSelect1244,First1246,PgSelectSingle1247,PgClassExpression1249,List1250,Lambda1251,PgSelect1253,First1255,PgSelectSingle1256,PgClassExpression1258,List1259,Lambda1260,PgSelect1262,First1264,PgSelectSingle1265,PgClassExpression1267,List1268,Lambda1269,PgSelect1271,First1273,PgSelectSingle1274,PgClassExpression1276,List1277,Lambda1278,PgSelect1280,First1282,PgSelectSingle1283,PgClassExpression1285,List1286,Lambda1287,PgSelect1289,First1291,PgSelectSingle1292,PgClassExpression1294,List1295,Lambda1296,Access5427,Access5428 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2224, 4091, 4096, 2, 29, 4105, 4110, 38, 4119, 4124, 47, 4133, 4138, 56, 4147, 4152, 65, 4161, 4166, 74, 4175, 4180, 85, 4189, 4194, 95, 4203, 4208, 104, 4217, 4222, 113, 4231, 4236, 122, 4245, 4250, 131, 4259, 4264, 140, 4273, 4278, 149, 4287, 4292, 158, 4301, 4306, 167, 4315, 4320, 176, 4329, 4334, 185, 4343, 4348, 194, 1299, 1298, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1307, 1308, 5429, 5430, 1309<br />2: 1306, 1317, 1326, 1335, 1344, 1353, 1364, 1374, 1383, 1392, 1401, 1410, 1419, 1428, 1437, 1446, 1455, 1464, 1473<br />ᐳ: 1310, 1311, 1313, 1314, 1315, 1319, 1320, 1322, 1323, 1324, 1328, 1329, 1331, 1332, 1333, 1337, 1338, 1340, 1341, 1342, 1346, 1347, 1349, 1350, 1351, 1355, 1356, 1358, 1359, 1360, 1366, 1367, 1369, 1370, 1371, 1372, 1376, 1377, 1379, 1380, 1381, 1385, 1386, 1388, 1389, 1390, 1394, 1395, 1397, 1398, 1399, 1403, 1404, 1406, 1407, 1408, 1412, 1413, 1415, 1416, 1417, 1421, 1422, 1424, 1425, 1426, 1430, 1431, 1433, 1434, 1435, 1439, 1440, 1442, 1443, 1444, 1448, 1449, 1451, 1452, 1453, 1457, 1458, 1460, 1461, 1462, 1466, 1467, 1469, 1470, 1471, 1475, 1476, 1478, 1479, 1480"):::bucket
+    class Bucket7,PgSelect1122,Access1123,Access1124,Object1125,First1126,PgSelectSingle1127,PgClassExpression1129,List1130,Lambda1131,PgSelect1133,First1135,PgSelectSingle1136,PgClassExpression1138,List1139,Lambda1140,PgSelect1142,First1144,PgSelectSingle1145,PgClassExpression1147,List1148,Lambda1149,PgSelect1151,First1153,PgSelectSingle1154,PgClassExpression1156,List1157,Lambda1158,PgSelect1160,First1162,PgSelectSingle1163,PgClassExpression1165,List1166,Lambda1167,PgSelect1169,First1171,PgSelectSingle1172,PgClassExpression1174,List1175,Lambda1176,PgSelect1180,First1182,PgSelectSingle1183,PgClassExpression1185,PgClassExpression1186,List1187,Lambda1188,PgSelect1190,First1192,PgSelectSingle1193,PgClassExpression1195,List1196,Lambda1197,PgSelect1199,First1201,PgSelectSingle1202,PgClassExpression1204,List1205,Lambda1206,PgSelect1208,First1210,PgSelectSingle1211,PgClassExpression1213,List1214,Lambda1215,PgSelect1217,First1219,PgSelectSingle1220,PgClassExpression1222,List1223,Lambda1224,PgSelect1226,First1228,PgSelectSingle1229,PgClassExpression1231,List1232,Lambda1233,PgSelect1235,First1237,PgSelectSingle1238,PgClassExpression1240,List1241,Lambda1242,PgSelect1244,First1246,PgSelectSingle1247,PgClassExpression1249,List1250,Lambda1251,PgSelect1253,First1255,PgSelectSingle1256,PgClassExpression1258,List1259,Lambda1260,PgSelect1262,First1264,PgSelectSingle1265,PgClassExpression1267,List1268,Lambda1269,PgSelect1271,First1273,PgSelectSingle1274,PgClassExpression1276,List1277,Lambda1278,PgSelect1280,First1282,PgSelectSingle1283,PgClassExpression1285,List1286,Lambda1287,PgSelect1289,First1291,PgSelectSingle1292,PgClassExpression1294,List1295,Lambda1296,Access5655,Access5656 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2225, 4225, 4230, 2, 29, 4240, 4245, 38, 4255, 4260, 47, 4270, 4275, 56, 4285, 4290, 65, 4300, 4305, 74, 4315, 4320, 85, 4330, 4335, 95, 4345, 4350, 104, 4360, 4365, 113, 4375, 4380, 122, 4390, 4395, 131, 4405, 4410, 140, 4420, 4425, 149, 4435, 4440, 158, 4450, 4455, 167, 4465, 4470, 176, 4480, 4485, 185, 4495, 4500, 194, 1299, 1298, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1307, 1308, 5657, 5658, 1309<br />2: 1306, 1317, 1326, 1335, 1344, 1353, 1364, 1374, 1383, 1392, 1401, 1410, 1419, 1428, 1437, 1446, 1455, 1464, 1473<br />ᐳ: 1310, 1311, 1313, 1314, 1315, 1319, 1320, 1322, 1323, 1324, 1328, 1329, 1331, 1332, 1333, 1337, 1338, 1340, 1341, 1342, 1346, 1347, 1349, 1350, 1351, 1355, 1356, 1358, 1359, 1360, 1366, 1367, 1369, 1370, 1371, 1372, 1376, 1377, 1379, 1380, 1381, 1385, 1386, 1388, 1389, 1390, 1394, 1395, 1397, 1398, 1399, 1403, 1404, 1406, 1407, 1408, 1412, 1413, 1415, 1416, 1417, 1421, 1422, 1424, 1425, 1426, 1430, 1431, 1433, 1434, 1435, 1439, 1440, 1442, 1443, 1444, 1448, 1449, 1451, 1452, 1453, 1457, 1458, 1460, 1461, 1462, 1466, 1467, 1469, 1470, 1471, 1475, 1476, 1478, 1479, 1480"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgSelect1306,Access1307,Access1308,Object1309,First1310,PgSelectSingle1311,PgClassExpression1313,List1314,Lambda1315,PgSelect1317,First1319,PgSelectSingle1320,PgClassExpression1322,List1323,Lambda1324,PgSelect1326,First1328,PgSelectSingle1329,PgClassExpression1331,List1332,Lambda1333,PgSelect1335,First1337,PgSelectSingle1338,PgClassExpression1340,List1341,Lambda1342,PgSelect1344,First1346,PgSelectSingle1347,PgClassExpression1349,List1350,Lambda1351,PgSelect1353,First1355,PgSelectSingle1356,PgClassExpression1358,List1359,Lambda1360,PgSelect1364,First1366,PgSelectSingle1367,PgClassExpression1369,PgClassExpression1370,List1371,Lambda1372,PgSelect1374,First1376,PgSelectSingle1377,PgClassExpression1379,List1380,Lambda1381,PgSelect1383,First1385,PgSelectSingle1386,PgClassExpression1388,List1389,Lambda1390,PgSelect1392,First1394,PgSelectSingle1395,PgClassExpression1397,List1398,Lambda1399,PgSelect1401,First1403,PgSelectSingle1404,PgClassExpression1406,List1407,Lambda1408,PgSelect1410,First1412,PgSelectSingle1413,PgClassExpression1415,List1416,Lambda1417,PgSelect1419,First1421,PgSelectSingle1422,PgClassExpression1424,List1425,Lambda1426,PgSelect1428,First1430,PgSelectSingle1431,PgClassExpression1433,List1434,Lambda1435,PgSelect1437,First1439,PgSelectSingle1440,PgClassExpression1442,List1443,Lambda1444,PgSelect1446,First1448,PgSelectSingle1449,PgClassExpression1451,List1452,Lambda1453,PgSelect1455,First1457,PgSelectSingle1458,PgClassExpression1460,List1461,Lambda1462,PgSelect1464,First1466,PgSelectSingle1467,PgClassExpression1469,List1470,Lambda1471,PgSelect1473,First1475,PgSelectSingle1476,PgClassExpression1478,List1479,Lambda1480,Access5429,Access5430 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2224, 4357, 4362, 2, 29, 4371, 4376, 38, 4385, 4390, 47, 4399, 4404, 56, 4413, 4418, 65, 4427, 4432, 74, 4441, 4446, 85, 4455, 4460, 95, 4469, 4474, 104, 4483, 4488, 113, 4497, 4502, 122, 4511, 4516, 131, 4525, 4530, 140, 4539, 4544, 149, 4553, 4558, 158, 4567, 4572, 167, 4581, 4586, 176, 4595, 4600, 185, 4609, 4614, 194, 1484, 1483, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1492, 1493, 5431, 5432, 1494<br />2: 1491, 1502, 1511, 1520, 1529, 1538, 1549, 1559, 1568, 1577, 1586, 1595, 1604, 1613, 1622, 1631, 1640, 1649, 1658<br />ᐳ: 1495, 1496, 1498, 1499, 1500, 1504, 1505, 1507, 1508, 1509, 1513, 1514, 1516, 1517, 1518, 1522, 1523, 1525, 1526, 1527, 1531, 1532, 1534, 1535, 1536, 1540, 1541, 1543, 1544, 1545, 1551, 1552, 1554, 1555, 1556, 1557, 1561, 1562, 1564, 1565, 1566, 1570, 1571, 1573, 1574, 1575, 1579, 1580, 1582, 1583, 1584, 1588, 1589, 1591, 1592, 1593, 1597, 1598, 1600, 1601, 1602, 1606, 1607, 1609, 1610, 1611, 1615, 1616, 1618, 1619, 1620, 1624, 1625, 1627, 1628, 1629, 1633, 1634, 1636, 1637, 1638, 1642, 1643, 1645, 1646, 1647, 1651, 1652, 1654, 1655, 1656, 1660, 1661, 1663, 1664, 1665"):::bucket
+    class Bucket8,PgSelect1306,Access1307,Access1308,Object1309,First1310,PgSelectSingle1311,PgClassExpression1313,List1314,Lambda1315,PgSelect1317,First1319,PgSelectSingle1320,PgClassExpression1322,List1323,Lambda1324,PgSelect1326,First1328,PgSelectSingle1329,PgClassExpression1331,List1332,Lambda1333,PgSelect1335,First1337,PgSelectSingle1338,PgClassExpression1340,List1341,Lambda1342,PgSelect1344,First1346,PgSelectSingle1347,PgClassExpression1349,List1350,Lambda1351,PgSelect1353,First1355,PgSelectSingle1356,PgClassExpression1358,List1359,Lambda1360,PgSelect1364,First1366,PgSelectSingle1367,PgClassExpression1369,PgClassExpression1370,List1371,Lambda1372,PgSelect1374,First1376,PgSelectSingle1377,PgClassExpression1379,List1380,Lambda1381,PgSelect1383,First1385,PgSelectSingle1386,PgClassExpression1388,List1389,Lambda1390,PgSelect1392,First1394,PgSelectSingle1395,PgClassExpression1397,List1398,Lambda1399,PgSelect1401,First1403,PgSelectSingle1404,PgClassExpression1406,List1407,Lambda1408,PgSelect1410,First1412,PgSelectSingle1413,PgClassExpression1415,List1416,Lambda1417,PgSelect1419,First1421,PgSelectSingle1422,PgClassExpression1424,List1425,Lambda1426,PgSelect1428,First1430,PgSelectSingle1431,PgClassExpression1433,List1434,Lambda1435,PgSelect1437,First1439,PgSelectSingle1440,PgClassExpression1442,List1443,Lambda1444,PgSelect1446,First1448,PgSelectSingle1449,PgClassExpression1451,List1452,Lambda1453,PgSelect1455,First1457,PgSelectSingle1458,PgClassExpression1460,List1461,Lambda1462,PgSelect1464,First1466,PgSelectSingle1467,PgClassExpression1469,List1470,Lambda1471,PgSelect1473,First1475,PgSelectSingle1476,PgClassExpression1478,List1479,Lambda1480,Access5657,Access5658 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2225, 4510, 4515, 2, 29, 4525, 4530, 38, 4540, 4545, 47, 4555, 4560, 56, 4570, 4575, 65, 4585, 4590, 74, 4600, 4605, 85, 4615, 4620, 95, 4630, 4635, 104, 4645, 4650, 113, 4660, 4665, 122, 4675, 4680, 131, 4690, 4695, 140, 4705, 4710, 149, 4720, 4725, 158, 4735, 4740, 167, 4750, 4755, 176, 4765, 4770, 185, 4780, 4785, 194, 1484, 1483, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1492, 1493, 5659, 5660, 1494<br />2: 1491, 1502, 1511, 1520, 1529, 1538, 1549, 1559, 1568, 1577, 1586, 1595, 1604, 1613, 1622, 1631, 1640, 1649, 1658<br />ᐳ: 1495, 1496, 1498, 1499, 1500, 1504, 1505, 1507, 1508, 1509, 1513, 1514, 1516, 1517, 1518, 1522, 1523, 1525, 1526, 1527, 1531, 1532, 1534, 1535, 1536, 1540, 1541, 1543, 1544, 1545, 1551, 1552, 1554, 1555, 1556, 1557, 1561, 1562, 1564, 1565, 1566, 1570, 1571, 1573, 1574, 1575, 1579, 1580, 1582, 1583, 1584, 1588, 1589, 1591, 1592, 1593, 1597, 1598, 1600, 1601, 1602, 1606, 1607, 1609, 1610, 1611, 1615, 1616, 1618, 1619, 1620, 1624, 1625, 1627, 1628, 1629, 1633, 1634, 1636, 1637, 1638, 1642, 1643, 1645, 1646, 1647, 1651, 1652, 1654, 1655, 1656, 1660, 1661, 1663, 1664, 1665"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgSelect1491,Access1492,Access1493,Object1494,First1495,PgSelectSingle1496,PgClassExpression1498,List1499,Lambda1500,PgSelect1502,First1504,PgSelectSingle1505,PgClassExpression1507,List1508,Lambda1509,PgSelect1511,First1513,PgSelectSingle1514,PgClassExpression1516,List1517,Lambda1518,PgSelect1520,First1522,PgSelectSingle1523,PgClassExpression1525,List1526,Lambda1527,PgSelect1529,First1531,PgSelectSingle1532,PgClassExpression1534,List1535,Lambda1536,PgSelect1538,First1540,PgSelectSingle1541,PgClassExpression1543,List1544,Lambda1545,PgSelect1549,First1551,PgSelectSingle1552,PgClassExpression1554,PgClassExpression1555,List1556,Lambda1557,PgSelect1559,First1561,PgSelectSingle1562,PgClassExpression1564,List1565,Lambda1566,PgSelect1568,First1570,PgSelectSingle1571,PgClassExpression1573,List1574,Lambda1575,PgSelect1577,First1579,PgSelectSingle1580,PgClassExpression1582,List1583,Lambda1584,PgSelect1586,First1588,PgSelectSingle1589,PgClassExpression1591,List1592,Lambda1593,PgSelect1595,First1597,PgSelectSingle1598,PgClassExpression1600,List1601,Lambda1602,PgSelect1604,First1606,PgSelectSingle1607,PgClassExpression1609,List1610,Lambda1611,PgSelect1613,First1615,PgSelectSingle1616,PgClassExpression1618,List1619,Lambda1620,PgSelect1622,First1624,PgSelectSingle1625,PgClassExpression1627,List1628,Lambda1629,PgSelect1631,First1633,PgSelectSingle1634,PgClassExpression1636,List1637,Lambda1638,PgSelect1640,First1642,PgSelectSingle1643,PgClassExpression1645,List1646,Lambda1647,PgSelect1649,First1651,PgSelectSingle1652,PgClassExpression1654,List1655,Lambda1656,PgSelect1658,First1660,PgSelectSingle1661,PgClassExpression1663,List1664,Lambda1665,Access5431,Access5432 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2224, 4623, 4628, 2, 29, 4637, 4642, 38, 4651, 4656, 47, 4665, 4670, 56, 4679, 4684, 65, 4693, 4698, 74, 4707, 4712, 85, 4721, 4726, 95, 4735, 4740, 104, 4749, 4754, 113, 4763, 4768, 122, 4777, 4782, 131, 4791, 4796, 140, 4805, 4810, 149, 4819, 4824, 158, 4833, 4838, 167, 4847, 4852, 176, 4861, 4866, 185, 4875, 4880, 194, 1668, 1667, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1676, 1677, 5433, 5434, 1678<br />2: 1675, 1686, 1695, 1704, 1713, 1722, 1733, 1743, 1752, 1761, 1770, 1779, 1788, 1797, 1806, 1815, 1824, 1833, 1842<br />ᐳ: 1679, 1680, 1682, 1683, 1684, 1688, 1689, 1691, 1692, 1693, 1697, 1698, 1700, 1701, 1702, 1706, 1707, 1709, 1710, 1711, 1715, 1716, 1718, 1719, 1720, 1724, 1725, 1727, 1728, 1729, 1735, 1736, 1738, 1739, 1740, 1741, 1745, 1746, 1748, 1749, 1750, 1754, 1755, 1757, 1758, 1759, 1763, 1764, 1766, 1767, 1768, 1772, 1773, 1775, 1776, 1777, 1781, 1782, 1784, 1785, 1786, 1790, 1791, 1793, 1794, 1795, 1799, 1800, 1802, 1803, 1804, 1808, 1809, 1811, 1812, 1813, 1817, 1818, 1820, 1821, 1822, 1826, 1827, 1829, 1830, 1831, 1835, 1836, 1838, 1839, 1840, 1844, 1845, 1847, 1848, 1849"):::bucket
+    class Bucket9,PgSelect1491,Access1492,Access1493,Object1494,First1495,PgSelectSingle1496,PgClassExpression1498,List1499,Lambda1500,PgSelect1502,First1504,PgSelectSingle1505,PgClassExpression1507,List1508,Lambda1509,PgSelect1511,First1513,PgSelectSingle1514,PgClassExpression1516,List1517,Lambda1518,PgSelect1520,First1522,PgSelectSingle1523,PgClassExpression1525,List1526,Lambda1527,PgSelect1529,First1531,PgSelectSingle1532,PgClassExpression1534,List1535,Lambda1536,PgSelect1538,First1540,PgSelectSingle1541,PgClassExpression1543,List1544,Lambda1545,PgSelect1549,First1551,PgSelectSingle1552,PgClassExpression1554,PgClassExpression1555,List1556,Lambda1557,PgSelect1559,First1561,PgSelectSingle1562,PgClassExpression1564,List1565,Lambda1566,PgSelect1568,First1570,PgSelectSingle1571,PgClassExpression1573,List1574,Lambda1575,PgSelect1577,First1579,PgSelectSingle1580,PgClassExpression1582,List1583,Lambda1584,PgSelect1586,First1588,PgSelectSingle1589,PgClassExpression1591,List1592,Lambda1593,PgSelect1595,First1597,PgSelectSingle1598,PgClassExpression1600,List1601,Lambda1602,PgSelect1604,First1606,PgSelectSingle1607,PgClassExpression1609,List1610,Lambda1611,PgSelect1613,First1615,PgSelectSingle1616,PgClassExpression1618,List1619,Lambda1620,PgSelect1622,First1624,PgSelectSingle1625,PgClassExpression1627,List1628,Lambda1629,PgSelect1631,First1633,PgSelectSingle1634,PgClassExpression1636,List1637,Lambda1638,PgSelect1640,First1642,PgSelectSingle1643,PgClassExpression1645,List1646,Lambda1647,PgSelect1649,First1651,PgSelectSingle1652,PgClassExpression1654,List1655,Lambda1656,PgSelect1658,First1660,PgSelectSingle1661,PgClassExpression1663,List1664,Lambda1665,Access5659,Access5660 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2225, 4795, 4800, 2, 29, 4810, 4815, 38, 4825, 4830, 47, 4840, 4845, 56, 4855, 4860, 65, 4870, 4875, 74, 4885, 4890, 85, 4900, 4905, 95, 4915, 4920, 104, 4930, 4935, 113, 4945, 4950, 122, 4960, 4965, 131, 4975, 4980, 140, 4990, 4995, 149, 5005, 5010, 158, 5020, 5025, 167, 5035, 5040, 176, 5050, 5055, 185, 5065, 5070, 194, 1668, 1667, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1676, 1677, 5661, 5662, 1678<br />2: 1675, 1686, 1695, 1704, 1713, 1722, 1733, 1743, 1752, 1761, 1770, 1779, 1788, 1797, 1806, 1815, 1824, 1833, 1842<br />ᐳ: 1679, 1680, 1682, 1683, 1684, 1688, 1689, 1691, 1692, 1693, 1697, 1698, 1700, 1701, 1702, 1706, 1707, 1709, 1710, 1711, 1715, 1716, 1718, 1719, 1720, 1724, 1725, 1727, 1728, 1729, 1735, 1736, 1738, 1739, 1740, 1741, 1745, 1746, 1748, 1749, 1750, 1754, 1755, 1757, 1758, 1759, 1763, 1764, 1766, 1767, 1768, 1772, 1773, 1775, 1776, 1777, 1781, 1782, 1784, 1785, 1786, 1790, 1791, 1793, 1794, 1795, 1799, 1800, 1802, 1803, 1804, 1808, 1809, 1811, 1812, 1813, 1817, 1818, 1820, 1821, 1822, 1826, 1827, 1829, 1830, 1831, 1835, 1836, 1838, 1839, 1840, 1844, 1845, 1847, 1848, 1849"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect1675,Access1676,Access1677,Object1678,First1679,PgSelectSingle1680,PgClassExpression1682,List1683,Lambda1684,PgSelect1686,First1688,PgSelectSingle1689,PgClassExpression1691,List1692,Lambda1693,PgSelect1695,First1697,PgSelectSingle1698,PgClassExpression1700,List1701,Lambda1702,PgSelect1704,First1706,PgSelectSingle1707,PgClassExpression1709,List1710,Lambda1711,PgSelect1713,First1715,PgSelectSingle1716,PgClassExpression1718,List1719,Lambda1720,PgSelect1722,First1724,PgSelectSingle1725,PgClassExpression1727,List1728,Lambda1729,PgSelect1733,First1735,PgSelectSingle1736,PgClassExpression1738,PgClassExpression1739,List1740,Lambda1741,PgSelect1743,First1745,PgSelectSingle1746,PgClassExpression1748,List1749,Lambda1750,PgSelect1752,First1754,PgSelectSingle1755,PgClassExpression1757,List1758,Lambda1759,PgSelect1761,First1763,PgSelectSingle1764,PgClassExpression1766,List1767,Lambda1768,PgSelect1770,First1772,PgSelectSingle1773,PgClassExpression1775,List1776,Lambda1777,PgSelect1779,First1781,PgSelectSingle1782,PgClassExpression1784,List1785,Lambda1786,PgSelect1788,First1790,PgSelectSingle1791,PgClassExpression1793,List1794,Lambda1795,PgSelect1797,First1799,PgSelectSingle1800,PgClassExpression1802,List1803,Lambda1804,PgSelect1806,First1808,PgSelectSingle1809,PgClassExpression1811,List1812,Lambda1813,PgSelect1815,First1817,PgSelectSingle1818,PgClassExpression1820,List1821,Lambda1822,PgSelect1824,First1826,PgSelectSingle1827,PgClassExpression1829,List1830,Lambda1831,PgSelect1833,First1835,PgSelectSingle1836,PgClassExpression1838,List1839,Lambda1840,PgSelect1842,First1844,PgSelectSingle1845,PgClassExpression1847,List1848,Lambda1849,Access5433,Access5434 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2224, 4889, 4894, 2, 29, 4903, 4908, 38, 4917, 4922, 47, 4931, 4936, 56, 4945, 4950, 65, 4959, 4964, 74, 4973, 4978, 85, 4987, 4992, 95, 5001, 5006, 104, 5015, 5020, 113, 5029, 5034, 122, 5043, 5048, 131, 5057, 5062, 140, 5071, 5076, 149, 5085, 5090, 158, 5099, 5104, 167, 5113, 5118, 176, 5127, 5132, 185, 5141, 5146, 194, 1853, 1852, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1861, 1862, 5435, 5436, 1863<br />2: 1860, 1871, 1880, 1889, 1898, 1907, 1918, 1928, 1937, 1946, 1955, 1964, 1973, 1982, 1991, 2000, 2009, 2018, 2027<br />ᐳ: 1864, 1865, 1867, 1868, 1869, 1873, 1874, 1876, 1877, 1878, 1882, 1883, 1885, 1886, 1887, 1891, 1892, 1894, 1895, 1896, 1900, 1901, 1903, 1904, 1905, 1909, 1910, 1912, 1913, 1914, 1920, 1921, 1923, 1924, 1925, 1926, 1930, 1931, 1933, 1934, 1935, 1939, 1940, 1942, 1943, 1944, 1948, 1949, 1951, 1952, 1953, 1957, 1958, 1960, 1961, 1962, 1966, 1967, 1969, 1970, 1971, 1975, 1976, 1978, 1979, 1980, 1984, 1985, 1987, 1988, 1989, 1993, 1994, 1996, 1997, 1998, 2002, 2003, 2005, 2006, 2007, 2011, 2012, 2014, 2015, 2016, 2020, 2021, 2023, 2024, 2025, 2029, 2030, 2032, 2033, 2034"):::bucket
+    class Bucket10,PgSelect1675,Access1676,Access1677,Object1678,First1679,PgSelectSingle1680,PgClassExpression1682,List1683,Lambda1684,PgSelect1686,First1688,PgSelectSingle1689,PgClassExpression1691,List1692,Lambda1693,PgSelect1695,First1697,PgSelectSingle1698,PgClassExpression1700,List1701,Lambda1702,PgSelect1704,First1706,PgSelectSingle1707,PgClassExpression1709,List1710,Lambda1711,PgSelect1713,First1715,PgSelectSingle1716,PgClassExpression1718,List1719,Lambda1720,PgSelect1722,First1724,PgSelectSingle1725,PgClassExpression1727,List1728,Lambda1729,PgSelect1733,First1735,PgSelectSingle1736,PgClassExpression1738,PgClassExpression1739,List1740,Lambda1741,PgSelect1743,First1745,PgSelectSingle1746,PgClassExpression1748,List1749,Lambda1750,PgSelect1752,First1754,PgSelectSingle1755,PgClassExpression1757,List1758,Lambda1759,PgSelect1761,First1763,PgSelectSingle1764,PgClassExpression1766,List1767,Lambda1768,PgSelect1770,First1772,PgSelectSingle1773,PgClassExpression1775,List1776,Lambda1777,PgSelect1779,First1781,PgSelectSingle1782,PgClassExpression1784,List1785,Lambda1786,PgSelect1788,First1790,PgSelectSingle1791,PgClassExpression1793,List1794,Lambda1795,PgSelect1797,First1799,PgSelectSingle1800,PgClassExpression1802,List1803,Lambda1804,PgSelect1806,First1808,PgSelectSingle1809,PgClassExpression1811,List1812,Lambda1813,PgSelect1815,First1817,PgSelectSingle1818,PgClassExpression1820,List1821,Lambda1822,PgSelect1824,First1826,PgSelectSingle1827,PgClassExpression1829,List1830,Lambda1831,PgSelect1833,First1835,PgSelectSingle1836,PgClassExpression1838,List1839,Lambda1840,PgSelect1842,First1844,PgSelectSingle1845,PgClassExpression1847,List1848,Lambda1849,Access5661,Access5662 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2225, 5080, 5085, 2, 29, 5095, 5100, 38, 5110, 5115, 47, 5125, 5130, 56, 5140, 5145, 65, 5155, 5160, 74, 5170, 5175, 85, 5185, 5190, 95, 5200, 5205, 104, 5215, 5220, 113, 5230, 5235, 122, 5245, 5250, 131, 5260, 5265, 140, 5275, 5280, 149, 5290, 5295, 158, 5305, 5310, 167, 5320, 5325, 176, 5335, 5340, 185, 5350, 5355, 194, 1853, 1852, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 1861, 1862, 5663, 5664, 1863<br />2: 1860, 1871, 1880, 1889, 1898, 1907, 1918, 1928, 1937, 1946, 1955, 1964, 1973, 1982, 1991, 2000, 2009, 2018, 2027<br />ᐳ: 1864, 1865, 1867, 1868, 1869, 1873, 1874, 1876, 1877, 1878, 1882, 1883, 1885, 1886, 1887, 1891, 1892, 1894, 1895, 1896, 1900, 1901, 1903, 1904, 1905, 1909, 1910, 1912, 1913, 1914, 1920, 1921, 1923, 1924, 1925, 1926, 1930, 1931, 1933, 1934, 1935, 1939, 1940, 1942, 1943, 1944, 1948, 1949, 1951, 1952, 1953, 1957, 1958, 1960, 1961, 1962, 1966, 1967, 1969, 1970, 1971, 1975, 1976, 1978, 1979, 1980, 1984, 1985, 1987, 1988, 1989, 1993, 1994, 1996, 1997, 1998, 2002, 2003, 2005, 2006, 2007, 2011, 2012, 2014, 2015, 2016, 2020, 2021, 2023, 2024, 2025, 2029, 2030, 2032, 2033, 2034"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgSelect1860,Access1861,Access1862,Object1863,First1864,PgSelectSingle1865,PgClassExpression1867,List1868,Lambda1869,PgSelect1871,First1873,PgSelectSingle1874,PgClassExpression1876,List1877,Lambda1878,PgSelect1880,First1882,PgSelectSingle1883,PgClassExpression1885,List1886,Lambda1887,PgSelect1889,First1891,PgSelectSingle1892,PgClassExpression1894,List1895,Lambda1896,PgSelect1898,First1900,PgSelectSingle1901,PgClassExpression1903,List1904,Lambda1905,PgSelect1907,First1909,PgSelectSingle1910,PgClassExpression1912,List1913,Lambda1914,PgSelect1918,First1920,PgSelectSingle1921,PgClassExpression1923,PgClassExpression1924,List1925,Lambda1926,PgSelect1928,First1930,PgSelectSingle1931,PgClassExpression1933,List1934,Lambda1935,PgSelect1937,First1939,PgSelectSingle1940,PgClassExpression1942,List1943,Lambda1944,PgSelect1946,First1948,PgSelectSingle1949,PgClassExpression1951,List1952,Lambda1953,PgSelect1955,First1957,PgSelectSingle1958,PgClassExpression1960,List1961,Lambda1962,PgSelect1964,First1966,PgSelectSingle1967,PgClassExpression1969,List1970,Lambda1971,PgSelect1973,First1975,PgSelectSingle1976,PgClassExpression1978,List1979,Lambda1980,PgSelect1982,First1984,PgSelectSingle1985,PgClassExpression1987,List1988,Lambda1989,PgSelect1991,First1993,PgSelectSingle1994,PgClassExpression1996,List1997,Lambda1998,PgSelect2000,First2002,PgSelectSingle2003,PgClassExpression2005,List2006,Lambda2007,PgSelect2009,First2011,PgSelectSingle2012,PgClassExpression2014,List2015,Lambda2016,PgSelect2018,First2020,PgSelectSingle2021,PgClassExpression2023,List2024,Lambda2025,PgSelect2027,First2029,PgSelectSingle2030,PgClassExpression2032,List2033,Lambda2034,Access5435,Access5436 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2224, 5155, 5160, 2, 29, 5169, 5174, 38, 5183, 5188, 47, 5197, 5202, 56, 5211, 5216, 65, 5225, 5230, 74, 5239, 5244, 85, 5253, 5258, 95, 5267, 5272, 104, 5281, 5286, 113, 5295, 5300, 122, 5309, 5314, 131, 5323, 5328, 140, 5337, 5342, 149, 5351, 5356, 158, 5365, 5370, 167, 5379, 5384, 176, 5393, 5398, 185, 5407, 5412, 194, 2037, 2036, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 2045, 2046, 5437, 5438, 2047<br />2: 2044, 2055, 2064, 2073, 2082, 2091, 2102, 2112, 2121, 2130, 2139, 2148, 2157, 2166, 2175, 2184, 2193, 2202, 2211<br />ᐳ: 2048, 2049, 2051, 2052, 2053, 2057, 2058, 2060, 2061, 2062, 2066, 2067, 2069, 2070, 2071, 2075, 2076, 2078, 2079, 2080, 2084, 2085, 2087, 2088, 2089, 2093, 2094, 2096, 2097, 2098, 2104, 2105, 2107, 2108, 2109, 2110, 2114, 2115, 2117, 2118, 2119, 2123, 2124, 2126, 2127, 2128, 2132, 2133, 2135, 2136, 2137, 2141, 2142, 2144, 2145, 2146, 2150, 2151, 2153, 2154, 2155, 2159, 2160, 2162, 2163, 2164, 2168, 2169, 2171, 2172, 2173, 2177, 2178, 2180, 2181, 2182, 2186, 2187, 2189, 2190, 2191, 2195, 2196, 2198, 2199, 2200, 2204, 2205, 2207, 2208, 2209, 2213, 2214, 2216, 2217, 2218"):::bucket
+    class Bucket11,PgSelect1860,Access1861,Access1862,Object1863,First1864,PgSelectSingle1865,PgClassExpression1867,List1868,Lambda1869,PgSelect1871,First1873,PgSelectSingle1874,PgClassExpression1876,List1877,Lambda1878,PgSelect1880,First1882,PgSelectSingle1883,PgClassExpression1885,List1886,Lambda1887,PgSelect1889,First1891,PgSelectSingle1892,PgClassExpression1894,List1895,Lambda1896,PgSelect1898,First1900,PgSelectSingle1901,PgClassExpression1903,List1904,Lambda1905,PgSelect1907,First1909,PgSelectSingle1910,PgClassExpression1912,List1913,Lambda1914,PgSelect1918,First1920,PgSelectSingle1921,PgClassExpression1923,PgClassExpression1924,List1925,Lambda1926,PgSelect1928,First1930,PgSelectSingle1931,PgClassExpression1933,List1934,Lambda1935,PgSelect1937,First1939,PgSelectSingle1940,PgClassExpression1942,List1943,Lambda1944,PgSelect1946,First1948,PgSelectSingle1949,PgClassExpression1951,List1952,Lambda1953,PgSelect1955,First1957,PgSelectSingle1958,PgClassExpression1960,List1961,Lambda1962,PgSelect1964,First1966,PgSelectSingle1967,PgClassExpression1969,List1970,Lambda1971,PgSelect1973,First1975,PgSelectSingle1976,PgClassExpression1978,List1979,Lambda1980,PgSelect1982,First1984,PgSelectSingle1985,PgClassExpression1987,List1988,Lambda1989,PgSelect1991,First1993,PgSelectSingle1994,PgClassExpression1996,List1997,Lambda1998,PgSelect2000,First2002,PgSelectSingle2003,PgClassExpression2005,List2006,Lambda2007,PgSelect2009,First2011,PgSelectSingle2012,PgClassExpression2014,List2015,Lambda2016,PgSelect2018,First2020,PgSelectSingle2021,PgClassExpression2023,List2024,Lambda2025,PgSelect2027,First2029,PgSelectSingle2030,PgClassExpression2032,List2033,Lambda2034,Access5663,Access5664 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 2221, 2225, 5365, 5370, 2, 29, 5380, 5385, 38, 5395, 5400, 47, 5410, 5415, 56, 5425, 5430, 65, 5440, 5445, 74, 5455, 5460, 85, 5470, 5475, 95, 5485, 5490, 104, 5500, 5505, 113, 5515, 5520, 122, 5530, 5535, 131, 5545, 5550, 140, 5560, 5565, 149, 5575, 5580, 158, 5590, 5595, 167, 5605, 5610, 176, 5620, 5625, 185, 5635, 5640, 194, 2037, 2036, 4, 7<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 2045, 2046, 5665, 5666, 2047<br />2: 2044, 2055, 2064, 2073, 2082, 2091, 2102, 2112, 2121, 2130, 2139, 2148, 2157, 2166, 2175, 2184, 2193, 2202, 2211<br />ᐳ: 2048, 2049, 2051, 2052, 2053, 2057, 2058, 2060, 2061, 2062, 2066, 2067, 2069, 2070, 2071, 2075, 2076, 2078, 2079, 2080, 2084, 2085, 2087, 2088, 2089, 2093, 2094, 2096, 2097, 2098, 2104, 2105, 2107, 2108, 2109, 2110, 2114, 2115, 2117, 2118, 2119, 2123, 2124, 2126, 2127, 2128, 2132, 2133, 2135, 2136, 2137, 2141, 2142, 2144, 2145, 2146, 2150, 2151, 2153, 2154, 2155, 2159, 2160, 2162, 2163, 2164, 2168, 2169, 2171, 2172, 2173, 2177, 2178, 2180, 2181, 2182, 2186, 2187, 2189, 2190, 2191, 2195, 2196, 2198, 2199, 2200, 2204, 2205, 2207, 2208, 2209, 2213, 2214, 2216, 2217, 2218"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgSelect2044,Access2045,Access2046,Object2047,First2048,PgSelectSingle2049,PgClassExpression2051,List2052,Lambda2053,PgSelect2055,First2057,PgSelectSingle2058,PgClassExpression2060,List2061,Lambda2062,PgSelect2064,First2066,PgSelectSingle2067,PgClassExpression2069,List2070,Lambda2071,PgSelect2073,First2075,PgSelectSingle2076,PgClassExpression2078,List2079,Lambda2080,PgSelect2082,First2084,PgSelectSingle2085,PgClassExpression2087,List2088,Lambda2089,PgSelect2091,First2093,PgSelectSingle2094,PgClassExpression2096,List2097,Lambda2098,PgSelect2102,First2104,PgSelectSingle2105,PgClassExpression2107,PgClassExpression2108,List2109,Lambda2110,PgSelect2112,First2114,PgSelectSingle2115,PgClassExpression2117,List2118,Lambda2119,PgSelect2121,First2123,PgSelectSingle2124,PgClassExpression2126,List2127,Lambda2128,PgSelect2130,First2132,PgSelectSingle2133,PgClassExpression2135,List2136,Lambda2137,PgSelect2139,First2141,PgSelectSingle2142,PgClassExpression2144,List2145,Lambda2146,PgSelect2148,First2150,PgSelectSingle2151,PgClassExpression2153,List2154,Lambda2155,PgSelect2157,First2159,PgSelectSingle2160,PgClassExpression2162,List2163,Lambda2164,PgSelect2166,First2168,PgSelectSingle2169,PgClassExpression2171,List2172,Lambda2173,PgSelect2175,First2177,PgSelectSingle2178,PgClassExpression2180,List2181,Lambda2182,PgSelect2184,First2186,PgSelectSingle2187,PgClassExpression2189,List2190,Lambda2191,PgSelect2193,First2195,PgSelectSingle2196,PgClassExpression2198,List2199,Lambda2200,PgSelect2202,First2204,PgSelectSingle2205,PgClassExpression2207,List2208,Lambda2209,PgSelect2211,First2213,PgSelectSingle2214,PgClassExpression2216,List2217,Lambda2218,Access5437,Access5438 bucket12
+    class Bucket12,PgSelect2044,Access2045,Access2046,Object2047,First2048,PgSelectSingle2049,PgClassExpression2051,List2052,Lambda2053,PgSelect2055,First2057,PgSelectSingle2058,PgClassExpression2060,List2061,Lambda2062,PgSelect2064,First2066,PgSelectSingle2067,PgClassExpression2069,List2070,Lambda2071,PgSelect2073,First2075,PgSelectSingle2076,PgClassExpression2078,List2079,Lambda2080,PgSelect2082,First2084,PgSelectSingle2085,PgClassExpression2087,List2088,Lambda2089,PgSelect2091,First2093,PgSelectSingle2094,PgClassExpression2096,List2097,Lambda2098,PgSelect2102,First2104,PgSelectSingle2105,PgClassExpression2107,PgClassExpression2108,List2109,Lambda2110,PgSelect2112,First2114,PgSelectSingle2115,PgClassExpression2117,List2118,Lambda2119,PgSelect2121,First2123,PgSelectSingle2124,PgClassExpression2126,List2127,Lambda2128,PgSelect2130,First2132,PgSelectSingle2133,PgClassExpression2135,List2136,Lambda2137,PgSelect2139,First2141,PgSelectSingle2142,PgClassExpression2144,List2145,Lambda2146,PgSelect2148,First2150,PgSelectSingle2151,PgClassExpression2153,List2154,Lambda2155,PgSelect2157,First2159,PgSelectSingle2160,PgClassExpression2162,List2163,Lambda2164,PgSelect2166,First2168,PgSelectSingle2169,PgClassExpression2171,List2172,Lambda2173,PgSelect2175,First2177,PgSelectSingle2178,PgClassExpression2180,List2181,Lambda2182,PgSelect2184,First2186,PgSelectSingle2187,PgClassExpression2189,List2190,Lambda2191,PgSelect2193,First2195,PgSelectSingle2196,PgClassExpression2198,List2199,Lambda2200,PgSelect2202,First2204,PgSelectSingle2205,PgClassExpression2207,List2208,Lambda2209,PgSelect2211,First2213,PgSelectSingle2214,PgClassExpression2216,List2217,Lambda2218,Access5665,Access5666 bucket12
     Bucket0 --> Bucket1 & Bucket4 & Bucket7 & Bucket8 & Bucket9 & Bucket10 & Bucket11 & Bucket12
     Bucket1 --> Bucket2 & Bucket3
     Bucket4 --> Bucket5 & Bucket6

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
@@ -11,123 +11,135 @@ graph TD
     %% plan dependencies
     PgSelect33[["PgSelect[33∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant460{{"Constant[460∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda244{{"Lambda[244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda249{{"Lambda[249∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant477{{"Constant[477∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Access212{{"Access[212∈0] ➊<br />ᐸ211.0ᐳ"}}:::plan
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda208{{"Lambda[208∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda260{{"Lambda[260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda265{{"Lambda[265∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant460 & Lambda211 & Lambda244 & Lambda249 & Lambda208 & Lambda211 & Lambda260 & Lambda265 --> PgSelect33
+    Lambda264{{"Lambda[264∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda269{{"Lambda[269∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant477 & Access212 & Lambda247 & Lambda252 & Lambda208 & Access212 & Lambda264 & Lambda269 --> PgSelect33
     PgSelect56[["PgSelect[56∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Access54{{"Access[54∈0] ➊<br />ᐸ53.1ᐳ"}}:::plan
-    Lambda274{{"Lambda[274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda295{{"Lambda[295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda284{{"Lambda[284∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda296{{"Lambda[296∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda301{{"Lambda[301∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object10 -->|rejectNull| PgSelect56
-    Access54 & Lambda211 & Lambda274 & Lambda279 & Lambda208 & Lambda211 & Lambda290 & Lambda295 --> PgSelect56
+    Access54 & Access212 & Lambda279 & Lambda284 & Lambda208 & Access212 & Lambda296 & Lambda301 --> PgSelect56
     PgSelect79[["PgSelect[79∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Access77{{"Access[77∈0] ➊<br />ᐸ76.1ᐳ"}}:::plan
-    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda320{{"Lambda[320∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda325{{"Lambda[325∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda316{{"Lambda[316∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda328{{"Lambda[328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda333{{"Lambda[333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object10 -->|rejectNull| PgSelect79
-    Access77 & Lambda211 & Lambda304 & Lambda309 & Lambda208 & Lambda211 & Lambda320 & Lambda325 --> PgSelect79
+    Access77 & Access212 & Lambda311 & Lambda316 & Lambda208 & Access212 & Lambda328 & Lambda333 --> PgSelect79
     PgSelect126[["PgSelect[126∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Constant464{{"Constant[464∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda362{{"Lambda[362∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda367{{"Lambda[367∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant481{{"Constant[481∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda373{{"Lambda[373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda378{{"Lambda[378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda383{{"Lambda[383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant464 & Lambda211 & Lambda362 & Lambda367 & Lambda208 & Lambda211 & Lambda378 & Lambda383 --> PgSelect126
+    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant481 & Access212 & Lambda373 & Lambda378 & Lambda208 & Access212 & Lambda390 & Lambda395 --> PgSelect126
     PgSelect175[["PgSelect[175∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Constant459{{"Constant[459∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Lambda420{{"Lambda[420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda425{{"Lambda[425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant459 & Lambda211 & Lambda420 & Lambda425 & Lambda208 & Lambda211 & Lambda439 & Lambda444 --> PgSelect175
+    Constant476{{"Constant[476∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Lambda435{{"Lambda[435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda440{{"Lambda[440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda455{{"Lambda[455∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda460{{"Lambda[460∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant476 & Access212 & Lambda435 & Lambda440 & Lambda208 & Access212 & Lambda455 & Lambda460 --> PgSelect175
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸperson_secretᐳ"]]:::plan
-    Lambda216{{"Lambda[216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda221{{"Lambda[221∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant459 & Lambda208 & Lambda211 & Lambda216 & Lambda221 --> PgSelect7
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant476 & Lambda208 & Access212 & Lambda217 & Lambda222 --> PgSelect7
     PgSelect99[["PgSelect[99∈0] ➊<br />ᐸleft_armᐳ"]]:::plan
-    Constant463{{"Constant[463∈0] ➊<br />ᐸ42ᐳ"}}:::plan
-    Lambda334{{"Lambda[334∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda339{{"Lambda[339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant463 & Lambda208 & Lambda211 & Lambda334 & Lambda339 --> PgSelect99
+    Constant480{{"Constant[480∈0] ➊<br />ᐸ42ᐳ"}}:::plan
+    Lambda343{{"Lambda[343∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant480 & Lambda208 & Access212 & Lambda343 & Lambda348 --> PgSelect99
     PgSelect148[["PgSelect[148∈0] ➊<br />ᐸpostᐳ"]]:::plan
-    Constant465{{"Constant[465∈0] ➊<br />ᐸ7ᐳ"}}:::plan
-    Lambda392{{"Lambda[392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda397{{"Lambda[397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant465 & Lambda208 & Lambda211 & Lambda392 & Lambda397 --> PgSelect148
+    Constant482{{"Constant[482∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    Lambda405{{"Lambda[405∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda410{{"Lambda[410∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant482 & Lambda208 & Access212 & Lambda405 & Lambda410 --> PgSelect148
     PgSelect200[["PgSelect[200∈0] ➊<br />ᐸreturn_table_without_grantsᐳ"]]:::plan
-    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda458{{"Lambda[458∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda208 & Lambda211 & Lambda453 & Lambda458 --> PgSelect200
-    Object215{{"Object[215∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Lambda208 & Constant212 & Constant213 & Constant214 --> Object215
-    Object243{{"Object[243∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant240{{"Constant[240∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant241{{"Constant[241∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda208 & Constant240 & Constant241 & Constant214 --> Object243
-    Object259{{"Object[259∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant256{{"Constant[256∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant257{{"Constant[257∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant258{{"Constant[258∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda208 & Constant256 & Constant257 & Constant258 --> Object259
-    Object273{{"Object[273∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda208 & Constant270 & Constant271 & Constant214 --> Object273
-    Object289{{"Object[289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda208 & Constant286 & Constant287 & Constant258 --> Object289
-    Object303{{"Object[303∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant300{{"Constant[300∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant301{{"Constant[301∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Lambda208 & Constant300 & Constant301 & Constant214 --> Object303
-    Object319{{"Object[319∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant317{{"Constant[317∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda208 & Constant316 & Constant317 & Constant258 --> Object319
-    Object333{{"Object[333∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant330{{"Constant[330∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant331{{"Constant[331∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant332{{"Constant[332∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda208 & Constant330 & Constant331 & Constant332 --> Object333
-    Object361{{"Object[361∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Lambda208 & Constant358 & Constant359 & Constant332 --> Object361
-    Object377{{"Object[377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda208 & Constant374 & Constant375 & Constant258 --> Object377
-    Object391{{"Object[391∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda208 & Constant388 & Constant389 & Constant390 --> Object391
+    Lambda470{{"Lambda[470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda475{{"Lambda[475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda208 & Access212 & Lambda470 & Lambda475 --> PgSelect200
+    Object216{{"Object[216∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant215{{"Constant[215∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda208 & Constant213 & Constant214 & Constant215 --> Object216
+    Object231{{"Object[231∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda208 & Constant228 & Constant229 & Constant215 --> Object231
+    Object246{{"Object[246∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda208 & Constant243 & Constant244 & Constant215 --> Object246
+    Object263{{"Object[263∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant260{{"Constant[260∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant261{{"Constant[261∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant262{{"Constant[262∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda208 & Constant260 & Constant261 & Constant262 --> Object263
+    Object278{{"Object[278∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant275{{"Constant[275∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant276{{"Constant[276∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda208 & Constant275 & Constant276 & Constant215 --> Object278
+    Object295{{"Object[295∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant292{{"Constant[292∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant293{{"Constant[293∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda208 & Constant292 & Constant293 & Constant262 --> Object295
+    Object310{{"Object[310∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant307{{"Constant[307∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant308{{"Constant[308∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Lambda208 & Constant307 & Constant308 & Constant215 --> Object310
+    Object327{{"Object[327∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant324{{"Constant[324∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant325{{"Constant[325∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda208 & Constant324 & Constant325 & Constant262 --> Object327
+    Object342{{"Object[342∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant339{{"Constant[339∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant340{{"Constant[340∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant341{{"Constant[341∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda208 & Constant339 & Constant340 & Constant341 --> Object342
+    Object357{{"Object[357∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant354{{"Constant[354∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant355{{"Constant[355∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda208 & Constant354 & Constant355 & Constant341 --> Object357
+    Object372{{"Object[372∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant369{{"Constant[369∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant370{{"Constant[370∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Lambda208 & Constant369 & Constant370 & Constant341 --> Object372
+    Object389{{"Object[389∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant386{{"Constant[386∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant387{{"Constant[387∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda208 & Constant386 & Constant387 & Constant262 --> Object389
+    Object404{{"Object[404∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant402{{"Constant[402∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant403{{"Constant[403∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda208 & Constant401 & Constant402 & Constant403 --> Object404
     Object419{{"Object[419∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant416{{"Constant[416∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
     Constant417{{"Constant[417∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda208 & Constant416 & Constant417 & Constant390 --> Object419
-    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda208 & Constant435 & Constant436 & Constant258 --> Object438
-    Object452{{"Object[452∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant449{{"Constant[449∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸsql.identifier(”return_table_without_grants”)ᐳ"}}:::plan
-    Constant451{{"Constant[451∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda208 & Constant449 & Constant450 & Constant451 --> Object452
+    Lambda208 & Constant416 & Constant417 & Constant403 --> Object419
+    Object434{{"Object[434∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda208 & Constant431 & Constant432 & Constant403 --> Object434
+    Object454{{"Object[454∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant451{{"Constant[451∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda208 & Constant451 & Constant452 & Constant262 --> Object454
+    Object469{{"Object[469∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant466{{"Constant[466∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant467{{"Constant[467∈0] ➊<br />ᐸsql.identifier(”return_table_without_grants”)ᐳ"}}:::plan
+    Constant468{{"Constant[468∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda208 & Constant466 & Constant467 & Constant468 --> Object469
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -143,16 +155,16 @@ graph TD
     PgSelectSingle36{{"PgSelectSingle[36∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First35 --> PgSelectSingle36
     Lambda53{{"Lambda[53∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant461{{"Constant[461∈0] ➊<br />ᐸ'fa4f3e13-456c-4a9e-8c1e-37a6e3177d0b'ᐳ"}}:::plan
-    Constant461 --> Lambda53
+    Constant478{{"Constant[478∈0] ➊<br />ᐸ'fa4f3e13-456c-4a9e-8c1e-37a6e3177d0b'ᐳ"}}:::plan
+    Constant478 --> Lambda53
     Lambda53 --> Access54
     First58{{"First[58∈0] ➊"}}:::plan
     PgSelect56 --> First58
     PgSelectSingle59{{"PgSelectSingle[59∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First58 --> PgSelectSingle59
     Lambda76{{"Lambda[76∈0] ➊<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant462{{"Constant[462∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDBd'ᐳ"}}:::plan
-    Constant462 --> Lambda76
+    Constant479{{"Constant[479∈0] ➊<br />ᐸ'WyJwZW9wbGUiLDBd'ᐳ"}}:::plan
+    Constant479 --> Lambda76
     Lambda76 --> Access77
     First81{{"First[81∈0] ➊"}}:::plan
     PgSelect79 --> First81
@@ -178,52 +190,69 @@ graph TD
     PgSelect200 --> First202
     PgSelectSingle203{{"PgSelectSingle[203∈0] ➊<br />ᐸreturn_table_without_grantsᐳ"}}:::plan
     First202 --> PgSelectSingle203
-    Constant466{{"Constant[466∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant466 --> Lambda208
-    Constant467{{"Constant[467∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant467 --> Lambda211
-    Object215 --> Lambda216
-    Constant468{{"Constant[468∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant468 --> Lambda221
-    Object243 --> Lambda244
-    Constant470{{"Constant[470∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant470 --> Lambda249
-    Object259 --> Lambda260
-    Constant471{{"Constant[471∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant471 --> Lambda265
-    Object273 --> Lambda274
-    Constant472{{"Constant[472∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant472 --> Lambda279
-    Object289 --> Lambda290
-    Constant473{{"Constant[473∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant473 --> Lambda295
-    Object303 --> Lambda304
-    Constant474{{"Constant[474∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant474 --> Lambda309
-    Object319 --> Lambda320
-    Constant475{{"Constant[475∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant475 --> Lambda325
-    Object333 --> Lambda334
-    Constant476{{"Constant[476∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant476 --> Lambda339
-    Object361 --> Lambda362
-    Constant478{{"Constant[478∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant478 --> Lambda367
-    Object377 --> Lambda378
-    Constant479{{"Constant[479∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant479 --> Lambda383
-    Object391 --> Lambda392
-    Constant480{{"Constant[480∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant480 --> Lambda397
+    Constant483{{"Constant[483∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant483 --> Lambda208
+    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant484{{"Constant[484∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant484 --> Lambda211
+    Lambda211 --> Access212
+    Object216 --> Lambda217
+    Constant485{{"Constant[485∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant485 --> Lambda222
+    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object231 --> Lambda232
+    Lambda237{{"Lambda[237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant486{{"Constant[486∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant486 --> Lambda237
+    Object246 --> Lambda247
+    Constant487{{"Constant[487∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant487 --> Lambda252
+    Object263 --> Lambda264
+    Constant488{{"Constant[488∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant488 --> Lambda269
+    Object278 --> Lambda279
+    Constant489{{"Constant[489∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant489 --> Lambda284
+    Object295 --> Lambda296
+    Constant490{{"Constant[490∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant490 --> Lambda301
+    Object310 --> Lambda311
+    Constant491{{"Constant[491∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant491 --> Lambda316
+    Object327 --> Lambda328
+    Constant492{{"Constant[492∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant492 --> Lambda333
+    Object342 --> Lambda343
+    Constant493{{"Constant[493∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant493 --> Lambda348
+    Lambda358{{"Lambda[358∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object357 --> Lambda358
+    Lambda363{{"Lambda[363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant494 --> Lambda363
+    Object372 --> Lambda373
+    Constant495{{"Constant[495∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant495 --> Lambda378
+    Object389 --> Lambda390
+    Constant496{{"Constant[496∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant496 --> Lambda395
+    Object404 --> Lambda405
+    Constant497{{"Constant[497∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant497 --> Lambda410
+    Lambda420{{"Lambda[420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object419 --> Lambda420
-    Constant482{{"Constant[482∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant482 --> Lambda425
-    Object438 --> Lambda439
-    Constant483{{"Constant[483∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant483 --> Lambda444
-    Object452 --> Lambda453
-    Constant484{{"Constant[484∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”returnᐳ"}}:::plan
-    Constant484 --> Lambda458
+    Lambda425{{"Lambda[425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant498{{"Constant[498∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant498 --> Lambda425
+    Object434 --> Lambda435
+    Constant499{{"Constant[499∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant499 --> Lambda440
+    Object454 --> Lambda455
+    Constant500{{"Constant[500∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant500 --> Lambda460
+    Object469 --> Lambda470
+    Constant501{{"Constant[501∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”returnᐳ"}}:::plan
+    Constant501 --> Lambda475
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant13{{"Constant[13∈0] ➊<br />ᐸ'person_secrets'ᐳ"}}:::plan
     Connection23{{"Connection[23∈0] ➊<br />ᐸ21ᐳ"}}:::plan
@@ -232,17 +261,9 @@ graph TD
     Connection114{{"Connection[114∈0] ➊<br />ᐸ112ᐳ"}}:::plan
     Constant152{{"Constant[152∈0] ➊<br />ᐸ'posts'ᐳ"}}:::plan
     Connection163{{"Connection[163∈0] ➊<br />ᐸ161ᐳ"}}:::plan
+    Connection189{{"Connection[189∈0] ➊<br />ᐸ185ᐳ"}}:::plan
     Constant206{{"Constant[206∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant209{{"Constant[209∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant469{{"Constant[469∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant477{{"Constant[477∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant481{{"Constant[481∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     List15{{"List[15∈1] ➊<br />ᐸ13,14ᐳ"}}:::plan
     PgClassExpression14{{"PgClassExpression[14∈1] ➊<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant13 & PgClassExpression14 --> List15
@@ -252,13 +273,7 @@ graph TD
     PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression17
     PgSelect24[["PgSelect[24∈2] ➊<br />ᐸperson_secretᐳ"]]:::plan
-    Lambda230{{"Lambda[230∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda235{{"Lambda[235∈2] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection23 & Lambda208 & Lambda211 & Lambda230 & Lambda235 --> PgSelect24
-    Object229{{"Object[229∈2] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda208 & Constant226 & Constant227 & Constant214 --> Object229
-    Object229 --> Lambda230
-    Constant469 --> Lambda235
+    Object10 & Connection23 & Lambda208 & Access212 & Lambda232 & Lambda237 --> PgSelect24
     __Item25[/"__Item[25∈3]<br />ᐸ24ᐳ"\]:::itemplan
     PgSelect24 ==> __Item25
     PgSelectSingle26{{"PgSelectSingle[26∈3]<br />ᐸperson_secretᐳ"}}:::plan
@@ -332,13 +347,7 @@ graph TD
     PgClassExpression109{{"PgClassExpression[109∈11] ➊<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
     PgSelectSingle102 --> PgClassExpression109
     PgSelect115[["PgSelect[115∈12] ➊<br />ᐸleft_armᐳ"]]:::plan
-    Lambda348{{"Lambda[348∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda353{{"Lambda[353∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection114 & Lambda208 & Lambda211 & Lambda348 & Lambda353 --> PgSelect115
-    Object347{{"Object[347∈12] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda208 & Constant344 & Constant345 & Constant332 --> Object347
-    Object347 --> Lambda348
-    Constant477 --> Lambda353
+    Object10 & Connection114 & Lambda208 & Access212 & Lambda358 & Lambda363 --> PgSelect115
     __Item116[/"__Item[116∈13]<br />ᐸ115ᐳ"\]:::itemplan
     PgSelect115 ==> __Item116
     PgSelectSingle117{{"PgSelectSingle[117∈13]<br />ᐸleft_armᐳ"}}:::plan
@@ -388,13 +397,7 @@ graph TD
     PgClassExpression158{{"PgClassExpression[158∈17] ➊<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle151 --> PgClassExpression158
     PgSelect164[["PgSelect[164∈18] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda406{{"Lambda[406∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda411{{"Lambda[411∈18] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection163 & Lambda208 & Lambda211 & Lambda406 & Lambda411 --> PgSelect164
-    Object405{{"Object[405∈18] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda208 & Constant402 & Constant403 & Constant390 --> Object405
-    Object405 --> Lambda406
-    Constant481 --> Lambda411
+    Object10 & Connection163 & Lambda208 & Access212 & Lambda420 & Lambda425 --> PgSelect164
     __Item165[/"__Item[165∈19]<br />ᐸ164ᐳ"\]:::itemplan
     PgSelect164 ==> __Item165
     PgSelectSingle166{{"PgSelectSingle[166∈19]<br />ᐸpostᐳ"}}:::plan
@@ -411,21 +414,20 @@ graph TD
     PgSelectSingle166 --> PgClassExpression172
     PgClassExpression173{{"PgClassExpression[173∈20]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle166 --> PgClassExpression173
-    Object429{{"Object[429∈21] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access427{{"Access[427∈21] ➊<br />ᐸ177.0ᐳ"}}:::plan
-    Access427 & Constant206 & Constant206 & Lambda208 & Constant209 --> Object429
+    Object444{{"Object[444∈21] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access442{{"Access[442∈21] ➊<br />ᐸ177.0ᐳ"}}:::plan
+    Access442 & Constant206 & Constant206 & Lambda208 & Constant209 --> Object444
     List181{{"List[181∈21] ➊<br />ᐸ37,180ᐳ"}}:::plan
     PgClassExpression180{{"PgClassExpression[180∈21] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant37 & PgClassExpression180 --> List181
     PgSelectSingle178 --> PgClassExpression180
     Lambda182{{"Lambda[182∈21] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List181 --> Lambda182
-    First177 --> Access427
-    Lambda430{{"Lambda[430∈21] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object429 --> Lambda430
-    Connection189{{"Connection[189∈21] ➊<br />ᐸ185ᐳ"}}:::plan
-    __Item191[/"__Item[191∈22]<br />ᐸ430ᐳ"\]:::itemplan
-    Lambda430 ==> __Item191
+    First177 --> Access442
+    Lambda445{{"Lambda[445∈21] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object444 --> Lambda445
+    __Item191[/"__Item[191∈22]<br />ᐸ445ᐳ"\]:::itemplan
+    Lambda445 ==> __Item191
     PgSelectSingle192{{"PgSelectSingle[192∈22]<br />ᐸpostᐳ"}}:::plan
     __Item191 --> PgSelectSingle192
     List195{{"List[195∈23]<br />ᐸ152,194ᐳ"}}:::plan
@@ -448,15 +450,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/rbac.basic"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 23, 37, 103, 114, 152, 163, 206, 209, 212, 213, 214, 226, 227, 240, 241, 256, 257, 258, 270, 271, 286, 287, 300, 301, 316, 317, 330, 331, 332, 344, 345, 358, 359, 374, 375, 388, 389, 390, 402, 403, 416, 417, 435, 436, 449, 450, 451, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 10, 53, 54, 76, 77, 208, 211, 215, 216, 221, 243, 244, 249, 259, 260, 265, 273, 274, 279, 289, 290, 295, 303, 304, 309, 319, 320, 325, 333, 334, 339, 361, 362, 367, 377, 378, 383, 391, 392, 397, 419, 420, 425, 438, 439, 444, 452, 453, 458<br />2: 7, 33, 56, 79, 99, 126, 148, 175, 200<br />ᐳ: 11, 12, 35, 36, 58, 59, 81, 82, 101, 102, 128, 129, 150, 151, 177, 178, 202, 203"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 13, 23, 37, 103, 114, 152, 163, 189, 206, 209, 213, 214, 215, 228, 229, 243, 244, 260, 261, 262, 275, 276, 292, 293, 307, 308, 324, 325, 339, 340, 341, 354, 355, 369, 370, 386, 387, 401, 402, 403, 416, 417, 431, 432, 451, 452, 466, 467, 468, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 10, 53, 54, 76, 77, 208, 211, 212, 216, 217, 222, 231, 232, 237, 246, 247, 252, 263, 264, 269, 278, 279, 284, 295, 296, 301, 310, 311, 316, 327, 328, 333, 342, 343, 348, 357, 358, 363, 372, 373, 378, 389, 390, 395, 404, 405, 410, 419, 420, 425, 434, 435, 440, 454, 455, 460, 469, 470, 475<br />2: 7, 33, 56, 79, 99, 126, 148, 175, 200<br />ᐳ: 11, 12, 35, 36, 58, 59, 81, 82, 101, 102, 128, 129, 150, 151, 177, 178, 202, 203"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Connection23,PgSelect33,First35,PgSelectSingle36,Constant37,Lambda53,Access54,PgSelect56,First58,PgSelectSingle59,Lambda76,Access77,PgSelect79,First81,PgSelectSingle82,PgSelect99,First101,PgSelectSingle102,Constant103,Connection114,PgSelect126,First128,PgSelectSingle129,PgSelect148,First150,PgSelectSingle151,Constant152,Connection163,PgSelect175,First177,PgSelectSingle178,PgSelect200,First202,PgSelectSingle203,Constant206,Lambda208,Constant209,Lambda211,Constant212,Constant213,Constant214,Object215,Lambda216,Lambda221,Constant226,Constant227,Constant240,Constant241,Object243,Lambda244,Lambda249,Constant256,Constant257,Constant258,Object259,Lambda260,Lambda265,Constant270,Constant271,Object273,Lambda274,Lambda279,Constant286,Constant287,Object289,Lambda290,Lambda295,Constant300,Constant301,Object303,Lambda304,Lambda309,Constant316,Constant317,Object319,Lambda320,Lambda325,Constant330,Constant331,Constant332,Object333,Lambda334,Lambda339,Constant344,Constant345,Constant358,Constant359,Object361,Lambda362,Lambda367,Constant374,Constant375,Object377,Lambda378,Lambda383,Constant388,Constant389,Constant390,Object391,Lambda392,Lambda397,Constant402,Constant403,Constant416,Constant417,Object419,Lambda420,Lambda425,Constant435,Constant436,Object438,Lambda439,Lambda444,Constant449,Constant450,Constant451,Object452,Lambda453,Lambda458,Constant459,Constant460,Constant461,Constant462,Constant463,Constant464,Constant465,Constant466,Constant467,Constant468,Constant469,Constant470,Constant471,Constant472,Constant473,Constant474,Constant475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483,Constant484 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Constant13,Connection23,PgSelect33,First35,PgSelectSingle36,Constant37,Lambda53,Access54,PgSelect56,First58,PgSelectSingle59,Lambda76,Access77,PgSelect79,First81,PgSelectSingle82,PgSelect99,First101,PgSelectSingle102,Constant103,Connection114,PgSelect126,First128,PgSelectSingle129,PgSelect148,First150,PgSelectSingle151,Constant152,Connection163,PgSelect175,First177,PgSelectSingle178,Connection189,PgSelect200,First202,PgSelectSingle203,Constant206,Lambda208,Constant209,Lambda211,Access212,Constant213,Constant214,Constant215,Object216,Lambda217,Lambda222,Constant228,Constant229,Object231,Lambda232,Lambda237,Constant243,Constant244,Object246,Lambda247,Lambda252,Constant260,Constant261,Constant262,Object263,Lambda264,Lambda269,Constant275,Constant276,Object278,Lambda279,Lambda284,Constant292,Constant293,Object295,Lambda296,Lambda301,Constant307,Constant308,Object310,Lambda311,Lambda316,Constant324,Constant325,Object327,Lambda328,Lambda333,Constant339,Constant340,Constant341,Object342,Lambda343,Lambda348,Constant354,Constant355,Object357,Lambda358,Lambda363,Constant369,Constant370,Object372,Lambda373,Lambda378,Constant386,Constant387,Object389,Lambda390,Lambda395,Constant401,Constant402,Constant403,Object404,Lambda405,Lambda410,Constant416,Constant417,Object419,Lambda420,Lambda425,Constant431,Constant432,Object434,Lambda435,Lambda440,Constant451,Constant452,Object454,Lambda455,Lambda460,Constant466,Constant467,Constant468,Object469,Lambda470,Lambda475,Constant476,Constant477,Constant478,Constant479,Constant480,Constant481,Constant482,Constant483,Constant484,Constant485,Constant486,Constant487,Constant488,Constant489,Constant490,Constant491,Constant492,Constant493,Constant494,Constant495,Constant496,Constant497,Constant498,Constant499,Constant500,Constant501 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13<br /><br />ROOT PgSelectSingleᐸperson_secretᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14,List15,Lambda16,PgClassExpression17 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 10, 23, 208, 211, 226, 227, 214, 469, 13<br /><br />ROOT Connectionᐸ21ᐳ[23]<br />1: <br />ᐳ: Object[229], Lambda[235], Lambda[230]<br />2: PgSelect[24]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 10, 23, 208, 212, 232, 237, 13<br /><br />ROOT Connectionᐸ21ᐳ[23]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect24,Object229,Lambda230,Lambda235 bucket2
+    class Bucket2,PgSelect24 bucket2
     Bucket3("Bucket 3 (listItem)<br />Deps: 13<br /><br />ROOT __Item{3}ᐸ24ᐳ[25]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item25,PgSelectSingle26 bucket3
@@ -484,9 +486,9 @@ graph TD
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 102, 103<br /><br />ROOT PgSelectSingleᐸleft_armᐳ[102]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression104,List105,Lambda106,PgClassExpression107,PgClassExpression108,PgClassExpression109 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 10, 114, 208, 211, 344, 345, 332, 477, 103<br /><br />ROOT Connectionᐸ112ᐳ[114]<br />1: <br />ᐳ: Object[347], Lambda[353], Lambda[348]<br />2: PgSelect[115]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 10, 114, 208, 212, 358, 363, 103<br /><br />ROOT Connectionᐸ112ᐳ[114]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgSelect115,Object347,Lambda348,Lambda353 bucket12
+    class Bucket12,PgSelect115 bucket12
     Bucket13("Bucket 13 (listItem)<br />Deps: 103<br /><br />ROOT __Item{13}ᐸ115ᐳ[116]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item116,PgSelectSingle117 bucket13
@@ -502,19 +504,19 @@ graph TD
     Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 151, 152<br /><br />ROOT PgSelectSingleᐸpostᐳ[151]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgClassExpression153,List154,Lambda155,PgClassExpression156,PgClassExpression157,PgClassExpression158 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 10, 163, 208, 211, 402, 403, 390, 481, 152<br /><br />ROOT Connectionᐸ161ᐳ[163]<br />1: <br />ᐳ: Object[405], Lambda[411], Lambda[406]<br />2: PgSelect[164]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 10, 163, 208, 212, 420, 425, 152<br /><br />ROOT Connectionᐸ161ᐳ[163]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PgSelect164,Object405,Lambda406,Lambda411 bucket18
+    class Bucket18,PgSelect164 bucket18
     Bucket19("Bucket 19 (listItem)<br />Deps: 152<br /><br />ROOT __Item{19}ᐸ164ᐳ[165]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item165,PgSelectSingle166 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 166, 152<br /><br />ROOT PgSelectSingle{19}ᐸpostᐳ[166]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20,PgClassExpression168,List169,Lambda170,PgClassExpression171,PgClassExpression172,PgClassExpression173 bucket20
-    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 178, 37, 177, 206, 208, 209, 152<br /><br />ROOT PgSelectSingleᐸpersonᐳ[178]"):::bucket
+    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 178, 37, 177, 206, 208, 209, 152, 189<br /><br />ROOT PgSelectSingleᐸpersonᐳ[178]"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PgClassExpression180,List181,Lambda182,Connection189,Access427,Object429,Lambda430 bucket21
-    Bucket22("Bucket 22 (listItem)<br />Deps: 152<br /><br />ROOT __Item{22}ᐸ430ᐳ[191]"):::bucket
+    class Bucket21,PgClassExpression180,List181,Lambda182,Access442,Object444,Lambda445 bucket21
+    Bucket22("Bucket 22 (listItem)<br />Deps: 152<br /><br />ROOT __Item{22}ᐸ445ᐳ[191]"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22,__Item191,PgSelectSingle192 bucket22
     Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 192, 152<br /><br />ROOT PgSelectSingle{22}ᐸpostᐳ[192]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/relation-head-tail.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/relation-head-tail.mermaid
@@ -9,6 +9,40 @@ graph TD
 
 
     %% plan dependencies
+    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant94{{"Constant[94∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda89 & Constant94 & Constant95 & Constant96 --> Object97
+    Object117{{"Object[117∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda110 & Constant114 & Constant115 & Constant96 --> Object117
+    Object135{{"Object[135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda110 & Constant132 & Constant133 & Constant134 --> Object135
+    Object153{{"Object[153∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda110 & Constant150 & Constant151 & Constant134 --> Object153
+    Object171{{"Object[171∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda110 & Constant168 & Constant169 & Constant170 --> Object171
+    Object186{{"Object[186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸsql.identifier(”foreign_key”)ᐳ"}}:::plan
+    Constant185{{"Constant[185∈0] ➊<br />ᐸRecordCodec(foreignKey)ᐳ"}}:::plan
+    Lambda110 & Constant183 & Constant184 & Constant185 --> Object186
+    Object206{{"Object[206∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant204{{"Constant[204∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda110 & Constant203 & Constant204 & Constant134 --> Object206
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,145 +50,128 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant217 --> Lambda89
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant208 --> Lambda109
-    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant209 --> Lambda111
+    Connection26{{"Connection[26∈0] ➊<br />ᐸ22ᐳ"}}:::plan
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant213 --> Connection26
+    Constant224{{"Constant[224∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant224 --> Lambda89
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant225 --> Lambda92
+    Access93{{"Access[93∈0] ➊<br />ᐸ92.0ᐳ"}}:::plan
+    Lambda92 --> Access93
+    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object97 --> Lambda98
+    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant217 --> Lambda103
+    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant215 --> Lambda110
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant216 --> Lambda112
+    Access113{{"Access[113∈0] ➊<br />ᐸ112.0ᐳ"}}:::plan
+    Lambda112 --> Access113
+    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object117 --> Lambda118
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant218 --> Lambda123
+    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object135 --> Lambda136
+    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant219 --> Lambda141
+    Lambda154{{"Lambda[154∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object153 --> Lambda154
+    Lambda159{{"Lambda[159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant220 --> Lambda159
+    Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object171 --> Lambda172
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant221 --> Lambda177
+    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object186 --> Lambda187
+    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”foreigᐳ"}}:::plan
+    Constant222 --> Lambda192
+    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object206 --> Lambda207
+    Lambda212{{"Lambda[212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant223 --> Lambda212
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Connection38{{"Connection[38∈0] ➊<br />ᐸ36ᐳ"}}:::plan
+    Connection48{{"Connection[48∈0] ➊<br />ᐸ46ᐳ"}}:::plan
+    Connection58{{"Connection[58∈0] ➊<br />ᐸ56ᐳ"}}:::plan
     Connection68{{"Connection[68∈0] ➊<br />ᐸ66ᐳ"}}:::plan
+    Connection80{{"Connection[80∈0] ➊<br />ᐸ76ᐳ"}}:::plan
     Constant87{{"Constant[87∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant90{{"Constant[90∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸsql.identifier(”foreign_key”)ᐳ"}}:::plan
-    Constant179{{"Constant[179∈0] ➊<br />ᐸRecordCodec(foreignKey)ᐳ"}}:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ'Large bet on myself in round one.'ᐳ"}}:::plan
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”foreigᐳ"}}:::plan
-    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸ'Large bet on myself in round one.'ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda92{{"Lambda[92∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda97{{"Lambda[97∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda102{{"Lambda[102∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda116{{"Lambda[116∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda121{{"Lambda[121∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda138{{"Lambda[138∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda150{{"Lambda[150∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda155{{"Lambda[155∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda167{{"Lambda[167∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda172{{"Lambda[172∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda92 & Lambda97 & Lambda102 & Constant207 & Lambda111 & Lambda116 & Lambda121 & Lambda111 & Lambda133 & Lambda138 & Lambda111 & Lambda150 & Lambda155 & Lambda109 & Lambda111 & Lambda167 & Lambda172 --> PgSelect14
-    Object96{{"Object[96∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda89 & Constant93 & Constant94 & Constant95 --> Object96
-    Object115{{"Object[115∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant112 & Constant113 & Constant95 --> Object115
-    Object132{{"Object[132∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant129 & Constant130 & Constant131 --> Object132
-    Object149{{"Object[149∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant146 & Constant147 & Constant131 --> Object149
-    Object166{{"Object[166∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant163 & Constant164 & Constant165 --> Object166
-    Connection26{{"Connection[26∈1] ➊<br />ᐸ22ᐳ"}}:::plan
-    Constant206 --> Connection26
-    Constant218 --> Lambda92
-    Object96 --> Lambda97
-    Constant210 --> Lambda102
-    Object115 --> Lambda116
-    Constant211 --> Lambda121
-    Object132 --> Lambda133
-    Constant212 --> Lambda138
-    Object149 --> Lambda150
-    Constant213 --> Lambda155
-    Object166 --> Lambda167
-    Constant214 --> Lambda172
-    Connection38{{"Connection[38∈1] ➊<br />ᐸ36ᐳ"}}:::plan
-    Connection48{{"Connection[48∈1] ➊<br />ᐸ46ᐳ"}}:::plan
-    Connection58{{"Connection[58∈1] ➊<br />ᐸ56ᐳ"}}:::plan
+    Object12 & Connection13 & Access93 & Lambda98 & Lambda103 & Constant214 & Access113 & Lambda118 & Lambda123 & Access113 & Lambda136 & Lambda141 & Access113 & Lambda154 & Lambda159 & Lambda110 & Access113 & Lambda172 & Lambda177 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸpersonᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
-    Object106{{"Object[106∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access104{{"Access[104∈3]<br />ᐸ15.0ᐳ"}}:::plan
-    Access104 & Constant87 & Constant206 & Lambda89 & Constant90 --> Object106
-    Object123{{"Object[123∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access122{{"Access[122∈3]<br />ᐸ15.1ᐳ"}}:::plan
-    Access122 & Constant87 & Constant87 & Lambda109 & Constant90 --> Object123
-    Object140{{"Object[140∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access139{{"Access[139∈3]<br />ᐸ15.2ᐳ"}}:::plan
-    Access139 & Constant87 & Constant87 & Lambda109 & Constant90 --> Object140
-    Object157{{"Object[157∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access156{{"Access[156∈3]<br />ᐸ15.3ᐳ"}}:::plan
-    Access156 & Constant87 & Constant87 & Lambda109 & Constant90 --> Object157
+    Object107{{"Object[107∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access105{{"Access[105∈3]<br />ᐸ15.0ᐳ"}}:::plan
+    Access105 & Constant87 & Constant213 & Lambda89 & Constant90 --> Object107
+    Object125{{"Object[125∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access124{{"Access[124∈3]<br />ᐸ15.1ᐳ"}}:::plan
+    Access124 & Constant87 & Constant87 & Lambda110 & Constant90 --> Object125
+    Object143{{"Object[143∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access142{{"Access[142∈3]<br />ᐸ15.2ᐳ"}}:::plan
+    Access142 & Constant87 & Constant87 & Lambda110 & Constant90 --> Object143
+    Object161{{"Object[161∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access160{{"Access[160∈3]<br />ᐸ15.3ᐳ"}}:::plan
+    Access160 & Constant87 & Constant87 & Lambda110 & Constant90 --> Object161
     PgClassExpression17{{"PgClassExpression[17∈3]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression18
-    __Item15 --> Access104
-    Lambda107{{"Lambda[107∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object106 --> Lambda107
-    __Item15 --> Access122
-    Lambda124{{"Lambda[124∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object123 --> Lambda124
-    __Item15 --> Access139
-    Lambda141{{"Lambda[141∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object140 --> Lambda141
-    __Item15 --> Access156
-    Lambda158{{"Lambda[158∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object157 --> Lambda158
-    __Item28[/"__Item[28∈4]<br />ᐸ107ᐳ"\]:::itemplan
-    Lambda107 ==> __Item28
+    __Item15 --> Access105
+    Lambda108{{"Lambda[108∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object107 --> Lambda108
+    __Item15 --> Access124
+    Lambda126{{"Lambda[126∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object125 --> Lambda126
+    __Item15 --> Access142
+    Lambda144{{"Lambda[144∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object143 --> Lambda144
+    __Item15 --> Access160
+    Lambda162{{"Lambda[162∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object161 --> Lambda162
+    __Item28[/"__Item[28∈4]<br />ᐸ108ᐳ"\]:::itemplan
+    Lambda108 ==> __Item28
     PgSelectSingle29{{"PgSelectSingle[29∈4]<br />ᐸpostᐳ"}}:::plan
     __Item28 --> PgSelectSingle29
     PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression30
     PgClassExpression31{{"PgClassExpression[31∈5]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression31
-    __Item40[/"__Item[40∈6]<br />ᐸ124ᐳ"\]:::itemplan
-    Lambda124 ==> __Item40
+    __Item40[/"__Item[40∈6]<br />ᐸ126ᐳ"\]:::itemplan
+    Lambda126 ==> __Item40
     PgSelectSingle41{{"PgSelectSingle[41∈6]<br />ᐸpostᐳ"}}:::plan
     __Item40 --> PgSelectSingle41
     PgClassExpression42{{"PgClassExpression[42∈7]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression42
     PgClassExpression43{{"PgClassExpression[43∈7]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle41 --> PgClassExpression43
-    __Item50[/"__Item[50∈8]<br />ᐸ141ᐳ"\]:::itemplan
-    Lambda141 ==> __Item50
+    __Item50[/"__Item[50∈8]<br />ᐸ144ᐳ"\]:::itemplan
+    Lambda144 ==> __Item50
     PgSelectSingle51{{"PgSelectSingle[51∈8]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item50 --> PgSelectSingle51
     PgClassExpression52{{"PgClassExpression[52∈9]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle51 --> PgClassExpression52
     PgClassExpression53{{"PgClassExpression[53∈9]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle51 --> PgClassExpression53
-    __Item60[/"__Item[60∈10]<br />ᐸ158ᐳ"\]:::itemplan
-    Lambda158 ==> __Item60
+    __Item60[/"__Item[60∈10]<br />ᐸ162ᐳ"\]:::itemplan
+    Lambda162 ==> __Item60
     PgSelectSingle61{{"PgSelectSingle[61∈10]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item60 --> PgSelectSingle61
     PgClassExpression62{{"PgClassExpression[62∈11]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
@@ -162,36 +179,23 @@ graph TD
     PgClassExpression63{{"PgClassExpression[63∈11]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle61 --> PgClassExpression63
     PgSelect69[["PgSelect[69∈12] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Lambda181{{"Lambda[181∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda186{{"Lambda[186∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda200{{"Lambda[200∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda205{{"Lambda[205∈12] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection68 & Lambda111 & Lambda181 & Lambda186 & Lambda109 & Lambda111 & Lambda200 & Lambda205 --> PgSelect69
-    Object180{{"Object[180∈12] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant177 & Constant178 & Constant179 --> Object180
-    Object199{{"Object[199∈12] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda109 & Constant196 & Constant197 & Constant131 --> Object199
-    Object180 --> Lambda181
-    Constant215 --> Lambda186
-    Object199 --> Lambda200
-    Constant216 --> Lambda205
-    Connection80{{"Connection[80∈12] ➊<br />ᐸ76ᐳ"}}:::plan
+    Object12 & Connection68 & Access113 & Lambda187 & Lambda192 & Lambda110 & Access113 & Lambda207 & Lambda212 --> PgSelect69
     __Item70[/"__Item[70∈13]<br />ᐸ69ᐳ"\]:::itemplan
     PgSelect69 ==> __Item70
     PgSelectSingle71{{"PgSelectSingle[71∈13]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item70 --> PgSelectSingle71
-    Object190{{"Object[190∈14]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access188{{"Access[188∈14]<br />ᐸ70.0ᐳ"}}:::plan
-    Access188 & Constant87 & Constant87 & Lambda109 & Constant90 --> Object190
+    Object196{{"Object[196∈14]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access194{{"Access[194∈14]<br />ᐸ70.0ᐳ"}}:::plan
+    Access194 & Constant87 & Constant87 & Lambda110 & Constant90 --> Object196
     PgClassExpression72{{"PgClassExpression[72∈14]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle71 --> PgClassExpression72
     PgClassExpression73{{"PgClassExpression[73∈14]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle71 --> PgClassExpression73
-    __Item70 --> Access188
-    Lambda191{{"Lambda[191∈14]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object190 --> Lambda191
-    __Item82[/"__Item[82∈15]<br />ᐸ191ᐳ"\]:::itemplan
-    Lambda191 ==> __Item82
+    __Item70 --> Access194
+    Lambda197{{"Lambda[197∈14]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object196 --> Lambda197
+    __Item82[/"__Item[82∈15]<br />ᐸ197ᐳ"\]:::itemplan
+    Lambda197 ==> __Item82
     PgSelectSingle83{{"PgSelectSingle[83∈15]<br />ᐸforeign_keyᐳ"}}:::plan
     __Item82 --> PgSelectSingle83
     PgClassExpression84{{"PgClassExpression[84∈16]<br />ᐸ__foreign_...person_id”ᐳ"}}:::plan
@@ -206,50 +210,50 @@ graph TD
     subgraph "Buckets for queries/v4/relation-head-tail"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection68,Constant87,Lambda89,Constant90,Constant93,Constant94,Constant95,Lambda109,Lambda111,Constant112,Constant113,Constant129,Constant130,Constant131,Constant146,Constant147,Constant163,Constant164,Constant165,Constant177,Constant178,Constant179,Constant196,Constant197,Constant206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 207, 111, 109, 206, 218, 89, 93, 94, 95, 210, 112, 113, 211, 129, 130, 131, 212, 146, 147, 213, 163, 164, 165, 214, 87, 90<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 26, 38, 48, 58, 92, 96, 102, 115, 121, 132, 138, 149, 155, 166, 172, 97, 116, 133, 150, 167<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection26,Connection38,Connection48,Connection58,Connection68,Connection80,Constant87,Lambda89,Constant90,Lambda92,Access93,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Lambda110,Lambda112,Access113,Constant114,Constant115,Object117,Lambda118,Lambda123,Constant132,Constant133,Constant134,Object135,Lambda136,Lambda141,Constant150,Constant151,Object153,Lambda154,Lambda159,Constant168,Constant169,Constant170,Object171,Lambda172,Lambda177,Constant183,Constant184,Constant185,Object186,Lambda187,Lambda192,Constant203,Constant204,Object206,Lambda207,Lambda212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222,Constant223,Constant224,Constant225 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 93, 98, 103, 214, 113, 118, 123, 136, 141, 154, 159, 110, 172, 177, 87, 213, 89, 90, 26, 38, 48, 58<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Connection26,Connection38,Connection48,Connection58,Lambda92,Object96,Lambda97,Lambda102,Object115,Lambda116,Lambda121,Object132,Lambda133,Lambda138,Object149,Lambda150,Lambda155,Object166,Lambda167,Lambda172 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 87, 206, 89, 90, 109, 26, 38, 48, 58<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
+    class Bucket1,PgSelect14 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 87, 213, 89, 90, 110, 26, 38, 48, 58<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 15, 87, 206, 89, 90, 109, 26, 38, 48, 58<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 15, 87, 213, 89, 90, 110, 26, 38, 48, 58<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression18,Access104,Object106,Lambda107,Access122,Object123,Lambda124,Access139,Object140,Lambda141,Access156,Object157,Lambda158 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ107ᐳ[28]"):::bucket
+    class Bucket3,PgClassExpression17,PgClassExpression18,Access105,Object107,Lambda108,Access124,Object125,Lambda126,Access142,Object143,Lambda144,Access160,Object161,Lambda162 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ108ᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item28,PgSelectSingle29 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 29<br /><br />ROOT PgSelectSingle{4}ᐸpostᐳ[29]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression30,PgClassExpression31 bucket5
-    Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ124ᐳ[40]"):::bucket
+    Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ126ᐳ[40]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 41<br /><br />ROOT PgSelectSingle{6}ᐸpostᐳ[41]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression42,PgClassExpression43 bucket7
-    Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ141ᐳ[50]"):::bucket
+    Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ144ᐳ[50]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item50,PgSelectSingle51 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 51<br /><br />ROOT PgSelectSingle{8}ᐸcompound_keyᐳ[51]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression52,PgClassExpression53 bucket9
-    Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ158ᐳ[60]"):::bucket
+    Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ162ᐳ[60]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item60,PgSelectSingle61 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 61<br /><br />ROOT PgSelectSingle{10}ᐸcompound_keyᐳ[61]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgClassExpression62,PgClassExpression63 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 12, 68, 111, 109, 177, 178, 179, 215, 196, 197, 131, 216, 87, 90<br /><br />ROOT Connectionᐸ66ᐳ[68]<br />1: <br />ᐳ: 80, 180, 186, 199, 205, 181, 200<br />2: PgSelect[69]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 12, 68, 113, 187, 192, 110, 207, 212, 87, 90, 80<br /><br />ROOT Connectionᐸ66ᐳ[68]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgSelect69,Connection80,Object180,Lambda181,Lambda186,Object199,Lambda200,Lambda205 bucket12
-    Bucket13("Bucket 13 (listItem)<br />Deps: 87, 109, 90, 80<br /><br />ROOT __Item{13}ᐸ69ᐳ[70]"):::bucket
+    class Bucket12,PgSelect69 bucket12
+    Bucket13("Bucket 13 (listItem)<br />Deps: 87, 110, 90, 80<br /><br />ROOT __Item{13}ᐸ69ᐳ[70]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item70,PgSelectSingle71 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 71, 70, 87, 109, 90, 80<br /><br />ROOT PgSelectSingle{13}ᐸcompound_keyᐳ[71]"):::bucket
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 71, 70, 87, 110, 90, 80<br /><br />ROOT PgSelectSingle{13}ᐸcompound_keyᐳ[71]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression72,PgClassExpression73,Access188,Object190,Lambda191 bucket14
-    Bucket15("Bucket 15 (listItem)<br /><br />ROOT __Item{15}ᐸ191ᐳ[82]"):::bucket
+    class Bucket14,PgClassExpression72,PgClassExpression73,Access194,Object196,Lambda197 bucket14
+    Bucket15("Bucket 15 (listItem)<br /><br />ROOT __Item{15}ᐸ197ᐳ[82]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,__Item82,PgSelectSingle83 bucket15
     Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 83<br /><br />ROOT PgSelectSingle{15}ᐸforeign_keyᐳ[83]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/relation-tail-head.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/relation-tail-head.mermaid
@@ -9,6 +9,34 @@ graph TD
 
 
     %% plan dependencies
+    Object72{{"Object[72∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant70{{"Constant[70∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda64 & Constant69 & Constant70 & Constant71 --> Object72
+    Object89{{"Object[89∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant86{{"Constant[86∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant87{{"Constant[87∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda64 & Constant86 & Constant87 & Constant71 --> Object89
+    Object106{{"Object[106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant103{{"Constant[103∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant104{{"Constant[104∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant105{{"Constant[105∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda64 & Constant103 & Constant104 & Constant105 --> Object106
+    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant118{{"Constant[118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda64 & Constant118 & Constant119 & Constant71 --> Object121
+    Object138{{"Object[138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda64 & Constant135 & Constant136 & Constant105 --> Object138
+    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant152{{"Constant[152∈0] ➊<br />ᐸ[ { attribute: 'person_id', direction: 'ASC' }, { attribute:ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”foreign_key”)ᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸRecordCodec(foreignKey)ᐳ"}}:::plan
+    Lambda64 & Constant152 & Constant153 & Constant154 --> Object155
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,56 +44,48 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda64{{"Lambda[64∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant156 --> Lambda64
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant162 --> Lambda64
     Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant157 --> Lambda67
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant163 --> Lambda67
+    Access68{{"Access[68∈0] ➊<br />ᐸ67.0ᐳ"}}:::plan
+    Lambda67 --> Access68
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object72 --> Lambda73
+    Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant164 --> Lambda78
+    Lambda90{{"Lambda[90∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object89 --> Lambda90
+    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant165 --> Lambda95
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object106 --> Lambda107
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant166 --> Lambda112
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object121 --> Lambda122
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant167 --> Lambda127
+    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object138 --> Lambda139
+    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant168 --> Lambda144
+    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object155 --> Lambda156
+    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_id', direcᐳ"}}:::plan
+    Constant169 --> Lambda161
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection40{{"Connection[40∈0] ➊<br />ᐸ38ᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant100{{"Constant[100∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant101{{"Constant[101∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant102{{"Constant[102∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Constant114{{"Constant[114∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant115{{"Constant[115∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant131{{"Constant[131∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { attribute: 'person_id', direction: 'ASC' }, { attribute:ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”foreign_key”)ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(foreignKey)ᐳ"}}:::plan
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_id', direcᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Lambda72{{"Lambda[72∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda77{{"Lambda[77∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda88{{"Lambda[88∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda104{{"Lambda[104∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda67 & Lambda72 & Lambda77 & Lambda67 & Lambda88 & Lambda93 & Lambda64 & Lambda67 & Lambda104 & Lambda109 --> PgSelect14
-    Object71{{"Object[71∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant68 & Constant69 & Constant70 --> Object71
-    Object87{{"Object[87∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant84 & Constant85 & Constant70 --> Object87
-    Object103{{"Object[103∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant100 & Constant101 & Constant102 --> Object103
-    Object71 --> Lambda72
-    Constant158 --> Lambda77
-    Object87 --> Lambda88
-    Constant159 --> Lambda93
-    Object103 --> Lambda104
-    Constant160 --> Lambda109
+    Object12 & Connection13 & Access68 & Lambda73 & Lambda78 & Access68 & Lambda90 & Lambda95 & Lambda64 & Access68 & Lambda107 & Lambda112 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸcompound_keyᐳ"}}:::plan
@@ -79,9 +99,9 @@ graph TD
     PgSelectSingle25{{"PgSelectSingle[25∈3]<br />ᐸpersonᐳ"}}:::plan
     PgSelectSingle16 --> PgSelectSingle25
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys94{{"RemapKeys[94∈3]<br />ᐸ16:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys94 --> PgSelectSingle31
-    PgSelectSingle16 --> RemapKeys94
+    RemapKeys96{{"RemapKeys[96∈3]<br />ᐸ16:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys96 --> PgSelectSingle31
+    PgSelectSingle16 --> RemapKeys96
     PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle25 --> PgClassExpression26
     PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -91,25 +111,7 @@ graph TD
     PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__person__.”email”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression33
     PgSelect41[["PgSelect[41∈6] ➊<br />ᐸforeign_keyᐳ"]]:::plan
-    Lambda118{{"Lambda[118∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda123{{"Lambda[123∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda134{{"Lambda[134∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda139{{"Lambda[139∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda150{{"Lambda[150∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda155{{"Lambda[155∈6] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection40 & Lambda67 & Lambda118 & Lambda123 & Lambda67 & Lambda134 & Lambda139 & Lambda64 & Lambda67 & Lambda150 & Lambda155 --> PgSelect41
-    Object117{{"Object[117∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant114 & Constant115 & Constant70 --> Object117
-    Object133{{"Object[133∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant130 & Constant131 & Constant102 --> Object133
-    Object149{{"Object[149∈6] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda64 & Constant146 & Constant147 & Constant148 --> Object149
-    Object117 --> Lambda118
-    Constant161 --> Lambda123
-    Object133 --> Lambda134
-    Constant162 --> Lambda139
-    Object149 --> Lambda150
-    Constant163 --> Lambda155
+    Object12 & Connection40 & Access68 & Lambda122 & Lambda127 & Access68 & Lambda139 & Lambda144 & Lambda64 & Access68 & Lambda156 & Lambda161 --> PgSelect41
     __Item42[/"__Item[42∈7]<br />ᐸ41ᐳ"\]:::itemplan
     PgSelect41 ==> __Item42
     PgSelectSingle43{{"PgSelectSingle[43∈7]<br />ᐸforeign_keyᐳ"}}:::plan
@@ -123,9 +125,9 @@ graph TD
     PgSelectSingle52{{"PgSelectSingle[52∈8]<br />ᐸpersonᐳ"}}:::plan
     PgSelectSingle43 --> PgSelectSingle52
     PgSelectSingle58{{"PgSelectSingle[58∈8]<br />ᐸcompound_keyᐳ"}}:::plan
-    RemapKeys140{{"RemapKeys[140∈8]<br />ᐸ43:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
-    RemapKeys140 --> PgSelectSingle58
-    PgSelectSingle43 --> RemapKeys140
+    RemapKeys145{{"RemapKeys[145∈8]<br />ᐸ43:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
+    RemapKeys145 --> PgSelectSingle58
+    PgSelectSingle43 --> RemapKeys145
     PgClassExpression53{{"PgClassExpression[53∈9]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle52 --> PgClassExpression53
     PgClassExpression54{{"PgClassExpression[54∈9]<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -142,31 +144,31 @@ graph TD
     subgraph "Buckets for queries/v4/relation-tail-head"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection40,Lambda64,Lambda67,Constant68,Constant69,Constant70,Constant84,Constant85,Constant100,Constant101,Constant102,Constant114,Constant115,Constant130,Constant131,Constant146,Constant147,Constant148,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 67, 64, 68, 69, 70, 158, 84, 85, 159, 100, 101, 102, 160<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 71, 77, 87, 93, 103, 109, 72, 88, 104<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection40,Lambda64,Lambda67,Access68,Constant69,Constant70,Constant71,Object72,Lambda73,Lambda78,Constant86,Constant87,Object89,Lambda90,Lambda95,Constant103,Constant104,Constant105,Object106,Lambda107,Lambda112,Constant118,Constant119,Object121,Lambda122,Lambda127,Constant135,Constant136,Object138,Lambda139,Lambda144,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167,Constant168,Constant169 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 68, 73, 78, 90, 95, 64, 107, 112<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object71,Lambda72,Lambda77,Object87,Lambda88,Lambda93,Object103,Lambda104,Lambda109 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸcompound_keyᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgSelectSingle25,PgSelectSingle31,RemapKeys94 bucket3
+    class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgSelectSingle25,PgSelectSingle31,RemapKeys96 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression26,PgClassExpression27 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[31]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression32,PgClassExpression33 bucket5
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 12, 40, 67, 64, 114, 115, 70, 161, 130, 131, 102, 162, 146, 147, 148, 163<br /><br />ROOT Connectionᐸ38ᐳ[40]<br />1: <br />ᐳ: 117, 123, 133, 139, 149, 155, 118, 134, 150<br />2: PgSelect[41]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 12, 40, 68, 122, 127, 139, 144, 64, 156, 161<br /><br />ROOT Connectionᐸ38ᐳ[40]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgSelect41,Object117,Lambda118,Lambda123,Object133,Lambda134,Lambda139,Object149,Lambda150,Lambda155 bucket6
+    class Bucket6,PgSelect41 bucket6
     Bucket7("Bucket 7 (listItem)<br /><br />ROOT __Item{7}ᐸ41ᐳ[42]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item42,PgSelectSingle43 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 43<br /><br />ROOT PgSelectSingle{7}ᐸforeign_keyᐳ[43]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgSelectSingle52,PgSelectSingle58,RemapKeys140 bucket8
+    class Bucket8,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgSelectSingle52,PgSelectSingle58,RemapKeys145 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 52<br /><br />ROOT PgSelectSingle{8}ᐸpersonᐳ[52]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression53,PgClassExpression54 bucket9

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-collections.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-collections.mermaid
@@ -11,154 +11,164 @@ graph TD
     %% plan dependencies
     PgSelect53[["PgSelect[53∈0] ➊<br />ᐸpostᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant243{{"Constant[243∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda120{{"Lambda[120∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda181{{"Lambda[181∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda186{{"Lambda[186∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant243 & Constant243 & Lambda118 & Lambda120 & Lambda181 & Lambda186 --> PgSelect53
+    Constant253{{"Constant[253∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access122{{"Access[122∈0] ➊<br />ᐸ121.0ᐳ"}}:::plan
+    Lambda187{{"Lambda[187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant253 & Constant253 & Lambda119 & Access122 & Lambda187 & Lambda192 --> PgSelect53
     PgSelect61[["PgSelect[61∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Constant244{{"Constant[244∈0] ➊<br />ᐸ3ᐳ"}}:::plan
-    Constant245{{"Constant[245∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda190{{"Lambda[190∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda195{{"Lambda[195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda200{{"Lambda[200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant244 & Constant245 & Lambda188 & Lambda190 & Lambda195 & Lambda200 --> PgSelect61
+    Constant254{{"Constant[254∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access197{{"Access[197∈0] ➊<br />ᐸ196.0ᐳ"}}:::plan
+    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda207{{"Lambda[207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant254 & Constant255 & Lambda194 & Access197 & Lambda202 & Lambda207 --> PgSelect61
     PgSelect17[["PgSelect[17∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda125{{"Lambda[125∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant243 & Lambda118 & Lambda120 & Lambda125 & Lambda130 --> PgSelect17
+    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant253 & Lambda119 & Access122 & Lambda127 & Lambda132 --> PgSelect17
     PgSelect44[["PgSelect[44∈0] ➊<br />ᐸpostᐳ"]]:::plan
     Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access107{{"Access[107∈0] ➊<br />ᐸ106.0ᐳ"}}:::plan
     Lambda172{{"Lambda[172∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant243 & Lambda103 & Lambda106 & Lambda167 & Lambda172 --> PgSelect44
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant253 & Lambda103 & Access107 & Lambda172 & Lambda177 --> PgSelect44
     PgSelect69[["PgSelect[69∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Constant246{{"Constant[246∈0] ➊<br />ᐸ0ᐳ"}}:::plan
-    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda204{{"Lambda[204∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda209{{"Lambda[209∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda214{{"Lambda[214∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant246 & Lambda202 & Lambda204 & Lambda209 & Lambda214 --> PgSelect69
+    Constant256{{"Constant[256∈0] ➊<br />ᐸ0ᐳ"}}:::plan
+    Lambda209{{"Lambda[209∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access212{{"Access[212∈0] ➊<br />ᐸ211.0ᐳ"}}:::plan
+    Lambda217{{"Lambda[217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda222{{"Lambda[222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant256 & Lambda209 & Access212 & Lambda217 & Lambda222 --> PgSelect69
     PgSelect95[["PgSelect[95∈0] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda237{{"Lambda[237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda242{{"Lambda[242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant244 & Lambda188 & Lambda232 & Lambda237 & Lambda242 --> PgSelect95
+    Access242{{"Access[242∈0] ➊<br />ᐸ241.0ᐳ"}}:::plan
+    Lambda247{{"Lambda[247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda252{{"Lambda[252∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant254 & Lambda194 & Access242 & Lambda247 & Lambda252 --> PgSelect95
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda103 & Lambda106 & Lambda111 & Lambda116 --> PgSelect7
+    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda103 & Access107 & Lambda112 & Lambda117 --> PgSelect7
     PgSelect26[["PgSelect[26∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda139{{"Lambda[139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda103 & Lambda106 & Lambda139 & Lambda144 --> PgSelect26
+    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda103 & Access107 & Lambda142 & Lambda147 --> PgSelect26
     PgSelect35[["PgSelect[35∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda153{{"Lambda[153∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda103 & Lambda106 & Lambda153 & Lambda158 --> PgSelect35
+    Lambda157{{"Lambda[157∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda103 & Access107 & Lambda157 & Lambda162 --> PgSelect35
     PgSelect84[["PgSelect[84∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda223{{"Lambda[223∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda228{{"Lambda[228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda103 & Lambda106 & Lambda223 & Lambda228 --> PgSelect84
-    Object110{{"Object[110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda103 & Constant107 & Constant108 & Constant109 --> Object110
-    Object124{{"Object[124∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda118 & Constant121 & Constant122 & Constant109 --> Object124
-    Object138{{"Object[138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant135{{"Constant[135∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'ASC' }, { fraᐳ"}}:::plan
-    Constant136{{"Constant[136∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda103 & Constant135 & Constant136 & Constant109 --> Object138
-    Object152{{"Object[152∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant149{{"Constant[149∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'DESC' }, { frᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda103 & Constant149 & Constant150 & Constant109 --> Object152
-    Object166{{"Object[166∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant163{{"Constant[163∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant164{{"Constant[164∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant165{{"Constant[165∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda103 & Constant163 & Constant164 & Constant165 --> Object166
-    Object180{{"Object[180∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant177{{"Constant[177∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant178{{"Constant[178∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda118 & Constant177 & Constant178 & Constant165 --> Object180
-    Object194{{"Object[194∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant191{{"Constant[191∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant192{{"Constant[192∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda188 & Constant191 & Constant192 & Constant109 --> Object194
-    Object208{{"Object[208∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant205{{"Constant[205∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant206{{"Constant[206∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda202 & Constant205 & Constant206 & Constant109 --> Object208
-    Object222{{"Object[222∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant219{{"Constant[219∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant220{{"Constant[220∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda103 & Constant219 & Constant220 & Constant109 --> Object222
-    Object236{{"Object[236∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant233{{"Constant[233∈0] ➊<br />ᐸ[ { attribute: 'author_id', direction: 'DESC' }, { attributeᐳ"}}:::plan
-    Constant234{{"Constant[234∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda188 & Constant233 & Constant234 & Constant165 --> Object236
+    Lambda232{{"Lambda[232∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda237{{"Lambda[237∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda103 & Access107 & Lambda232 & Lambda237 --> PgSelect84
+    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant108{{"Constant[108∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant110{{"Constant[110∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda103 & Constant108 & Constant109 & Constant110 --> Object111
+    Object126{{"Object[126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant124{{"Constant[124∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda119 & Constant123 & Constant124 & Constant110 --> Object126
+    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant138{{"Constant[138∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'ASC' }, { fraᐳ"}}:::plan
+    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda103 & Constant138 & Constant139 & Constant110 --> Object141
+    Object156{{"Object[156∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant153{{"Constant[153∈0] ➊<br />ᐸ[ { attribute: 'person_full_name', direction: 'DESC' }, { frᐳ"}}:::plan
+    Constant154{{"Constant[154∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda103 & Constant153 & Constant154 & Constant110 --> Object156
+    Object171{{"Object[171∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant168{{"Constant[168∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant169{{"Constant[169∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant170{{"Constant[170∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda103 & Constant168 & Constant169 & Constant170 --> Object171
+    Object186{{"Object[186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant183{{"Constant[183∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant184{{"Constant[184∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda119 & Constant183 & Constant184 & Constant170 --> Object186
+    Object201{{"Object[201∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant198{{"Constant[198∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant199{{"Constant[199∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda194 & Constant198 & Constant199 & Constant110 --> Object201
+    Object216{{"Object[216∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant214{{"Constant[214∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda209 & Constant213 & Constant214 & Constant110 --> Object216
+    Object231{{"Object[231∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant229{{"Constant[229∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda103 & Constant228 & Constant229 & Constant110 --> Object231
+    Object246{{"Object[246∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant243{{"Constant[243∈0] ➊<br />ᐸ[ { attribute: 'author_id', direction: 'DESC' }, { attributeᐳ"}}:::plan
+    Constant244{{"Constant[244∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda194 & Constant243 & Constant244 & Constant170 --> Object246
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
-    Constant247{{"Constant[247∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant247 --> Lambda103
-    Constant248{{"Constant[248∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant248 --> Lambda106
-    Object110 --> Lambda111
-    Constant249{{"Constant[249∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant249 --> Lambda116
-    Constant259{{"Constant[259∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant259 --> Lambda118
-    Constant260{{"Constant[260∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant260 --> Lambda120
-    Object124 --> Lambda125
-    Constant250{{"Constant[250∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant250 --> Lambda130
-    Object138 --> Lambda139
-    Constant251{{"Constant[251∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
-    Constant251 --> Lambda144
-    Object152 --> Lambda153
-    Constant252{{"Constant[252∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
-    Constant252 --> Lambda158
-    Object166 --> Lambda167
-    Constant253{{"Constant[253∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant253 --> Lambda172
-    Object180 --> Lambda181
-    Constant254{{"Constant[254∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant254 --> Lambda186
-    Constant261{{"Constant[261∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant261 --> Lambda188
-    Constant262{{"Constant[262∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant262 --> Lambda190
-    Object194 --> Lambda195
-    Constant255{{"Constant[255∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant255 --> Lambda200
-    Constant263{{"Constant[263∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant263 --> Lambda202
-    Constant264{{"Constant[264∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant264 --> Lambda204
-    Object208 --> Lambda209
-    Constant256{{"Constant[256∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant256 --> Lambda214
-    Object222 --> Lambda223
-    Constant257{{"Constant[257∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant257 --> Lambda228
-    Constant265{{"Constant[265∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant265 --> Lambda232
-    Object236 --> Lambda237
-    Constant258{{"Constant[258∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'author_id', direcᐳ"}}:::plan
-    Constant258 --> Lambda242
+    Constant257{{"Constant[257∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant257 --> Lambda103
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant258{{"Constant[258∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant258 --> Lambda106
+    Lambda106 --> Access107
+    Object111 --> Lambda112
+    Constant259{{"Constant[259∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant259 --> Lambda117
+    Constant269{{"Constant[269∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant269 --> Lambda119
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant270{{"Constant[270∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant270 --> Lambda121
+    Lambda121 --> Access122
+    Object126 --> Lambda127
+    Constant260{{"Constant[260∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant260 --> Lambda132
+    Object141 --> Lambda142
+    Constant261{{"Constant[261∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
+    Constant261 --> Lambda147
+    Object156 --> Lambda157
+    Constant262{{"Constant[262∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_full_name'ᐳ"}}:::plan
+    Constant262 --> Lambda162
+    Object171 --> Lambda172
+    Constant263{{"Constant[263∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant263 --> Lambda177
+    Object186 --> Lambda187
+    Constant264{{"Constant[264∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant264 --> Lambda192
+    Constant271{{"Constant[271∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant271 --> Lambda194
+    Lambda196{{"Lambda[196∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant272{{"Constant[272∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant272 --> Lambda196
+    Lambda196 --> Access197
+    Object201 --> Lambda202
+    Constant265{{"Constant[265∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant265 --> Lambda207
+    Constant273{{"Constant[273∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant273 --> Lambda209
+    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant274{{"Constant[274∈0] ➊<br />ᐸ§{ first: 0, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant274 --> Lambda211
+    Lambda211 --> Access212
+    Object216 --> Lambda217
+    Constant266{{"Constant[266∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant266 --> Lambda222
+    Object231 --> Lambda232
+    Constant267{{"Constant[267∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant267 --> Lambda237
+    Lambda241{{"Lambda[241∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant275{{"Constant[275∈0] ➊<br />ᐸ§{ first: 3, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant275 --> Lambda241
+    Lambda241 --> Access242
+    Object246 --> Lambda247
+    Constant268{{"Constant[268∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'author_id', direcᐳ"}}:::plan
+    Constant268 --> Lambda252
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
@@ -258,9 +268,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/simple-collections"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 107, 108, 109, 121, 122, 135, 136, 149, 150, 163, 164, 165, 177, 178, 191, 192, 205, 206, 219, 220, 233, 234, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 10, 103, 106, 110, 111, 116, 118, 120, 124, 125, 130, 138, 139, 144, 152, 153, 158, 166, 167, 172, 180, 181, 186, 188, 190, 194, 195, 200, 202, 204, 208, 209, 214, 222, 223, 228, 232, 236, 237, 242<br />2: 7, 17, 26, 35, 44, 53, 61, 69, 84, 95"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 108, 109, 110, 123, 124, 138, 139, 153, 154, 168, 169, 170, 183, 184, 198, 199, 213, 214, 228, 229, 243, 244, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 10, 103, 106, 107, 111, 112, 117, 119, 121, 122, 126, 127, 132, 141, 142, 147, 156, 157, 162, 171, 172, 177, 186, 187, 192, 194, 196, 197, 201, 202, 207, 209, 211, 212, 216, 217, 222, 231, 232, 237, 241, 242, 246, 247, 252<br />2: 7, 17, 26, 35, 44, 53, 61, 69, 84, 95"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect17,PgSelect26,PgSelect35,PgSelect44,PgSelect53,PgSelect61,PgSelect69,PgSelect84,PgSelect95,Lambda103,Lambda106,Constant107,Constant108,Constant109,Object110,Lambda111,Lambda116,Lambda118,Lambda120,Constant121,Constant122,Object124,Lambda125,Lambda130,Constant135,Constant136,Object138,Lambda139,Lambda144,Constant149,Constant150,Object152,Lambda153,Lambda158,Constant163,Constant164,Constant165,Object166,Lambda167,Lambda172,Constant177,Constant178,Object180,Lambda181,Lambda186,Lambda188,Lambda190,Constant191,Constant192,Object194,Lambda195,Lambda200,Lambda202,Lambda204,Constant205,Constant206,Object208,Lambda209,Lambda214,Constant219,Constant220,Object222,Lambda223,Lambda228,Lambda232,Constant233,Constant234,Object236,Lambda237,Lambda242,Constant243,Constant244,Constant245,Constant246,Constant247,Constant248,Constant249,Constant250,Constant251,Constant252,Constant253,Constant254,Constant255,Constant256,Constant257,Constant258,Constant259,Constant260,Constant261,Constant262,Constant263,Constant264,Constant265 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect17,PgSelect26,PgSelect35,PgSelect44,PgSelect53,PgSelect61,PgSelect69,PgSelect84,PgSelect95,Lambda103,Lambda106,Access107,Constant108,Constant109,Constant110,Object111,Lambda112,Lambda117,Lambda119,Lambda121,Access122,Constant123,Constant124,Object126,Lambda127,Lambda132,Constant138,Constant139,Object141,Lambda142,Lambda147,Constant153,Constant154,Object156,Lambda157,Lambda162,Constant168,Constant169,Constant170,Object171,Lambda172,Lambda177,Constant183,Constant184,Object186,Lambda187,Lambda192,Lambda194,Lambda196,Access197,Constant198,Constant199,Object201,Lambda202,Lambda207,Lambda209,Lambda211,Access212,Constant213,Constant214,Object216,Lambda217,Lambda222,Constant228,Constant229,Object231,Lambda232,Lambda237,Lambda241,Access242,Constant243,Constant244,Object246,Lambda247,Lambda252,Constant253,Constant254,Constant255,Constant256,Constant257,Constant258,Constant259,Constant260,Constant261,Constant262,Constant263,Constant264,Constant265,Constant266,Constant267,Constant268,Constant269,Constant270,Constant271,Constant272,Constant273,Constant274,Constant275 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression15 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-computed-fields.mermaid
@@ -11,292 +11,431 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda375{{"Lambda[375∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda380{{"Lambda[380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda385{{"Lambda[385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda394{{"Lambda[394∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda399{{"Lambda[399∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda404{{"Lambda[404∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda418{{"Lambda[418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda423{{"Lambda[423∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda437{{"Lambda[437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda442{{"Lambda[442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda449{{"Lambda[449∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda454{{"Lambda[454∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access376{{"Access[376∈0] ➊<br />ᐸ375.0ᐳ"}}:::plan
+    Lambda381{{"Lambda[381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda386{{"Lambda[386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access396{{"Access[396∈0] ➊<br />ᐸ395.0ᐳ"}}:::plan
+    Lambda401{{"Lambda[401∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda406{{"Lambda[406∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda421{{"Lambda[421∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda426{{"Lambda[426∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda441{{"Lambda[441∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda446{{"Lambda[446∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access454{{"Access[454∈0] ➊<br />ᐸ453.0ᐳ"}}:::plan
     Lambda459{{"Lambda[459∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda471{{"Lambda[471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda476{{"Lambda[476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda490{{"Lambda[490∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda495{{"Lambda[495∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda502{{"Lambda[502∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda512{{"Lambda[512∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant1002{{"Constant[1002∈0] ➊<br />ᐸ'Large bet on myself in round one.'ᐳ"}}:::plan
-    Lambda524{{"Lambda[524∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda529{{"Lambda[529∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda543{{"Lambda[543∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda548{{"Lambda[548∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda560{{"Lambda[560∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda565{{"Lambda[565∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda577{{"Lambda[577∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda582{{"Lambda[582∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda596{{"Lambda[596∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda601{{"Lambda[601∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda613{{"Lambda[613∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda618{{"Lambda[618∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda630{{"Lambda[630∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda635{{"Lambda[635∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda647{{"Lambda[647∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda652{{"Lambda[652∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda664{{"Lambda[664∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda669{{"Lambda[669∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda464{{"Lambda[464∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda477{{"Lambda[477∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda482{{"Lambda[482∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda497{{"Lambda[497∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda502{{"Lambda[502∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access510{{"Access[510∈0] ➊<br />ᐸ509.0ᐳ"}}:::plan
+    Lambda515{{"Lambda[515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda520{{"Lambda[520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1038{{"Constant[1038∈0] ➊<br />ᐸ'Large bet on myself in round one.'ᐳ"}}:::plan
+    Lambda533{{"Lambda[533∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda538{{"Lambda[538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda553{{"Lambda[553∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda558{{"Lambda[558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda571{{"Lambda[571∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda576{{"Lambda[576∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda589{{"Lambda[589∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda594{{"Lambda[594∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda609{{"Lambda[609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda614{{"Lambda[614∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda627{{"Lambda[627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda632{{"Lambda[632∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda645{{"Lambda[645∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda650{{"Lambda[650∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda663{{"Lambda[663∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda668{{"Lambda[668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda681{{"Lambda[681∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda686{{"Lambda[686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda392{{"Lambda[392∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda698{{"Lambda[698∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda703{{"Lambda[703∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda375 & Lambda380 & Lambda385 & Lambda394 & Lambda399 & Lambda404 & Lambda375 & Lambda418 & Lambda423 & Lambda375 & Lambda437 & Lambda442 & Lambda449 & Lambda454 & Lambda459 & Lambda375 & Lambda471 & Lambda476 & Lambda375 & Lambda490 & Lambda495 & Lambda502 & Lambda507 & Lambda512 & Constant1002 & Lambda375 & Lambda524 & Lambda529 & Lambda375 & Lambda543 & Lambda548 & Lambda394 & Lambda560 & Lambda565 & Constant1002 & Lambda375 & Lambda577 & Lambda582 & Lambda375 & Lambda596 & Lambda601 & Lambda394 & Lambda613 & Lambda618 & Lambda394 & Lambda630 & Lambda635 & Lambda394 & Lambda647 & Lambda652 & Lambda394 & Lambda664 & Lambda669 & Lambda394 & Lambda681 & Lambda686 & Lambda392 & Lambda394 & Lambda698 & Lambda703 --> PgSelect7
-    Object379{{"Object[379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda699{{"Lambda[699∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda704{{"Lambda[704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda393{{"Lambda[393∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda717{{"Lambda[717∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda722{{"Lambda[722∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Access376 & Lambda381 & Lambda386 & Access396 & Lambda401 & Lambda406 & Access376 & Lambda421 & Lambda426 & Access376 & Lambda441 & Lambda446 & Access454 & Lambda459 & Lambda464 & Access376 & Lambda477 & Lambda482 & Access376 & Lambda497 & Lambda502 & Access510 & Lambda515 & Lambda520 & Constant1038 & Access376 & Lambda533 & Lambda538 & Access376 & Lambda553 & Lambda558 & Access396 & Lambda571 & Lambda576 & Constant1038 & Access376 & Lambda589 & Lambda594 & Access376 & Lambda609 & Lambda614 & Access396 & Lambda627 & Lambda632 & Access396 & Lambda645 & Lambda650 & Access396 & Lambda663 & Lambda668 & Access396 & Lambda681 & Lambda686 & Access396 & Lambda699 & Lambda704 & Lambda393 & Access396 & Lambda717 & Lambda722 --> PgSelect7
+    Object380{{"Object[380∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda372{{"Lambda[372∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant376{{"Constant[376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant377{{"Constant[377∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Constant378{{"Constant[378∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda372 & Constant376 & Constant377 & Constant378 --> Object379
-    Object398{{"Object[398∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant396{{"Constant[396∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
-    Lambda392 & Constant395 & Constant396 & Constant378 --> Object398
-    Object417{{"Object[417∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant414{{"Constant[414∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant415{{"Constant[415∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant416{{"Constant[416∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
-    Lambda372 & Constant414 & Constant415 & Constant416 --> Object417
-    Object436{{"Object[436∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant433{{"Constant[433∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant434{{"Constant[434∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant433 & Constant434 & Constant416 --> Object436
-    Object453{{"Object[453∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda447{{"Lambda[447∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant450{{"Constant[450∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant451{{"Constant[451∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant452{{"Constant[452∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda447 & Constant450 & Constant451 & Constant452 --> Object453
-    Object470{{"Object[470∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant467{{"Constant[467∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant468{{"Constant[468∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant467 & Constant468 & Constant416 --> Object470
-    Object489{{"Object[489∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant486{{"Constant[486∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant487{{"Constant[487∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant486 & Constant487 & Constant416 --> Object489
-    Object506{{"Object[506∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda500{{"Lambda[500∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant503{{"Constant[503∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant504{{"Constant[504∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda500 & Constant503 & Constant504 & Constant452 --> Object506
-    Object523{{"Object[523∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant520{{"Constant[520∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant521{{"Constant[521∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant520 & Constant521 & Constant416 --> Object523
-    Object542{{"Object[542∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant539{{"Constant[539∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant540{{"Constant[540∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant539 & Constant540 & Constant416 --> Object542
-    Object559{{"Object[559∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant556{{"Constant[556∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant557{{"Constant[557∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda392 & Constant556 & Constant557 & Constant452 --> Object559
-    Object576{{"Object[576∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant573{{"Constant[573∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant574{{"Constant[574∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant573 & Constant574 & Constant416 --> Object576
-    Object595{{"Object[595∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant592{{"Constant[592∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant593{{"Constant[593∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda372 & Constant592 & Constant593 & Constant416 --> Object595
-    Object612{{"Object[612∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant609{{"Constant[609∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant610{{"Constant[610∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda392 & Constant609 & Constant610 & Constant452 --> Object612
-    Object629{{"Object[629∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant626{{"Constant[626∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant627{{"Constant[627∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant628{{"Constant[628∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda392 & Constant626 & Constant627 & Constant628 --> Object629
-    Object646{{"Object[646∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant643{{"Constant[643∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Lambda392 & Constant643 & Constant627 & Constant628 --> Object646
-    Object663{{"Object[663∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant660{{"Constant[660∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant661{{"Constant[661∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda392 & Constant660 & Constant661 & Constant628 --> Object663
+    Constant377{{"Constant[377∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant378{{"Constant[378∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Constant379{{"Constant[379∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda372 & Constant377 & Constant378 & Constant379 --> Object380
+    Object400{{"Object[400∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant397{{"Constant[397∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸsql.identifier(”person_friends”)ᐳ"}}:::plan
+    Lambda393 & Constant397 & Constant398 & Constant379 --> Object400
+    Object420{{"Object[420∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Constant419{{"Constant[419∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
+    Lambda372 & Constant417 & Constant418 & Constant419 --> Object420
+    Object440{{"Object[440∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant437{{"Constant[437∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant438{{"Constant[438∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant437 & Constant438 & Constant419 --> Object440
+    Object458{{"Object[458∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda451{{"Lambda[451∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant455{{"Constant[455∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant456{{"Constant[456∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant457{{"Constant[457∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda451 & Constant455 & Constant456 & Constant457 --> Object458
+    Object476{{"Object[476∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant473{{"Constant[473∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant474{{"Constant[474∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant473 & Constant474 & Constant419 --> Object476
+    Object496{{"Object[496∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant493{{"Constant[493∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant494{{"Constant[494∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant493 & Constant494 & Constant419 --> Object496
+    Object514{{"Object[514∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda507{{"Lambda[507∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant511{{"Constant[511∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant512{{"Constant[512∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda507 & Constant511 & Constant512 & Constant457 --> Object514
+    Object532{{"Object[532∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant529{{"Constant[529∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant530{{"Constant[530∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant529 & Constant530 & Constant419 --> Object532
+    Object552{{"Object[552∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant549{{"Constant[549∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant550{{"Constant[550∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant549 & Constant550 & Constant419 --> Object552
+    Object570{{"Object[570∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant567{{"Constant[567∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant568{{"Constant[568∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda393 & Constant567 & Constant568 & Constant457 --> Object570
+    Object588{{"Object[588∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant585{{"Constant[585∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant586{{"Constant[586∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant585 & Constant586 & Constant419 --> Object588
+    Object608{{"Object[608∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant605{{"Constant[605∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant606{{"Constant[606∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant605 & Constant606 & Constant419 --> Object608
+    Object626{{"Object[626∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda393 & Constant623 & Constant624 & Constant457 --> Object626
+    Object644{{"Object[644∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant641{{"Constant[641∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant642{{"Constant[642∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant643{{"Constant[643∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda393 & Constant641 & Constant642 & Constant643 --> Object644
+    Object662{{"Object[662∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant659{{"Constant[659∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Lambda393 & Constant659 & Constant642 & Constant643 --> Object662
     Object680{{"Object[680∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant677{{"Constant[677∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Lambda392 & Constant677 & Constant661 & Constant628 --> Object680
-    Object697{{"Object[697∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant694{{"Constant[694∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant695{{"Constant[695∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda392 & Constant694 & Constant695 & Constant378 --> Object697
+    Constant678{{"Constant[678∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda393 & Constant677 & Constant678 & Constant643 --> Object680
+    Object698{{"Object[698∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant695{{"Constant[695∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Lambda393 & Constant695 & Constant678 & Constant643 --> Object698
+    Object716{{"Object[716∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant713{{"Constant[713∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant714{{"Constant[714∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda393 & Constant713 & Constant714 & Constant379 --> Object716
+    Object731{{"Object[731∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant728{{"Constant[728∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant729{{"Constant[729∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant728 & Constant729 & Constant419 --> Object731
+    Object751{{"Object[751∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant748{{"Constant[748∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant749{{"Constant[749∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant748 & Constant749 & Constant419 --> Object751
+    Object769{{"Object[769∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant766{{"Constant[766∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant767{{"Constant[767∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda451 & Constant766 & Constant767 & Constant457 --> Object769
+    Object789{{"Object[789∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant786{{"Constant[786∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant787{{"Constant[787∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant786 & Constant787 & Constant419 --> Object789
+    Object809{{"Object[809∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant806{{"Constant[806∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant807{{"Constant[807∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant806 & Constant807 & Constant419 --> Object809
+    Object827{{"Object[827∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant824{{"Constant[824∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant825{{"Constant[825∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda507 & Constant824 & Constant825 & Constant457 --> Object827
+    Object845{{"Object[845∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant842{{"Constant[842∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant843{{"Constant[843∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant842 & Constant843 & Constant419 --> Object845
+    Object865{{"Object[865∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant862{{"Constant[862∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant863{{"Constant[863∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant862 & Constant863 & Constant419 --> Object865
+    Object883{{"Object[883∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant880{{"Constant[880∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant881{{"Constant[881∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda393 & Constant880 & Constant881 & Constant457 --> Object883
+    Object901{{"Object[901∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant898{{"Constant[898∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant899{{"Constant[899∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant898 & Constant899 & Constant419 --> Object901
+    Object921{{"Object[921∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant918{{"Constant[918∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant919{{"Constant[919∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda372 & Constant918 & Constant919 & Constant419 --> Object921
+    Object939{{"Object[939∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant936{{"Constant[936∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant937{{"Constant[937∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda393 & Constant936 & Constant937 & Constant457 --> Object939
+    Object957{{"Object[957∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant954{{"Constant[954∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant955{{"Constant[955∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda393 & Constant954 & Constant955 & Constant643 --> Object957
+    Object975{{"Object[975∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant972{{"Constant[972∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Lambda393 & Constant972 & Constant955 & Constant643 --> Object975
+    Object993{{"Object[993∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant990{{"Constant[990∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant991{{"Constant[991∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda393 & Constant990 & Constant991 & Constant643 --> Object993
+    Object1011{{"Object[1011∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1008{{"Constant[1008∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Lambda393 & Constant1008 & Constant991 & Constant643 --> Object1011
+    Object1029{{"Object[1029∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant1026{{"Constant[1026∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Lambda393 & Constant1026 & Constant714 & Constant379 --> Object1029
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
-    Constant1041{{"Constant[1041∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1041 --> Lambda372
-    Constant1042{{"Constant[1042∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1042 --> Lambda375
-    Object379 --> Lambda380
-    Constant1005{{"Constant[1005∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1005 --> Lambda385
-    Constant1003{{"Constant[1003∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1003 --> Lambda392
-    Constant1004{{"Constant[1004∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant1004 --> Lambda394
-    Object398 --> Lambda399
-    Constant1006{{"Constant[1006∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant1006 --> Lambda404
-    Object417 --> Lambda418
-    Constant1007{{"Constant[1007∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1007 --> Lambda423
-    Object436 --> Lambda437
-    Constant1008{{"Constant[1008∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1008 --> Lambda442
-    Constant1043{{"Constant[1043∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1043 --> Lambda447
-    Constant1044{{"Constant[1044∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1044 --> Lambda449
-    Object453 --> Lambda454
-    Constant1009{{"Constant[1009∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1009 --> Lambda459
-    Object470 --> Lambda471
-    Constant1010{{"Constant[1010∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1010 --> Lambda476
-    Object489 --> Lambda490
-    Constant1011{{"Constant[1011∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1011 --> Lambda495
-    Constant1045{{"Constant[1045∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1045 --> Lambda500
-    Constant1046{{"Constant[1046∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant1046 --> Lambda502
-    Object506 --> Lambda507
-    Constant1012{{"Constant[1012∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant1012 --> Lambda512
-    Object523 --> Lambda524
-    Constant1013{{"Constant[1013∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1013 --> Lambda529
-    Object542 --> Lambda543
-    Constant1014{{"Constant[1014∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1014 --> Lambda548
-    Object559 --> Lambda560
-    Constant1015{{"Constant[1015∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1015 --> Lambda565
-    Object576 --> Lambda577
-    Constant1016{{"Constant[1016∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1016 --> Lambda582
-    Object595 --> Lambda596
-    Constant1017{{"Constant[1017∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1017 --> Lambda601
-    Object612 --> Lambda613
-    Constant1018{{"Constant[1018∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant1018 --> Lambda618
-    Object629 --> Lambda630
-    Constant1019{{"Constant[1019∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1019 --> Lambda635
-    Object646 --> Lambda647
-    Constant1020{{"Constant[1020∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1020 --> Lambda652
-    Object663 --> Lambda664
-    Constant1021{{"Constant[1021∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1021 --> Lambda669
+    Connection34{{"Connection[34∈0] ➊<br />ᐸ30ᐳ"}}:::plan
+    Constant1036{{"Constant[1036∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant1036 --> Connection34
+    Connection47{{"Connection[47∈0] ➊<br />ᐸ45ᐳ"}}:::plan
+    Constant1037{{"Constant[1037∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant1037 --> Connection47
+    Connection61{{"Connection[61∈0] ➊<br />ᐸ57ᐳ"}}:::plan
+    Constant1036 --> Connection61
+    Connection90{{"Connection[90∈0] ➊<br />ᐸ86ᐳ"}}:::plan
+    Constant1036 --> Connection90
+    Connection124{{"Connection[124∈0] ➊<br />ᐸ120ᐳ"}}:::plan
+    Constant1036 --> Connection124
+    Connection154{{"Connection[154∈0] ➊<br />ᐸ150ᐳ"}}:::plan
+    Constant1036 --> Connection154
+    Connection217{{"Connection[217∈0] ➊<br />ᐸ213ᐳ"}}:::plan
+    Constant1037 --> Connection217
+    Connection231{{"Connection[231∈0] ➊<br />ᐸ227ᐳ"}}:::plan
+    Constant1036 --> Connection231
+    Connection260{{"Connection[260∈0] ➊<br />ᐸ256ᐳ"}}:::plan
+    Constant1036 --> Connection260
+    Connection294{{"Connection[294∈0] ➊<br />ᐸ290ᐳ"}}:::plan
+    Constant1036 --> Connection294
+    Connection324{{"Connection[324∈0] ➊<br />ᐸ320ᐳ"}}:::plan
+    Constant1036 --> Connection324
+    Constant1077{{"Constant[1077∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1077 --> Lambda372
+    Lambda375{{"Lambda[375∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1078{{"Constant[1078∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1078 --> Lambda375
+    Lambda375 --> Access376
+    Object380 --> Lambda381
+    Constant1041{{"Constant[1041∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1041 --> Lambda386
+    Constant1039{{"Constant[1039∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1039 --> Lambda393
+    Lambda395{{"Lambda[395∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1040{{"Constant[1040∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant1040 --> Lambda395
+    Lambda395 --> Access396
+    Object400 --> Lambda401
+    Constant1042{{"Constant[1042∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant1042 --> Lambda406
+    Object420 --> Lambda421
+    Constant1043{{"Constant[1043∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1043 --> Lambda426
+    Object440 --> Lambda441
+    Constant1044{{"Constant[1044∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1044 --> Lambda446
+    Constant1079{{"Constant[1079∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1079 --> Lambda451
+    Lambda453{{"Lambda[453∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1080{{"Constant[1080∈0] ➊<br />ᐸ§{ first: null, last: 2, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1080 --> Lambda453
+    Lambda453 --> Access454
+    Object458 --> Lambda459
+    Constant1045{{"Constant[1045∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1045 --> Lambda464
+    Object476 --> Lambda477
+    Constant1046{{"Constant[1046∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1046 --> Lambda482
+    Object496 --> Lambda497
+    Constant1047{{"Constant[1047∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1047 --> Lambda502
+    Constant1081{{"Constant[1081∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1081 --> Lambda507
+    Lambda509{{"Lambda[509∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant1082{{"Constant[1082∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant1082 --> Lambda509
+    Lambda509 --> Access510
+    Object514 --> Lambda515
+    Constant1048{{"Constant[1048∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1048 --> Lambda520
+    Object532 --> Lambda533
+    Constant1049{{"Constant[1049∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1049 --> Lambda538
+    Object552 --> Lambda553
+    Constant1050{{"Constant[1050∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1050 --> Lambda558
+    Object570 --> Lambda571
+    Constant1051{{"Constant[1051∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1051 --> Lambda576
+    Object588 --> Lambda589
+    Constant1052{{"Constant[1052∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1052 --> Lambda594
+    Object608 --> Lambda609
+    Constant1053{{"Constant[1053∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1053 --> Lambda614
+    Object626 --> Lambda627
+    Constant1054{{"Constant[1054∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1054 --> Lambda632
+    Object644 --> Lambda645
+    Constant1055{{"Constant[1055∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1055 --> Lambda650
+    Object662 --> Lambda663
+    Constant1056{{"Constant[1056∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1056 --> Lambda668
     Object680 --> Lambda681
-    Constant1022{{"Constant[1022∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1022 --> Lambda686
-    Object697 --> Lambda698
-    Constant1023{{"Constant[1023∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant1023 --> Lambda703
+    Constant1057{{"Constant[1057∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1057 --> Lambda686
+    Object698 --> Lambda699
+    Constant1058{{"Constant[1058∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1058 --> Lambda704
+    Object716 --> Lambda717
+    Constant1059{{"Constant[1059∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1059 --> Lambda722
+    Lambda732{{"Lambda[732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object731 --> Lambda732
+    Lambda737{{"Lambda[737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1060{{"Constant[1060∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1060 --> Lambda737
+    Lambda752{{"Lambda[752∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object751 --> Lambda752
+    Lambda757{{"Lambda[757∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1061{{"Constant[1061∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1061 --> Lambda757
+    Lambda770{{"Lambda[770∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object769 --> Lambda770
+    Lambda775{{"Lambda[775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1062{{"Constant[1062∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1062 --> Lambda775
+    Lambda790{{"Lambda[790∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object789 --> Lambda790
+    Lambda795{{"Lambda[795∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1063{{"Constant[1063∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1063 --> Lambda795
+    Lambda810{{"Lambda[810∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object809 --> Lambda810
+    Lambda815{{"Lambda[815∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1064{{"Constant[1064∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1064 --> Lambda815
+    Lambda828{{"Lambda[828∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object827 --> Lambda828
+    Lambda833{{"Lambda[833∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1065{{"Constant[1065∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1065 --> Lambda833
+    Lambda846{{"Lambda[846∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object845 --> Lambda846
+    Lambda851{{"Lambda[851∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1066{{"Constant[1066∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1066 --> Lambda851
+    Lambda866{{"Lambda[866∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object865 --> Lambda866
+    Lambda871{{"Lambda[871∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1067{{"Constant[1067∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1067 --> Lambda871
+    Lambda884{{"Lambda[884∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object883 --> Lambda884
+    Lambda889{{"Lambda[889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1068{{"Constant[1068∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1068 --> Lambda889
+    Lambda902{{"Lambda[902∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object901 --> Lambda902
+    Lambda907{{"Lambda[907∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1069{{"Constant[1069∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1069 --> Lambda907
+    Lambda922{{"Lambda[922∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object921 --> Lambda922
+    Lambda927{{"Lambda[927∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1070{{"Constant[1070∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant1070 --> Lambda927
+    Lambda940{{"Lambda[940∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object939 --> Lambda940
+    Lambda945{{"Lambda[945∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1071{{"Constant[1071∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1071 --> Lambda945
+    Lambda958{{"Lambda[958∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object957 --> Lambda958
+    Lambda963{{"Lambda[963∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1072{{"Constant[1072∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1072 --> Lambda963
+    Lambda976{{"Lambda[976∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object975 --> Lambda976
+    Lambda981{{"Lambda[981∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1073{{"Constant[1073∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1073 --> Lambda981
+    Lambda994{{"Lambda[994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object993 --> Lambda994
+    Lambda999{{"Lambda[999∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1074{{"Constant[1074∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1074 --> Lambda999
+    Lambda1012{{"Lambda[1012∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1011 --> Lambda1012
+    Lambda1017{{"Lambda[1017∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1075{{"Constant[1075∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant1075 --> Lambda1017
+    Lambda1030{{"Lambda[1030∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object1029 --> Lambda1030
+    Lambda1035{{"Lambda[1035∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant1076{{"Constant[1076∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant1076 --> Lambda1035
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection21{{"Connection[21∈0] ➊<br />ᐸ17ᐳ"}}:::plan
+    Connection110{{"Connection[110∈0] ➊<br />ᐸ108ᐳ"}}:::plan
+    Connection172{{"Connection[172∈0] ➊<br />ᐸ170ᐳ"}}:::plan
+    Connection182{{"Connection[182∈0] ➊<br />ᐸ180ᐳ"}}:::plan
     Connection204{{"Connection[204∈0] ➊<br />ᐸ202ᐳ"}}:::plan
+    Connection280{{"Connection[280∈0] ➊<br />ᐸ278ᐳ"}}:::plan
+    Connection342{{"Connection[342∈0] ➊<br />ᐸ340ᐳ"}}:::plan
+    Connection352{{"Connection[352∈0] ➊<br />ᐸ350ᐳ"}}:::plan
     Constant370{{"Constant[370∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant373{{"Constant[373∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant708{{"Constant[708∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant709{{"Constant[709∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant727{{"Constant[727∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant728{{"Constant[728∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant744{{"Constant[744∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant745{{"Constant[745∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant763{{"Constant[763∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant764{{"Constant[764∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant782{{"Constant[782∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant783{{"Constant[783∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant799{{"Constant[799∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant800{{"Constant[800∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant816{{"Constant[816∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant817{{"Constant[817∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant835{{"Constant[835∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant836{{"Constant[836∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant852{{"Constant[852∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant853{{"Constant[853∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant869{{"Constant[869∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant870{{"Constant[870∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant888{{"Constant[888∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant889{{"Constant[889∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Constant905{{"Constant[905∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant906{{"Constant[906∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant922{{"Constant[922∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant923{{"Constant[923∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant939{{"Constant[939∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant956{{"Constant[956∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant957{{"Constant[957∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant973{{"Constant[973∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant990{{"Constant[990∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant1000{{"Constant[1000∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant1001{{"Constant[1001∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant1024{{"Constant[1024∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1025{{"Constant[1025∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1026{{"Constant[1026∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1027{{"Constant[1027∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1028{{"Constant[1028∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1029{{"Constant[1029∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant1030{{"Constant[1030∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1031{{"Constant[1031∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1032{{"Constant[1032∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1033{{"Constant[1033∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1034{{"Constant[1034∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant1035{{"Constant[1035∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant1036{{"Constant[1036∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1037{{"Constant[1037∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1038{{"Constant[1038∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1039{{"Constant[1039∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant1040{{"Constant[1040∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Object408{{"Object[408∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access406{{"Access[406∈1]<br />ᐸ11.1ᐳ"}}:::plan
-    Access406 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object408
-    Object461{{"Object[461∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access460{{"Access[460∈1]<br />ᐸ11.3ᐳ"}}:::plan
-    Access460 & Constant370 & Constant1001 & Lambda447 & Constant373 --> Object461
-    Object514{{"Object[514∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access513{{"Access[513∈1]<br />ᐸ11.4ᐳ"}}:::plan
-    Access513 & Constant1001 & Constant370 & Lambda500 & Constant373 --> Object514
-    Object567{{"Object[567∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access566{{"Access[566∈1]<br />ᐸ11.5ᐳ"}}:::plan
-    Access566 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object567
-    Object620{{"Object[620∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access619{{"Access[619∈1]<br />ᐸ11.6ᐳ"}}:::plan
-    Access619 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object620
-    Object637{{"Object[637∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access636{{"Access[636∈1]<br />ᐸ11.7ᐳ"}}:::plan
-    Access636 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object637
-    Object654{{"Object[654∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access653{{"Access[653∈1]<br />ᐸ11.8ᐳ"}}:::plan
-    Access653 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object654
-    Object671{{"Object[671∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access670{{"Access[670∈1]<br />ᐸ11.9ᐳ"}}:::plan
-    Access670 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object671
+    Object410{{"Object[410∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access408{{"Access[408∈1]<br />ᐸ11.1ᐳ"}}:::plan
+    Access408 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object410
+    Object466{{"Object[466∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access465{{"Access[465∈1]<br />ᐸ11.3ᐳ"}}:::plan
+    Access465 & Constant370 & Constant1037 & Lambda451 & Constant373 --> Object466
+    Object522{{"Object[522∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access521{{"Access[521∈1]<br />ᐸ11.4ᐳ"}}:::plan
+    Access521 & Constant1037 & Constant370 & Lambda507 & Constant373 --> Object522
+    Object578{{"Object[578∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access577{{"Access[577∈1]<br />ᐸ11.5ᐳ"}}:::plan
+    Access577 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object578
+    Object634{{"Object[634∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access633{{"Access[633∈1]<br />ᐸ11.6ᐳ"}}:::plan
+    Access633 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object634
+    Object652{{"Object[652∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access651{{"Access[651∈1]<br />ᐸ11.7ᐳ"}}:::plan
+    Access651 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object652
+    Object670{{"Object[670∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access669{{"Access[669∈1]<br />ᐸ11.8ᐳ"}}:::plan
+    Access669 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object670
     Object688{{"Object[688∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access687{{"Access[687∈1]<br />ᐸ11.10ᐳ"}}:::plan
-    Access687 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object688
+    Access687{{"Access[687∈1]<br />ᐸ11.9ᐳ"}}:::plan
+    Access687 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object688
+    Object706{{"Object[706∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access705{{"Access[705∈1]<br />ᐸ11.10ᐳ"}}:::plan
+    Access705 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object706
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpersonᐳ"}}:::plan
@@ -305,115 +444,99 @@ graph TD
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression15{{"PgClassExpression[15∈1]<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression15
-    Connection34{{"Connection[34∈1] ➊<br />ᐸ30ᐳ"}}:::plan
-    Constant1000 --> Connection34
     PgClassExpression41{{"PgClassExpression[41∈1]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression41
-    Connection47{{"Connection[47∈1] ➊<br />ᐸ45ᐳ"}}:::plan
-    Constant1001 --> Connection47
-    Connection61{{"Connection[61∈1] ➊<br />ᐸ57ᐳ"}}:::plan
-    Constant1000 --> Connection61
-    Connection90{{"Connection[90∈1] ➊<br />ᐸ86ᐳ"}}:::plan
-    Constant1000 --> Connection90
-    Connection124{{"Connection[124∈1] ➊<br />ᐸ120ᐳ"}}:::plan
-    Constant1000 --> Connection124
-    Connection154{{"Connection[154∈1] ➊<br />ᐸ150ᐳ"}}:::plan
-    Constant1000 --> Connection154
-    __Item11 --> Access406
-    Lambda409{{"Lambda[409∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object408 --> Lambda409
-    __Item11 --> Access460
-    Lambda462{{"Lambda[462∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object461 --> Lambda462
-    __Item11 --> Access513
-    Lambda515{{"Lambda[515∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object514 --> Lambda515
-    __Item11 --> Access566
-    Lambda568{{"Lambda[568∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object567 --> Lambda568
-    __Item11 --> Access619
-    Lambda621{{"Lambda[621∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object620 --> Lambda621
-    __Item11 --> Access636
-    Lambda638{{"Lambda[638∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object637 --> Lambda638
-    __Item11 --> Access653
-    Lambda655{{"Lambda[655∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object654 --> Lambda655
-    __Item11 --> Access670
-    Lambda672{{"Lambda[672∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object671 --> Lambda672
+    __Item11 --> Access408
+    Lambda411{{"Lambda[411∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object410 --> Lambda411
+    __Item11 --> Access465
+    Lambda467{{"Lambda[467∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object466 --> Lambda467
+    __Item11 --> Access521
+    Lambda523{{"Lambda[523∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object522 --> Lambda523
+    __Item11 --> Access577
+    Lambda579{{"Lambda[579∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object578 --> Lambda579
+    __Item11 --> Access633
+    Lambda635{{"Lambda[635∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object634 --> Lambda635
+    __Item11 --> Access651
+    Lambda653{{"Lambda[653∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object652 --> Lambda653
+    __Item11 --> Access669
+    Lambda671{{"Lambda[671∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object670 --> Lambda671
     __Item11 --> Access687
     Lambda689{{"Lambda[689∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
     Object688 --> Lambda689
-    Connection21{{"Connection[21∈1] ➊<br />ᐸ17ᐳ"}}:::plan
-    Connection110{{"Connection[110∈1] ➊<br />ᐸ108ᐳ"}}:::plan
-    Connection172{{"Connection[172∈1] ➊<br />ᐸ170ᐳ"}}:::plan
-    Connection182{{"Connection[182∈1] ➊<br />ᐸ180ᐳ"}}:::plan
-    __Item23[/"__Item[23∈2]<br />ᐸ409ᐳ"\]:::itemplan
-    Lambda409 ==> __Item23
+    __Item11 --> Access705
+    Lambda707{{"Lambda[707∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object706 --> Lambda707
+    __Item23[/"__Item[23∈2]<br />ᐸ411ᐳ"\]:::itemplan
+    Lambda411 ==> __Item23
     PgSelectSingle24{{"PgSelectSingle[24∈2]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item23 --> PgSelectSingle24
-    Object389{{"Object[389∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access387{{"Access[387∈3]<br />ᐸ23.1ᐳ"}}:::plan
-    Access387 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object389
+    Object390{{"Object[390∈3]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access388{{"Access[388∈3]<br />ᐸ23.1ᐳ"}}:::plan
+    Access388 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object390
     PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ”c”.”perso...friends__)ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression27
-    __Item23 --> Access387
-    Lambda390{{"Lambda[390∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object389 --> Lambda390
-    __Item36[/"__Item[36∈4]<br />ᐸ390ᐳ"\]:::itemplan
-    Lambda390 ==> __Item36
+    __Item23 --> Access388
+    Lambda391{{"Lambda[391∈3]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object390 --> Lambda391
+    __Item36[/"__Item[36∈4]<br />ᐸ391ᐳ"\]:::itemplan
+    Lambda391 ==> __Item36
     PgSelectSingle37{{"PgSelectSingle[37∈4]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item36 --> PgSelectSingle37
     PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
     PgSelectSingle37 --> PgClassExpression38
     PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ”c”.”perso...friends__)ᐳ"}}:::plan
     PgSelectSingle37 --> PgClassExpression40
-    __Item49[/"__Item[49∈6]<br />ᐸ462ᐳ"\]:::itemplan
-    Lambda462 ==> __Item49
+    __Item49[/"__Item[49∈6]<br />ᐸ467ᐳ"\]:::itemplan
+    Lambda467 ==> __Item49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸpostᐳ"}}:::plan
     __Item49 --> PgSelectSingle50
-    Object427{{"Object[427∈7]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access425{{"Access[425∈7]<br />ᐸ49.1ᐳ"}}:::plan
-    Access425 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object427
-    Object444{{"Object[444∈7]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access443{{"Access[443∈7]<br />ᐸ49.2ᐳ"}}:::plan
-    Access443 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object444
+    Object430{{"Object[430∈7]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access428{{"Access[428∈7]<br />ᐸ49.1ᐳ"}}:::plan
+    Access428 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object430
+    Object448{{"Object[448∈7]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access447{{"Access[447∈7]<br />ᐸ49.2ᐳ"}}:::plan
+    Access447 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object448
     PgClassExpression51{{"PgClassExpression[51∈7]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle50 --> PgClassExpression51
     PgClassExpression53{{"PgClassExpression[53∈7]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle50 --> PgClassExpression53
     PgClassExpression54{{"PgClassExpression[54∈7]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle50 --> PgClassExpression54
-    __Item49 --> Access425
-    Lambda428{{"Lambda[428∈7]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object427 --> Lambda428
-    __Item49 --> Access443
-    Lambda445{{"Lambda[445∈7]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object444 --> Lambda445
-    __Item63[/"__Item[63∈8]<br />ᐸ428ᐳ"\]:::itemplan
-    Lambda428 ==> __Item63
+    __Item49 --> Access428
+    Lambda431{{"Lambda[431∈7]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object430 --> Lambda431
+    __Item49 --> Access447
+    Lambda449{{"Lambda[449∈7]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object448 --> Lambda449
+    __Item63[/"__Item[63∈8]<br />ᐸ431ᐳ"\]:::itemplan
+    Lambda431 ==> __Item63
     PgSelectSingle64{{"PgSelectSingle[64∈8]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈8]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    __Item71[/"__Item[71∈10]<br />ᐸ445ᐳ"\]:::itemplan
-    Lambda445 ==> __Item71
+    __Item71[/"__Item[71∈10]<br />ᐸ449ᐳ"\]:::itemplan
+    Lambda449 ==> __Item71
     PgSelectSingle72{{"PgSelectSingle[72∈10]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item71 --> PgSelectSingle72
     PgClassExpression73{{"PgClassExpression[73∈10]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle72 --> PgClassExpression73
-    Object480{{"Object[480∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access478{{"Access[478∈12]<br />ᐸ78.1ᐳ"}}:::plan
-    Access478 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object480
-    Object497{{"Object[497∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access496{{"Access[496∈12]<br />ᐸ78.2ᐳ"}}:::plan
-    Access496 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object497
-    __Item78[/"__Item[78∈12]<br />ᐸ515ᐳ"\]:::itemplan
-    Lambda515 ==> __Item78
+    Object486{{"Object[486∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access484{{"Access[484∈12]<br />ᐸ78.1ᐳ"}}:::plan
+    Access484 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object486
+    Object504{{"Object[504∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access503{{"Access[503∈12]<br />ᐸ78.2ᐳ"}}:::plan
+    Access503 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object504
+    __Item78[/"__Item[78∈12]<br />ᐸ523ᐳ"\]:::itemplan
+    Lambda523 ==> __Item78
     PgSelectSingle79{{"PgSelectSingle[79∈12]<br />ᐸpostᐳ"}}:::plan
     __Item78 --> PgSelectSingle79
     PgClassExpression80{{"PgClassExpression[80∈12]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -422,66 +545,66 @@ graph TD
     PgSelectSingle79 --> PgClassExpression82
     PgClassExpression83{{"PgClassExpression[83∈12]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle79 --> PgClassExpression83
-    __Item78 --> Access478
-    Lambda481{{"Lambda[481∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object480 --> Lambda481
-    __Item78 --> Access496
-    Lambda498{{"Lambda[498∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object497 --> Lambda498
-    __Item92[/"__Item[92∈13]<br />ᐸ481ᐳ"\]:::itemplan
-    Lambda481 ==> __Item92
+    __Item78 --> Access484
+    Lambda487{{"Lambda[487∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object486 --> Lambda487
+    __Item78 --> Access503
+    Lambda505{{"Lambda[505∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object504 --> Lambda505
+    __Item92[/"__Item[92∈13]<br />ᐸ487ᐳ"\]:::itemplan
+    Lambda487 ==> __Item92
     PgSelectSingle93{{"PgSelectSingle[93∈13]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item92 --> PgSelectSingle93
     PgClassExpression94{{"PgClassExpression[94∈13]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle93 --> PgClassExpression94
-    __Item100[/"__Item[100∈15]<br />ᐸ498ᐳ"\]:::itemplan
-    Lambda498 ==> __Item100
+    __Item100[/"__Item[100∈15]<br />ᐸ505ᐳ"\]:::itemplan
+    Lambda505 ==> __Item100
     PgSelectSingle101{{"PgSelectSingle[101∈15]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item100 --> PgSelectSingle101
     PgClassExpression102{{"PgClassExpression[102∈15]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle101 --> PgClassExpression102
-    __Item112[/"__Item[112∈17]<br />ᐸ568ᐳ"\]:::itemplan
-    Lambda568 ==> __Item112
+    __Item112[/"__Item[112∈17]<br />ᐸ579ᐳ"\]:::itemplan
+    Lambda579 ==> __Item112
     PgSelectSingle113{{"PgSelectSingle[113∈17]<br />ᐸpostᐳ"}}:::plan
     __Item112 --> PgSelectSingle113
-    Object533{{"Object[533∈18]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access531{{"Access[531∈18]<br />ᐸ112.1ᐳ"}}:::plan
-    Access531 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object533
-    Object550{{"Object[550∈18]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access549{{"Access[549∈18]<br />ᐸ112.2ᐳ"}}:::plan
-    Access549 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object550
+    Object542{{"Object[542∈18]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access540{{"Access[540∈18]<br />ᐸ112.1ᐳ"}}:::plan
+    Access540 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object542
+    Object560{{"Object[560∈18]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access559{{"Access[559∈18]<br />ᐸ112.2ᐳ"}}:::plan
+    Access559 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object560
     PgClassExpression114{{"PgClassExpression[114∈18]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle113 --> PgClassExpression114
     PgClassExpression116{{"PgClassExpression[116∈18]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle113 --> PgClassExpression116
     PgClassExpression117{{"PgClassExpression[117∈18]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle113 --> PgClassExpression117
-    __Item112 --> Access531
-    Lambda534{{"Lambda[534∈18]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object533 --> Lambda534
-    __Item112 --> Access549
-    Lambda551{{"Lambda[551∈18]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object550 --> Lambda551
-    __Item126[/"__Item[126∈19]<br />ᐸ534ᐳ"\]:::itemplan
-    Lambda534 ==> __Item126
+    __Item112 --> Access540
+    Lambda543{{"Lambda[543∈18]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object542 --> Lambda543
+    __Item112 --> Access559
+    Lambda561{{"Lambda[561∈18]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object560 --> Lambda561
+    __Item126[/"__Item[126∈19]<br />ᐸ543ᐳ"\]:::itemplan
+    Lambda543 ==> __Item126
     PgSelectSingle127{{"PgSelectSingle[127∈19]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item126 --> PgSelectSingle127
     PgClassExpression128{{"PgClassExpression[128∈19]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle127 --> PgClassExpression128
-    __Item134[/"__Item[134∈21]<br />ᐸ551ᐳ"\]:::itemplan
-    Lambda551 ==> __Item134
+    __Item134[/"__Item[134∈21]<br />ᐸ561ᐳ"\]:::itemplan
+    Lambda561 ==> __Item134
     PgSelectSingle135{{"PgSelectSingle[135∈21]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item134 --> PgSelectSingle135
     PgClassExpression136{{"PgClassExpression[136∈21]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle135 --> PgClassExpression136
-    Object586{{"Object[586∈23]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access584{{"Access[584∈23]<br />ᐸ142.1ᐳ"}}:::plan
-    Access584 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object586
-    Object603{{"Object[603∈23]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access602{{"Access[602∈23]<br />ᐸ142.2ᐳ"}}:::plan
-    Access602 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object603
-    __Item142[/"__Item[142∈23]<br />ᐸ621ᐳ"\]:::itemplan
-    Lambda621 ==> __Item142
+    Object598{{"Object[598∈23]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access596{{"Access[596∈23]<br />ᐸ142.1ᐳ"}}:::plan
+    Access596 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object598
+    Object616{{"Object[616∈23]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access615{{"Access[615∈23]<br />ᐸ142.2ᐳ"}}:::plan
+    Access615 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object616
+    __Item142[/"__Item[142∈23]<br />ᐸ635ᐳ"\]:::itemplan
+    Lambda635 ==> __Item142
     PgSelectSingle143{{"PgSelectSingle[143∈23]<br />ᐸpostᐳ"}}:::plan
     __Item142 --> PgSelectSingle143
     PgClassExpression144{{"PgClassExpression[144∈23]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -490,50 +613,50 @@ graph TD
     PgSelectSingle143 --> PgClassExpression146
     PgClassExpression147{{"PgClassExpression[147∈23]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle143 --> PgClassExpression147
-    __Item142 --> Access584
-    Lambda587{{"Lambda[587∈23]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object586 --> Lambda587
-    __Item142 --> Access602
-    Lambda604{{"Lambda[604∈23]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object603 --> Lambda604
-    __Item156[/"__Item[156∈24]<br />ᐸ587ᐳ"\]:::itemplan
-    Lambda587 ==> __Item156
+    __Item142 --> Access596
+    Lambda599{{"Lambda[599∈23]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object598 --> Lambda599
+    __Item142 --> Access615
+    Lambda617{{"Lambda[617∈23]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object616 --> Lambda617
+    __Item156[/"__Item[156∈24]<br />ᐸ599ᐳ"\]:::itemplan
+    Lambda599 ==> __Item156
     PgSelectSingle157{{"PgSelectSingle[157∈24]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item156 --> PgSelectSingle157
     PgClassExpression158{{"PgClassExpression[158∈24]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression158
-    __Item164[/"__Item[164∈26]<br />ᐸ604ᐳ"\]:::itemplan
-    Lambda604 ==> __Item164
+    __Item164[/"__Item[164∈26]<br />ᐸ617ᐳ"\]:::itemplan
+    Lambda617 ==> __Item164
     PgSelectSingle165{{"PgSelectSingle[165∈26]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item164 --> PgSelectSingle165
     PgClassExpression166{{"PgClassExpression[166∈26]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle165 --> PgClassExpression166
-    __Item174[/"__Item[174∈28]<br />ᐸ655ᐳ"\]:::itemplan
-    Lambda655 ==> __Item174
+    __Item174[/"__Item[174∈28]<br />ᐸ671ᐳ"\]:::itemplan
+    Lambda671 ==> __Item174
     PgSelectSingle175{{"PgSelectSingle[175∈28]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item174 --> PgSelectSingle175
     PgClassExpression176{{"PgClassExpression[176∈29]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle175 --> PgClassExpression176
     PgClassExpression177{{"PgClassExpression[177∈29]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle175 --> PgClassExpression177
-    __Item184[/"__Item[184∈30]<br />ᐸ689ᐳ"\]:::itemplan
-    Lambda689 ==> __Item184
+    __Item184[/"__Item[184∈30]<br />ᐸ707ᐳ"\]:::itemplan
+    Lambda707 ==> __Item184
     PgSelectSingle185{{"PgSelectSingle[185∈30]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item184 --> PgSelectSingle185
     PgClassExpression186{{"PgClassExpression[186∈31]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle185 --> PgClassExpression186
     PgClassExpression187{{"PgClassExpression[187∈31]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle185 --> PgClassExpression187
-    __Item190[/"__Item[190∈32]<br />ᐸ638ᐳ"\]:::itemplan
-    Lambda638 ==> __Item190
+    __Item190[/"__Item[190∈32]<br />ᐸ653ᐳ"\]:::itemplan
+    Lambda653 ==> __Item190
     PgSelectSingle191{{"PgSelectSingle[191∈32]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item190 --> PgSelectSingle191
     PgClassExpression192{{"PgClassExpression[192∈32]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle191 --> PgClassExpression192
     PgClassExpression193{{"PgClassExpression[193∈32]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle191 --> PgClassExpression193
-    __Item196[/"__Item[196∈33]<br />ᐸ672ᐳ"\]:::itemplan
-    Lambda672 ==> __Item196
+    __Item196[/"__Item[196∈33]<br />ᐸ689ᐳ"\]:::itemplan
+    Lambda689 ==> __Item196
     PgSelectSingle197{{"PgSelectSingle[197∈33]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item196 --> PgSelectSingle197
     PgClassExpression198{{"PgClassExpression[198∈33]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
@@ -541,220 +664,105 @@ graph TD
     PgClassExpression199{{"PgClassExpression[199∈33]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle197 --> PgClassExpression199
     PgSelect205[["PgSelect[205∈34] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda712{{"Lambda[712∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda717{{"Lambda[717∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda731{{"Lambda[731∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda736{{"Lambda[736∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda748{{"Lambda[748∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda753{{"Lambda[753∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda767{{"Lambda[767∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda772{{"Lambda[772∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda786{{"Lambda[786∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda791{{"Lambda[791∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda803{{"Lambda[803∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda808{{"Lambda[808∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda820{{"Lambda[820∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda825{{"Lambda[825∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda839{{"Lambda[839∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda844{{"Lambda[844∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda856{{"Lambda[856∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda861{{"Lambda[861∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda873{{"Lambda[873∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda878{{"Lambda[878∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda892{{"Lambda[892∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda897{{"Lambda[897∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda909{{"Lambda[909∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda914{{"Lambda[914∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda926{{"Lambda[926∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda931{{"Lambda[931∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda943{{"Lambda[943∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda948{{"Lambda[948∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda960{{"Lambda[960∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda965{{"Lambda[965∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda977{{"Lambda[977∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda982{{"Lambda[982∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda994{{"Lambda[994∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda999{{"Lambda[999∈34] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Connection204 & Lambda375 & Lambda712 & Lambda717 & Lambda375 & Lambda731 & Lambda736 & Lambda449 & Lambda748 & Lambda753 & Lambda375 & Lambda767 & Lambda772 & Lambda375 & Lambda786 & Lambda791 & Lambda502 & Lambda803 & Lambda808 & Constant1002 & Lambda375 & Lambda820 & Lambda825 & Lambda375 & Lambda839 & Lambda844 & Lambda394 & Lambda856 & Lambda861 & Constant1002 & Lambda375 & Lambda873 & Lambda878 & Lambda375 & Lambda892 & Lambda897 & Lambda394 & Lambda909 & Lambda914 & Lambda394 & Lambda926 & Lambda931 & Lambda394 & Lambda943 & Lambda948 & Lambda394 & Lambda960 & Lambda965 & Lambda394 & Lambda977 & Lambda982 & Lambda392 & Lambda394 & Lambda994 & Lambda999 --> PgSelect205
-    Object711{{"Object[711∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant708 & Constant709 & Constant416 --> Object711
-    Object730{{"Object[730∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant727 & Constant728 & Constant416 --> Object730
-    Object747{{"Object[747∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda447 & Constant744 & Constant745 & Constant452 --> Object747
-    Object766{{"Object[766∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant763 & Constant764 & Constant416 --> Object766
-    Object785{{"Object[785∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant782 & Constant783 & Constant416 --> Object785
-    Object802{{"Object[802∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda500 & Constant799 & Constant800 & Constant452 --> Object802
-    Object819{{"Object[819∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant816 & Constant817 & Constant416 --> Object819
-    Object838{{"Object[838∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant835 & Constant836 & Constant416 --> Object838
-    Object855{{"Object[855∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant852 & Constant853 & Constant452 --> Object855
-    Object872{{"Object[872∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant869 & Constant870 & Constant416 --> Object872
-    Object891{{"Object[891∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda372 & Constant888 & Constant889 & Constant416 --> Object891
-    Object908{{"Object[908∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant905 & Constant906 & Constant452 --> Object908
-    Object925{{"Object[925∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant922 & Constant923 & Constant628 --> Object925
-    Object942{{"Object[942∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant939 & Constant923 & Constant628 --> Object942
-    Object959{{"Object[959∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant956 & Constant957 & Constant628 --> Object959
-    Object976{{"Object[976∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant973 & Constant957 & Constant628 --> Object976
-    Object993{{"Object[993∈34] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda392 & Constant990 & Constant695 & Constant378 --> Object993
-    Connection217{{"Connection[217∈34] ➊<br />ᐸ213ᐳ"}}:::plan
-    Constant1001 --> Connection217
-    Connection231{{"Connection[231∈34] ➊<br />ᐸ227ᐳ"}}:::plan
-    Constant1000 --> Connection231
-    Connection260{{"Connection[260∈34] ➊<br />ᐸ256ᐳ"}}:::plan
-    Constant1000 --> Connection260
-    Connection294{{"Connection[294∈34] ➊<br />ᐸ290ᐳ"}}:::plan
-    Constant1000 --> Connection294
-    Connection324{{"Connection[324∈34] ➊<br />ᐸ320ᐳ"}}:::plan
-    Constant1000 --> Connection324
-    Object711 --> Lambda712
-    Constant1024 --> Lambda717
-    Object730 --> Lambda731
-    Constant1025 --> Lambda736
-    Object747 --> Lambda748
-    Constant1026 --> Lambda753
-    Object766 --> Lambda767
-    Constant1027 --> Lambda772
-    Object785 --> Lambda786
-    Constant1028 --> Lambda791
-    Object802 --> Lambda803
-    Constant1029 --> Lambda808
-    Object819 --> Lambda820
-    Constant1030 --> Lambda825
-    Object838 --> Lambda839
-    Constant1031 --> Lambda844
-    Object855 --> Lambda856
-    Constant1032 --> Lambda861
-    Object872 --> Lambda873
-    Constant1033 --> Lambda878
-    Object891 --> Lambda892
-    Constant1034 --> Lambda897
-    Object908 --> Lambda909
-    Constant1035 --> Lambda914
-    Object925 --> Lambda926
-    Constant1036 --> Lambda931
-    Object942 --> Lambda943
-    Constant1037 --> Lambda948
-    Object959 --> Lambda960
-    Constant1038 --> Lambda965
-    Object976 --> Lambda977
-    Constant1039 --> Lambda982
-    Object993 --> Lambda994
-    Constant1040 --> Lambda999
-    Connection280{{"Connection[280∈34] ➊<br />ᐸ278ᐳ"}}:::plan
-    Connection342{{"Connection[342∈34] ➊<br />ᐸ340ᐳ"}}:::plan
-    Connection352{{"Connection[352∈34] ➊<br />ᐸ350ᐳ"}}:::plan
+    Object10 & Connection204 & Access376 & Lambda732 & Lambda737 & Access376 & Lambda752 & Lambda757 & Access454 & Lambda770 & Lambda775 & Access376 & Lambda790 & Lambda795 & Access376 & Lambda810 & Lambda815 & Access510 & Lambda828 & Lambda833 & Constant1038 & Access376 & Lambda846 & Lambda851 & Access376 & Lambda866 & Lambda871 & Access396 & Lambda884 & Lambda889 & Constant1038 & Access376 & Lambda902 & Lambda907 & Access376 & Lambda922 & Lambda927 & Access396 & Lambda940 & Lambda945 & Access396 & Lambda958 & Lambda963 & Access396 & Lambda976 & Lambda981 & Access396 & Lambda994 & Lambda999 & Access396 & Lambda1012 & Lambda1017 & Lambda393 & Access396 & Lambda1030 & Lambda1035 --> PgSelect205
     __Item206[/"__Item[206∈35]<br />ᐸ205ᐳ"\]:::itemplan
     PgSelect205 ==> __Item206
     PgSelectSingle207{{"PgSelectSingle[207∈35]<br />ᐸpersonᐳ"}}:::plan
     __Item206 --> PgSelectSingle207
-    Object757{{"Object[757∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access755{{"Access[755∈36]<br />ᐸ206.0ᐳ"}}:::plan
-    Access755 & Constant370 & Constant1001 & Lambda447 & Constant373 --> Object757
-    Object810{{"Object[810∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access809{{"Access[809∈36]<br />ᐸ206.1ᐳ"}}:::plan
-    Access809 & Constant1001 & Constant370 & Lambda500 & Constant373 --> Object810
-    Object863{{"Object[863∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access862{{"Access[862∈36]<br />ᐸ206.2ᐳ"}}:::plan
-    Access862 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object863
-    Object916{{"Object[916∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access915{{"Access[915∈36]<br />ᐸ206.3ᐳ"}}:::plan
-    Access915 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object916
-    Object933{{"Object[933∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access932{{"Access[932∈36]<br />ᐸ206.4ᐳ"}}:::plan
-    Access932 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object933
-    Object950{{"Object[950∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access949{{"Access[949∈36]<br />ᐸ206.5ᐳ"}}:::plan
-    Access949 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object950
-    Object967{{"Object[967∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access966{{"Access[966∈36]<br />ᐸ206.6ᐳ"}}:::plan
-    Access966 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object967
-    Object984{{"Object[984∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access983{{"Access[983∈36]<br />ᐸ206.7ᐳ"}}:::plan
-    Access983 & Constant370 & Constant370 & Lambda392 & Constant373 --> Object984
+    Object779{{"Object[779∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access777{{"Access[777∈36]<br />ᐸ206.0ᐳ"}}:::plan
+    Access777 & Constant370 & Constant1037 & Lambda451 & Constant373 --> Object779
+    Object835{{"Object[835∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access834{{"Access[834∈36]<br />ᐸ206.1ᐳ"}}:::plan
+    Access834 & Constant1037 & Constant370 & Lambda507 & Constant373 --> Object835
+    Object891{{"Object[891∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access890{{"Access[890∈36]<br />ᐸ206.2ᐳ"}}:::plan
+    Access890 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object891
+    Object947{{"Object[947∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access946{{"Access[946∈36]<br />ᐸ206.3ᐳ"}}:::plan
+    Access946 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object947
+    Object965{{"Object[965∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access964{{"Access[964∈36]<br />ᐸ206.4ᐳ"}}:::plan
+    Access964 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object965
+    Object983{{"Object[983∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access982{{"Access[982∈36]<br />ᐸ206.5ᐳ"}}:::plan
+    Access982 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object983
+    Object1001{{"Object[1001∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access1000{{"Access[1000∈36]<br />ᐸ206.6ᐳ"}}:::plan
+    Access1000 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object1001
+    Object1019{{"Object[1019∈36]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access1018{{"Access[1018∈36]<br />ᐸ206.7ᐳ"}}:::plan
+    Access1018 & Constant370 & Constant370 & Lambda393 & Constant373 --> Object1019
     PgClassExpression208{{"PgClassExpression[208∈36]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle207 --> PgClassExpression208
     PgClassExpression209{{"PgClassExpression[209∈36]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle207 --> PgClassExpression209
-    __Item206 --> Access755
-    Lambda758{{"Lambda[758∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object757 --> Lambda758
-    __Item206 --> Access809
-    Lambda811{{"Lambda[811∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object810 --> Lambda811
-    __Item206 --> Access862
-    Lambda864{{"Lambda[864∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object863 --> Lambda864
-    __Item206 --> Access915
-    Lambda917{{"Lambda[917∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object916 --> Lambda917
-    __Item206 --> Access932
-    Lambda934{{"Lambda[934∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object933 --> Lambda934
-    __Item206 --> Access949
-    Lambda951{{"Lambda[951∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object950 --> Lambda951
-    __Item206 --> Access966
-    Lambda968{{"Lambda[968∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object967 --> Lambda968
-    __Item206 --> Access983
-    Lambda985{{"Lambda[985∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object984 --> Lambda985
-    __Item219[/"__Item[219∈37]<br />ᐸ758ᐳ"\]:::itemplan
-    Lambda758 ==> __Item219
+    __Item206 --> Access777
+    Lambda780{{"Lambda[780∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object779 --> Lambda780
+    __Item206 --> Access834
+    Lambda836{{"Lambda[836∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object835 --> Lambda836
+    __Item206 --> Access890
+    Lambda892{{"Lambda[892∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object891 --> Lambda892
+    __Item206 --> Access946
+    Lambda948{{"Lambda[948∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object947 --> Lambda948
+    __Item206 --> Access964
+    Lambda966{{"Lambda[966∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object965 --> Lambda966
+    __Item206 --> Access982
+    Lambda984{{"Lambda[984∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object983 --> Lambda984
+    __Item206 --> Access1000
+    Lambda1002{{"Lambda[1002∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object1001 --> Lambda1002
+    __Item206 --> Access1018
+    Lambda1020{{"Lambda[1020∈36]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object1019 --> Lambda1020
+    __Item219[/"__Item[219∈37]<br />ᐸ780ᐳ"\]:::itemplan
+    Lambda780 ==> __Item219
     PgSelectSingle220{{"PgSelectSingle[220∈37]<br />ᐸpostᐳ"}}:::plan
     __Item219 --> PgSelectSingle220
-    Object721{{"Object[721∈38]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access719{{"Access[719∈38]<br />ᐸ219.1ᐳ"}}:::plan
-    Access719 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object721
-    Object738{{"Object[738∈38]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access737{{"Access[737∈38]<br />ᐸ219.2ᐳ"}}:::plan
-    Access737 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object738
+    Object741{{"Object[741∈38]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access739{{"Access[739∈38]<br />ᐸ219.1ᐳ"}}:::plan
+    Access739 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object741
+    Object759{{"Object[759∈38]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access758{{"Access[758∈38]<br />ᐸ219.2ᐳ"}}:::plan
+    Access758 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object759
     PgClassExpression221{{"PgClassExpression[221∈38]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle220 --> PgClassExpression221
     PgClassExpression223{{"PgClassExpression[223∈38]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle220 --> PgClassExpression223
     PgClassExpression224{{"PgClassExpression[224∈38]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle220 --> PgClassExpression224
-    __Item219 --> Access719
-    Lambda722{{"Lambda[722∈38]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object721 --> Lambda722
-    __Item219 --> Access737
-    Lambda739{{"Lambda[739∈38]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object738 --> Lambda739
-    __Item233[/"__Item[233∈39]<br />ᐸ722ᐳ"\]:::itemplan
-    Lambda722 ==> __Item233
+    __Item219 --> Access739
+    Lambda742{{"Lambda[742∈38]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object741 --> Lambda742
+    __Item219 --> Access758
+    Lambda760{{"Lambda[760∈38]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object759 --> Lambda760
+    __Item233[/"__Item[233∈39]<br />ᐸ742ᐳ"\]:::itemplan
+    Lambda742 ==> __Item233
     PgSelectSingle234{{"PgSelectSingle[234∈39]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item233 --> PgSelectSingle234
     PgClassExpression235{{"PgClassExpression[235∈39]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle234 --> PgClassExpression235
-    __Item241[/"__Item[241∈41]<br />ᐸ739ᐳ"\]:::itemplan
-    Lambda739 ==> __Item241
+    __Item241[/"__Item[241∈41]<br />ᐸ760ᐳ"\]:::itemplan
+    Lambda760 ==> __Item241
     PgSelectSingle242{{"PgSelectSingle[242∈41]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item241 --> PgSelectSingle242
     PgClassExpression243{{"PgClassExpression[243∈41]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle242 --> PgClassExpression243
-    Object776{{"Object[776∈43]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access774{{"Access[774∈43]<br />ᐸ248.1ᐳ"}}:::plan
-    Access774 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object776
-    Object793{{"Object[793∈43]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access792{{"Access[792∈43]<br />ᐸ248.2ᐳ"}}:::plan
-    Access792 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object793
-    __Item248[/"__Item[248∈43]<br />ᐸ811ᐳ"\]:::itemplan
-    Lambda811 ==> __Item248
+    Object799{{"Object[799∈43]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access797{{"Access[797∈43]<br />ᐸ248.1ᐳ"}}:::plan
+    Access797 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object799
+    Object817{{"Object[817∈43]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access816{{"Access[816∈43]<br />ᐸ248.2ᐳ"}}:::plan
+    Access816 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object817
+    __Item248[/"__Item[248∈43]<br />ᐸ836ᐳ"\]:::itemplan
+    Lambda836 ==> __Item248
     PgSelectSingle249{{"PgSelectSingle[249∈43]<br />ᐸpostᐳ"}}:::plan
     __Item248 --> PgSelectSingle249
     PgClassExpression250{{"PgClassExpression[250∈43]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -763,66 +771,66 @@ graph TD
     PgSelectSingle249 --> PgClassExpression252
     PgClassExpression253{{"PgClassExpression[253∈43]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle249 --> PgClassExpression253
-    __Item248 --> Access774
-    Lambda777{{"Lambda[777∈43]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object776 --> Lambda777
-    __Item248 --> Access792
-    Lambda794{{"Lambda[794∈43]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object793 --> Lambda794
-    __Item262[/"__Item[262∈44]<br />ᐸ777ᐳ"\]:::itemplan
-    Lambda777 ==> __Item262
+    __Item248 --> Access797
+    Lambda800{{"Lambda[800∈43]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object799 --> Lambda800
+    __Item248 --> Access816
+    Lambda818{{"Lambda[818∈43]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object817 --> Lambda818
+    __Item262[/"__Item[262∈44]<br />ᐸ800ᐳ"\]:::itemplan
+    Lambda800 ==> __Item262
     PgSelectSingle263{{"PgSelectSingle[263∈44]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item262 --> PgSelectSingle263
     PgClassExpression264{{"PgClassExpression[264∈44]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle263 --> PgClassExpression264
-    __Item270[/"__Item[270∈46]<br />ᐸ794ᐳ"\]:::itemplan
-    Lambda794 ==> __Item270
+    __Item270[/"__Item[270∈46]<br />ᐸ818ᐳ"\]:::itemplan
+    Lambda818 ==> __Item270
     PgSelectSingle271{{"PgSelectSingle[271∈46]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item270 --> PgSelectSingle271
     PgClassExpression272{{"PgClassExpression[272∈46]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle271 --> PgClassExpression272
-    __Item282[/"__Item[282∈48]<br />ᐸ864ᐳ"\]:::itemplan
-    Lambda864 ==> __Item282
+    __Item282[/"__Item[282∈48]<br />ᐸ892ᐳ"\]:::itemplan
+    Lambda892 ==> __Item282
     PgSelectSingle283{{"PgSelectSingle[283∈48]<br />ᐸpostᐳ"}}:::plan
     __Item282 --> PgSelectSingle283
-    Object829{{"Object[829∈49]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access827{{"Access[827∈49]<br />ᐸ282.1ᐳ"}}:::plan
-    Access827 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object829
-    Object846{{"Object[846∈49]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access845{{"Access[845∈49]<br />ᐸ282.2ᐳ"}}:::plan
-    Access845 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object846
+    Object855{{"Object[855∈49]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access853{{"Access[853∈49]<br />ᐸ282.1ᐳ"}}:::plan
+    Access853 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object855
+    Object873{{"Object[873∈49]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access872{{"Access[872∈49]<br />ᐸ282.2ᐳ"}}:::plan
+    Access872 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object873
     PgClassExpression284{{"PgClassExpression[284∈49]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle283 --> PgClassExpression284
     PgClassExpression286{{"PgClassExpression[286∈49]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle283 --> PgClassExpression286
     PgClassExpression287{{"PgClassExpression[287∈49]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle283 --> PgClassExpression287
-    __Item282 --> Access827
-    Lambda830{{"Lambda[830∈49]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object829 --> Lambda830
-    __Item282 --> Access845
-    Lambda847{{"Lambda[847∈49]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object846 --> Lambda847
-    __Item296[/"__Item[296∈50]<br />ᐸ830ᐳ"\]:::itemplan
-    Lambda830 ==> __Item296
+    __Item282 --> Access853
+    Lambda856{{"Lambda[856∈49]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object855 --> Lambda856
+    __Item282 --> Access872
+    Lambda874{{"Lambda[874∈49]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object873 --> Lambda874
+    __Item296[/"__Item[296∈50]<br />ᐸ856ᐳ"\]:::itemplan
+    Lambda856 ==> __Item296
     PgSelectSingle297{{"PgSelectSingle[297∈50]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item296 --> PgSelectSingle297
     PgClassExpression298{{"PgClassExpression[298∈50]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle297 --> PgClassExpression298
-    __Item304[/"__Item[304∈52]<br />ᐸ847ᐳ"\]:::itemplan
-    Lambda847 ==> __Item304
+    __Item304[/"__Item[304∈52]<br />ᐸ874ᐳ"\]:::itemplan
+    Lambda874 ==> __Item304
     PgSelectSingle305{{"PgSelectSingle[305∈52]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item304 --> PgSelectSingle305
     PgClassExpression306{{"PgClassExpression[306∈52]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle305 --> PgClassExpression306
-    Object882{{"Object[882∈54]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access880{{"Access[880∈54]<br />ᐸ312.1ᐳ"}}:::plan
-    Access880 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object882
-    Object899{{"Object[899∈54]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access898{{"Access[898∈54]<br />ᐸ312.2ᐳ"}}:::plan
-    Access898 & Constant1000 & Constant370 & Lambda372 & Constant373 --> Object899
-    __Item312[/"__Item[312∈54]<br />ᐸ917ᐳ"\]:::itemplan
-    Lambda917 ==> __Item312
+    Object911{{"Object[911∈54]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access909{{"Access[909∈54]<br />ᐸ312.1ᐳ"}}:::plan
+    Access909 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object911
+    Object929{{"Object[929∈54]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access928{{"Access[928∈54]<br />ᐸ312.2ᐳ"}}:::plan
+    Access928 & Constant1036 & Constant370 & Lambda372 & Constant373 --> Object929
+    __Item312[/"__Item[312∈54]<br />ᐸ948ᐳ"\]:::itemplan
+    Lambda948 ==> __Item312
     PgSelectSingle313{{"PgSelectSingle[313∈54]<br />ᐸpostᐳ"}}:::plan
     __Item312 --> PgSelectSingle313
     PgClassExpression314{{"PgClassExpression[314∈54]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -831,50 +839,50 @@ graph TD
     PgSelectSingle313 --> PgClassExpression316
     PgClassExpression317{{"PgClassExpression[317∈54]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle313 --> PgClassExpression317
-    __Item312 --> Access880
-    Lambda883{{"Lambda[883∈54]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object882 --> Lambda883
-    __Item312 --> Access898
-    Lambda900{{"Lambda[900∈54]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object899 --> Lambda900
-    __Item326[/"__Item[326∈55]<br />ᐸ883ᐳ"\]:::itemplan
-    Lambda883 ==> __Item326
+    __Item312 --> Access909
+    Lambda912{{"Lambda[912∈54]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object911 --> Lambda912
+    __Item312 --> Access928
+    Lambda930{{"Lambda[930∈54]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object929 --> Lambda930
+    __Item326[/"__Item[326∈55]<br />ᐸ912ᐳ"\]:::itemplan
+    Lambda912 ==> __Item326
     PgSelectSingle327{{"PgSelectSingle[327∈55]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item326 --> PgSelectSingle327
     PgClassExpression328{{"PgClassExpression[328∈55]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle327 --> PgClassExpression328
-    __Item334[/"__Item[334∈57]<br />ᐸ900ᐳ"\]:::itemplan
-    Lambda900 ==> __Item334
+    __Item334[/"__Item[334∈57]<br />ᐸ930ᐳ"\]:::itemplan
+    Lambda930 ==> __Item334
     PgSelectSingle335{{"PgSelectSingle[335∈57]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item334 --> PgSelectSingle335
     PgClassExpression336{{"PgClassExpression[336∈57]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle335 --> PgClassExpression336
-    __Item344[/"__Item[344∈59]<br />ᐸ951ᐳ"\]:::itemplan
-    Lambda951 ==> __Item344
+    __Item344[/"__Item[344∈59]<br />ᐸ984ᐳ"\]:::itemplan
+    Lambda984 ==> __Item344
     PgSelectSingle345{{"PgSelectSingle[345∈59]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item344 --> PgSelectSingle345
     PgClassExpression346{{"PgClassExpression[346∈60]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle345 --> PgClassExpression346
     PgClassExpression347{{"PgClassExpression[347∈60]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle345 --> PgClassExpression347
-    __Item354[/"__Item[354∈61]<br />ᐸ985ᐳ"\]:::itemplan
-    Lambda985 ==> __Item354
+    __Item354[/"__Item[354∈61]<br />ᐸ1020ᐳ"\]:::itemplan
+    Lambda1020 ==> __Item354
     PgSelectSingle355{{"PgSelectSingle[355∈61]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item354 --> PgSelectSingle355
     PgClassExpression356{{"PgClassExpression[356∈62]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle355 --> PgClassExpression356
     PgClassExpression357{{"PgClassExpression[357∈62]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle355 --> PgClassExpression357
-    __Item360[/"__Item[360∈63]<br />ᐸ934ᐳ"\]:::itemplan
-    Lambda934 ==> __Item360
+    __Item360[/"__Item[360∈63]<br />ᐸ966ᐳ"\]:::itemplan
+    Lambda966 ==> __Item360
     PgSelectSingle361{{"PgSelectSingle[361∈63]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item360 --> PgSelectSingle361
     PgClassExpression362{{"PgClassExpression[362∈63]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle361 --> PgClassExpression362
     PgClassExpression363{{"PgClassExpression[363∈63]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle361 --> PgClassExpression363
-    __Item366[/"__Item[366∈64]<br />ᐸ968ᐳ"\]:::itemplan
-    Lambda968 ==> __Item366
+    __Item366[/"__Item[366∈64]<br />ᐸ1002ᐳ"\]:::itemplan
+    Lambda1002 ==> __Item366
     PgSelectSingle367{{"PgSelectSingle[367∈64]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item366 --> PgSelectSingle367
     PgClassExpression368{{"PgClassExpression[368∈64]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
@@ -885,199 +893,199 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/simple-procedure-computed-fields"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 204, 370, 373, 376, 377, 378, 395, 396, 414, 415, 416, 433, 434, 450, 451, 452, 467, 468, 486, 487, 503, 504, 520, 521, 539, 540, 556, 557, 573, 574, 592, 593, 609, 610, 626, 627, 628, 643, 660, 661, 677, 694, 695, 708, 709, 727, 728, 744, 745, 763, 764, 782, 783, 799, 800, 816, 817, 835, 836, 852, 853, 869, 870, 888, 889, 905, 906, 922, 923, 939, 956, 957, 973, 990, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041, 1042, 1043, 1044, 1045, 1046, 10, 372, 375, 379, 380, 385, 392, 394, 398, 399, 404, 417, 418, 423, 436, 437, 442, 447, 449, 453, 454, 459, 470, 471, 476, 489, 490, 495, 500, 502, 506, 507, 512, 523, 524, 529, 542, 543, 548, 559, 560, 565, 576, 577, 582, 595, 596, 601, 612, 613, 618, 629, 630, 635, 646, 647, 652, 663, 664, 669, 680, 681, 686, 697, 698, 703<br />2: PgSelect[7]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 110, 172, 182, 204, 280, 342, 352, 370, 373, 377, 378, 379, 397, 398, 417, 418, 419, 437, 438, 455, 456, 457, 473, 474, 493, 494, 511, 512, 529, 530, 549, 550, 567, 568, 585, 586, 605, 606, 623, 624, 641, 642, 643, 659, 677, 678, 695, 713, 714, 728, 729, 748, 749, 766, 767, 786, 787, 806, 807, 824, 825, 842, 843, 862, 863, 880, 881, 898, 899, 918, 919, 936, 937, 954, 955, 972, 990, 991, 1008, 1026, 1036, 1037, 1038, 1039, 1040, 1041, 1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069, 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 10, 34, 47, 61, 90, 124, 154, 217, 231, 260, 294, 324, 372, 375, 376, 380, 381, 386, 393, 395, 396, 400, 401, 406, 420, 421, 426, 440, 441, 446, 451, 453, 454, 458, 459, 464, 476, 477, 482, 496, 497, 502, 507, 509, 510, 514, 515, 520, 532, 533, 538, 552, 553, 558, 570, 571, 576, 588, 589, 594, 608, 609, 614, 626, 627, 632, 644, 645, 650, 662, 663, 668, 680, 681, 686, 698, 699, 704, 716, 717, 722, 731, 732, 737, 751, 752, 757, 769, 770, 775, 789, 790, 795, 809, 810, 815, 827, 828, 833, 845, 846, 851, 865, 866, 871, 883, 884, 889, 901, 902, 907, 921, 922, 927, 939, 940, 945, 957, 958, 963, 975, 976, 981, 993, 994, 999, 1011, 1012, 1017, 1029, 1030, 1035<br />2: PgSelect[7]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,Connection204,Constant370,Lambda372,Constant373,Lambda375,Constant376,Constant377,Constant378,Object379,Lambda380,Lambda385,Lambda392,Lambda394,Constant395,Constant396,Object398,Lambda399,Lambda404,Constant414,Constant415,Constant416,Object417,Lambda418,Lambda423,Constant433,Constant434,Object436,Lambda437,Lambda442,Lambda447,Lambda449,Constant450,Constant451,Constant452,Object453,Lambda454,Lambda459,Constant467,Constant468,Object470,Lambda471,Lambda476,Constant486,Constant487,Object489,Lambda490,Lambda495,Lambda500,Lambda502,Constant503,Constant504,Object506,Lambda507,Lambda512,Constant520,Constant521,Object523,Lambda524,Lambda529,Constant539,Constant540,Object542,Lambda543,Lambda548,Constant556,Constant557,Object559,Lambda560,Lambda565,Constant573,Constant574,Object576,Lambda577,Lambda582,Constant592,Constant593,Object595,Lambda596,Lambda601,Constant609,Constant610,Object612,Lambda613,Lambda618,Constant626,Constant627,Constant628,Object629,Lambda630,Lambda635,Constant643,Object646,Lambda647,Lambda652,Constant660,Constant661,Object663,Lambda664,Lambda669,Constant677,Object680,Lambda681,Lambda686,Constant694,Constant695,Object697,Lambda698,Lambda703,Constant708,Constant709,Constant727,Constant728,Constant744,Constant745,Constant763,Constant764,Constant782,Constant783,Constant799,Constant800,Constant816,Constant817,Constant835,Constant836,Constant852,Constant853,Constant869,Constant870,Constant888,Constant889,Constant905,Constant906,Constant922,Constant923,Constant939,Constant956,Constant957,Constant973,Constant990,Constant1000,Constant1001,Constant1002,Constant1003,Constant1004,Constant1005,Constant1006,Constant1007,Constant1008,Constant1009,Constant1010,Constant1011,Constant1012,Constant1013,Constant1014,Constant1015,Constant1016,Constant1017,Constant1018,Constant1019,Constant1020,Constant1021,Constant1022,Constant1023,Constant1024,Constant1025,Constant1026,Constant1027,Constant1028,Constant1029,Constant1030,Constant1031,Constant1032,Constant1033,Constant1034,Constant1035,Constant1036,Constant1037,Constant1038,Constant1039,Constant1040,Constant1041,Constant1042,Constant1043,Constant1044,Constant1045,Constant1046 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 1000, 1001, 370, 392, 373, 447, 500, 372<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,Connection21,Connection34,Connection47,Connection61,Connection90,Connection110,Connection124,Connection154,Connection172,Connection182,Connection204,Connection217,Connection231,Connection260,Connection280,Connection294,Connection324,Connection342,Connection352,Constant370,Lambda372,Constant373,Lambda375,Access376,Constant377,Constant378,Constant379,Object380,Lambda381,Lambda386,Lambda393,Lambda395,Access396,Constant397,Constant398,Object400,Lambda401,Lambda406,Constant417,Constant418,Constant419,Object420,Lambda421,Lambda426,Constant437,Constant438,Object440,Lambda441,Lambda446,Lambda451,Lambda453,Access454,Constant455,Constant456,Constant457,Object458,Lambda459,Lambda464,Constant473,Constant474,Object476,Lambda477,Lambda482,Constant493,Constant494,Object496,Lambda497,Lambda502,Lambda507,Lambda509,Access510,Constant511,Constant512,Object514,Lambda515,Lambda520,Constant529,Constant530,Object532,Lambda533,Lambda538,Constant549,Constant550,Object552,Lambda553,Lambda558,Constant567,Constant568,Object570,Lambda571,Lambda576,Constant585,Constant586,Object588,Lambda589,Lambda594,Constant605,Constant606,Object608,Lambda609,Lambda614,Constant623,Constant624,Object626,Lambda627,Lambda632,Constant641,Constant642,Constant643,Object644,Lambda645,Lambda650,Constant659,Object662,Lambda663,Lambda668,Constant677,Constant678,Object680,Lambda681,Lambda686,Constant695,Object698,Lambda699,Lambda704,Constant713,Constant714,Object716,Lambda717,Lambda722,Constant728,Constant729,Object731,Lambda732,Lambda737,Constant748,Constant749,Object751,Lambda752,Lambda757,Constant766,Constant767,Object769,Lambda770,Lambda775,Constant786,Constant787,Object789,Lambda790,Lambda795,Constant806,Constant807,Object809,Lambda810,Lambda815,Constant824,Constant825,Object827,Lambda828,Lambda833,Constant842,Constant843,Object845,Lambda846,Lambda851,Constant862,Constant863,Object865,Lambda866,Lambda871,Constant880,Constant881,Object883,Lambda884,Lambda889,Constant898,Constant899,Object901,Lambda902,Lambda907,Constant918,Constant919,Object921,Lambda922,Lambda927,Constant936,Constant937,Object939,Lambda940,Lambda945,Constant954,Constant955,Object957,Lambda958,Lambda963,Constant972,Object975,Lambda976,Lambda981,Constant990,Constant991,Object993,Lambda994,Lambda999,Constant1008,Object1011,Lambda1012,Lambda1017,Constant1026,Object1029,Lambda1030,Lambda1035,Constant1036,Constant1037,Constant1038,Constant1039,Constant1040,Constant1041,Constant1042,Constant1043,Constant1044,Constant1045,Constant1046,Constant1047,Constant1048,Constant1049,Constant1050,Constant1051,Constant1052,Constant1053,Constant1054,Constant1055,Constant1056,Constant1057,Constant1058,Constant1059,Constant1060,Constant1061,Constant1062,Constant1063,Constant1064,Constant1065,Constant1066,Constant1067,Constant1068,Constant1069,Constant1070,Constant1071,Constant1072,Constant1073,Constant1074,Constant1075,Constant1076,Constant1077,Constant1078,Constant1079,Constant1080,Constant1081,Constant1082 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 370, 393, 373, 1037, 451, 507, 1036, 372, 21, 34, 47, 61, 90, 110, 124, 154, 172, 182<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression15,Connection21,Connection34,PgClassExpression41,Connection47,Connection61,Connection90,Connection110,Connection124,Connection154,Connection172,Connection182,Access406,Object408,Lambda409,Access460,Object461,Lambda462,Access513,Object514,Lambda515,Access566,Object567,Lambda568,Access619,Object620,Lambda621,Access636,Object637,Lambda638,Access653,Object654,Lambda655,Access670,Object671,Lambda672,Access687,Object688,Lambda689 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 1000, 370, 372, 373, 34<br /><br />ROOT __Item{2}ᐸ409ᐳ[23]"):::bucket
+    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression15,PgClassExpression41,Access408,Object410,Lambda411,Access465,Object466,Lambda467,Access521,Object522,Lambda523,Access577,Object578,Lambda579,Access633,Object634,Lambda635,Access651,Object652,Lambda653,Access669,Object670,Lambda671,Access687,Object688,Lambda689,Access705,Object706,Lambda707 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 1036, 370, 372, 373, 34<br /><br />ROOT __Item{2}ᐸ411ᐳ[23]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item23,PgSelectSingle24 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 23, 1000, 370, 372, 373, 34<br /><br />ROOT PgSelectSingle{2}ᐸperson_friendsᐳ[24]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 23, 1036, 370, 372, 373, 34<br /><br />ROOT PgSelectSingle{2}ᐸperson_friendsᐳ[24]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression25,PgClassExpression27,Access387,Object389,Lambda390 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ390ᐳ[36]"):::bucket
+    class Bucket3,PgClassExpression25,PgClassExpression27,Access388,Object390,Lambda391 bucket3
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ391ᐳ[36]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item36,PgSelectSingle37 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 37<br /><br />ROOT PgSelectSingle{4}ᐸperson_friendsᐳ[37]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression38,PgClassExpression40 bucket5
-    Bucket6("Bucket 6 (listItem)<br />Deps: 1000, 370, 372, 373, 61<br /><br />ROOT __Item{6}ᐸ462ᐳ[49]"):::bucket
+    Bucket6("Bucket 6 (listItem)<br />Deps: 1036, 370, 372, 373, 61<br /><br />ROOT __Item{6}ᐸ467ᐳ[49]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item49,PgSelectSingle50 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 50, 49, 1000, 370, 372, 373, 61<br /><br />ROOT PgSelectSingle{6}ᐸpostᐳ[50]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 50, 49, 1036, 370, 372, 373, 61<br /><br />ROOT PgSelectSingle{6}ᐸpostᐳ[50]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression51,PgClassExpression53,PgClassExpression54,Access425,Object427,Lambda428,Access443,Object444,Lambda445 bucket7
-    Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ428ᐳ[63]"):::bucket
+    class Bucket7,PgClassExpression51,PgClassExpression53,PgClassExpression54,Access428,Object430,Lambda431,Access447,Object448,Lambda449 bucket7
+    Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ431ᐳ[63]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,__Item63,PgSelectSingle64,PgClassExpression65 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 65<br /><br />ROOT PgClassExpression{8}ᐸ__post_com...al_set__.vᐳ[65]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9 bucket9
-    Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ445ᐳ[71]"):::bucket
+    Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ449ᐳ[71]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item71,PgSelectSingle72,PgClassExpression73 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 73<br /><br />ROOT PgClassExpression{10}ᐸ__post_com...al_set__.vᐳ[73]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 1000, 370, 372, 373, 90<br /><br />ROOT __Item{12}ᐸ515ᐳ[78]"):::bucket
+    Bucket12("Bucket 12 (listItem)<br />Deps: 1036, 370, 372, 373, 90<br /><br />ROOT __Item{12}ᐸ523ᐳ[78]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,__Item78,PgSelectSingle79,PgClassExpression80,PgClassExpression82,PgClassExpression83,Access478,Object480,Lambda481,Access496,Object497,Lambda498 bucket12
-    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ481ᐳ[92]"):::bucket
+    class Bucket12,__Item78,PgSelectSingle79,PgClassExpression80,PgClassExpression82,PgClassExpression83,Access484,Object486,Lambda487,Access503,Object504,Lambda505 bucket12
+    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ487ᐳ[92]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item92,PgSelectSingle93,PgClassExpression94 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 94<br /><br />ROOT PgClassExpression{13}ᐸ__post_com...al_set__.vᐳ[94]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14 bucket14
-    Bucket15("Bucket 15 (listItem)<br /><br />ROOT __Item{15}ᐸ498ᐳ[100]"):::bucket
+    Bucket15("Bucket 15 (listItem)<br /><br />ROOT __Item{15}ᐸ505ᐳ[100]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,__Item100,PgSelectSingle101,PgClassExpression102 bucket15
     Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 102<br /><br />ROOT PgClassExpression{15}ᐸ__post_com...al_set__.vᐳ[102]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16 bucket16
-    Bucket17("Bucket 17 (listItem)<br />Deps: 1000, 370, 372, 373, 124<br /><br />ROOT __Item{17}ᐸ568ᐳ[112]"):::bucket
+    Bucket17("Bucket 17 (listItem)<br />Deps: 1036, 370, 372, 373, 124<br /><br />ROOT __Item{17}ᐸ579ᐳ[112]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,__Item112,PgSelectSingle113 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 113, 112, 1000, 370, 372, 373, 124<br /><br />ROOT PgSelectSingle{17}ᐸpostᐳ[113]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 113, 112, 1036, 370, 372, 373, 124<br /><br />ROOT PgSelectSingle{17}ᐸpostᐳ[113]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PgClassExpression114,PgClassExpression116,PgClassExpression117,Access531,Object533,Lambda534,Access549,Object550,Lambda551 bucket18
-    Bucket19("Bucket 19 (listItem)<br /><br />ROOT __Item{19}ᐸ534ᐳ[126]"):::bucket
+    class Bucket18,PgClassExpression114,PgClassExpression116,PgClassExpression117,Access540,Object542,Lambda543,Access559,Object560,Lambda561 bucket18
+    Bucket19("Bucket 19 (listItem)<br /><br />ROOT __Item{19}ᐸ543ᐳ[126]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item126,PgSelectSingle127,PgClassExpression128 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 128<br /><br />ROOT PgClassExpression{19}ᐸ__post_com...al_set__.vᐳ[128]"):::bucket
     classDef bucket20 stroke:#ffa500
     class Bucket20 bucket20
-    Bucket21("Bucket 21 (listItem)<br /><br />ROOT __Item{21}ᐸ551ᐳ[134]"):::bucket
+    Bucket21("Bucket 21 (listItem)<br /><br />ROOT __Item{21}ᐸ561ᐳ[134]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,__Item134,PgSelectSingle135,PgClassExpression136 bucket21
     Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 136<br /><br />ROOT PgClassExpression{21}ᐸ__post_com...al_set__.vᐳ[136]"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22 bucket22
-    Bucket23("Bucket 23 (listItem)<br />Deps: 1000, 370, 372, 373, 154<br /><br />ROOT __Item{23}ᐸ621ᐳ[142]"):::bucket
+    Bucket23("Bucket 23 (listItem)<br />Deps: 1036, 370, 372, 373, 154<br /><br />ROOT __Item{23}ᐸ635ᐳ[142]"):::bucket
     classDef bucket23 stroke:#ff1493
-    class Bucket23,__Item142,PgSelectSingle143,PgClassExpression144,PgClassExpression146,PgClassExpression147,Access584,Object586,Lambda587,Access602,Object603,Lambda604 bucket23
-    Bucket24("Bucket 24 (listItem)<br /><br />ROOT __Item{24}ᐸ587ᐳ[156]"):::bucket
+    class Bucket23,__Item142,PgSelectSingle143,PgClassExpression144,PgClassExpression146,PgClassExpression147,Access596,Object598,Lambda599,Access615,Object616,Lambda617 bucket23
+    Bucket24("Bucket 24 (listItem)<br /><br />ROOT __Item{24}ᐸ599ᐳ[156]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24,__Item156,PgSelectSingle157,PgClassExpression158 bucket24
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 158<br /><br />ROOT PgClassExpression{24}ᐸ__post_com...al_set__.vᐳ[158]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25 bucket25
-    Bucket26("Bucket 26 (listItem)<br /><br />ROOT __Item{26}ᐸ604ᐳ[164]"):::bucket
+    Bucket26("Bucket 26 (listItem)<br /><br />ROOT __Item{26}ᐸ617ᐳ[164]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,__Item164,PgSelectSingle165,PgClassExpression166 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 166<br /><br />ROOT PgClassExpression{26}ᐸ__post_com...al_set__.vᐳ[166]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27 bucket27
-    Bucket28("Bucket 28 (listItem)<br /><br />ROOT __Item{28}ᐸ655ᐳ[174]"):::bucket
+    Bucket28("Bucket 28 (listItem)<br /><br />ROOT __Item{28}ᐸ671ᐳ[174]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,__Item174,PgSelectSingle175 bucket28
     Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 175<br /><br />ROOT PgSelectSingle{28}ᐸcompound_keyᐳ[175]"):::bucket
     classDef bucket29 stroke:#4169e1
     class Bucket29,PgClassExpression176,PgClassExpression177 bucket29
-    Bucket30("Bucket 30 (listItem)<br /><br />ROOT __Item{30}ᐸ689ᐳ[184]"):::bucket
+    Bucket30("Bucket 30 (listItem)<br /><br />ROOT __Item{30}ᐸ707ᐳ[184]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,__Item184,PgSelectSingle185 bucket30
     Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 185<br /><br />ROOT PgSelectSingle{30}ᐸcompound_keyᐳ[185]"):::bucket
     classDef bucket31 stroke:#a52a2a
     class Bucket31,PgClassExpression186,PgClassExpression187 bucket31
-    Bucket32("Bucket 32 (listItem)<br /><br />ROOT __Item{32}ᐸ638ᐳ[190]"):::bucket
+    Bucket32("Bucket 32 (listItem)<br /><br />ROOT __Item{32}ᐸ653ᐳ[190]"):::bucket
     classDef bucket32 stroke:#ff00ff
     class Bucket32,__Item190,PgSelectSingle191,PgClassExpression192,PgClassExpression193 bucket32
-    Bucket33("Bucket 33 (listItem)<br /><br />ROOT __Item{33}ᐸ672ᐳ[196]"):::bucket
+    Bucket33("Bucket 33 (listItem)<br /><br />ROOT __Item{33}ᐸ689ᐳ[196]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,__Item196,PgSelectSingle197,PgClassExpression198,PgClassExpression199 bucket33
-    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 10, 204, 375, 449, 502, 1002, 394, 392, 1001, 1000, 372, 708, 709, 416, 1024, 727, 728, 1025, 447, 744, 745, 452, 1026, 763, 764, 1027, 782, 783, 1028, 500, 799, 800, 1029, 816, 817, 1030, 835, 836, 1031, 852, 853, 1032, 869, 870, 1033, 888, 889, 1034, 905, 906, 1035, 922, 923, 628, 1036, 939, 1037, 956, 957, 1038, 973, 1039, 990, 695, 378, 1040, 370, 373<br /><br />ROOT Connectionᐸ202ᐳ[204]<br />1: <br />ᐳ: 217, 231, 260, 280, 294, 324, 342, 352, 711, 717, 730, 736, 747, 753, 766, 772, 785, 791, 802, 808, 819, 825, 838, 844, 855, 861, 872, 878, 891, 897, 908, 914, 925, 931, 942, 948, 959, 965, 976, 982, 993, 999, 712, 731, 748, 767, 786, 803, 820, 839, 856, 873, 892, 909, 926, 943, 960, 977, 994<br />2: PgSelect[205]"):::bucket
+    Bucket34("Bucket 34 (nullableBoundary)<br />Deps: 10, 204, 376, 732, 737, 752, 757, 454, 770, 775, 790, 795, 810, 815, 510, 828, 833, 1038, 846, 851, 866, 871, 396, 884, 889, 902, 907, 922, 927, 940, 945, 958, 963, 976, 981, 994, 999, 1012, 1017, 393, 1030, 1035, 370, 1037, 451, 373, 507, 1036, 372, 217, 231, 260, 280, 294, 324, 342, 352<br /><br />ROOT Connectionᐸ202ᐳ[204]"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgSelect205,Connection217,Connection231,Connection260,Connection280,Connection294,Connection324,Connection342,Connection352,Object711,Lambda712,Lambda717,Object730,Lambda731,Lambda736,Object747,Lambda748,Lambda753,Object766,Lambda767,Lambda772,Object785,Lambda786,Lambda791,Object802,Lambda803,Lambda808,Object819,Lambda820,Lambda825,Object838,Lambda839,Lambda844,Object855,Lambda856,Lambda861,Object872,Lambda873,Lambda878,Object891,Lambda892,Lambda897,Object908,Lambda909,Lambda914,Object925,Lambda926,Lambda931,Object942,Lambda943,Lambda948,Object959,Lambda960,Lambda965,Object976,Lambda977,Lambda982,Object993,Lambda994,Lambda999 bucket34
-    Bucket35("Bucket 35 (listItem)<br />Deps: 370, 1001, 447, 373, 500, 392, 1000, 372, 217, 231, 260, 280, 294, 324, 342, 352<br /><br />ROOT __Item{35}ᐸ205ᐳ[206]"):::bucket
+    class Bucket34,PgSelect205 bucket34
+    Bucket35("Bucket 35 (listItem)<br />Deps: 370, 1037, 451, 373, 507, 393, 1036, 372, 217, 231, 260, 280, 294, 324, 342, 352<br /><br />ROOT __Item{35}ᐸ205ᐳ[206]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,__Item206,PgSelectSingle207 bucket35
-    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 207, 206, 370, 1001, 447, 373, 500, 392, 1000, 372, 217, 231, 260, 280, 294, 324, 342, 352<br /><br />ROOT PgSelectSingle{35}ᐸpersonᐳ[207]"):::bucket
+    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 207, 206, 370, 1037, 451, 373, 507, 393, 1036, 372, 217, 231, 260, 280, 294, 324, 342, 352<br /><br />ROOT PgSelectSingle{35}ᐸpersonᐳ[207]"):::bucket
     classDef bucket36 stroke:#7f007f
-    class Bucket36,PgClassExpression208,PgClassExpression209,Access755,Object757,Lambda758,Access809,Object810,Lambda811,Access862,Object863,Lambda864,Access915,Object916,Lambda917,Access932,Object933,Lambda934,Access949,Object950,Lambda951,Access966,Object967,Lambda968,Access983,Object984,Lambda985 bucket36
-    Bucket37("Bucket 37 (listItem)<br />Deps: 1000, 370, 372, 373, 231<br /><br />ROOT __Item{37}ᐸ758ᐳ[219]"):::bucket
+    class Bucket36,PgClassExpression208,PgClassExpression209,Access777,Object779,Lambda780,Access834,Object835,Lambda836,Access890,Object891,Lambda892,Access946,Object947,Lambda948,Access964,Object965,Lambda966,Access982,Object983,Lambda984,Access1000,Object1001,Lambda1002,Access1018,Object1019,Lambda1020 bucket36
+    Bucket37("Bucket 37 (listItem)<br />Deps: 1036, 370, 372, 373, 231<br /><br />ROOT __Item{37}ᐸ780ᐳ[219]"):::bucket
     classDef bucket37 stroke:#ffa500
     class Bucket37,__Item219,PgSelectSingle220 bucket37
-    Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 220, 219, 1000, 370, 372, 373, 231<br /><br />ROOT PgSelectSingle{37}ᐸpostᐳ[220]"):::bucket
+    Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 220, 219, 1036, 370, 372, 373, 231<br /><br />ROOT PgSelectSingle{37}ᐸpostᐳ[220]"):::bucket
     classDef bucket38 stroke:#0000ff
-    class Bucket38,PgClassExpression221,PgClassExpression223,PgClassExpression224,Access719,Object721,Lambda722,Access737,Object738,Lambda739 bucket38
-    Bucket39("Bucket 39 (listItem)<br /><br />ROOT __Item{39}ᐸ722ᐳ[233]"):::bucket
+    class Bucket38,PgClassExpression221,PgClassExpression223,PgClassExpression224,Access739,Object741,Lambda742,Access758,Object759,Lambda760 bucket38
+    Bucket39("Bucket 39 (listItem)<br /><br />ROOT __Item{39}ᐸ742ᐳ[233]"):::bucket
     classDef bucket39 stroke:#7fff00
     class Bucket39,__Item233,PgSelectSingle234,PgClassExpression235 bucket39
     Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 235<br /><br />ROOT PgClassExpression{39}ᐸ__post_com...al_set__.vᐳ[235]"):::bucket
     classDef bucket40 stroke:#ff1493
     class Bucket40 bucket40
-    Bucket41("Bucket 41 (listItem)<br /><br />ROOT __Item{41}ᐸ739ᐳ[241]"):::bucket
+    Bucket41("Bucket 41 (listItem)<br /><br />ROOT __Item{41}ᐸ760ᐳ[241]"):::bucket
     classDef bucket41 stroke:#808000
     class Bucket41,__Item241,PgSelectSingle242,PgClassExpression243 bucket41
     Bucket42("Bucket 42 (nullableBoundary)<br />Deps: 243<br /><br />ROOT PgClassExpression{41}ᐸ__post_com...al_set__.vᐳ[243]"):::bucket
     classDef bucket42 stroke:#dda0dd
     class Bucket42 bucket42
-    Bucket43("Bucket 43 (listItem)<br />Deps: 1000, 370, 372, 373, 260<br /><br />ROOT __Item{43}ᐸ811ᐳ[248]"):::bucket
+    Bucket43("Bucket 43 (listItem)<br />Deps: 1036, 370, 372, 373, 260<br /><br />ROOT __Item{43}ᐸ836ᐳ[248]"):::bucket
     classDef bucket43 stroke:#ff0000
-    class Bucket43,__Item248,PgSelectSingle249,PgClassExpression250,PgClassExpression252,PgClassExpression253,Access774,Object776,Lambda777,Access792,Object793,Lambda794 bucket43
-    Bucket44("Bucket 44 (listItem)<br /><br />ROOT __Item{44}ᐸ777ᐳ[262]"):::bucket
+    class Bucket43,__Item248,PgSelectSingle249,PgClassExpression250,PgClassExpression252,PgClassExpression253,Access797,Object799,Lambda800,Access816,Object817,Lambda818 bucket43
+    Bucket44("Bucket 44 (listItem)<br /><br />ROOT __Item{44}ᐸ800ᐳ[262]"):::bucket
     classDef bucket44 stroke:#ffff00
     class Bucket44,__Item262,PgSelectSingle263,PgClassExpression264 bucket44
     Bucket45("Bucket 45 (nullableBoundary)<br />Deps: 264<br /><br />ROOT PgClassExpression{44}ᐸ__post_com...al_set__.vᐳ[264]"):::bucket
     classDef bucket45 stroke:#00ffff
     class Bucket45 bucket45
-    Bucket46("Bucket 46 (listItem)<br /><br />ROOT __Item{46}ᐸ794ᐳ[270]"):::bucket
+    Bucket46("Bucket 46 (listItem)<br /><br />ROOT __Item{46}ᐸ818ᐳ[270]"):::bucket
     classDef bucket46 stroke:#4169e1
     class Bucket46,__Item270,PgSelectSingle271,PgClassExpression272 bucket46
     Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 272<br /><br />ROOT PgClassExpression{46}ᐸ__post_com...al_set__.vᐳ[272]"):::bucket
     classDef bucket47 stroke:#3cb371
     class Bucket47 bucket47
-    Bucket48("Bucket 48 (listItem)<br />Deps: 1000, 370, 372, 373, 294<br /><br />ROOT __Item{48}ᐸ864ᐳ[282]"):::bucket
+    Bucket48("Bucket 48 (listItem)<br />Deps: 1036, 370, 372, 373, 294<br /><br />ROOT __Item{48}ᐸ892ᐳ[282]"):::bucket
     classDef bucket48 stroke:#a52a2a
     class Bucket48,__Item282,PgSelectSingle283 bucket48
-    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 283, 282, 1000, 370, 372, 373, 294<br /><br />ROOT PgSelectSingle{48}ᐸpostᐳ[283]"):::bucket
+    Bucket49("Bucket 49 (nullableBoundary)<br />Deps: 283, 282, 1036, 370, 372, 373, 294<br /><br />ROOT PgSelectSingle{48}ᐸpostᐳ[283]"):::bucket
     classDef bucket49 stroke:#ff00ff
-    class Bucket49,PgClassExpression284,PgClassExpression286,PgClassExpression287,Access827,Object829,Lambda830,Access845,Object846,Lambda847 bucket49
-    Bucket50("Bucket 50 (listItem)<br /><br />ROOT __Item{50}ᐸ830ᐳ[296]"):::bucket
+    class Bucket49,PgClassExpression284,PgClassExpression286,PgClassExpression287,Access853,Object855,Lambda856,Access872,Object873,Lambda874 bucket49
+    Bucket50("Bucket 50 (listItem)<br /><br />ROOT __Item{50}ᐸ856ᐳ[296]"):::bucket
     classDef bucket50 stroke:#f5deb3
     class Bucket50,__Item296,PgSelectSingle297,PgClassExpression298 bucket50
     Bucket51("Bucket 51 (nullableBoundary)<br />Deps: 298<br /><br />ROOT PgClassExpression{50}ᐸ__post_com...al_set__.vᐳ[298]"):::bucket
     classDef bucket51 stroke:#696969
     class Bucket51 bucket51
-    Bucket52("Bucket 52 (listItem)<br /><br />ROOT __Item{52}ᐸ847ᐳ[304]"):::bucket
+    Bucket52("Bucket 52 (listItem)<br /><br />ROOT __Item{52}ᐸ874ᐳ[304]"):::bucket
     classDef bucket52 stroke:#00bfff
     class Bucket52,__Item304,PgSelectSingle305,PgClassExpression306 bucket52
     Bucket53("Bucket 53 (nullableBoundary)<br />Deps: 306<br /><br />ROOT PgClassExpression{52}ᐸ__post_com...al_set__.vᐳ[306]"):::bucket
     classDef bucket53 stroke:#7f007f
     class Bucket53 bucket53
-    Bucket54("Bucket 54 (listItem)<br />Deps: 1000, 370, 372, 373, 324<br /><br />ROOT __Item{54}ᐸ917ᐳ[312]"):::bucket
+    Bucket54("Bucket 54 (listItem)<br />Deps: 1036, 370, 372, 373, 324<br /><br />ROOT __Item{54}ᐸ948ᐳ[312]"):::bucket
     classDef bucket54 stroke:#ffa500
-    class Bucket54,__Item312,PgSelectSingle313,PgClassExpression314,PgClassExpression316,PgClassExpression317,Access880,Object882,Lambda883,Access898,Object899,Lambda900 bucket54
-    Bucket55("Bucket 55 (listItem)<br /><br />ROOT __Item{55}ᐸ883ᐳ[326]"):::bucket
+    class Bucket54,__Item312,PgSelectSingle313,PgClassExpression314,PgClassExpression316,PgClassExpression317,Access909,Object911,Lambda912,Access928,Object929,Lambda930 bucket54
+    Bucket55("Bucket 55 (listItem)<br /><br />ROOT __Item{55}ᐸ912ᐳ[326]"):::bucket
     classDef bucket55 stroke:#0000ff
     class Bucket55,__Item326,PgSelectSingle327,PgClassExpression328 bucket55
     Bucket56("Bucket 56 (nullableBoundary)<br />Deps: 328<br /><br />ROOT PgClassExpression{55}ᐸ__post_com...al_set__.vᐳ[328]"):::bucket
     classDef bucket56 stroke:#7fff00
     class Bucket56 bucket56
-    Bucket57("Bucket 57 (listItem)<br /><br />ROOT __Item{57}ᐸ900ᐳ[334]"):::bucket
+    Bucket57("Bucket 57 (listItem)<br /><br />ROOT __Item{57}ᐸ930ᐳ[334]"):::bucket
     classDef bucket57 stroke:#ff1493
     class Bucket57,__Item334,PgSelectSingle335,PgClassExpression336 bucket57
     Bucket58("Bucket 58 (nullableBoundary)<br />Deps: 336<br /><br />ROOT PgClassExpression{57}ᐸ__post_com...al_set__.vᐳ[336]"):::bucket
     classDef bucket58 stroke:#808000
     class Bucket58 bucket58
-    Bucket59("Bucket 59 (listItem)<br /><br />ROOT __Item{59}ᐸ951ᐳ[344]"):::bucket
+    Bucket59("Bucket 59 (listItem)<br /><br />ROOT __Item{59}ᐸ984ᐳ[344]"):::bucket
     classDef bucket59 stroke:#dda0dd
     class Bucket59,__Item344,PgSelectSingle345 bucket59
     Bucket60("Bucket 60 (nullableBoundary)<br />Deps: 345<br /><br />ROOT PgSelectSingle{59}ᐸcompound_keyᐳ[345]"):::bucket
     classDef bucket60 stroke:#ff0000
     class Bucket60,PgClassExpression346,PgClassExpression347 bucket60
-    Bucket61("Bucket 61 (listItem)<br /><br />ROOT __Item{61}ᐸ985ᐳ[354]"):::bucket
+    Bucket61("Bucket 61 (listItem)<br /><br />ROOT __Item{61}ᐸ1020ᐳ[354]"):::bucket
     classDef bucket61 stroke:#ffff00
     class Bucket61,__Item354,PgSelectSingle355 bucket61
     Bucket62("Bucket 62 (nullableBoundary)<br />Deps: 355<br /><br />ROOT PgSelectSingle{61}ᐸcompound_keyᐳ[355]"):::bucket
     classDef bucket62 stroke:#00ffff
     class Bucket62,PgClassExpression356,PgClassExpression357 bucket62
-    Bucket63("Bucket 63 (listItem)<br /><br />ROOT __Item{63}ᐸ934ᐳ[360]"):::bucket
+    Bucket63("Bucket 63 (listItem)<br /><br />ROOT __Item{63}ᐸ966ᐳ[360]"):::bucket
     classDef bucket63 stroke:#4169e1
     class Bucket63,__Item360,PgSelectSingle361,PgClassExpression362,PgClassExpression363 bucket63
-    Bucket64("Bucket 64 (listItem)<br /><br />ROOT __Item{64}ᐸ968ᐳ[366]"):::bucket
+    Bucket64("Bucket 64 (listItem)<br /><br />ROOT __Item{64}ᐸ1002ᐳ[366]"):::bucket
     classDef bucket64 stroke:#3cb371
     class Bucket64,__Item366,PgSelectSingle367,PgClassExpression368,PgClassExpression369 bucket64
     Bucket0 --> Bucket1 & Bucket34

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-query.mermaid
@@ -11,132 +11,140 @@ graph TD
     %% plan dependencies
     PgSelect61[["PgSelect[61∈0] ➊<br />ᐸpostᐳ"]]:::plan
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant200{{"Constant[200∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Lambda95{{"Lambda[95∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda170{{"Lambda[170∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda175{{"Lambda[175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda184{{"Lambda[184∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda194{{"Lambda[194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant200 & Lambda95 & Lambda170 & Lambda175 & Lambda182 & Lambda184 & Lambda189 & Lambda194 --> PgSelect61
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Access97{{"Access[97∈0] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Lambda177{{"Lambda[177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda182{{"Lambda[182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda189{{"Lambda[189∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access192{{"Access[192∈0] ➊<br />ᐸ191.0ᐳ"}}:::plan
+    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda202{{"Lambda[202∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant208 & Access97 & Lambda177 & Lambda182 & Lambda189 & Access192 & Lambda197 & Lambda202 --> PgSelect61
     PgSelect39[["PgSelect[39∈0] ➊<br />ᐸint_set_queryᐳ"]]:::plan
-    Constant195{{"Constant[195∈0] ➊<br />ᐸ5ᐳ"}}:::plan
+    Constant203{{"Constant[203∈0] ➊<br />ᐸ5ᐳ"}}:::plan
     Constant38{{"Constant[38∈0] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant197{{"Constant[197∈0] ➊<br />ᐸ6ᐳ"}}:::plan
-    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant195 & Constant38 & Constant197 & Lambda93 & Lambda95 & Lambda128 & Lambda133 --> PgSelect39
+    Constant205{{"Constant[205∈0] ➊<br />ᐸ6ᐳ"}}:::plan
+    Lambda94{{"Lambda[94∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda132{{"Lambda[132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda137{{"Lambda[137∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant203 & Constant38 & Constant205 & Lambda94 & Access97 & Lambda132 & Lambda137 --> PgSelect39
     PgSelect31[["PgSelect[31∈0] ➊<br />ᐸtable_set_queryᐳ"]]:::plan
-    Constant196{{"Constant[196∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda119{{"Lambda[119∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant196 & Constant196 & Lambda107 & Lambda109 & Lambda114 & Lambda119 --> PgSelect31
+    Constant204{{"Constant[204∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Lambda109{{"Lambda[109∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Access112{{"Access[112∈0] ➊<br />ᐸ111.0ᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant204 & Constant204 & Lambda109 & Access112 & Lambda117 & Lambda122 --> PgSelect31
     PgSelect8[["PgSelect[8∈0] ➊<br />ᐸcompound_type_set_queryᐳ"]]:::plan
     Lambda78{{"Lambda[78∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda91{{"Lambda[91∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Constant195 & Lambda78 & Lambda81 & Lambda86 & Lambda91 --> PgSelect8
+    Access82{{"Access[82∈0] ➊<br />ᐸ81.0ᐳ"}}:::plan
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Constant203 & Lambda78 & Access82 & Lambda87 & Lambda92 --> PgSelect8
     PgSelect24[["PgSelect[24∈0] ➊<br />ᐸtable_set_queryᐳ"]]:::plan
-    Lambda100{{"Lambda[100∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda93 & Lambda95 & Lambda100 & Lambda105 --> PgSelect24
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda94 & Access97 & Lambda102 & Lambda107 --> PgSelect24
     PgSelect44[["PgSelect[44∈0] ➊<br />ᐸstatic_big_integerᐳ"]]:::plan
-    Lambda142{{"Lambda[142∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda147{{"Lambda[147∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda93 & Lambda95 & Lambda142 & Lambda147 --> PgSelect44
+    Lambda152{{"Lambda[152∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda94 & Access97 & Lambda147 & Lambda152 --> PgSelect44
     PgSelect49[["PgSelect[49∈0] ➊<br />ᐸquery_interval_setᐳ"]]:::plan
-    Lambda156{{"Lambda[156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda161{{"Lambda[161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object11 & Lambda93 & Lambda95 & Lambda156 & Lambda161 --> PgSelect49
-    Object85{{"Object[85∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant83{{"Constant[83∈0] ➊<br />ᐸsql.identifier(”compound_type_set_query”)ᐳ"}}:::plan
-    Constant84{{"Constant[84∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda78 & Constant82 & Constant83 & Constant84 --> Object85
-    Object99{{"Object[99∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda93 & Constant96 & Constant97 & Constant98 --> Object99
-    Object113{{"Object[113∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
-    Lambda107 & Constant110 & Constant111 & Constant98 --> Object113
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”int_set_query”)ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
-    Lambda93 & Constant124 & Constant125 & Constant126 --> Object127
-    Object141{{"Object[141∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant139{{"Constant[139∈0] ➊<br />ᐸsql.identifier(”static_big_integer”)ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸCodec(int8)ᐳ"}}:::plan
-    Lambda93 & Constant138 & Constant139 & Constant140 --> Object141
-    Object155{{"Object[155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0] ➊<br />ᐸsql.identifier(”query_interval_set”)ᐳ"}}:::plan
-    Constant154{{"Constant[154∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
-    Lambda93 & Constant152 & Constant153 & Constant154 --> Object155
-    Object169{{"Object[169∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant166{{"Constant[166∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant167{{"Constant[167∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
-    Lambda93 & Constant166 & Constant167 & Constant154 --> Object169
-    Object188{{"Object[188∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant185{{"Constant[185∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant186{{"Constant[186∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant187{{"Constant[187∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda182 & Constant185 & Constant186 & Constant187 --> Object188
+    Lambda162{{"Lambda[162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda167{{"Lambda[167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object11 & Lambda94 & Access97 & Lambda162 & Lambda167 --> PgSelect49
+    Object86{{"Object[86∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸsql.identifier(”compound_type_set_query”)ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda78 & Constant83 & Constant84 & Constant85 --> Object86
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
+    Constant100{{"Constant[100∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda94 & Constant98 & Constant99 & Constant100 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”table_set_query”)ᐳ"}}:::plan
+    Lambda109 & Constant113 & Constant114 & Constant100 --> Object116
+    Object131{{"Object[131∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸsql.identifier(”int_set_query”)ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸCodec(int4)ᐳ"}}:::plan
+    Lambda94 & Constant128 & Constant129 & Constant130 --> Object131
+    Object146{{"Object[146∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant143{{"Constant[143∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant144{{"Constant[144∈0] ➊<br />ᐸsql.identifier(”static_big_integer”)ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸCodec(int8)ᐳ"}}:::plan
+    Lambda94 & Constant143 & Constant144 & Constant145 --> Object146
+    Object161{{"Object[161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸsql.identifier(”query_interval_set”)ᐳ"}}:::plan
+    Constant160{{"Constant[160∈0] ➊<br />ᐸCodec(interval)ᐳ"}}:::plan
+    Lambda94 & Constant158 & Constant159 & Constant160 --> Object161
+    Object176{{"Object[176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant173{{"Constant[173∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant174{{"Constant[174∈0] ➊<br />ᐸsql.identifier(”post_computed_interval_set”)ᐳ"}}:::plan
+    Lambda94 & Constant173 & Constant174 & Constant160 --> Object176
+    Object196{{"Object[196∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant193{{"Constant[193∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda189 & Constant193 & Constant194 & Constant195 --> Object196
     Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant209 --> Lambda78
-    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant210 --> Lambda81
-    Object85 --> Lambda86
-    Constant201{{"Constant[201∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant201 --> Lambda91
-    Constant198{{"Constant[198∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant198 --> Lambda93
-    Constant199{{"Constant[199∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant199 --> Lambda95
-    Object99 --> Lambda100
-    Constant202{{"Constant[202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant202 --> Lambda105
-    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant211 --> Lambda107
-    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant212 --> Lambda109
-    Object113 --> Lambda114
-    Constant203{{"Constant[203∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
-    Constant203 --> Lambda119
-    Object127 --> Lambda128
-    Constant204{{"Constant[204∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
-    Constant204 --> Lambda133
-    Object141 --> Lambda142
-    Constant205{{"Constant[205∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”staticᐳ"}}:::plan
-    Constant205 --> Lambda147
-    Object155 --> Lambda156
-    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
-    Constant206 --> Lambda161
-    Object169 --> Lambda170
-    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
-    Constant207 --> Lambda175
-    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant213 --> Lambda182
-    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant214 --> Lambda184
-    Object188 --> Lambda189
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant208 --> Lambda194
+    Constant217{{"Constant[217∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant217 --> Lambda78
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant218{{"Constant[218∈0] ➊<br />ᐸ§{ first: 5, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant218 --> Lambda81
+    Lambda81 --> Access82
+    Object86 --> Lambda87
+    Constant209{{"Constant[209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant209 --> Lambda92
+    Constant206{{"Constant[206∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant206 --> Lambda94
+    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant207{{"Constant[207∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant207 --> Lambda96
+    Lambda96 --> Access97
+    Object101 --> Lambda102
+    Constant210{{"Constant[210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant210 --> Lambda107
+    Constant219{{"Constant[219∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant219 --> Lambda109
+    Lambda111{{"Lambda[111∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant220{{"Constant[220∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant220 --> Lambda111
+    Lambda111 --> Access112
+    Object116 --> Lambda117
+    Constant211{{"Constant[211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”table_ᐳ"}}:::plan
+    Constant211 --> Lambda122
+    Object131 --> Lambda132
+    Constant212{{"Constant[212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”int_seᐳ"}}:::plan
+    Constant212 --> Lambda137
+    Object146 --> Lambda147
+    Constant213{{"Constant[213∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”staticᐳ"}}:::plan
+    Constant213 --> Lambda152
+    Object161 --> Lambda162
+    Constant214{{"Constant[214∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”query_ᐳ"}}:::plan
+    Constant214 --> Lambda167
+    Object176 --> Lambda177
+    Constant215{{"Constant[215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post_cᐳ"}}:::plan
+    Constant215 --> Lambda182
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant221 --> Lambda189
+    Lambda191{{"Lambda[191∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant222 --> Lambda191
+    Lambda191 --> Access192
+    Object196 --> Lambda197
+    Constant216{{"Constant[216∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant216 --> Lambda202
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant79{{"Constant[79∈0] ➊<br />ᐸfalseᐳ"}}:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ8ᐳ"\]:::itemplan
@@ -187,20 +195,20 @@ graph TD
     __Item51 --> PgSelectSingle52
     PgClassExpression53{{"PgClassExpression[53∈10]<br />ᐸ__query_in...al_set__.vᐳ"}}:::plan
     PgSelectSingle52 --> PgClassExpression53
-    Object179{{"Object[179∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access177{{"Access[177∈12]<br />ᐸ63.1ᐳ"}}:::plan
-    Access177 & Constant38 & Constant38 & Lambda93 & Constant79 --> Object179
+    Object186{{"Object[186∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access184{{"Access[184∈12]<br />ᐸ63.1ᐳ"}}:::plan
+    Access184 & Constant38 & Constant38 & Lambda94 & Constant79 --> Object186
     __Item63[/"__Item[63∈12]<br />ᐸ61ᐳ"\]:::itemplan
     PgSelect61 ==> __Item63
     PgSelectSingle64{{"PgSelectSingle[64∈12]<br />ᐸpostᐳ"}}:::plan
     __Item63 --> PgSelectSingle64
     PgClassExpression65{{"PgClassExpression[65∈12]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression65
-    __Item63 --> Access177
-    Lambda180{{"Lambda[180∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object179 --> Lambda180
-    __Item71[/"__Item[71∈13]<br />ᐸ180ᐳ"\]:::itemplan
-    Lambda180 ==> __Item71
+    __Item63 --> Access184
+    Lambda187{{"Lambda[187∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object186 --> Lambda187
+    __Item71[/"__Item[71∈13]<br />ᐸ187ᐳ"\]:::itemplan
+    Lambda187 ==> __Item71
     PgSelectSingle72{{"PgSelectSingle[72∈13]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item71 --> PgSelectSingle72
     PgClassExpression73{{"PgClassExpression[73∈13]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
@@ -209,9 +217,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/simple-procedure-query"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 38, 79, 82, 83, 84, 96, 97, 98, 110, 111, 124, 125, 126, 138, 139, 140, 152, 153, 154, 166, 167, 185, 186, 187, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 11, 78, 81, 85, 86, 91, 93, 95, 99, 100, 105, 107, 109, 113, 114, 119, 127, 128, 133, 141, 142, 147, 155, 156, 161, 169, 170, 175, 182, 184, 188, 189, 194<br />2: 8, 24, 31, 39, 44, 49, 61"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 38, 79, 83, 84, 85, 98, 99, 100, 113, 114, 128, 129, 130, 143, 144, 145, 158, 159, 160, 173, 174, 193, 194, 195, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 11, 78, 81, 82, 86, 87, 92, 94, 96, 97, 101, 102, 107, 109, 111, 112, 116, 117, 122, 131, 132, 137, 146, 147, 152, 161, 162, 167, 176, 177, 182, 189, 191, 192, 196, 197, 202<br />2: 8, 24, 31, 39, 44, 49, 61"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,PgSelect24,PgSelect31,Constant38,PgSelect39,PgSelect44,PgSelect49,PgSelect61,Lambda78,Constant79,Lambda81,Constant82,Constant83,Constant84,Object85,Lambda86,Lambda91,Lambda93,Lambda95,Constant96,Constant97,Constant98,Object99,Lambda100,Lambda105,Lambda107,Lambda109,Constant110,Constant111,Object113,Lambda114,Lambda119,Constant124,Constant125,Constant126,Object127,Lambda128,Lambda133,Constant138,Constant139,Constant140,Object141,Lambda142,Lambda147,Constant152,Constant153,Constant154,Object155,Lambda156,Lambda161,Constant166,Constant167,Object169,Lambda170,Lambda175,Lambda182,Lambda184,Constant185,Constant186,Constant187,Object188,Lambda189,Lambda194,Constant195,Constant196,Constant197,Constant198,Constant199,Constant200,Constant201,Constant202,Constant203,Constant204,Constant205,Constant206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212,Constant213,Constant214 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,PgSelect24,PgSelect31,Constant38,PgSelect39,PgSelect44,PgSelect49,PgSelect61,Lambda78,Constant79,Lambda81,Access82,Constant83,Constant84,Constant85,Object86,Lambda87,Lambda92,Lambda94,Lambda96,Access97,Constant98,Constant99,Constant100,Object101,Lambda102,Lambda107,Lambda109,Lambda111,Access112,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant128,Constant129,Constant130,Object131,Lambda132,Lambda137,Constant143,Constant144,Constant145,Object146,Lambda147,Lambda152,Constant158,Constant159,Constant160,Object161,Lambda162,Lambda167,Constant173,Constant174,Object176,Lambda177,Lambda182,Lambda189,Lambda191,Access192,Constant193,Constant194,Constant195,Object196,Lambda197,Lambda202,Constant203,Constant204,Constant205,Constant206,Constant207,Constant208,Constant209,Constant210,Constant211,Constant212,Constant213,Constant214,Constant215,Constant216,Constant217,Constant218,Constant219,Constant220,Constant221,Constant222 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ8ᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item12,PgSelectSingle13 bucket1
@@ -245,10 +253,10 @@ graph TD
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 53<br /><br />ROOT PgClassExpression{10}ᐸ__query_in...al_set__.vᐳ[53]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 38, 93, 79<br /><br />ROOT __Item{12}ᐸ61ᐳ[63]"):::bucket
+    Bucket12("Bucket 12 (listItem)<br />Deps: 38, 94, 79<br /><br />ROOT __Item{12}ᐸ61ᐳ[63]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,__Item63,PgSelectSingle64,PgClassExpression65,Access177,Object179,Lambda180 bucket12
-    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ180ᐳ[71]"):::bucket
+    class Bucket12,__Item63,PgSelectSingle64,PgClassExpression65,Access184,Object186,Lambda187 bucket12
+    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ187ᐳ[71]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item71,PgSelectSingle72,PgClassExpression73 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 73<br /><br />ROOT PgClassExpression{13}ᐸ__post_com...al_set__.vᐳ[73]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-relations-head-tail.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-relations-head-tail.mermaid
@@ -11,101 +11,105 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda60{{"Lambda[60∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda65{{"Lambda[65∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ'Large bet on myself in round one.'ᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda79{{"Lambda[79∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda96{{"Lambda[96∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda113{{"Lambda[113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda118{{"Lambda[118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda130{{"Lambda[130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access56{{"Access[56∈0] ➊<br />ᐸ55.0ᐳ"}}:::plan
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ'Large bet on myself in round one.'ᐳ"}}:::plan
+    Access76{{"Access[76∈0] ➊<br />ᐸ75.0ᐳ"}}:::plan
+    Lambda81{{"Lambda[81∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda86{{"Lambda[86∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda99{{"Lambda[99∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda104{{"Lambda[104∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda73{{"Lambda[73∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
     Lambda135{{"Lambda[135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda55 & Lambda60 & Lambda65 & Constant151 & Lambda74 & Lambda79 & Lambda84 & Lambda74 & Lambda96 & Lambda101 & Lambda74 & Lambda113 & Lambda118 & Lambda72 & Lambda74 & Lambda130 & Lambda135 --> PgSelect7
+    Lambda140{{"Lambda[140∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Access56 & Lambda61 & Lambda66 & Constant157 & Access76 & Lambda81 & Lambda86 & Access76 & Lambda99 & Lambda104 & Access76 & Lambda117 & Lambda122 & Lambda73 & Access76 & Lambda135 & Lambda140 --> PgSelect7
     PgSelect44[["PgSelect[44∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda72 & Lambda74 & Lambda144 & Lambda149 --> PgSelect44
-    Object59{{"Object[59∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Lambda73 & Access76 & Lambda150 & Lambda155 --> PgSelect44
+    Object60{{"Object[60∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda52{{"Lambda[52∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant56{{"Constant[56∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda52 & Constant56 & Constant57 & Constant58 --> Object59
-    Object78{{"Object[78∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda72 & Constant75 & Constant76 & Constant58 --> Object78
-    Object95{{"Object[95∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant92{{"Constant[92∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant93{{"Constant[93∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda72 & Constant92 & Constant93 & Constant94 --> Object95
-    Object112{{"Object[112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda72 & Constant109 & Constant110 & Constant94 --> Object112
-    Object129{{"Object[129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant127{{"Constant[127∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant128{{"Constant[128∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda72 & Constant126 & Constant127 & Constant128 --> Object129
-    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda72 & Constant140 & Constant141 & Constant94 --> Object143
+    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda52 & Constant57 & Constant58 & Constant59 --> Object60
+    Object80{{"Object[80∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda73 & Constant77 & Constant78 & Constant59 --> Object80
+    Object98{{"Object[98∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant95{{"Constant[95∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant96{{"Constant[96∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda73 & Constant95 & Constant96 & Constant97 --> Object98
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda73 & Constant113 & Constant114 & Constant97 --> Object116
+    Object134{{"Object[134∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant132{{"Constant[132∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant133{{"Constant[133∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda73 & Constant131 & Constant132 & Constant133 --> Object134
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda73 & Constant146 & Constant147 & Constant97 --> Object149
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant160 --> Lambda52
-    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant161 --> Lambda55
-    Object59 --> Lambda60
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant154 --> Lambda65
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant152 --> Lambda72
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant153 --> Lambda74
-    Object78 --> Lambda79
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant155 --> Lambda84
-    Object95 --> Lambda96
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant156 --> Lambda101
-    Object112 --> Lambda113
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant157 --> Lambda118
-    Object129 --> Lambda130
-    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant158 --> Lambda135
-    Object143 --> Lambda144
-    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant159 --> Lambda149
+    Constant166{{"Constant[166∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant166 --> Lambda52
+    Lambda55{{"Lambda[55∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant167{{"Constant[167∈0] ➊<br />ᐸ§{ first: 2, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant167 --> Lambda55
+    Lambda55 --> Access56
+    Object60 --> Lambda61
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant160 --> Lambda66
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant158 --> Lambda73
+    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant159 --> Lambda75
+    Lambda75 --> Access76
+    Object80 --> Lambda81
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant161 --> Lambda86
+    Object98 --> Lambda99
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant162 --> Lambda104
+    Object116 --> Lambda117
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant163 --> Lambda122
+    Object134 --> Lambda135
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant164 --> Lambda140
+    Object149 --> Lambda150
+    Constant165{{"Constant[165∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant165 --> Lambda155
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant50{{"Constant[50∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant53{{"Constant[53∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Object69{{"Object[69∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access67{{"Access[67∈1]<br />ᐸ11.0ᐳ"}}:::plan
-    Access67 & Constant150 & Constant50 & Lambda52 & Constant53 --> Object69
-    Object86{{"Object[86∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access85{{"Access[85∈1]<br />ᐸ11.1ᐳ"}}:::plan
-    Access85 & Constant50 & Constant50 & Lambda72 & Constant53 --> Object86
-    Object103{{"Object[103∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access102{{"Access[102∈1]<br />ᐸ11.2ᐳ"}}:::plan
-    Access102 & Constant50 & Constant50 & Lambda72 & Constant53 --> Object103
-    Object120{{"Object[120∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access119{{"Access[119∈1]<br />ᐸ11.3ᐳ"}}:::plan
-    Access119 & Constant50 & Constant50 & Lambda72 & Constant53 --> Object120
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Object70{{"Object[70∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access68{{"Access[68∈1]<br />ᐸ11.0ᐳ"}}:::plan
+    Access68 & Constant156 & Constant50 & Lambda52 & Constant53 --> Object70
+    Object88{{"Object[88∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access87{{"Access[87∈1]<br />ᐸ11.1ᐳ"}}:::plan
+    Access87 & Constant50 & Constant50 & Lambda73 & Constant53 --> Object88
+    Object106{{"Object[106∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access105{{"Access[105∈1]<br />ᐸ11.2ᐳ"}}:::plan
+    Access105 & Constant50 & Constant50 & Lambda73 & Constant53 --> Object106
+    Object124{{"Object[124∈1]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access123{{"Access[123∈1]<br />ᐸ11.3ᐳ"}}:::plan
+    Access123 & Constant50 & Constant50 & Lambda73 & Constant53 --> Object124
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpersonᐳ"}}:::plan
@@ -114,44 +118,44 @@ graph TD
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression14{{"PgClassExpression[14∈1]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression14
-    __Item11 --> Access67
-    Lambda70{{"Lambda[70∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object69 --> Lambda70
-    __Item11 --> Access85
-    Lambda87{{"Lambda[87∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object86 --> Lambda87
-    __Item11 --> Access102
-    Lambda104{{"Lambda[104∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object103 --> Lambda104
-    __Item11 --> Access119
-    Lambda121{{"Lambda[121∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object120 --> Lambda121
-    __Item20[/"__Item[20∈2]<br />ᐸ70ᐳ"\]:::itemplan
-    Lambda70 ==> __Item20
+    __Item11 --> Access68
+    Lambda71{{"Lambda[71∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object70 --> Lambda71
+    __Item11 --> Access87
+    Lambda89{{"Lambda[89∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object88 --> Lambda89
+    __Item11 --> Access105
+    Lambda107{{"Lambda[107∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object106 --> Lambda107
+    __Item11 --> Access123
+    Lambda125{{"Lambda[125∈1]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object124 --> Lambda125
+    __Item20[/"__Item[20∈2]<br />ᐸ71ᐳ"\]:::itemplan
+    Lambda71 ==> __Item20
     PgSelectSingle21{{"PgSelectSingle[21∈2]<br />ᐸpostᐳ"}}:::plan
     __Item20 --> PgSelectSingle21
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression22
     PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression23
-    __Item28[/"__Item[28∈3]<br />ᐸ87ᐳ"\]:::itemplan
-    Lambda87 ==> __Item28
+    __Item28[/"__Item[28∈3]<br />ᐸ89ᐳ"\]:::itemplan
+    Lambda89 ==> __Item28
     PgSelectSingle29{{"PgSelectSingle[29∈3]<br />ᐸpostᐳ"}}:::plan
     __Item28 --> PgSelectSingle29
     PgClassExpression30{{"PgClassExpression[30∈3]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression30
     PgClassExpression31{{"PgClassExpression[31∈3]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression31
-    __Item34[/"__Item[34∈4]<br />ᐸ104ᐳ"\]:::itemplan
-    Lambda104 ==> __Item34
+    __Item34[/"__Item[34∈4]<br />ᐸ107ᐳ"\]:::itemplan
+    Lambda107 ==> __Item34
     PgSelectSingle35{{"PgSelectSingle[35∈4]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item34 --> PgSelectSingle35
     PgClassExpression36{{"PgClassExpression[36∈4]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression37
-    __Item40[/"__Item[40∈5]<br />ᐸ121ᐳ"\]:::itemplan
-    Lambda121 ==> __Item40
+    __Item40[/"__Item[40∈5]<br />ᐸ125ᐳ"\]:::itemplan
+    Lambda125 ==> __Item40
     PgSelectSingle41{{"PgSelectSingle[41∈5]<br />ᐸcompound_keyᐳ"}}:::plan
     __Item40 --> PgSelectSingle41
     PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
@@ -170,22 +174,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/simple-relations-head-tail"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 50, 53, 56, 57, 58, 75, 76, 92, 93, 94, 109, 110, 126, 127, 128, 140, 141, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 10, 52, 55, 59, 60, 65, 72, 74, 78, 79, 84, 95, 96, 101, 112, 113, 118, 129, 130, 135, 143, 144, 149<br />2: PgSelect[7], PgSelect[44]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 50, 53, 57, 58, 59, 77, 78, 95, 96, 97, 113, 114, 131, 132, 133, 146, 147, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 10, 52, 55, 56, 60, 61, 66, 73, 75, 76, 80, 81, 86, 98, 99, 104, 116, 117, 122, 134, 135, 140, 149, 150, 155<br />2: PgSelect[7], PgSelect[44]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect44,Constant50,Lambda52,Constant53,Lambda55,Constant56,Constant57,Constant58,Object59,Lambda60,Lambda65,Lambda72,Lambda74,Constant75,Constant76,Object78,Lambda79,Lambda84,Constant92,Constant93,Constant94,Object95,Lambda96,Lambda101,Constant109,Constant110,Object112,Lambda113,Lambda118,Constant126,Constant127,Constant128,Object129,Lambda130,Lambda135,Constant140,Constant141,Object143,Lambda144,Lambda149,Constant150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 150, 50, 52, 53, 72<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect44,Constant50,Lambda52,Constant53,Lambda55,Access56,Constant57,Constant58,Constant59,Object60,Lambda61,Lambda66,Lambda73,Lambda75,Access76,Constant77,Constant78,Object80,Lambda81,Lambda86,Constant95,Constant96,Constant97,Object98,Lambda99,Lambda104,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant131,Constant132,Constant133,Object134,Lambda135,Lambda140,Constant146,Constant147,Object149,Lambda150,Lambda155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163,Constant164,Constant165,Constant166,Constant167 bucket0
+    Bucket1("Bucket 1 (listItem)<br />Deps: 156, 50, 52, 53, 73<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,Access67,Object69,Lambda70,Access85,Object86,Lambda87,Access102,Object103,Lambda104,Access119,Object120,Lambda121 bucket1
-    Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ70ᐳ[20]"):::bucket
+    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,Access68,Object70,Lambda71,Access87,Object88,Lambda89,Access105,Object106,Lambda107,Access123,Object124,Lambda125 bucket1
+    Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ71ᐳ[20]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item20,PgSelectSingle21,PgClassExpression22,PgClassExpression23 bucket2
-    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ87ᐳ[28]"):::bucket
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ89ᐳ[28]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,PgSelectSingle29,PgClassExpression30,PgClassExpression31 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ104ᐳ[34]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ107ᐳ[34]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item34,PgSelectSingle35,PgClassExpression36,PgClassExpression37 bucket4
-    Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ121ᐳ[40]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ125ᐳ[40]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item40,PgSelectSingle41,PgClassExpression42,PgClassExpression43 bucket5
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ44ᐳ[46]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-relations-tail-head.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-relations-tail-head.mermaid
@@ -11,78 +11,80 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda82{{"Lambda[82∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access62{{"Access[62∈0] ➊<br />ᐸ61.0ᐳ"}}:::plan
+    Lambda67{{"Lambda[67∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda61 & Lambda66 & Lambda71 & Lambda61 & Lambda82 & Lambda87 & Lambda58 & Lambda61 & Lambda98 & Lambda103 --> PgSelect7
+    Lambda101{{"Lambda[101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda106{{"Lambda[106∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Access62 & Lambda67 & Lambda72 & Access62 & Lambda84 & Lambda89 & Lambda58 & Access62 & Lambda101 & Lambda106 --> PgSelect7
     PgSelect34[["PgSelect[34∈0] ➊<br />ᐸforeign_keyᐳ"]]:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda116{{"Lambda[116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda121{{"Lambda[121∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda133{{"Lambda[133∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda144{{"Lambda[144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda149{{"Lambda[149∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Lambda61 & Lambda112 & Lambda117 & Lambda61 & Lambda128 & Lambda133 & Lambda58 & Lambda61 & Lambda144 & Lambda149 --> PgSelect34
-    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda58 & Constant62 & Constant63 & Constant64 --> Object65
-    Object81{{"Object[81∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant78{{"Constant[78∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant79{{"Constant[79∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda58 & Constant78 & Constant79 & Constant64 --> Object81
-    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda58 & Constant94 & Constant95 & Constant96 --> Object97
-    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda58 & Constant108 & Constant109 & Constant64 --> Object111
-    Object127{{"Object[127∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant125{{"Constant[125∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda58 & Constant124 & Constant125 & Constant96 --> Object127
-    Object143{{"Object[143∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant140{{"Constant[140∈0] ➊<br />ᐸ[ { attribute: 'person_id', direction: 'ASC' }, { attribute:ᐳ"}}:::plan
-    Constant141{{"Constant[141∈0] ➊<br />ᐸsql.identifier(”foreign_key”)ᐳ"}}:::plan
-    Constant142{{"Constant[142∈0] ➊<br />ᐸRecordCodec(foreignKey)ᐳ"}}:::plan
-    Lambda58 & Constant140 & Constant141 & Constant142 --> Object143
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Access62 & Lambda116 & Lambda121 & Access62 & Lambda133 & Lambda138 & Lambda58 & Access62 & Lambda150 & Lambda155 --> PgSelect34
+    Object66{{"Object[66∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant64{{"Constant[64∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda58 & Constant63 & Constant64 & Constant65 --> Object66
+    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda58 & Constant80 & Constant81 & Constant65 --> Object83
+    Object100{{"Object[100∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant97{{"Constant[97∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 1168, [Symbol(pg-sql2-tᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda58 & Constant97 & Constant98 & Constant99 --> Object100
+    Object115{{"Object[115∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda58 & Constant112 & Constant113 & Constant65 --> Object115
+    Object132{{"Object[132∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda58 & Constant129 & Constant130 & Constant99 --> Object132
+    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant146{{"Constant[146∈0] ➊<br />ᐸ[ { attribute: 'person_id', direction: 'ASC' }, { attribute:ᐳ"}}:::plan
+    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”foreign_key”)ᐳ"}}:::plan
+    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(foreignKey)ᐳ"}}:::plan
+    Lambda58 & Constant146 & Constant147 & Constant148 --> Object149
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
-    Constant150{{"Constant[150∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant150 --> Lambda58
-    Constant151{{"Constant[151∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant151 --> Lambda61
-    Object65 --> Lambda66
-    Constant152{{"Constant[152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant152 --> Lambda71
-    Object81 --> Lambda82
-    Constant153{{"Constant[153∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant153 --> Lambda87
-    Object97 --> Lambda98
-    Constant154{{"Constant[154∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant154 --> Lambda103
-    Object111 --> Lambda112
-    Constant155{{"Constant[155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant155 --> Lambda117
-    Object127 --> Lambda128
-    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant156 --> Lambda133
-    Object143 --> Lambda144
-    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_id', direcᐳ"}}:::plan
-    Constant157 --> Lambda149
+    Constant156{{"Constant[156∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant156 --> Lambda58
+    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant157{{"Constant[157∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant157 --> Lambda61
+    Lambda61 --> Access62
+    Object66 --> Lambda67
+    Constant158{{"Constant[158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant158 --> Lambda72
+    Object83 --> Lambda84
+    Constant159{{"Constant[159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant159 --> Lambda89
+    Object100 --> Lambda101
+    Constant160{{"Constant[160∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant160 --> Lambda106
+    Object115 --> Lambda116
+    Constant161{{"Constant[161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant161 --> Lambda121
+    Object132 --> Lambda133
+    Constant162{{"Constant[162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant162 --> Lambda138
+    Object149 --> Lambda150
+    Constant163{{"Constant[163∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'person_id', direcᐳ"}}:::plan
+    Constant163 --> Lambda155
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item11[/"__Item[11∈1]<br />ᐸ7ᐳ"\]:::itemplan
     PgSelect7 ==> __Item11
@@ -97,9 +99,9 @@ graph TD
     PgSelectSingle21{{"PgSelectSingle[21∈1]<br />ᐸpersonᐳ"}}:::plan
     PgSelectSingle12 --> PgSelectSingle21
     PgSelectSingle27{{"PgSelectSingle[27∈1]<br />ᐸpersonᐳ"}}:::plan
-    RemapKeys88{{"RemapKeys[88∈1]<br />ᐸ12:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys88 --> PgSelectSingle27
-    PgSelectSingle12 --> RemapKeys88
+    RemapKeys90{{"RemapKeys[90∈1]<br />ᐸ12:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys90 --> PgSelectSingle27
+    PgSelectSingle12 --> RemapKeys90
     PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle21 --> PgClassExpression22
     PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -121,9 +123,9 @@ graph TD
     PgSelectSingle46{{"PgSelectSingle[46∈4]<br />ᐸpersonᐳ"}}:::plan
     PgSelectSingle37 --> PgSelectSingle46
     PgSelectSingle52{{"PgSelectSingle[52∈4]<br />ᐸcompound_keyᐳ"}}:::plan
-    RemapKeys134{{"RemapKeys[134∈4]<br />ᐸ37:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
-    RemapKeys134 --> PgSelectSingle52
-    PgSelectSingle37 --> RemapKeys134
+    RemapKeys139{{"RemapKeys[139∈4]<br />ᐸ37:{”0”:3,”1”:4,”2”:5}ᐳ"}}:::plan
+    RemapKeys139 --> PgSelectSingle52
+    PgSelectSingle37 --> RemapKeys139
     PgClassExpression47{{"PgClassExpression[47∈5]<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle46 --> PgClassExpression47
     PgClassExpression48{{"PgClassExpression[48∈5]<br />ᐸ__person__.”email”ᐳ"}}:::plan
@@ -138,12 +140,12 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/simple-relations-tail-head"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 62, 63, 64, 78, 79, 94, 95, 96, 108, 109, 124, 125, 140, 141, 142, 150, 151, 152, 153, 154, 155, 156, 157, 10, 58, 61, 65, 66, 71, 81, 82, 87, 97, 98, 103, 111, 112, 117, 127, 128, 133, 143, 144, 149<br />2: PgSelect[7], PgSelect[34]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 63, 64, 65, 80, 81, 97, 98, 99, 112, 113, 129, 130, 146, 147, 148, 156, 157, 158, 159, 160, 161, 162, 163, 10, 58, 61, 62, 66, 67, 72, 83, 84, 89, 100, 101, 106, 115, 116, 121, 132, 133, 138, 149, 150, 155<br />2: PgSelect[7], PgSelect[34]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect34,Lambda58,Lambda61,Constant62,Constant63,Constant64,Object65,Lambda66,Lambda71,Constant78,Constant79,Object81,Lambda82,Lambda87,Constant94,Constant95,Constant96,Object97,Lambda98,Lambda103,Constant108,Constant109,Object111,Lambda112,Lambda117,Constant124,Constant125,Object127,Lambda128,Lambda133,Constant140,Constant141,Constant142,Object143,Lambda144,Lambda149,Constant150,Constant151,Constant152,Constant153,Constant154,Constant155,Constant156,Constant157 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,PgSelect34,Lambda58,Lambda61,Access62,Constant63,Constant64,Constant65,Object66,Lambda67,Lambda72,Constant80,Constant81,Object83,Lambda84,Lambda89,Constant97,Constant98,Constant99,Object100,Lambda101,Lambda106,Constant112,Constant113,Object115,Lambda116,Lambda121,Constant129,Constant130,Object132,Lambda133,Lambda138,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant156,Constant157,Constant158,Constant159,Constant160,Constant161,Constant162,Constant163 bucket0
     Bucket1("Bucket 1 (listItem)<br /><br />ROOT __Item{1}ᐸ7ᐳ[11]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelectSingle21,PgSelectSingle27,RemapKeys88 bucket1
+    class Bucket1,__Item11,PgSelectSingle12,PgClassExpression13,PgClassExpression14,PgClassExpression15,PgSelectSingle21,PgSelectSingle27,RemapKeys90 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21<br /><br />ROOT PgSelectSingle{1}ᐸpersonᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression22,PgClassExpression23 bucket2
@@ -152,7 +154,7 @@ graph TD
     class Bucket3,PgClassExpression28,PgClassExpression29 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ34ᐳ[36]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item36,PgSelectSingle37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgSelectSingle46,PgSelectSingle52,RemapKeys134 bucket4
+    class Bucket4,__Item36,PgSelectSingle37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgSelectSingle46,PgSelectSingle52,RemapKeys139 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 46<br /><br />ROOT PgSelectSingle{4}ᐸpersonᐳ[46]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,PgClassExpression47,PgClassExpression48 bucket5

--- a/postgraphile/postgraphile/__tests__/queries/v4/smart_comment_relations.houses.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/smart_comment_relations.houses.mermaid
@@ -11,30 +11,106 @@ graph TD
     %% plan dependencies
     PgSelect233[["PgSelect[233∈0] ➊<br />ᐸhousesᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant597{{"Constant[597∈0] ➊<br />ᐸ2ᐳ"}}:::plan
-    Constant598{{"Constant[598∈0] ➊<br />ᐸ3ᐳ"}}:::plan
+    Constant617{{"Constant[617∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant618{{"Constant[618∈0] ➊<br />ᐸ3ᐳ"}}:::plan
     Lambda265{{"Lambda[265∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda268{{"Lambda[268∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda577{{"Lambda[577∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda582{{"Lambda[582∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant597 & Constant598 & Lambda265 & Lambda268 & Lambda577 & Lambda582 --> PgSelect233
+    Access269{{"Access[269∈0] ➊<br />ᐸ268.0ᐳ"}}:::plan
+    Lambda596{{"Lambda[596∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda601{{"Lambda[601∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant617 & Constant618 & Lambda265 & Access269 & Lambda596 & Lambda601 --> PgSelect233
     PgSelect251[["PgSelect[251∈0] ➊<br />ᐸhousesᐳ"]]:::plan
     Access247{{"Access[247∈0] ➊<br />ᐸ246.1ᐳ"}}:::plan
     Access249{{"Access[249∈0] ➊<br />ᐸ246.2ᐳ"}}:::plan
-    Lambda591{{"Lambda[591∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda596{{"Lambda[596∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda611{{"Lambda[611∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda616{{"Lambda[616∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect251
     Access247 -->|rejectNull| PgSelect251
-    Access249 & Lambda265 & Lambda268 & Lambda591 & Lambda596 --> PgSelect251
-    Object576{{"Object[576∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant573{{"Constant[573∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant574{{"Constant[574∈0] ➊<br />ᐸsql.identifier(”houses”)ᐳ"}}:::plan
-    Constant561{{"Constant[561∈0] ➊<br />ᐸRecordCodec(houses)ᐳ"}}:::plan
-    Lambda265 & Constant573 & Constant574 & Constant561 --> Object576
-    Object590{{"Object[590∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant587{{"Constant[587∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant588{{"Constant[588∈0] ➊<br />ᐸsql.identifier(”houses”)ᐳ"}}:::plan
-    Lambda265 & Constant587 & Constant588 & Constant561 --> Object590
+    Access249 & Lambda265 & Access269 & Lambda611 & Lambda616 --> PgSelect251
+    Object273{{"Object[273∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant270{{"Constant[270∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant271{{"Constant[271∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Constant272{{"Constant[272∈0] ➊<br />ᐸRecordCodec(buildings)ᐳ"}}:::plan
+    Lambda265 & Constant270 & Constant271 & Constant272 --> Object273
+    Object293{{"Object[293∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant290{{"Constant[290∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant291{{"Constant[291∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
+    Constant292{{"Constant[292∈0] ➊<br />ᐸRecordCodec(streets)ᐳ"}}:::plan
+    Lambda265 & Constant290 & Constant291 & Constant292 --> Object293
+    Object310{{"Object[310∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant307{{"Constant[307∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant308{{"Constant[308∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Lambda265 & Constant307 & Constant308 & Constant272 --> Object310
+    Object330{{"Object[330∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant327{{"Constant[327∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant328{{"Constant[328∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
+    Lambda265 & Constant327 & Constant328 & Constant292 --> Object330
+    Object347{{"Object[347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant344{{"Constant[344∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Lambda265 & Constant344 & Constant345 & Constant272 --> Object347
+    Object367{{"Object[367∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant364{{"Constant[364∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant365{{"Constant[365∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
+    Lambda265 & Constant364 & Constant365 & Constant292 --> Object367
+    Object384{{"Object[384∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant381{{"Constant[381∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant382{{"Constant[382∈0] ➊<br />ᐸsql.identifier(”properties”)ᐳ"}}:::plan
+    Constant383{{"Constant[383∈0] ➊<br />ᐸRecordCodec(properties)ᐳ"}}:::plan
+    Lambda265 & Constant381 & Constant382 & Constant383 --> Object384
+    Object401{{"Object[401∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant398{{"Constant[398∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant399{{"Constant[399∈0] ➊<br />ᐸsql.identifier(”street_property”)ᐳ"}}:::plan
+    Constant400{{"Constant[400∈0] ➊<br />ᐸRecordCodec(streetProperty)ᐳ"}}:::plan
+    Lambda265 & Constant398 & Constant399 & Constant400 --> Object401
+    Object418{{"Object[418∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant415{{"Constant[415∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant416{{"Constant[416∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Lambda265 & Constant415 & Constant416 & Constant272 --> Object418
+    Object438{{"Object[438∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant436{{"Constant[436∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
+    Lambda265 & Constant435 & Constant436 & Constant292 --> Object438
+    Object455{{"Object[455∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant452{{"Constant[452∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant453{{"Constant[453∈0] ➊<br />ᐸsql.identifier(”properties”)ᐳ"}}:::plan
+    Lambda265 & Constant452 & Constant453 & Constant383 --> Object455
+    Object472{{"Object[472∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant469{{"Constant[469∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant470{{"Constant[470∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Lambda265 & Constant469 & Constant470 & Constant272 --> Object472
+    Object492{{"Object[492∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant489{{"Constant[489∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant490{{"Constant[490∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
+    Lambda265 & Constant489 & Constant490 & Constant292 --> Object492
+    Object509{{"Object[509∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant506{{"Constant[506∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant507{{"Constant[507∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Lambda265 & Constant506 & Constant507 & Constant272 --> Object509
+    Object529{{"Object[529∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant526{{"Constant[526∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant527{{"Constant[527∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
+    Lambda265 & Constant526 & Constant527 & Constant292 --> Object529
+    Object546{{"Object[546∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant543{{"Constant[543∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant544{{"Constant[544∈0] ➊<br />ᐸsql.identifier(”properties”)ᐳ"}}:::plan
+    Lambda265 & Constant543 & Constant544 & Constant383 --> Object546
+    Object563{{"Object[563∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant560{{"Constant[560∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant561{{"Constant[561∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
+    Lambda265 & Constant560 & Constant561 & Constant272 --> Object563
+    Object580{{"Object[580∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant577{{"Constant[577∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
+    Constant578{{"Constant[578∈0] ➊<br />ᐸsql.identifier(”houses”)ᐳ"}}:::plan
+    Constant579{{"Constant[579∈0] ➊<br />ᐸRecordCodec(houses)ᐳ"}}:::plan
+    Lambda265 & Constant577 & Constant578 & Constant579 --> Object580
+    Object595{{"Object[595∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant592{{"Constant[592∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant593{{"Constant[593∈0] ➊<br />ᐸsql.identifier(”houses”)ᐳ"}}:::plan
+    Lambda265 & Constant592 & Constant593 & Constant579 --> Object595
+    Object610{{"Object[610∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant607{{"Constant[607∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant608{{"Constant[608∈0] ➊<br />ᐸsql.identifier(”houses”)ᐳ"}}:::plan
+    Lambda265 & Constant607 & Constant608 & Constant579 --> Object610
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -46,206 +122,132 @@ graph TD
     PgSelectSingle236{{"PgSelectSingle[236∈0] ➊<br />ᐸhousesᐳ"}}:::plan
     First235 --> PgSelectSingle236
     Lambda246{{"Lambda[246∈0] ➊<br />ᐸspecifier_House_base64JSONᐳ"}}:::plan
-    Constant599{{"Constant[599∈0] ➊<br />ᐸ'WyJob3VzZXMiLDIsM10='ᐳ"}}:::plan
-    Constant599 --> Lambda246
+    Constant619{{"Constant[619∈0] ➊<br />ᐸ'WyJob3VzZXMiLDIsM10='ᐳ"}}:::plan
+    Constant619 --> Lambda246
     Lambda246 --> Access247
     Lambda246 --> Access249
     First253{{"First[253∈0] ➊"}}:::plan
     PgSelect251 --> First253
     PgSelectSingle254{{"PgSelectSingle[254∈0] ➊<br />ᐸhousesᐳ"}}:::plan
     First253 --> PgSelectSingle254
-    Constant600{{"Constant[600∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant600 --> Lambda265
-    Constant601{{"Constant[601∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant601 --> Lambda268
-    Object576 --> Lambda577
-    Constant620{{"Constant[620∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”housesᐳ"}}:::plan
-    Constant620 --> Lambda582
-    Object590 --> Lambda591
-    Constant621{{"Constant[621∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”housesᐳ"}}:::plan
-    Constant621 --> Lambda596
+    Constant620{{"Constant[620∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant620 --> Lambda265
+    Lambda268{{"Lambda[268∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant621{{"Constant[621∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant621 --> Lambda268
+    Lambda268 --> Access269
+    Lambda274{{"Lambda[274∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object273 --> Lambda274
+    Lambda279{{"Lambda[279∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant622{{"Constant[622∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant622 --> Lambda279
+    Lambda294{{"Lambda[294∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object293 --> Lambda294
+    Lambda299{{"Lambda[299∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant623{{"Constant[623∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant623 --> Lambda299
+    Lambda311{{"Lambda[311∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object310 --> Lambda311
+    Lambda316{{"Lambda[316∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant624{{"Constant[624∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant624 --> Lambda316
+    Lambda331{{"Lambda[331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object330 --> Lambda331
+    Lambda336{{"Lambda[336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant625{{"Constant[625∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant625 --> Lambda336
+    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object347 --> Lambda348
+    Lambda353{{"Lambda[353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant626{{"Constant[626∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant626 --> Lambda353
+    Lambda368{{"Lambda[368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object367 --> Lambda368
+    Lambda373{{"Lambda[373∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant627{{"Constant[627∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant627 --> Lambda373
+    Lambda385{{"Lambda[385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object384 --> Lambda385
+    Lambda390{{"Lambda[390∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant628{{"Constant[628∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”properᐳ"}}:::plan
+    Constant628 --> Lambda390
+    Lambda402{{"Lambda[402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object401 --> Lambda402
+    Lambda407{{"Lambda[407∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant629{{"Constant[629∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant629 --> Lambda407
+    Lambda419{{"Lambda[419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object418 --> Lambda419
+    Lambda424{{"Lambda[424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant630{{"Constant[630∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant630 --> Lambda424
+    Lambda439{{"Lambda[439∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object438 --> Lambda439
+    Lambda444{{"Lambda[444∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant631{{"Constant[631∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant631 --> Lambda444
+    Lambda456{{"Lambda[456∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object455 --> Lambda456
+    Lambda461{{"Lambda[461∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant632{{"Constant[632∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”properᐳ"}}:::plan
+    Constant632 --> Lambda461
+    Lambda473{{"Lambda[473∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object472 --> Lambda473
+    Lambda478{{"Lambda[478∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant633{{"Constant[633∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant633 --> Lambda478
+    Lambda493{{"Lambda[493∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object492 --> Lambda493
+    Lambda498{{"Lambda[498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant634{{"Constant[634∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant634 --> Lambda498
+    Lambda510{{"Lambda[510∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object509 --> Lambda510
+    Lambda515{{"Lambda[515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant635{{"Constant[635∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant635 --> Lambda515
+    Lambda530{{"Lambda[530∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object529 --> Lambda530
+    Lambda535{{"Lambda[535∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant636{{"Constant[636∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
+    Constant636 --> Lambda535
+    Lambda547{{"Lambda[547∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object546 --> Lambda547
+    Lambda552{{"Lambda[552∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant637{{"Constant[637∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”properᐳ"}}:::plan
+    Constant637 --> Lambda552
+    Lambda564{{"Lambda[564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object563 --> Lambda564
+    Lambda569{{"Lambda[569∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant638{{"Constant[638∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”buildiᐳ"}}:::plan
+    Constant638 --> Lambda569
+    Lambda581{{"Lambda[581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object580 --> Lambda581
+    Lambda586{{"Lambda[586∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant639{{"Constant[639∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant639 --> Lambda586
+    Object595 --> Lambda596
+    Constant640{{"Constant[640∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”housesᐳ"}}:::plan
+    Constant640 --> Lambda601
+    Object610 --> Lambda611
+    Constant641{{"Constant[641∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”housesᐳ"}}:::plan
+    Constant641 --> Lambda616
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Constant17{{"Constant[17∈0] ➊<br />ᐸ'houses'ᐳ"}}:::plan
     Constant32{{"Constant[32∈0] ➊<br />ᐸ'streets'ᐳ"}}:::plan
+    Connection43{{"Connection[43∈0] ➊<br />ᐸ39ᐳ"}}:::plan
     Constant47{{"Constant[47∈0] ➊<br />ᐸ'buildings'ᐳ"}}:::plan
+    Connection80{{"Connection[80∈0] ➊<br />ᐸ76ᐳ"}}:::plan
     Constant94{{"Constant[94∈0] ➊<br />ᐸ'properties'ᐳ"}}:::plan
+    Connection117{{"Connection[117∈0] ➊<br />ᐸ113ᐳ"}}:::plan
+    Connection153{{"Connection[153∈0] ➊<br />ᐸ149ᐳ"}}:::plan
+    Connection186{{"Connection[186∈0] ➊<br />ᐸ182ᐳ"}}:::plan
+    Connection222{{"Connection[222∈0] ➊<br />ᐸ218ᐳ"}}:::plan
     Constant263{{"Constant[263∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant266{{"Constant[266∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant269{{"Constant[269∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant270{{"Constant[270∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant271{{"Constant[271∈0] ➊<br />ᐸRecordCodec(buildings)ᐳ"}}:::plan
-    Constant288{{"Constant[288∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant289{{"Constant[289∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
-    Constant290{{"Constant[290∈0] ➊<br />ᐸRecordCodec(streets)ᐳ"}}:::plan
-    Constant304{{"Constant[304∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant305{{"Constant[305∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant323{{"Constant[323∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant324{{"Constant[324∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
-    Constant339{{"Constant[339∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant340{{"Constant[340∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant359{{"Constant[359∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
-    Constant374{{"Constant[374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant375{{"Constant[375∈0] ➊<br />ᐸsql.identifier(”properties”)ᐳ"}}:::plan
-    Constant376{{"Constant[376∈0] ➊<br />ᐸRecordCodec(properties)ᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant391{{"Constant[391∈0] ➊<br />ᐸsql.identifier(”street_property”)ᐳ"}}:::plan
-    Constant392{{"Constant[392∈0] ➊<br />ᐸRecordCodec(streetProperty)ᐳ"}}:::plan
-    Constant406{{"Constant[406∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant407{{"Constant[407∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant425{{"Constant[425∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant426{{"Constant[426∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
-    Constant441{{"Constant[441∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant442{{"Constant[442∈0] ➊<br />ᐸsql.identifier(”properties”)ᐳ"}}:::plan
-    Constant457{{"Constant[457∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant458{{"Constant[458∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant476{{"Constant[476∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant477{{"Constant[477∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
-    Constant492{{"Constant[492∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant493{{"Constant[493∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant511{{"Constant[511∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant512{{"Constant[512∈0] ➊<br />ᐸsql.identifier(”streets”)ᐳ"}}:::plan
-    Constant527{{"Constant[527∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant528{{"Constant[528∈0] ➊<br />ᐸsql.identifier(”properties”)ᐳ"}}:::plan
-    Constant543{{"Constant[543∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant544{{"Constant[544∈0] ➊<br />ᐸsql.identifier(”buildings”)ᐳ"}}:::plan
-    Constant559{{"Constant[559∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 102ᐳ"}}:::plan
-    Constant560{{"Constant[560∈0] ➊<br />ᐸsql.identifier(”houses”)ᐳ"}}:::plan
-    Constant602{{"Constant[602∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant603{{"Constant[603∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant604{{"Constant[604∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant605{{"Constant[605∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant606{{"Constant[606∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant607{{"Constant[607∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant608{{"Constant[608∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”properᐳ"}}:::plan
-    Constant609{{"Constant[609∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant610{{"Constant[610∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant611{{"Constant[611∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant612{{"Constant[612∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”properᐳ"}}:::plan
-    Constant613{{"Constant[613∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant614{{"Constant[614∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant615{{"Constant[615∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant616{{"Constant[616∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”streetᐳ"}}:::plan
-    Constant617{{"Constant[617∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”properᐳ"}}:::plan
-    Constant618{{"Constant[618∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”buildiᐳ"}}:::plan
-    Constant619{{"Constant[619∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸhousesᐳ"]]:::plan
-    Lambda273{{"Lambda[273∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda278{{"Lambda[278∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda292{{"Lambda[292∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda297{{"Lambda[297∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda308{{"Lambda[308∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda313{{"Lambda[313∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda327{{"Lambda[327∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda332{{"Lambda[332∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda343{{"Lambda[343∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda348{{"Lambda[348∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda362{{"Lambda[362∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda367{{"Lambda[367∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda378{{"Lambda[378∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda383{{"Lambda[383∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda394{{"Lambda[394∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda399{{"Lambda[399∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda410{{"Lambda[410∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda415{{"Lambda[415∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda429{{"Lambda[429∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda434{{"Lambda[434∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda445{{"Lambda[445∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda450{{"Lambda[450∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda461{{"Lambda[461∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda466{{"Lambda[466∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda480{{"Lambda[480∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda485{{"Lambda[485∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda496{{"Lambda[496∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda501{{"Lambda[501∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda515{{"Lambda[515∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda520{{"Lambda[520∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda531{{"Lambda[531∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda536{{"Lambda[536∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda547{{"Lambda[547∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda552{{"Lambda[552∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda563{{"Lambda[563∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda568{{"Lambda[568∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda268 & Lambda273 & Lambda278 & Lambda268 & Lambda292 & Lambda297 & Lambda308 & Lambda313 & Lambda327 & Lambda332 & Lambda343 & Lambda348 & Lambda362 & Lambda367 & Lambda378 & Lambda383 & Lambda268 & Lambda394 & Lambda399 & Lambda410 & Lambda415 & Lambda429 & Lambda434 & Lambda268 & Lambda445 & Lambda450 & Lambda461 & Lambda466 & Lambda480 & Lambda485 & Lambda496 & Lambda501 & Lambda515 & Lambda520 & Lambda531 & Lambda536 & Lambda268 & Lambda547 & Lambda552 & Lambda265 & Lambda268 & Lambda563 & Lambda568 --> PgSelect14
-    Object272{{"Object[272∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant269 & Constant270 & Constant271 --> Object272
-    Object291{{"Object[291∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant288 & Constant289 & Constant290 --> Object291
-    Object307{{"Object[307∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant304 & Constant305 & Constant271 --> Object307
-    Object326{{"Object[326∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant323 & Constant324 & Constant290 --> Object326
-    Object342{{"Object[342∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant339 & Constant340 & Constant271 --> Object342
-    Object361{{"Object[361∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant358 & Constant359 & Constant290 --> Object361
-    Object377{{"Object[377∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant374 & Constant375 & Constant376 --> Object377
-    Object393{{"Object[393∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant390 & Constant391 & Constant392 --> Object393
-    Object409{{"Object[409∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant406 & Constant407 & Constant271 --> Object409
-    Object428{{"Object[428∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant425 & Constant426 & Constant290 --> Object428
-    Object444{{"Object[444∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant441 & Constant442 & Constant376 --> Object444
-    Object460{{"Object[460∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant457 & Constant458 & Constant271 --> Object460
-    Object479{{"Object[479∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant476 & Constant477 & Constant290 --> Object479
-    Object495{{"Object[495∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant492 & Constant493 & Constant271 --> Object495
-    Object514{{"Object[514∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant511 & Constant512 & Constant290 --> Object514
-    Object530{{"Object[530∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant527 & Constant528 & Constant376 --> Object530
-    Object546{{"Object[546∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant543 & Constant544 & Constant271 --> Object546
-    Object562{{"Object[562∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda265 & Constant559 & Constant560 & Constant561 --> Object562
-    Object272 --> Lambda273
-    Constant602 --> Lambda278
-    Object291 --> Lambda292
-    Constant603 --> Lambda297
-    Object307 --> Lambda308
-    Constant604 --> Lambda313
-    Object326 --> Lambda327
-    Constant605 --> Lambda332
-    Object342 --> Lambda343
-    Constant606 --> Lambda348
-    Object361 --> Lambda362
-    Constant607 --> Lambda367
-    Object377 --> Lambda378
-    Constant608 --> Lambda383
-    Object393 --> Lambda394
-    Constant609 --> Lambda399
-    Object409 --> Lambda410
-    Constant610 --> Lambda415
-    Object428 --> Lambda429
-    Constant611 --> Lambda434
-    Object444 --> Lambda445
-    Constant612 --> Lambda450
-    Object460 --> Lambda461
-    Constant613 --> Lambda466
-    Object479 --> Lambda480
-    Constant614 --> Lambda485
-    Object495 --> Lambda496
-    Constant615 --> Lambda501
-    Object514 --> Lambda515
-    Constant616 --> Lambda520
-    Object530 --> Lambda531
-    Constant617 --> Lambda536
-    Object546 --> Lambda547
-    Constant618 --> Lambda552
-    Object562 --> Lambda563
-    Constant619 --> Lambda568
-    Connection43{{"Connection[43∈1] ➊<br />ᐸ39ᐳ"}}:::plan
-    Connection80{{"Connection[80∈1] ➊<br />ᐸ76ᐳ"}}:::plan
-    Connection117{{"Connection[117∈1] ➊<br />ᐸ113ᐳ"}}:::plan
-    Connection153{{"Connection[153∈1] ➊<br />ᐸ149ᐳ"}}:::plan
-    Connection186{{"Connection[186∈1] ➊<br />ᐸ182ᐳ"}}:::plan
-    Connection222{{"Connection[222∈1] ➊<br />ᐸ218ᐳ"}}:::plan
+    Object12 & Connection13 & Access269 & Lambda274 & Lambda279 & Access269 & Lambda294 & Lambda299 & Lambda311 & Lambda316 & Lambda331 & Lambda336 & Lambda348 & Lambda353 & Lambda368 & Lambda373 & Lambda385 & Lambda390 & Access269 & Lambda402 & Lambda407 & Lambda419 & Lambda424 & Lambda439 & Lambda444 & Access269 & Lambda456 & Lambda461 & Lambda473 & Lambda478 & Lambda493 & Lambda498 & Lambda510 & Lambda515 & Lambda530 & Lambda535 & Lambda547 & Lambda552 & Access269 & Lambda564 & Lambda569 & Lambda265 & Access269 & Lambda581 & Lambda586 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸhousesᐳ"}}:::plan
@@ -269,20 +271,20 @@ graph TD
     PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸstreetsᐳ"}}:::plan
     PgSelectSingle16 --> PgSelectSingle31
     PgSelectSingle55{{"PgSelectSingle[55∈3]<br />ᐸbuildingsᐳ"}}:::plan
-    RemapKeys553{{"RemapKeys[553∈3]<br />ᐸ16:{”0”:26,”1”:27,”2”:28,”3”:29,”4”:30,”5”:31,”6”:32,”7”:33,”8”:34,”9”:35,”10”:36,”11”:37,”12”:38}ᐳ"}}:::plan
-    RemapKeys553 --> PgSelectSingle55
+    RemapKeys570{{"RemapKeys[570∈3]<br />ᐸ16:{”0”:26,”1”:27,”2”:28,”3”:29,”4”:30,”5”:31,”6”:32,”7”:33,”8”:34,”9”:35,”10”:36,”11”:37,”12”:38}ᐳ"}}:::plan
+    RemapKeys570 --> PgSelectSingle55
     PgSelectSingle129{{"PgSelectSingle[129∈3]<br />ᐸpropertiesᐳ"}}:::plan
-    RemapKeys451{{"RemapKeys[451∈3]<br />ᐸ16:{”0”:16,”1”:17,”2”:18,”3”:19,”4”:20,”5”:21}ᐳ"}}:::plan
-    RemapKeys451 --> PgSelectSingle129
+    RemapKeys462{{"RemapKeys[462∈3]<br />ᐸ16:{”0”:16,”1”:17,”2”:18,”3”:19,”4”:20,”5”:21}ᐳ"}}:::plan
+    RemapKeys462 --> PgSelectSingle129
     PgSelectSingle165{{"PgSelectSingle[165∈3]<br />ᐸstreet_propertyᐳ"}}:::plan
-    RemapKeys400{{"RemapKeys[400∈3]<br />ᐸ16:{”0”:3,”1”:4,”2”:5,”3”:6,”4”:7,”5”:8,”6”:9,”7”:10,”8”:11,”9”:12,”10”:13,”11”:14}ᐳ"}}:::plan
-    RemapKeys400 --> PgSelectSingle165
-    PgSelectSingle16 --> RemapKeys400
-    PgSelectSingle16 --> RemapKeys451
-    PgSelectSingle16 --> RemapKeys553
-    Object282{{"Object[282∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access280{{"Access[280∈4]<br />ᐸ16.1ᐳ"}}:::plan
-    Access280 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object282
+    RemapKeys408{{"RemapKeys[408∈3]<br />ᐸ16:{”0”:3,”1”:4,”2”:5,”3”:6,”4”:7,”5”:8,”6”:9,”7”:10,”8”:11,”9”:12,”10”:13,”11”:14}ᐳ"}}:::plan
+    RemapKeys408 --> PgSelectSingle165
+    PgSelectSingle16 --> RemapKeys408
+    PgSelectSingle16 --> RemapKeys462
+    PgSelectSingle16 --> RemapKeys570
+    Object283{{"Object[283∈4]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access281{{"Access[281∈4]<br />ᐸ16.1ᐳ"}}:::plan
+    Access281 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object283
     List34{{"List[34∈4]<br />ᐸ32,33ᐳ"}}:::plan
     PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__streets__.”id”ᐳ"}}:::plan
     Constant32 & PgClassExpression33 --> List34
@@ -291,11 +293,11 @@ graph TD
     List34 --> Lambda35
     PgClassExpression36{{"PgClassExpression[36∈4]<br />ᐸ__streets__.”name”ᐳ"}}:::plan
     PgSelectSingle31 --> PgClassExpression36
-    PgSelectSingle16 --> Access280
-    Lambda283{{"Lambda[283∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object282 --> Lambda283
-    __Item45[/"__Item[45∈5]<br />ᐸ283ᐳ"\]:::itemplan
-    Lambda283 ==> __Item45
+    PgSelectSingle16 --> Access281
+    Lambda284{{"Lambda[284∈4]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object283 --> Lambda284
+    __Item45[/"__Item[45∈5]<br />ᐸ284ᐳ"\]:::itemplan
+    Lambda284 ==> __Item45
     PgSelectSingle46{{"PgSelectSingle[46∈5]<br />ᐸbuildingsᐳ"}}:::plan
     __Item45 --> PgSelectSingle46
     List49{{"List[49∈6]<br />ᐸ47,48ᐳ"}}:::plan
@@ -319,16 +321,16 @@ graph TD
     PgClassExpression62{{"PgClassExpression[62∈7]<br />ᐸ__building...s_primary”ᐳ"}}:::plan
     PgSelectSingle55 --> PgClassExpression62
     PgSelectSingle68{{"PgSelectSingle[68∈7]<br />ᐸstreetsᐳ"}}:::plan
-    RemapKeys486{{"RemapKeys[486∈7]<br />ᐸ55:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
-    RemapKeys486 --> PgSelectSingle68
+    RemapKeys499{{"RemapKeys[499∈7]<br />ᐸ55:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
+    RemapKeys499 --> PgSelectSingle68
     PgSelectSingle93{{"PgSelectSingle[93∈7]<br />ᐸpropertiesᐳ"}}:::plan
-    RemapKeys537{{"RemapKeys[537∈7]<br />ᐸ55:{”0”:7,”1”:8,”2”:9,”3”:10,”4”:11,”5”:12}ᐳ"}}:::plan
-    RemapKeys537 --> PgSelectSingle93
-    PgSelectSingle55 --> RemapKeys486
-    PgSelectSingle55 --> RemapKeys537
-    Object470{{"Object[470∈8]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access468{{"Access[468∈8]<br />ᐸ486.1ᐳ"}}:::plan
-    Access468 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object470
+    RemapKeys553{{"RemapKeys[553∈7]<br />ᐸ55:{”0”:7,”1”:8,”2”:9,”3”:10,”4”:11,”5”:12}ᐳ"}}:::plan
+    RemapKeys553 --> PgSelectSingle93
+    PgSelectSingle55 --> RemapKeys499
+    PgSelectSingle55 --> RemapKeys553
+    Object482{{"Object[482∈8]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access480{{"Access[480∈8]<br />ᐸ499.1ᐳ"}}:::plan
+    Access480 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object482
     List71{{"List[71∈8]<br />ᐸ32,70ᐳ"}}:::plan
     PgClassExpression70{{"PgClassExpression[70∈8]<br />ᐸ__streets__.”id”ᐳ"}}:::plan
     Constant32 & PgClassExpression70 --> List71
@@ -337,11 +339,11 @@ graph TD
     List71 --> Lambda72
     PgClassExpression73{{"PgClassExpression[73∈8]<br />ᐸ__streets__.”name”ᐳ"}}:::plan
     PgSelectSingle68 --> PgClassExpression73
-    RemapKeys486 --> Access468
-    Lambda471{{"Lambda[471∈8]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object470 --> Lambda471
-    __Item82[/"__Item[82∈9]<br />ᐸ471ᐳ"\]:::itemplan
-    Lambda471 ==> __Item82
+    RemapKeys499 --> Access480
+    Lambda483{{"Lambda[483∈8]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object482 --> Lambda483
+    __Item82[/"__Item[82∈9]<br />ᐸ483ᐳ"\]:::itemplan
+    Lambda483 ==> __Item82
     PgSelectSingle83{{"PgSelectSingle[83∈9]<br />ᐸbuildingsᐳ"}}:::plan
     __Item82 --> PgSelectSingle83
     List86{{"List[86∈10]<br />ᐸ47,85ᐳ"}}:::plan
@@ -363,12 +365,12 @@ graph TD
     PgClassExpression99{{"PgClassExpression[99∈11]<br />ᐸ__properti...or_number”ᐳ"}}:::plan
     PgSelectSingle93 --> PgClassExpression99
     PgSelectSingle105{{"PgSelectSingle[105∈11]<br />ᐸstreetsᐳ"}}:::plan
-    RemapKeys521{{"RemapKeys[521∈11]<br />ᐸ93:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
-    RemapKeys521 --> PgSelectSingle105
-    PgSelectSingle93 --> RemapKeys521
-    Object505{{"Object[505∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access503{{"Access[503∈12]<br />ᐸ521.1ᐳ"}}:::plan
-    Access503 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object505
+    RemapKeys536{{"RemapKeys[536∈11]<br />ᐸ93:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
+    RemapKeys536 --> PgSelectSingle105
+    PgSelectSingle93 --> RemapKeys536
+    Object519{{"Object[519∈12]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access517{{"Access[517∈12]<br />ᐸ536.1ᐳ"}}:::plan
+    Access517 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object519
     List108{{"List[108∈12]<br />ᐸ32,107ᐳ"}}:::plan
     PgClassExpression107{{"PgClassExpression[107∈12]<br />ᐸ__streets__.”id”ᐳ"}}:::plan
     Constant32 & PgClassExpression107 --> List108
@@ -377,11 +379,11 @@ graph TD
     List108 --> Lambda109
     PgClassExpression110{{"PgClassExpression[110∈12]<br />ᐸ__streets__.”name”ᐳ"}}:::plan
     PgSelectSingle105 --> PgClassExpression110
-    RemapKeys521 --> Access503
-    Lambda506{{"Lambda[506∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object505 --> Lambda506
-    __Item119[/"__Item[119∈13]<br />ᐸ506ᐳ"\]:::itemplan
-    Lambda506 ==> __Item119
+    RemapKeys536 --> Access517
+    Lambda520{{"Lambda[520∈12]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object519 --> Lambda520
+    __Item119[/"__Item[119∈13]<br />ᐸ520ᐳ"\]:::itemplan
+    Lambda520 ==> __Item119
     PgSelectSingle120{{"PgSelectSingle[120∈13]<br />ᐸbuildingsᐳ"}}:::plan
     __Item119 --> PgSelectSingle120
     List123{{"List[123∈14]<br />ᐸ47,122ᐳ"}}:::plan
@@ -403,12 +405,12 @@ graph TD
     PgClassExpression135{{"PgClassExpression[135∈15]<br />ᐸ__properti...or_number”ᐳ"}}:::plan
     PgSelectSingle129 --> PgClassExpression135
     PgSelectSingle141{{"PgSelectSingle[141∈15]<br />ᐸstreetsᐳ"}}:::plan
-    RemapKeys435{{"RemapKeys[435∈15]<br />ᐸ129:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
-    RemapKeys435 --> PgSelectSingle141
-    PgSelectSingle129 --> RemapKeys435
-    Object419{{"Object[419∈16]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access417{{"Access[417∈16]<br />ᐸ435.1ᐳ"}}:::plan
-    Access417 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object419
+    RemapKeys445{{"RemapKeys[445∈15]<br />ᐸ129:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
+    RemapKeys445 --> PgSelectSingle141
+    PgSelectSingle129 --> RemapKeys445
+    Object428{{"Object[428∈16]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access426{{"Access[426∈16]<br />ᐸ445.1ᐳ"}}:::plan
+    Access426 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object428
     List144{{"List[144∈16]<br />ᐸ32,143ᐳ"}}:::plan
     PgClassExpression143{{"PgClassExpression[143∈16]<br />ᐸ__streets__.”id”ᐳ"}}:::plan
     Constant32 & PgClassExpression143 --> List144
@@ -417,11 +419,11 @@ graph TD
     List144 --> Lambda145
     PgClassExpression146{{"PgClassExpression[146∈16]<br />ᐸ__streets__.”name”ᐳ"}}:::plan
     PgSelectSingle141 --> PgClassExpression146
-    RemapKeys435 --> Access417
-    Lambda420{{"Lambda[420∈16]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object419 --> Lambda420
-    __Item155[/"__Item[155∈17]<br />ᐸ420ᐳ"\]:::itemplan
-    Lambda420 ==> __Item155
+    RemapKeys445 --> Access426
+    Lambda429{{"Lambda[429∈16]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object428 --> Lambda429
+    __Item155[/"__Item[155∈17]<br />ᐸ429ᐳ"\]:::itemplan
+    Lambda429 ==> __Item155
     PgSelectSingle156{{"PgSelectSingle[156∈17]<br />ᐸbuildingsᐳ"}}:::plan
     __Item155 --> PgSelectSingle156
     List159{{"List[159∈18]<br />ᐸ47,158ᐳ"}}:::plan
@@ -441,12 +443,12 @@ graph TD
     PgSelectSingle174{{"PgSelectSingle[174∈19]<br />ᐸstreetsᐳ"}}:::plan
     PgSelectSingle165 --> PgSelectSingle174
     PgSelectSingle198{{"PgSelectSingle[198∈19]<br />ᐸpropertiesᐳ"}}:::plan
-    RemapKeys384{{"RemapKeys[384∈19]<br />ᐸ165:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9}ᐳ"}}:::plan
-    RemapKeys384 --> PgSelectSingle198
-    PgSelectSingle165 --> RemapKeys384
-    Object317{{"Object[317∈20]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access315{{"Access[315∈20]<br />ᐸ165.1ᐳ"}}:::plan
-    Access315 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object317
+    RemapKeys391{{"RemapKeys[391∈19]<br />ᐸ165:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9}ᐳ"}}:::plan
+    RemapKeys391 --> PgSelectSingle198
+    PgSelectSingle165 --> RemapKeys391
+    Object320{{"Object[320∈20]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access318{{"Access[318∈20]<br />ᐸ165.1ᐳ"}}:::plan
+    Access318 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object320
     List177{{"List[177∈20]<br />ᐸ32,176ᐳ"}}:::plan
     PgClassExpression176{{"PgClassExpression[176∈20]<br />ᐸ__streets__.”id”ᐳ"}}:::plan
     Constant32 & PgClassExpression176 --> List177
@@ -455,11 +457,11 @@ graph TD
     List177 --> Lambda178
     PgClassExpression179{{"PgClassExpression[179∈20]<br />ᐸ__streets__.”name”ᐳ"}}:::plan
     PgSelectSingle174 --> PgClassExpression179
-    PgSelectSingle165 --> Access315
-    Lambda318{{"Lambda[318∈20]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object317 --> Lambda318
-    __Item188[/"__Item[188∈21]<br />ᐸ318ᐳ"\]:::itemplan
-    Lambda318 ==> __Item188
+    PgSelectSingle165 --> Access318
+    Lambda321{{"Lambda[321∈20]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object320 --> Lambda321
+    __Item188[/"__Item[188∈21]<br />ᐸ321ᐳ"\]:::itemplan
+    Lambda321 ==> __Item188
     PgSelectSingle189{{"PgSelectSingle[189∈21]<br />ᐸbuildingsᐳ"}}:::plan
     __Item188 --> PgSelectSingle189
     List192{{"List[192∈22]<br />ᐸ47,191ᐳ"}}:::plan
@@ -481,12 +483,12 @@ graph TD
     PgClassExpression204{{"PgClassExpression[204∈23]<br />ᐸ__properti...or_number”ᐳ"}}:::plan
     PgSelectSingle198 --> PgClassExpression204
     PgSelectSingle210{{"PgSelectSingle[210∈23]<br />ᐸstreetsᐳ"}}:::plan
-    RemapKeys368{{"RemapKeys[368∈23]<br />ᐸ198:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
-    RemapKeys368 --> PgSelectSingle210
-    PgSelectSingle198 --> RemapKeys368
-    Object352{{"Object[352∈24]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access350{{"Access[350∈24]<br />ᐸ368.1ᐳ"}}:::plan
-    Access350 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object352
+    RemapKeys374{{"RemapKeys[374∈23]<br />ᐸ198:{”0”:1,”1”:2,”2”:3}ᐳ"}}:::plan
+    RemapKeys374 --> PgSelectSingle210
+    PgSelectSingle198 --> RemapKeys374
+    Object357{{"Object[357∈24]<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access355{{"Access[355∈24]<br />ᐸ374.1ᐳ"}}:::plan
+    Access355 & Constant263 & Constant263 & Lambda265 & Constant266 --> Object357
     List213{{"List[213∈24]<br />ᐸ32,212ᐳ"}}:::plan
     PgClassExpression212{{"PgClassExpression[212∈24]<br />ᐸ__streets__.”id”ᐳ"}}:::plan
     Constant32 & PgClassExpression212 --> List213
@@ -495,11 +497,11 @@ graph TD
     List213 --> Lambda214
     PgClassExpression215{{"PgClassExpression[215∈24]<br />ᐸ__streets__.”name”ᐳ"}}:::plan
     PgSelectSingle210 --> PgClassExpression215
-    RemapKeys368 --> Access350
-    Lambda353{{"Lambda[353∈24]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object352 --> Lambda353
-    __Item224[/"__Item[224∈25]<br />ᐸ353ᐳ"\]:::itemplan
-    Lambda353 ==> __Item224
+    RemapKeys374 --> Access355
+    Lambda358{{"Lambda[358∈24]<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object357 --> Lambda358
+    __Item224[/"__Item[224∈25]<br />ᐸ358ᐳ"\]:::itemplan
+    Lambda358 ==> __Item224
     PgSelectSingle225{{"PgSelectSingle[225∈25]<br />ᐸbuildingsᐳ"}}:::plan
     __Item224 --> PgSelectSingle225
     List228{{"List[228∈26]<br />ᐸ47,227ᐳ"}}:::plan
@@ -542,22 +544,22 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/smart_comment_relations.houses"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 32, 47, 94, 263, 266, 269, 270, 271, 288, 289, 290, 304, 305, 323, 324, 339, 340, 358, 359, 374, 375, 376, 390, 391, 392, 406, 407, 425, 426, 441, 442, 457, 458, 476, 477, 492, 493, 511, 512, 527, 528, 543, 544, 559, 560, 561, 573, 574, 587, 588, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 12, 246, 247, 249, 265, 268, 576, 577, 582, 590, 591, 596<br />2: PgSelect[233], PgSelect[251]<br />ᐳ: 235, 236, 253, 254"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 13, 17, 32, 43, 47, 80, 94, 117, 153, 186, 222, 263, 266, 270, 271, 272, 290, 291, 292, 307, 308, 327, 328, 344, 345, 364, 365, 381, 382, 383, 398, 399, 400, 415, 416, 435, 436, 452, 453, 469, 470, 489, 490, 506, 507, 526, 527, 543, 544, 560, 561, 577, 578, 579, 592, 593, 607, 608, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 12, 246, 247, 249, 265, 268, 269, 273, 274, 279, 293, 294, 299, 310, 311, 316, 330, 331, 336, 347, 348, 353, 367, 368, 373, 384, 385, 390, 401, 402, 407, 418, 419, 424, 438, 439, 444, 455, 456, 461, 472, 473, 478, 492, 493, 498, 509, 510, 515, 529, 530, 535, 546, 547, 552, 563, 564, 569, 580, 581, 586, 595, 596, 601, 610, 611, 616<br />2: PgSelect[233], PgSelect[251]<br />ᐳ: 235, 236, 253, 254"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Constant32,Constant47,Constant94,PgSelect233,First235,PgSelectSingle236,Lambda246,Access247,Access249,PgSelect251,First253,PgSelectSingle254,Constant263,Lambda265,Constant266,Lambda268,Constant269,Constant270,Constant271,Constant288,Constant289,Constant290,Constant304,Constant305,Constant323,Constant324,Constant339,Constant340,Constant358,Constant359,Constant374,Constant375,Constant376,Constant390,Constant391,Constant392,Constant406,Constant407,Constant425,Constant426,Constant441,Constant442,Constant457,Constant458,Constant476,Constant477,Constant492,Constant493,Constant511,Constant512,Constant527,Constant528,Constant543,Constant544,Constant559,Constant560,Constant561,Constant573,Constant574,Object576,Lambda577,Lambda582,Constant587,Constant588,Object590,Lambda591,Lambda596,Constant597,Constant598,Constant599,Constant600,Constant601,Constant602,Constant603,Constant604,Constant605,Constant606,Constant607,Constant608,Constant609,Constant610,Constant611,Constant612,Constant613,Constant614,Constant615,Constant616,Constant617,Constant618,Constant619,Constant620,Constant621 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 268, 265, 269, 270, 271, 602, 288, 289, 290, 603, 304, 305, 604, 323, 324, 605, 339, 340, 606, 358, 359, 607, 374, 375, 376, 608, 390, 391, 392, 609, 406, 407, 610, 425, 426, 611, 441, 442, 612, 457, 458, 613, 476, 477, 614, 492, 493, 615, 511, 512, 616, 527, 528, 617, 543, 544, 618, 559, 560, 561, 619, 17, 32, 263, 266, 47, 94<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 43, 80, 117, 153, 186, 222, 272, 278, 291, 297, 307, 313, 326, 332, 342, 348, 361, 367, 377, 383, 393, 399, 409, 415, 428, 434, 444, 450, 460, 466, 479, 485, 495, 501, 514, 520, 530, 536, 546, 552, 562, 568, 273, 292, 308, 327, 343, 362, 378, 394, 410, 429, 445, 461, 480, 496, 515, 531, 547, 563<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Constant17,Constant32,Connection43,Constant47,Connection80,Constant94,Connection117,Connection153,Connection186,Connection222,PgSelect233,First235,PgSelectSingle236,Lambda246,Access247,Access249,PgSelect251,First253,PgSelectSingle254,Constant263,Lambda265,Constant266,Lambda268,Access269,Constant270,Constant271,Constant272,Object273,Lambda274,Lambda279,Constant290,Constant291,Constant292,Object293,Lambda294,Lambda299,Constant307,Constant308,Object310,Lambda311,Lambda316,Constant327,Constant328,Object330,Lambda331,Lambda336,Constant344,Constant345,Object347,Lambda348,Lambda353,Constant364,Constant365,Object367,Lambda368,Lambda373,Constant381,Constant382,Constant383,Object384,Lambda385,Lambda390,Constant398,Constant399,Constant400,Object401,Lambda402,Lambda407,Constant415,Constant416,Object418,Lambda419,Lambda424,Constant435,Constant436,Object438,Lambda439,Lambda444,Constant452,Constant453,Object455,Lambda456,Lambda461,Constant469,Constant470,Object472,Lambda473,Lambda478,Constant489,Constant490,Object492,Lambda493,Lambda498,Constant506,Constant507,Object509,Lambda510,Lambda515,Constant526,Constant527,Object529,Lambda530,Lambda535,Constant543,Constant544,Object546,Lambda547,Lambda552,Constant560,Constant561,Object563,Lambda564,Lambda569,Constant577,Constant578,Constant579,Object580,Lambda581,Lambda586,Constant592,Constant593,Object595,Lambda596,Lambda601,Constant607,Constant608,Object610,Lambda611,Lambda616,Constant617,Constant618,Constant619,Constant620,Constant621,Constant622,Constant623,Constant624,Constant625,Constant626,Constant627,Constant628,Constant629,Constant630,Constant631,Constant632,Constant633,Constant634,Constant635,Constant636,Constant637,Constant638,Constant639,Constant640,Constant641 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 269, 274, 279, 294, 299, 311, 316, 331, 336, 348, 353, 368, 373, 385, 390, 402, 407, 419, 424, 439, 444, 456, 461, 473, 478, 493, 498, 510, 515, 530, 535, 547, 552, 564, 569, 265, 581, 586, 17, 32, 263, 266, 47, 94, 43, 80, 117, 153, 186, 222<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Connection43,Connection80,Connection117,Connection153,Connection186,Connection222,Object272,Lambda273,Lambda278,Object291,Lambda292,Lambda297,Object307,Lambda308,Lambda313,Object326,Lambda327,Lambda332,Object342,Lambda343,Lambda348,Object361,Lambda362,Lambda367,Object377,Lambda378,Lambda383,Object393,Lambda394,Lambda399,Object409,Lambda410,Lambda415,Object428,Lambda429,Lambda434,Object444,Lambda445,Lambda450,Object460,Lambda461,Lambda466,Object479,Lambda480,Lambda485,Object495,Lambda496,Lambda501,Object514,Lambda515,Lambda520,Object530,Lambda531,Lambda536,Object546,Lambda547,Lambda552,Object562,Lambda563,Lambda568 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 17, 32, 263, 265, 266, 47, 94, 43, 80, 117, 153, 186, 222<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 17, 32, 263, 265, 266, 47, 94, 43, 80, 117, 153, 186, 222<br /><br />ROOT PgSelectSingle{2}ᐸhousesᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression18,PgClassExpression19,List20,Lambda21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgSelectSingle31,PgSelectSingle55,PgSelectSingle129,PgSelectSingle165,RemapKeys400,RemapKeys451,RemapKeys553 bucket3
+    class Bucket3,PgClassExpression18,PgClassExpression19,List20,Lambda21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgSelectSingle31,PgSelectSingle55,PgSelectSingle129,PgSelectSingle165,RemapKeys408,RemapKeys462,RemapKeys570 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 32, 16, 263, 265, 266, 47, 43<br /><br />ROOT PgSelectSingle{3}ᐸstreetsᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression33,List34,Lambda35,PgClassExpression36,Access280,Object282,Lambda283 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 47<br /><br />ROOT __Item{5}ᐸ283ᐳ[45]"):::bucket
+    class Bucket4,PgClassExpression33,List34,Lambda35,PgClassExpression36,Access281,Object283,Lambda284 bucket4
+    Bucket5("Bucket 5 (listItem)<br />Deps: 47<br /><br />ROOT __Item{5}ᐸ284ᐳ[45]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item45,PgSelectSingle46 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 46, 47<br /><br />ROOT PgSelectSingle{5}ᐸbuildingsᐳ[46]"):::bucket
@@ -565,11 +567,11 @@ graph TD
     class Bucket6,PgClassExpression48,List49,Lambda50,PgClassExpression51 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 55, 47, 32, 263, 265, 266, 94, 80, 117<br /><br />ROOT PgSelectSingle{3}ᐸbuildingsᐳ[55]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression57,List58,Lambda59,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgSelectSingle68,PgSelectSingle93,RemapKeys486,RemapKeys537 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 68, 32, 486, 263, 265, 266, 47, 80<br /><br />ROOT PgSelectSingle{7}ᐸstreetsᐳ[68]"):::bucket
+    class Bucket7,PgClassExpression57,List58,Lambda59,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgSelectSingle68,PgSelectSingle93,RemapKeys499,RemapKeys553 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 68, 32, 499, 263, 265, 266, 47, 80<br /><br />ROOT PgSelectSingle{7}ᐸstreetsᐳ[68]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression70,List71,Lambda72,PgClassExpression73,Access468,Object470,Lambda471 bucket8
-    Bucket9("Bucket 9 (listItem)<br />Deps: 47<br /><br />ROOT __Item{9}ᐸ471ᐳ[82]"):::bucket
+    class Bucket8,PgClassExpression70,List71,Lambda72,PgClassExpression73,Access480,Object482,Lambda483 bucket8
+    Bucket9("Bucket 9 (listItem)<br />Deps: 47<br /><br />ROOT __Item{9}ᐸ483ᐳ[82]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,__Item82,PgSelectSingle83 bucket9
     Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 83, 47<br /><br />ROOT PgSelectSingle{9}ᐸbuildingsᐳ[83]"):::bucket
@@ -577,11 +579,11 @@ graph TD
     class Bucket10,PgClassExpression85,List86,Lambda87,PgClassExpression88 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 93, 94, 32, 263, 265, 266, 47, 117<br /><br />ROOT PgSelectSingle{7}ᐸpropertiesᐳ[93]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression95,List96,Lambda97,PgClassExpression98,PgClassExpression99,PgSelectSingle105,RemapKeys521 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 105, 32, 521, 263, 265, 266, 47, 117<br /><br />ROOT PgSelectSingle{11}ᐸstreetsᐳ[105]"):::bucket
+    class Bucket11,PgClassExpression95,List96,Lambda97,PgClassExpression98,PgClassExpression99,PgSelectSingle105,RemapKeys536 bucket11
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 105, 32, 536, 263, 265, 266, 47, 117<br /><br />ROOT PgSelectSingle{11}ᐸstreetsᐳ[105]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression107,List108,Lambda109,PgClassExpression110,Access503,Object505,Lambda506 bucket12
-    Bucket13("Bucket 13 (listItem)<br />Deps: 47<br /><br />ROOT __Item{13}ᐸ506ᐳ[119]"):::bucket
+    class Bucket12,PgClassExpression107,List108,Lambda109,PgClassExpression110,Access517,Object519,Lambda520 bucket12
+    Bucket13("Bucket 13 (listItem)<br />Deps: 47<br /><br />ROOT __Item{13}ᐸ520ᐳ[119]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item119,PgSelectSingle120 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 120, 47<br /><br />ROOT PgSelectSingle{13}ᐸbuildingsᐳ[120]"):::bucket
@@ -589,11 +591,11 @@ graph TD
     class Bucket14,PgClassExpression122,List123,Lambda124,PgClassExpression125 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 129, 94, 32, 263, 265, 266, 47, 153<br /><br />ROOT PgSelectSingle{3}ᐸpropertiesᐳ[129]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression131,List132,Lambda133,PgClassExpression134,PgClassExpression135,PgSelectSingle141,RemapKeys435 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 141, 32, 435, 263, 265, 266, 47, 153<br /><br />ROOT PgSelectSingle{15}ᐸstreetsᐳ[141]"):::bucket
+    class Bucket15,PgClassExpression131,List132,Lambda133,PgClassExpression134,PgClassExpression135,PgSelectSingle141,RemapKeys445 bucket15
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 141, 32, 445, 263, 265, 266, 47, 153<br /><br />ROOT PgSelectSingle{15}ᐸstreetsᐳ[141]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgClassExpression143,List144,Lambda145,PgClassExpression146,Access417,Object419,Lambda420 bucket16
-    Bucket17("Bucket 17 (listItem)<br />Deps: 47<br /><br />ROOT __Item{17}ᐸ420ᐳ[155]"):::bucket
+    class Bucket16,PgClassExpression143,List144,Lambda145,PgClassExpression146,Access426,Object428,Lambda429 bucket16
+    Bucket17("Bucket 17 (listItem)<br />Deps: 47<br /><br />ROOT __Item{17}ᐸ429ᐳ[155]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,__Item155,PgSelectSingle156 bucket17
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 156, 47<br /><br />ROOT PgSelectSingle{17}ᐸbuildingsᐳ[156]"):::bucket
@@ -601,11 +603,11 @@ graph TD
     class Bucket18,PgClassExpression158,List159,Lambda160,PgClassExpression161 bucket18
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 165, 32, 263, 265, 266, 47, 94, 186, 222<br /><br />ROOT PgSelectSingle{3}ᐸstreet_propertyᐳ[165]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgClassExpression166,PgClassExpression167,PgClassExpression168,PgSelectSingle174,PgSelectSingle198,RemapKeys384 bucket19
+    class Bucket19,PgClassExpression166,PgClassExpression167,PgClassExpression168,PgSelectSingle174,PgSelectSingle198,RemapKeys391 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 174, 32, 165, 263, 265, 266, 47, 186<br /><br />ROOT PgSelectSingle{19}ᐸstreetsᐳ[174]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression176,List177,Lambda178,PgClassExpression179,Access315,Object317,Lambda318 bucket20
-    Bucket21("Bucket 21 (listItem)<br />Deps: 47<br /><br />ROOT __Item{21}ᐸ318ᐳ[188]"):::bucket
+    class Bucket20,PgClassExpression176,List177,Lambda178,PgClassExpression179,Access318,Object320,Lambda321 bucket20
+    Bucket21("Bucket 21 (listItem)<br />Deps: 47<br /><br />ROOT __Item{21}ᐸ321ᐳ[188]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,__Item188,PgSelectSingle189 bucket21
     Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 189, 47<br /><br />ROOT PgSelectSingle{21}ᐸbuildingsᐳ[189]"):::bucket
@@ -613,11 +615,11 @@ graph TD
     class Bucket22,PgClassExpression191,List192,Lambda193,PgClassExpression194 bucket22
     Bucket23("Bucket 23 (nullableBoundary)<br />Deps: 198, 94, 32, 263, 265, 266, 47, 222<br /><br />ROOT PgSelectSingle{19}ᐸpropertiesᐳ[198]"):::bucket
     classDef bucket23 stroke:#ff1493
-    class Bucket23,PgClassExpression200,List201,Lambda202,PgClassExpression203,PgClassExpression204,PgSelectSingle210,RemapKeys368 bucket23
-    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 210, 32, 368, 263, 265, 266, 47, 222<br /><br />ROOT PgSelectSingle{23}ᐸstreetsᐳ[210]"):::bucket
+    class Bucket23,PgClassExpression200,List201,Lambda202,PgClassExpression203,PgClassExpression204,PgSelectSingle210,RemapKeys374 bucket23
+    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 210, 32, 374, 263, 265, 266, 47, 222<br /><br />ROOT PgSelectSingle{23}ᐸstreetsᐳ[210]"):::bucket
     classDef bucket24 stroke:#808000
-    class Bucket24,PgClassExpression212,List213,Lambda214,PgClassExpression215,Access350,Object352,Lambda353 bucket24
-    Bucket25("Bucket 25 (listItem)<br />Deps: 47<br /><br />ROOT __Item{25}ᐸ353ᐳ[224]"):::bucket
+    class Bucket24,PgClassExpression212,List213,Lambda214,PgClassExpression215,Access355,Object357,Lambda358 bucket24
+    Bucket25("Bucket 25 (listItem)<br />Deps: 47<br /><br />ROOT __Item{25}ᐸ358ᐳ[224]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,__Item224,PgSelectSingle225 bucket25
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 225, 47<br /><br />ROOT PgSelectSingle{25}ᐸbuildingsᐳ[225]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
@@ -9,43 +9,45 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”spacecraft”)ᐳ"}}:::plan
-    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(spacecraft)ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ[ { codec: Codec(int8), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸsql.identifier(”spacecraft”)ᐳ"}}:::plan
-    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”spacecᐳ"}}:::plan
-    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int8), fragment:ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ id: '1', type: 'MOBILE' }ᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸspacecraftᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda43{{"Lambda[43∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda40{{"Lambda[40∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda64{{"Lambda[64∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Constant76 & Lambda43 & Lambda48 & Lambda53 & Lambda40 & Lambda43 & Lambda64 & Lambda69 --> PgSelect14
-    Object47{{"Object[47∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda40 & Constant44 & Constant45 & Constant46 --> Object47
-    Object63{{"Object[63∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda40 & Constant60 & Constant61 & Constant46 --> Object63
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object48{{"Object[48∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda40{{"Lambda[40∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸsql.identifier(”spacecraft”)ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸRecordCodec(spacecraft)ᐳ"}}:::plan
+    Lambda40 & Constant45 & Constant46 & Constant47 --> Object48
+    Object65{{"Object[65∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ[ { codec: Codec(int8), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸsql.identifier(”spacecraft”)ᐳ"}}:::plan
+    Lambda40 & Constant62 & Constant63 & Constant47 --> Object65
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant72 --> Lambda40
-    Constant73 --> Lambda43
-    Object47 --> Lambda48
-    Constant74 --> Lambda53
-    Object63 --> Lambda64
-    Constant75 --> Lambda69
+    Constant74{{"Constant[74∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant74 --> Lambda40
+    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant75{{"Constant[75∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant75 --> Lambda43
+    Access44{{"Access[44∈0] ➊<br />ᐸ43.0ᐳ"}}:::plan
+    Lambda43 --> Access44
+    Lambda49{{"Lambda[49∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object48 --> Lambda49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant76{{"Constant[76∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”spacecᐳ"}}:::plan
+    Constant76 --> Lambda54
+    Lambda66{{"Lambda[66∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object65 --> Lambda66
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant77{{"Constant[77∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int8), fragment:ᐳ"}}:::plan
+    Constant77 --> Lambda71
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    Constant78{{"Constant[78∈0] ➊<br />ᐸ§{ id: '1', type: 'MOBILE' }ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸspacecraftᐳ"]]:::plan
+    Object12 & Connection13 & Constant78 & Access44 & Lambda49 & Lambda54 & Lambda40 & Access44 & Lambda66 & Lambda71 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸspacecraftᐳ"}}:::plan
@@ -55,11 +57,11 @@ graph TD
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__spacecraft__.”name”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression18
     PgSelectSingle29{{"PgSelectSingle[29∈3]<br />ᐸspacecraftᐳ"}}:::plan
-    RemapKeys54{{"RemapKeys[54∈3]<br />ᐸ16:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys54 --> PgSelectSingle29
+    RemapKeys55{{"RemapKeys[55∈3]<br />ᐸ16:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys55 --> PgSelectSingle29
     PgClassExpression31{{"PgClassExpression[31∈3]<br />ᐸ”space”.”s...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle29 --> PgClassExpression31
-    PgSelectSingle16 --> RemapKeys54
+    PgSelectSingle16 --> RemapKeys55
     Access32{{"Access[32∈4]<br />ᐸ31.startᐳ"}}:::plan
     PgClassExpression31 --> Access32
     Access35{{"Access[35∈4]<br />ᐸ31.endᐳ"}}:::plan
@@ -70,16 +72,16 @@ graph TD
     subgraph "Buckets for queries/v4/space"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant44,Constant45,Constant46,Constant60,Constant61,Constant72,Constant73,Constant74,Constant75,Constant76 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 76, 72, 73, 44, 45, 46, 74, 60, 61, 75<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 40, 43, 53, 69, 12, 47, 48, 63, 64<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda40,Lambda43,Access44,Constant45,Constant46,Constant47,Object48,Lambda49,Lambda54,Constant62,Constant63,Object65,Lambda66,Lambda71,Constant74,Constant75,Constant76,Constant77,Constant78 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 78, 44, 49, 54, 40, 66, 71<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda40,Lambda43,Object47,Lambda48,Lambda53,Object63,Lambda64,Lambda69 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸspacecraftᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression18,PgSelectSingle29,PgClassExpression31,RemapKeys54 bucket3
+    class Bucket3,PgClassExpression17,PgClassExpression18,PgSelectSingle29,PgClassExpression31,RemapKeys55 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31<br /><br />ROOT PgClassExpression{3}ᐸ”space”.”s...lder! */<br />)ᐳ[31]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,Access32,Access35 bucket4

--- a/postgraphile/postgraphile/__tests__/queries/v4/streamLoads.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/streamLoads.mermaid
@@ -9,6 +9,18 @@ graph TD
 
 
     %% plan dependencies
+    Object37{{"Object[37∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
+    Constant35{{"Constant[35∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda29 & Constant34 & Constant35 & Constant36 --> Object37
+    Object52{{"Object[52∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant49{{"Constant[49∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -17,50 +29,42 @@ graph TD
     __Value2 --> Access11
     __Value2 --> Access12
     Connection14{{"Connection[14∈0] ➊<br />ᐸ10ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant57 --> Connection14
-    Lambda29{{"Lambda[29∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant58 --> Lambda29
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant59 --> Connection14
+    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant60 --> Lambda29
+    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant61 --> Lambda32
+    Access33{{"Access[33∈0] ➊<br />ᐸ32.0ᐳ"}}:::plan
+    Lambda32 --> Access33
+    Lambda38{{"Lambda[38∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object37 --> Lambda38
+    Lambda43{{"Lambda[43∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
+    Constant62 --> Lambda43
+    Constant64{{"Constant[64∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant64 --> Lambda45
+    Lambda47{{"Lambda[47∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant65{{"Constant[65∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
+    Constant65 --> Lambda47
+    Access48{{"Access[48∈0] ➊<br />ᐸ47.0ᐳ"}}:::plan
+    Lambda47 --> Access48
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object52 --> Lambda53
+    Lambda58{{"Lambda[58∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant63 --> Lambda58
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ[ { fragment: { n: [Array], f: 0, c: 266, [Symbol(pg-sql2-tyᐳ"}}:::plan
-    Constant34{{"Constant[34∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant35{{"Constant[35∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant48{{"Constant[48∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Constant59{{"Constant[59∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant60{{"Constant[60∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { fragment: [Object], codec: Coᐳ"}}:::plan
-    Constant61{{"Constant[61∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant62{{"Constant[62∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
-    Constant63{{"Constant[63∈0] ➊<br />ᐸ§{ first: 1, last: null, cursorLower: null, cursorUpper: nulᐳ"}}:::plan
     PgSelect15[["PgSelect[15∈1] ➊<br />ᐸpersonᐳ"]]:::plan
-    Lambda44{{"Lambda[44∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda46{{"Lambda[46∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object13 & Connection14 & Constant57 & Lambda44 & Lambda46 & Lambda51 & Lambda56 --> PgSelect15
-    Object36{{"Object[36∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda29 & Constant33 & Constant34 & Constant35 --> Object36
-    Object50{{"Object[50∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda44 & Constant47 & Constant48 & Constant49 --> Object50
-    Lambda32{{"Lambda[32∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant59 --> Lambda32
-    Lambda37{{"Lambda[37∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object36 --> Lambda37
-    Lambda42{{"Lambda[42∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant60 --> Lambda42
-    Constant62 --> Lambda44
-    Constant63 --> Lambda46
-    Object50 --> Lambda51
-    Constant61 --> Lambda56
+    Object13 & Connection14 & Constant59 & Lambda45 & Access48 & Lambda53 & Lambda58 --> PgSelect15
     __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
     PgSelect15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpersonᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
     PgSelect19[["PgSelect[19∈3@s2]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Object13 & PgClassExpression18 & Lambda29 & Lambda32 & Lambda37 & Lambda42 --> PgSelect19
+    Object13 & PgClassExpression18 & Lambda29 & Access33 & Lambda38 & Lambda43 --> PgSelect19
     PgSelectSingle17 --> PgClassExpression18
     __Item23[/"__Item[23∈4]<br />ᐸ19ᐳ"\]:::itemplan
     PgSelect19 ==> __Item23
@@ -76,14 +80,14 @@ graph TD
     subgraph "Buckets for queries/v4/streamLoads"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda29,Constant33,Constant34,Constant35,Constant47,Constant48,Constant49,Constant57,Constant58,Constant59,Constant60,Constant61,Constant62,Constant63 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 57, 59, 29, 33, 34, 35, 60, 62, 63, 47, 48, 49, 61<br /><br />ROOT Connectionᐸ10ᐳ[14]<br />1: <br />ᐳ: 32, 36, 42, 44, 46, 56, 37, 50, 51<br />2: PgSelect[15]"):::bucket
+    class Bucket0,__Value2,__Value4,Access11,Access12,Object13,Connection14,Lambda29,Lambda32,Access33,Constant34,Constant35,Constant36,Object37,Lambda38,Lambda43,Lambda45,Lambda47,Access48,Constant49,Constant50,Constant51,Object52,Lambda53,Lambda58,Constant59,Constant60,Constant61,Constant62,Constant63,Constant64,Constant65 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14, 59, 45, 48, 53, 58, 29, 33, 38, 43<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect15,Lambda32,Object36,Lambda37,Lambda42,Lambda44,Lambda46,Object50,Lambda51,Lambda56 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 29, 32, 37, 42<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    class Bucket1,PgSelect15 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 13, 29, 33, 38, 43<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 29, 32, 37, 42<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[17]<br />1: <br />ᐳ: PgClassExpression[18]<br />2: PgSelect[19]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 13, 29, 33, 38, 43<br /><br />ROOT PgSelectSingle{2}ᐸpersonᐳ[17]<br />1: <br />ᐳ: PgClassExpression[18]<br />2: PgSelect[19]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression18,PgSelect19 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/v4/ts.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/ts.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrange_testᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ934ᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ934ᐳ"}}:::plan
     Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant33 & Lambda19 & Lambda22 & Lambda27 & Lambda32 --> PgSelect7
-    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
-    Lambda19 & Constant23 & Constant24 & Constant25 --> Object26
+    Access23{{"Access[23∈0] ➊<br />ᐸ22.0ᐳ"}}:::plan
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant34 & Lambda19 & Access23 & Lambda28 & Lambda33 --> PgSelect7
+    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
+    Lambda19 & Constant24 & Constant25 & Constant26 --> Object27
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrange_testᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda19
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda22
-    Object26 --> Lambda27
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
-    Constant36 --> Lambda32
+    Constant35 --> Lambda19
+    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda22
+    Lambda22 --> Access23
+    Object27 --> Lambda28
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
+    Constant37 --> Lambda33
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__range_test__.”ts”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -48,9 +50,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/ts"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 23, 24, 25, 33, 34, 35, 36, 10, 19, 22, 26, 27, 32<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 24, 25, 26, 34, 35, 36, 37, 10, 19, 22, 23, 27, 28, 33<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda19,Lambda22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35,Constant36 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda19,Lambda22,Access23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant34,Constant35,Constant36,Constant37 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/tstz.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/tstz.mermaid
@@ -11,17 +11,17 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrange_testᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ934ᐳ"}}:::plan
+    Constant34{{"Constant[34∈0] ➊<br />ᐸ934ᐳ"}}:::plan
     Lambda19{{"Lambda[19∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda27{{"Lambda[27∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda32{{"Lambda[32∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant33 & Lambda19 & Lambda22 & Lambda27 & Lambda32 --> PgSelect7
-    Object26{{"Object[26∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant23{{"Constant[23∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant24{{"Constant[24∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
-    Constant25{{"Constant[25∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
-    Lambda19 & Constant23 & Constant24 & Constant25 --> Object26
+    Access23{{"Access[23∈0] ➊<br />ᐸ22.0ᐳ"}}:::plan
+    Lambda28{{"Lambda[28∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda33{{"Lambda[33∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant34 & Lambda19 & Access23 & Lambda28 & Lambda33 --> PgSelect7
+    Object27{{"Object[27∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant24{{"Constant[24∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant25{{"Constant[25∈0] ➊<br />ᐸsql.identifier(”range_test”)ᐳ"}}:::plan
+    Constant26{{"Constant[26∈0] ➊<br />ᐸRecordCodec(rangeTest)ᐳ"}}:::plan
+    Lambda19 & Constant24 & Constant25 & Constant26 --> Object27
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -32,13 +32,15 @@ graph TD
     PgSelect7 --> First11
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸrange_testᐳ"}}:::plan
     First11 --> PgSelectSingle12
-    Constant34{{"Constant[34∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant34 --> Lambda19
     Constant35{{"Constant[35∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant35 --> Lambda22
-    Object26 --> Lambda27
-    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
-    Constant36 --> Lambda32
+    Constant35 --> Lambda19
+    Lambda22{{"Lambda[22∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant36{{"Constant[36∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant36 --> Lambda22
+    Lambda22 --> Access23
+    Object27 --> Lambda28
+    Constant37{{"Constant[37∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”range_ᐳ"}}:::plan
+    Constant37 --> Lambda33
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__range_test__.”tstz”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -48,9 +50,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/tstz"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 23, 24, 25, 33, 34, 35, 36, 10, 19, 22, 26, 27, 32<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 24, 25, 26, 34, 35, 36, 37, 10, 19, 22, 23, 27, 28, 33<br />2: PgSelect[7]<br />ᐳ: First[11], PgSelectSingle[12]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda19,Lambda22,Constant23,Constant24,Constant25,Object26,Lambda27,Lambda32,Constant33,Constant34,Constant35,Constant36 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,Lambda19,Lambda22,Access23,Constant24,Constant25,Constant26,Object27,Lambda28,Lambda33,Constant34,Constant35,Constant36,Constant37 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/types-single-node.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types-single-node.mermaid
@@ -9,270 +9,272 @@ graph TD
 
 
     %% plan dependencies
-    Object121{{"Object[121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Object122{{"Object[122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Lambda114{{"Lambda[114∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
-    Lambda114 & Constant118 & Constant119 & Constant120 --> Object121
-    Object135{{"Object[135∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant132{{"Constant[132∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant133{{"Constant[133∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Constant134{{"Constant[134∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
-    Lambda114 & Constant132 & Constant133 & Constant134 --> Object135
-    Object149{{"Object[149∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant146{{"Constant[146∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant147{{"Constant[147∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Constant148{{"Constant[148∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
-    Lambda114 & Constant146 & Constant147 & Constant148 --> Object149
-    Object163{{"Object[163∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant160{{"Constant[160∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant161{{"Constant[161∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
-    Lambda114 & Constant160 & Constant161 & Constant162 --> Object163
-    Object177{{"Object[177∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant174{{"Constant[174∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant175{{"Constant[175∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Constant176{{"Constant[176∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
-    Lambda114 & Constant174 & Constant175 & Constant176 --> Object177
-    Object191{{"Object[191∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant188{{"Constant[188∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant189{{"Constant[189∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Constant190{{"Constant[190∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
-    Lambda114 & Constant188 & Constant189 & Constant190 --> Object191
-    Object205{{"Object[205∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant202{{"Constant[202∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant203{{"Constant[203∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant204{{"Constant[204∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda114 & Constant202 & Constant203 & Constant204 --> Object205
-    Object219{{"Object[219∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant216{{"Constant[216∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant217{{"Constant[217∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant218{{"Constant[218∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda114 & Constant216 & Constant217 & Constant218 --> Object219
-    Object233{{"Object[233∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant230{{"Constant[230∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant231{{"Constant[231∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant232{{"Constant[232∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda114 & Constant230 & Constant231 & Constant232 --> Object233
-    Object247{{"Object[247∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant244{{"Constant[244∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant245{{"Constant[245∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant246{{"Constant[246∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Lambda114 & Constant244 & Constant245 & Constant246 --> Object247
-    Object261{{"Object[261∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant258{{"Constant[258∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant259{{"Constant[259∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant260{{"Constant[260∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Lambda114 & Constant258 & Constant259 & Constant260 --> Object261
-    Object275{{"Object[275∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant272{{"Constant[272∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant273{{"Constant[273∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant274{{"Constant[274∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda114 & Constant272 & Constant273 & Constant274 --> Object275
-    Object289{{"Object[289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant286{{"Constant[286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant287{{"Constant[287∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant288{{"Constant[288∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
-    Lambda114 & Constant286 & Constant287 & Constant288 --> Object289
-    Object303{{"Object[303∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant300{{"Constant[300∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant301{{"Constant[301∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Constant302{{"Constant[302∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
-    Lambda114 & Constant300 & Constant301 & Constant302 --> Object303
+    Constant119{{"Constant[119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant120{{"Constant[120∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Constant121{{"Constant[121∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
+    Lambda114 & Constant119 & Constant120 & Constant121 --> Object122
+    Object137{{"Object[137∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant135{{"Constant[135∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Constant136{{"Constant[136∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
+    Lambda114 & Constant134 & Constant135 & Constant136 --> Object137
+    Object152{{"Object[152∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant149{{"Constant[149∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant150{{"Constant[150∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Constant151{{"Constant[151∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
+    Lambda114 & Constant149 & Constant150 & Constant151 --> Object152
+    Object167{{"Object[167∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant164{{"Constant[164∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant165{{"Constant[165∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Constant166{{"Constant[166∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
+    Lambda114 & Constant164 & Constant165 & Constant166 --> Object167
+    Object182{{"Object[182∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant179{{"Constant[179∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant180{{"Constant[180∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Constant181{{"Constant[181∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
+    Lambda114 & Constant179 & Constant180 & Constant181 --> Object182
+    Object197{{"Object[197∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant194{{"Constant[194∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant195{{"Constant[195∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Constant196{{"Constant[196∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
+    Lambda114 & Constant194 & Constant195 & Constant196 --> Object197
+    Object212{{"Object[212∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant209{{"Constant[209∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant210{{"Constant[210∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant211{{"Constant[211∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda114 & Constant209 & Constant210 & Constant211 --> Object212
+    Object227{{"Object[227∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant224{{"Constant[224∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant226{{"Constant[226∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda114 & Constant224 & Constant225 & Constant226 --> Object227
+    Object242{{"Object[242∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant239{{"Constant[239∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant240{{"Constant[240∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant241{{"Constant[241∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda114 & Constant239 & Constant240 & Constant241 --> Object242
+    Object257{{"Object[257∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant254{{"Constant[254∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant255{{"Constant[255∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant256{{"Constant[256∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda114 & Constant254 & Constant255 & Constant256 --> Object257
+    Object272{{"Object[272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant269{{"Constant[269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant270{{"Constant[270∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant271{{"Constant[271∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda114 & Constant269 & Constant270 & Constant271 --> Object272
+    Object287{{"Object[287∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant284{{"Constant[284∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant285{{"Constant[285∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant286{{"Constant[286∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda114 & Constant284 & Constant285 & Constant286 --> Object287
+    Object302{{"Object[302∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant299{{"Constant[299∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant300{{"Constant[300∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Constant301{{"Constant[301∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
+    Lambda114 & Constant299 & Constant300 & Constant301 --> Object302
     Object317{{"Object[317∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant314{{"Constant[314∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant315{{"Constant[315∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Constant316{{"Constant[316∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Constant315{{"Constant[315∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Constant316{{"Constant[316∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
     Lambda114 & Constant314 & Constant315 & Constant316 --> Object317
-    Object331{{"Object[331∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant328{{"Constant[328∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant329{{"Constant[329∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Constant330{{"Constant[330∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
-    Lambda114 & Constant328 & Constant329 & Constant330 --> Object331
-    Object345{{"Object[345∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant342{{"Constant[342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant343{{"Constant[343∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Constant344{{"Constant[344∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
-    Lambda114 & Constant342 & Constant343 & Constant344 --> Object345
-    Object359{{"Object[359∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant356{{"Constant[356∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant357{{"Constant[357∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Constant358{{"Constant[358∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
-    Lambda114 & Constant356 & Constant357 & Constant358 --> Object359
-    Object373{{"Object[373∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant370{{"Constant[370∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant371{{"Constant[371∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Constant372{{"Constant[372∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
-    Lambda114 & Constant370 & Constant371 & Constant372 --> Object373
+    Object332{{"Object[332∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant329{{"Constant[329∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant330{{"Constant[330∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Constant331{{"Constant[331∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Lambda114 & Constant329 & Constant330 & Constant331 --> Object332
+    Object347{{"Object[347∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant344{{"Constant[344∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant345{{"Constant[345∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Constant346{{"Constant[346∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
+    Lambda114 & Constant344 & Constant345 & Constant346 --> Object347
+    Object362{{"Object[362∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant359{{"Constant[359∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant360{{"Constant[360∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Constant361{{"Constant[361∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
+    Lambda114 & Constant359 & Constant360 & Constant361 --> Object362
+    Object377{{"Object[377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant374{{"Constant[374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant375{{"Constant[375∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Constant376{{"Constant[376∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
+    Lambda114 & Constant374 & Constant375 & Constant376 --> Object377
+    Object392{{"Object[392∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant389{{"Constant[389∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant390{{"Constant[390∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Constant391{{"Constant[391∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
+    Lambda114 & Constant389 & Constant390 & Constant391 --> Object392
     Node7{{"Node[7∈0] ➊"}}:::plan
     Lambda8{{"Lambda[8∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda8 --> Node7
-    Constant382{{"Constant[382∈0] ➊<br />ᐸ'WyJ0eXBlcyIsMTFd'ᐳ"}}:::plan
-    Constant382 --> Lambda8
-    Constant383{{"Constant[383∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant383 --> Lambda114
+    Constant401{{"Constant[401∈0] ➊<br />ᐸ'WyJ0eXBlcyIsMTFd'ᐳ"}}:::plan
+    Constant401 --> Lambda8
+    Constant402{{"Constant[402∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant402 --> Lambda114
     Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant384{{"Constant[384∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant384 --> Lambda117
-    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object121 --> Lambda122
-    Lambda127{{"Lambda[127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant385{{"Constant[385∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant385 --> Lambda127
-    Lambda136{{"Lambda[136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object135 --> Lambda136
-    Lambda141{{"Lambda[141∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant386{{"Constant[386∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant386 --> Lambda141
-    Lambda150{{"Lambda[150∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object149 --> Lambda150
-    Lambda155{{"Lambda[155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant387{{"Constant[387∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant387 --> Lambda155
-    Lambda164{{"Lambda[164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object163 --> Lambda164
-    Lambda169{{"Lambda[169∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant388{{"Constant[388∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant388 --> Lambda169
-    Lambda178{{"Lambda[178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object177 --> Lambda178
+    Constant403{{"Constant[403∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant403 --> Lambda117
+    Access118{{"Access[118∈0] ➊<br />ᐸ117.0ᐳ"}}:::plan
+    Lambda117 --> Access118
+    Lambda123{{"Lambda[123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object122 --> Lambda123
+    Lambda128{{"Lambda[128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant404{{"Constant[404∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant404 --> Lambda128
+    Lambda138{{"Lambda[138∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object137 --> Lambda138
+    Lambda143{{"Lambda[143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant405{{"Constant[405∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant405 --> Lambda143
+    Lambda153{{"Lambda[153∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object152 --> Lambda153
+    Lambda158{{"Lambda[158∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant406{{"Constant[406∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant406 --> Lambda158
+    Lambda168{{"Lambda[168∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object167 --> Lambda168
+    Lambda173{{"Lambda[173∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant407{{"Constant[407∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant407 --> Lambda173
     Lambda183{{"Lambda[183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant389{{"Constant[389∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant389 --> Lambda183
-    Lambda192{{"Lambda[192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object191 --> Lambda192
-    Lambda197{{"Lambda[197∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant390{{"Constant[390∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant390 --> Lambda197
-    Lambda206{{"Lambda[206∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object205 --> Lambda206
-    Lambda211{{"Lambda[211∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant391{{"Constant[391∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant391 --> Lambda211
-    Lambda220{{"Lambda[220∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object219 --> Lambda220
-    Lambda225{{"Lambda[225∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant392{{"Constant[392∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant392 --> Lambda225
-    Lambda234{{"Lambda[234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object233 --> Lambda234
-    Lambda239{{"Lambda[239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant393{{"Constant[393∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant393 --> Lambda239
+    Object182 --> Lambda183
+    Lambda188{{"Lambda[188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant408{{"Constant[408∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant408 --> Lambda188
+    Lambda198{{"Lambda[198∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object197 --> Lambda198
+    Lambda203{{"Lambda[203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant409{{"Constant[409∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant409 --> Lambda203
+    Lambda213{{"Lambda[213∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object212 --> Lambda213
+    Lambda218{{"Lambda[218∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant410{{"Constant[410∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant410 --> Lambda218
+    Lambda228{{"Lambda[228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object227 --> Lambda228
+    Lambda233{{"Lambda[233∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant411{{"Constant[411∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant411 --> Lambda233
+    Lambda243{{"Lambda[243∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object242 --> Lambda243
     Lambda248{{"Lambda[248∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object247 --> Lambda248
-    Lambda253{{"Lambda[253∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant394{{"Constant[394∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant394 --> Lambda253
-    Lambda262{{"Lambda[262∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object261 --> Lambda262
-    Lambda267{{"Lambda[267∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant395{{"Constant[395∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant395 --> Lambda267
-    Lambda276{{"Lambda[276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object275 --> Lambda276
-    Lambda281{{"Lambda[281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant396{{"Constant[396∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant396 --> Lambda281
-    Lambda290{{"Lambda[290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object289 --> Lambda290
-    Lambda295{{"Lambda[295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant397{{"Constant[397∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant397 --> Lambda295
-    Lambda304{{"Lambda[304∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object303 --> Lambda304
-    Lambda309{{"Lambda[309∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant398{{"Constant[398∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant398 --> Lambda309
+    Constant412{{"Constant[412∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant412 --> Lambda248
+    Lambda258{{"Lambda[258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object257 --> Lambda258
+    Lambda263{{"Lambda[263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant413{{"Constant[413∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant413 --> Lambda263
+    Lambda273{{"Lambda[273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object272 --> Lambda273
+    Lambda278{{"Lambda[278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant414{{"Constant[414∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant414 --> Lambda278
+    Lambda288{{"Lambda[288∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object287 --> Lambda288
+    Lambda293{{"Lambda[293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant415{{"Constant[415∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant415 --> Lambda293
+    Lambda303{{"Lambda[303∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object302 --> Lambda303
+    Lambda308{{"Lambda[308∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant416{{"Constant[416∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant416 --> Lambda308
     Lambda318{{"Lambda[318∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object317 --> Lambda318
     Lambda323{{"Lambda[323∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant399{{"Constant[399∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant399 --> Lambda323
-    Lambda332{{"Lambda[332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object331 --> Lambda332
-    Lambda337{{"Lambda[337∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant400{{"Constant[400∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant400 --> Lambda337
-    Lambda346{{"Lambda[346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object345 --> Lambda346
-    Lambda351{{"Lambda[351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant401{{"Constant[401∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant401 --> Lambda351
-    Lambda360{{"Lambda[360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object359 --> Lambda360
-    Lambda365{{"Lambda[365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant402{{"Constant[402∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant402 --> Lambda365
-    Lambda374{{"Lambda[374∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object373 --> Lambda374
-    Lambda379{{"Lambda[379∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant403{{"Constant[403∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant403 --> Lambda379
+    Constant417{{"Constant[417∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant417 --> Lambda323
+    Lambda333{{"Lambda[333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object332 --> Lambda333
+    Lambda338{{"Lambda[338∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant418{{"Constant[418∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant418 --> Lambda338
+    Lambda348{{"Lambda[348∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object347 --> Lambda348
+    Lambda353{{"Lambda[353∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant419{{"Constant[419∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant419 --> Lambda353
+    Lambda363{{"Lambda[363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object362 --> Lambda363
+    Lambda368{{"Lambda[368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant420{{"Constant[420∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant420 --> Lambda368
+    Lambda378{{"Lambda[378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object377 --> Lambda378
+    Lambda383{{"Lambda[383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant421{{"Constant[421∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant421 --> Lambda383
+    Lambda393{{"Lambda[393∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object392 --> Lambda393
+    Lambda398{{"Lambda[398∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant422{{"Constant[422∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant422 --> Lambda398
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect47[["PgSelect[47∈1] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object16{{"Object[16∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access380{{"Access[380∈1] ➊<br />ᐸ8.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
-    Access381{{"Access[381∈1] ➊<br />ᐸ8.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access399{{"Access[399∈1] ➊<br />ᐸ8.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access400{{"Access[400∈1] ➊<br />ᐸ8.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object16 -->|rejectNull| PgSelect47
-    Access380 -->|rejectNull| PgSelect47
-    Access381 & Lambda114 & Lambda117 & Lambda206 & Lambda211 --> PgSelect47
+    Access399 -->|rejectNull| PgSelect47
+    Access400 & Lambda114 & Access118 & Lambda213 & Lambda218 --> PgSelect47
     PgSelect13[["PgSelect[13∈1] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object16 -->|rejectNull| PgSelect13
-    Access380 & Lambda114 & Lambda117 & Lambda122 & Lambda127 --> PgSelect13
+    Access399 & Lambda114 & Access118 & Lambda123 & Lambda128 --> PgSelect13
     PgSelect20[["PgSelect[20∈1] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object16 -->|rejectNull| PgSelect20
-    Access380 & Lambda114 & Lambda117 & Lambda136 & Lambda141 --> PgSelect20
+    Access399 & Lambda114 & Access118 & Lambda138 & Lambda143 --> PgSelect20
     PgSelect25[["PgSelect[25∈1] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object16 -->|rejectNull| PgSelect25
-    Access380 & Lambda114 & Lambda117 & Lambda150 & Lambda155 --> PgSelect25
+    Access399 & Lambda114 & Access118 & Lambda153 & Lambda158 --> PgSelect25
     PgSelect30[["PgSelect[30∈1] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object16 -->|rejectNull| PgSelect30
-    Access380 & Lambda114 & Lambda117 & Lambda164 & Lambda169 --> PgSelect30
+    Access399 & Lambda114 & Access118 & Lambda168 & Lambda173 --> PgSelect30
     PgSelect35[["PgSelect[35∈1] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object16 -->|rejectNull| PgSelect35
-    Access380 & Lambda114 & Lambda117 & Lambda178 & Lambda183 --> PgSelect35
+    Access399 & Lambda114 & Access118 & Lambda183 & Lambda188 --> PgSelect35
     PgSelect40[["PgSelect[40∈1] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object16 -->|rejectNull| PgSelect40
-    Access380 & Lambda114 & Lambda117 & Lambda192 & Lambda197 --> PgSelect40
+    Access399 & Lambda114 & Access118 & Lambda198 & Lambda203 --> PgSelect40
     PgSelect52[["PgSelect[52∈1] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object16 -->|rejectNull| PgSelect52
-    Access380 & Lambda114 & Lambda117 & Lambda220 & Lambda225 --> PgSelect52
+    Access399 & Lambda114 & Access118 & Lambda228 & Lambda233 --> PgSelect52
     PgSelect57[["PgSelect[57∈1] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object16 -->|rejectNull| PgSelect57
-    Access380 & Lambda114 & Lambda117 & Lambda234 & Lambda239 --> PgSelect57
+    Access399 & Lambda114 & Access118 & Lambda243 & Lambda248 --> PgSelect57
     PgSelect62[["PgSelect[62∈1] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
     Object16 -->|rejectNull| PgSelect62
-    Access380 & Lambda114 & Lambda117 & Lambda248 & Lambda253 --> PgSelect62
+    Access399 & Lambda114 & Access118 & Lambda258 & Lambda263 --> PgSelect62
     PgSelect68[["PgSelect[68∈1] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object16 -->|rejectNull| PgSelect68
-    Access380 & Lambda114 & Lambda117 & Lambda262 & Lambda267 --> PgSelect68
+    Access399 & Lambda114 & Access118 & Lambda273 & Lambda278 --> PgSelect68
     PgSelect73[["PgSelect[73∈1] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object16 -->|rejectNull| PgSelect73
-    Access380 & Lambda114 & Lambda117 & Lambda276 & Lambda281 --> PgSelect73
+    Access399 & Lambda114 & Access118 & Lambda288 & Lambda293 --> PgSelect73
     PgSelect78[["PgSelect[78∈1] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object16 -->|rejectNull| PgSelect78
-    Access380 & Lambda114 & Lambda117 & Lambda290 & Lambda295 --> PgSelect78
+    Access399 & Lambda114 & Access118 & Lambda303 & Lambda308 --> PgSelect78
     PgSelect83[["PgSelect[83∈1] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object16 -->|rejectNull| PgSelect83
-    Access380 & Lambda114 & Lambda117 & Lambda304 & Lambda309 --> PgSelect83
+    Access399 & Lambda114 & Access118 & Lambda318 & Lambda323 --> PgSelect83
     PgSelect88[["PgSelect[88∈1] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object16 -->|rejectNull| PgSelect88
-    Access380 & Lambda114 & Lambda117 & Lambda318 & Lambda323 --> PgSelect88
+    Access399 & Lambda114 & Access118 & Lambda333 & Lambda338 --> PgSelect88
     PgSelect93[["PgSelect[93∈1] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object16 -->|rejectNull| PgSelect93
-    Access380 & Lambda114 & Lambda117 & Lambda332 & Lambda337 --> PgSelect93
+    Access399 & Lambda114 & Access118 & Lambda348 & Lambda353 --> PgSelect93
     PgSelect98[["PgSelect[98∈1] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object16 -->|rejectNull| PgSelect98
-    Access380 & Lambda114 & Lambda117 & Lambda346 & Lambda351 --> PgSelect98
+    Access399 & Lambda114 & Access118 & Lambda363 & Lambda368 --> PgSelect98
     PgSelect103[["PgSelect[103∈1] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object16 -->|rejectNull| PgSelect103
-    Access380 & Lambda114 & Lambda117 & Lambda360 & Lambda365 --> PgSelect103
+    Access399 & Lambda114 & Access118 & Lambda378 & Lambda383 --> PgSelect103
     PgSelect108[["PgSelect[108∈1] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object16 -->|rejectNull| PgSelect108
-    Access380 & Lambda114 & Lambda117 & Lambda374 & Lambda379 --> PgSelect108
+    Access399 & Lambda114 & Access118 & Lambda393 & Lambda398 --> PgSelect108
     Access14{{"Access[14∈1] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
     Access15{{"Access[15∈1] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
     Access14 & Access15 --> Object16
@@ -356,17 +358,17 @@ graph TD
     PgSelect108 --> First110
     PgSelectSingle111{{"PgSelectSingle[111∈1] ➊<br />ᐸlistsᐳ"}}:::plan
     First110 --> PgSelectSingle111
-    Lambda8 --> Access380
-    Lambda8 --> Access381
+    Lambda8 --> Access399
+    Lambda8 --> Access400
 
     %% define steps
 
     subgraph "Buckets for queries/v4/types-single-node"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Node7,Lambda8,Lambda114,Lambda117,Constant118,Constant119,Constant120,Object121,Lambda122,Lambda127,Constant132,Constant133,Constant134,Object135,Lambda136,Lambda141,Constant146,Constant147,Constant148,Object149,Lambda150,Lambda155,Constant160,Constant161,Constant162,Object163,Lambda164,Lambda169,Constant174,Constant175,Constant176,Object177,Lambda178,Lambda183,Constant188,Constant189,Constant190,Object191,Lambda192,Lambda197,Constant202,Constant203,Constant204,Object205,Lambda206,Lambda211,Constant216,Constant217,Constant218,Object219,Lambda220,Lambda225,Constant230,Constant231,Constant232,Object233,Lambda234,Lambda239,Constant244,Constant245,Constant246,Object247,Lambda248,Lambda253,Constant258,Constant259,Constant260,Object261,Lambda262,Lambda267,Constant272,Constant273,Constant274,Object275,Lambda276,Lambda281,Constant286,Constant287,Constant288,Object289,Lambda290,Lambda295,Constant300,Constant301,Constant302,Object303,Lambda304,Lambda309,Constant314,Constant315,Constant316,Object317,Lambda318,Lambda323,Constant328,Constant329,Constant330,Object331,Lambda332,Lambda337,Constant342,Constant343,Constant344,Object345,Lambda346,Lambda351,Constant356,Constant357,Constant358,Object359,Lambda360,Lambda365,Constant370,Constant371,Constant372,Object373,Lambda374,Lambda379,Constant382,Constant383,Constant384,Constant385,Constant386,Constant387,Constant388,Constant389,Constant390,Constant391,Constant392,Constant393,Constant394,Constant395,Constant396,Constant397,Constant398,Constant399,Constant400,Constant401,Constant402,Constant403 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 114, 117, 122, 127, 2, 136, 141, 150, 155, 164, 169, 178, 183, 192, 197, 206, 211, 220, 225, 234, 239, 248, 253, 262, 267, 276, 281, 290, 295, 304, 309, 318, 323, 332, 337, 346, 351, 360, 365, 374, 379, 8, 7, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 14, 15, 380, 381, 16<br />2: 13, 20, 25, 30, 35, 40, 47, 52, 57, 62, 68, 73, 78, 83, 88, 93, 98, 103, 108<br />ᐳ: 17, 18, 22, 23, 27, 28, 32, 33, 37, 38, 42, 43, 49, 50, 54, 55, 59, 60, 64, 65, 66, 70, 71, 75, 76, 80, 81, 85, 86, 90, 91, 95, 96, 100, 101, 105, 106, 110, 111"):::bucket
+    class Bucket0,__Value2,__Value4,Node7,Lambda8,Lambda114,Lambda117,Access118,Constant119,Constant120,Constant121,Object122,Lambda123,Lambda128,Constant134,Constant135,Constant136,Object137,Lambda138,Lambda143,Constant149,Constant150,Constant151,Object152,Lambda153,Lambda158,Constant164,Constant165,Constant166,Object167,Lambda168,Lambda173,Constant179,Constant180,Constant181,Object182,Lambda183,Lambda188,Constant194,Constant195,Constant196,Object197,Lambda198,Lambda203,Constant209,Constant210,Constant211,Object212,Lambda213,Lambda218,Constant224,Constant225,Constant226,Object227,Lambda228,Lambda233,Constant239,Constant240,Constant241,Object242,Lambda243,Lambda248,Constant254,Constant255,Constant256,Object257,Lambda258,Lambda263,Constant269,Constant270,Constant271,Object272,Lambda273,Lambda278,Constant284,Constant285,Constant286,Object287,Lambda288,Lambda293,Constant299,Constant300,Constant301,Object302,Lambda303,Lambda308,Constant314,Constant315,Constant316,Object317,Lambda318,Lambda323,Constant329,Constant330,Constant331,Object332,Lambda333,Lambda338,Constant344,Constant345,Constant346,Object347,Lambda348,Lambda353,Constant359,Constant360,Constant361,Object362,Lambda363,Lambda368,Constant374,Constant375,Constant376,Object377,Lambda378,Lambda383,Constant389,Constant390,Constant391,Object392,Lambda393,Lambda398,Constant401,Constant402,Constant403,Constant404,Constant405,Constant406,Constant407,Constant408,Constant409,Constant410,Constant411,Constant412,Constant413,Constant414,Constant415,Constant416,Constant417,Constant418,Constant419,Constant420,Constant421,Constant422 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 114, 118, 123, 128, 2, 138, 143, 153, 158, 168, 173, 183, 188, 198, 203, 213, 218, 228, 233, 243, 248, 258, 263, 273, 278, 288, 293, 303, 308, 318, 323, 333, 338, 348, 353, 363, 368, 378, 383, 393, 398, 8, 7, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: 14, 15, 399, 400, 16<br />2: 13, 20, 25, 30, 35, 40, 47, 52, 57, 62, 68, 73, 78, 83, 88, 93, 98, 103, 108<br />ᐳ: 17, 18, 22, 23, 27, 28, 32, 33, 37, 38, 42, 43, 49, 50, 54, 55, 59, 60, 64, 65, 66, 70, 71, 75, 76, 80, 81, 85, 86, 90, 91, 95, 96, 100, 101, 105, 106, 110, 111"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect13,Access14,Access15,Object16,First17,PgSelectSingle18,PgSelect20,First22,PgSelectSingle23,PgSelect25,First27,PgSelectSingle28,PgSelect30,First32,PgSelectSingle33,PgSelect35,First37,PgSelectSingle38,PgSelect40,First42,PgSelectSingle43,PgSelect47,First49,PgSelectSingle50,PgSelect52,First54,PgSelectSingle55,PgSelect57,First59,PgSelectSingle60,PgSelect62,First64,PgSelectSingle65,PgClassExpression66,PgSelect68,First70,PgSelectSingle71,PgSelect73,First75,PgSelectSingle76,PgSelect78,First80,PgSelectSingle81,PgSelect83,First85,PgSelectSingle86,PgSelect88,First90,PgSelectSingle91,PgSelect93,First95,PgSelectSingle96,PgSelect98,First100,PgSelectSingle101,PgSelect103,First105,PgSelectSingle106,PgSelect108,First110,PgSelectSingle111,Access380,Access381 bucket1
+    class Bucket1,PgSelect13,Access14,Access15,Object16,First17,PgSelectSingle18,PgSelect20,First22,PgSelectSingle23,PgSelect25,First27,PgSelectSingle28,PgSelect30,First32,PgSelectSingle33,PgSelect35,First37,PgSelectSingle38,PgSelect40,First42,PgSelectSingle43,PgSelect47,First49,PgSelectSingle50,PgSelect52,First54,PgSelectSingle55,PgSelect57,First59,PgSelectSingle60,PgSelect62,First64,PgSelectSingle65,PgClassExpression66,PgSelect68,First70,PgSelectSingle71,PgSelect73,First75,PgSelectSingle76,PgSelect78,First80,PgSelectSingle81,PgSelect83,First85,PgSelectSingle86,PgSelect88,First90,PgSelectSingle91,PgSelect93,First95,PgSelectSingle96,PgSelect98,First100,PgSelectSingle101,PgSelect103,First105,PgSelectSingle106,PgSelect108,First110,PgSelectSingle111,Access399,Access400 bucket1
     Bucket0 --> Bucket1
     end

--- a/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
@@ -11,941 +11,1130 @@ graph TD
     %% plan dependencies
     PgSelect2139[["PgSelect[2139∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant6850{{"Constant[6850∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant6846{{"Constant[6846∈0] ➊<br />ᐸ11ᐳ"}}:::plan
-    Lambda3599{{"Lambda[3599∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda5590{{"Lambda[5590∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5595{{"Lambda[5595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5606{{"Lambda[5606∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5611{{"Lambda[5611∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5622{{"Lambda[5622∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5627{{"Lambda[5627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5638{{"Lambda[5638∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5643{{"Lambda[5643∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5654{{"Lambda[5654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5659{{"Lambda[5659∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5670{{"Lambda[5670∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5675{{"Lambda[5675∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5686{{"Lambda[5686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5691{{"Lambda[5691∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5702{{"Lambda[5702∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5707{{"Lambda[5707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5718{{"Lambda[5718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5723{{"Lambda[5723∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5734{{"Lambda[5734∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5739{{"Lambda[5739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5750{{"Lambda[5750∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5755{{"Lambda[5755∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5766{{"Lambda[5766∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5771{{"Lambda[5771∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5782{{"Lambda[5782∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7057{{"Constant[7057∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant7053{{"Constant[7053∈0] ➊<br />ᐸ11ᐳ"}}:::plan
+    Access3600{{"Access[3600∈0] ➊<br />ᐸ3599.0ᐳ"}}:::plan
+    Lambda5719{{"Lambda[5719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5724{{"Lambda[5724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5736{{"Lambda[5736∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5741{{"Lambda[5741∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5753{{"Lambda[5753∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5758{{"Lambda[5758∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5770{{"Lambda[5770∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5775{{"Lambda[5775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda5787{{"Lambda[5787∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5798{{"Lambda[5798∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5803{{"Lambda[5803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5814{{"Lambda[5814∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5819{{"Lambda[5819∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5830{{"Lambda[5830∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5835{{"Lambda[5835∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5846{{"Lambda[5846∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5851{{"Lambda[5851∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5862{{"Lambda[5862∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5867{{"Lambda[5867∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5878{{"Lambda[5878∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5883{{"Lambda[5883∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5792{{"Lambda[5792∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5804{{"Lambda[5804∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5809{{"Lambda[5809∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5821{{"Lambda[5821∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5826{{"Lambda[5826∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5838{{"Lambda[5838∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5843{{"Lambda[5843∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5855{{"Lambda[5855∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5860{{"Lambda[5860∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5872{{"Lambda[5872∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5877{{"Lambda[5877∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5889{{"Lambda[5889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda5894{{"Lambda[5894∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5899{{"Lambda[5899∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5910{{"Lambda[5910∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5915{{"Lambda[5915∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5926{{"Lambda[5926∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5931{{"Lambda[5931∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5973{{"Lambda[5973∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5978{{"Lambda[5978∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5989{{"Lambda[5989∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5994{{"Lambda[5994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6005{{"Lambda[6005∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6010{{"Lambda[6010∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6021{{"Lambda[6021∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6026{{"Lambda[6026∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6037{{"Lambda[6037∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5906{{"Lambda[5906∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5911{{"Lambda[5911∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5923{{"Lambda[5923∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5928{{"Lambda[5928∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5940{{"Lambda[5940∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5945{{"Lambda[5945∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5957{{"Lambda[5957∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5962{{"Lambda[5962∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5974{{"Lambda[5974∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5979{{"Lambda[5979∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5991{{"Lambda[5991∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5996{{"Lambda[5996∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6008{{"Lambda[6008∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6013{{"Lambda[6013∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6025{{"Lambda[6025∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6030{{"Lambda[6030∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6042{{"Lambda[6042∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6053{{"Lambda[6053∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6058{{"Lambda[6058∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6069{{"Lambda[6069∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6074{{"Lambda[6074∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6085{{"Lambda[6085∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6090{{"Lambda[6090∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6130{{"Lambda[6130∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6135{{"Lambda[6135∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6146{{"Lambda[6146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6151{{"Lambda[6151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6162{{"Lambda[6162∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6167{{"Lambda[6167∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6178{{"Lambda[6178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6183{{"Lambda[6183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6047{{"Lambda[6047∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6059{{"Lambda[6059∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6064{{"Lambda[6064∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6076{{"Lambda[6076∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6081{{"Lambda[6081∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6126{{"Lambda[6126∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6131{{"Lambda[6131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6143{{"Lambda[6143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6148{{"Lambda[6148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6160{{"Lambda[6160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6165{{"Lambda[6165∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6177{{"Lambda[6177∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6182{{"Lambda[6182∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6194{{"Lambda[6194∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6199{{"Lambda[6199∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6210{{"Lambda[6210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6215{{"Lambda[6215∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6226{{"Lambda[6226∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6231{{"Lambda[6231∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6242{{"Lambda[6242∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6247{{"Lambda[6247∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4094{{"Lambda[4094∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda6258{{"Lambda[6258∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6263{{"Lambda[6263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6276{{"Lambda[6276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6281{{"Lambda[6281∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3596{{"Lambda[3596∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda6211{{"Lambda[6211∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6216{{"Lambda[6216∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6228{{"Lambda[6228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6233{{"Lambda[6233∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6245{{"Lambda[6245∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6250{{"Lambda[6250∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6293{{"Lambda[6293∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6298{{"Lambda[6298∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant6850 & Constant6846 & Lambda3599 & Lambda5590 & Lambda5595 & Lambda5606 & Lambda5611 & Lambda5622 & Lambda5627 & Lambda5638 & Lambda5643 & Lambda5654 & Lambda5659 & Lambda5670 & Lambda5675 & Lambda5686 & Lambda5691 & Lambda5702 & Lambda5707 & Lambda5718 & Lambda5723 & Lambda5734 & Lambda5739 & Lambda3599 & Lambda5750 & Lambda5755 & Lambda5766 & Lambda5771 & Lambda5782 & Lambda5787 & Lambda5798 & Lambda5803 & Lambda5814 & Lambda5819 & Lambda5830 & Lambda5835 & Lambda5846 & Lambda5851 & Lambda5862 & Lambda5867 & Lambda5878 & Lambda5883 & Lambda5894 & Lambda5899 & Lambda5910 & Lambda5915 & Lambda3599 & Lambda5926 & Lambda5931 & Lambda5973 & Lambda5978 & Lambda5989 & Lambda5994 & Lambda6005 & Lambda6010 & Lambda6021 & Lambda6026 & Lambda6037 & Lambda6042 & Lambda6053 & Lambda6058 & Lambda6069 & Lambda6074 & Lambda6085 & Lambda6090 & Lambda6130 & Lambda6135 & Lambda6146 & Lambda6151 & Lambda6162 & Lambda6167 & Lambda6178 & Lambda6183 & Lambda6194 & Lambda6199 & Lambda6210 & Lambda6215 & Lambda6226 & Lambda6231 & Lambda6242 & Lambda6247 & Lambda4094 & Lambda6258 & Lambda6263 & Lambda3599 & Lambda6276 & Lambda6281 & Lambda3596 & Lambda3599 & Lambda6293 & Lambda6298 --> PgSelect2139
-    PgSelect2969[["PgSelect[2969∈0] ➊<br />ᐸpostᐳ"]]:::plan
-    Lambda6307{{"Lambda[6307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6312{{"Lambda[6312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6323{{"Lambda[6323∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6328{{"Lambda[6328∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6339{{"Lambda[6339∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6310{{"Lambda[6310∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6315{{"Lambda[6315∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6327{{"Lambda[6327∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6332{{"Lambda[6332∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6344{{"Lambda[6344∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6355{{"Lambda[6355∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6360{{"Lambda[6360∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6371{{"Lambda[6371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6376{{"Lambda[6376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6387{{"Lambda[6387∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6392{{"Lambda[6392∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6403{{"Lambda[6403∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6408{{"Lambda[6408∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6419{{"Lambda[6419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6424{{"Lambda[6424∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6435{{"Lambda[6435∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6440{{"Lambda[6440∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6451{{"Lambda[6451∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6456{{"Lambda[6456∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6467{{"Lambda[6467∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6472{{"Lambda[6472∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6483{{"Lambda[6483∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6488{{"Lambda[6488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6499{{"Lambda[6499∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6504{{"Lambda[6504∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6349{{"Lambda[6349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6361{{"Lambda[6361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6366{{"Lambda[6366∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6378{{"Lambda[6378∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6383{{"Lambda[6383∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6395{{"Lambda[6395∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6400{{"Lambda[6400∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6412{{"Lambda[6412∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6417{{"Lambda[6417∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Access4126{{"Access[4126∈0] ➊<br />ᐸ4125.0ᐳ"}}:::plan
+    Lambda6429{{"Lambda[6429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6434{{"Lambda[6434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6448{{"Lambda[6448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6453{{"Lambda[6453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3596{{"Lambda[3596∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Lambda6466{{"Lambda[6466∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6471{{"Lambda[6471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant7057 & Constant7053 & Access3600 & Lambda5719 & Lambda5724 & Lambda5736 & Lambda5741 & Lambda5753 & Lambda5758 & Lambda5770 & Lambda5775 & Lambda5787 & Lambda5792 & Lambda5804 & Lambda5809 & Lambda5821 & Lambda5826 & Lambda5838 & Lambda5843 & Lambda5855 & Lambda5860 & Lambda5872 & Lambda5877 & Access3600 & Lambda5889 & Lambda5894 & Lambda5906 & Lambda5911 & Lambda5923 & Lambda5928 & Lambda5940 & Lambda5945 & Lambda5957 & Lambda5962 & Lambda5974 & Lambda5979 & Lambda5991 & Lambda5996 & Lambda6008 & Lambda6013 & Lambda6025 & Lambda6030 & Lambda6042 & Lambda6047 & Lambda6059 & Lambda6064 & Access3600 & Lambda6076 & Lambda6081 & Lambda6126 & Lambda6131 & Lambda6143 & Lambda6148 & Lambda6160 & Lambda6165 & Lambda6177 & Lambda6182 & Lambda6194 & Lambda6199 & Lambda6211 & Lambda6216 & Lambda6228 & Lambda6233 & Lambda6245 & Lambda6250 & Lambda6293 & Lambda6298 & Lambda6310 & Lambda6315 & Lambda6327 & Lambda6332 & Lambda6344 & Lambda6349 & Lambda6361 & Lambda6366 & Lambda6378 & Lambda6383 & Lambda6395 & Lambda6400 & Lambda6412 & Lambda6417 & Access4126 & Lambda6429 & Lambda6434 & Access3600 & Lambda6448 & Lambda6453 & Lambda3596 & Access3600 & Lambda6466 & Lambda6471 --> PgSelect2139
+    PgSelect2969[["PgSelect[2969∈0] ➊<br />ᐸpostᐳ"]]:::plan
+    Lambda6481{{"Lambda[6481∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6486{{"Lambda[6486∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6498{{"Lambda[6498∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6503{{"Lambda[6503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6515{{"Lambda[6515∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6520{{"Lambda[6520∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6531{{"Lambda[6531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6536{{"Lambda[6536∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6547{{"Lambda[6547∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6552{{"Lambda[6552∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6563{{"Lambda[6563∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6568{{"Lambda[6568∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6579{{"Lambda[6579∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6584{{"Lambda[6584∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6595{{"Lambda[6595∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6532{{"Lambda[6532∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6537{{"Lambda[6537∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6549{{"Lambda[6549∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6554{{"Lambda[6554∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6566{{"Lambda[6566∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6571{{"Lambda[6571∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6583{{"Lambda[6583∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6588{{"Lambda[6588∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6600{{"Lambda[6600∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6611{{"Lambda[6611∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6616{{"Lambda[6616∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6627{{"Lambda[6627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6632{{"Lambda[6632∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6643{{"Lambda[6643∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6648{{"Lambda[6648∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6659{{"Lambda[6659∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6664{{"Lambda[6664∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6675{{"Lambda[6675∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6680{{"Lambda[6680∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6691{{"Lambda[6691∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6696{{"Lambda[6696∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6605{{"Lambda[6605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6617{{"Lambda[6617∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6622{{"Lambda[6622∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6634{{"Lambda[6634∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6639{{"Lambda[6639∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6651{{"Lambda[6651∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6656{{"Lambda[6656∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6668{{"Lambda[6668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6673{{"Lambda[6673∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6685{{"Lambda[6685∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6690{{"Lambda[6690∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6702{{"Lambda[6702∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6707{{"Lambda[6707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6712{{"Lambda[6712∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6723{{"Lambda[6723∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6728{{"Lambda[6728∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6739{{"Lambda[6739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6744{{"Lambda[6744∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6755{{"Lambda[6755∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6760{{"Lambda[6760∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6771{{"Lambda[6771∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6776{{"Lambda[6776∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6719{{"Lambda[6719∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6724{{"Lambda[6724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6736{{"Lambda[6736∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6741{{"Lambda[6741∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6753{{"Lambda[6753∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6758{{"Lambda[6758∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6770{{"Lambda[6770∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6775{{"Lambda[6775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6787{{"Lambda[6787∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda6792{{"Lambda[6792∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6803{{"Lambda[6803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6808{{"Lambda[6808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6822{{"Lambda[6822∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6827{{"Lambda[6827∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6840{{"Lambda[6840∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda6845{{"Lambda[6845∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant6846 & Lambda3599 & Lambda6307 & Lambda6312 & Lambda6323 & Lambda6328 & Lambda6339 & Lambda6344 & Lambda6355 & Lambda6360 & Lambda6371 & Lambda6376 & Lambda6387 & Lambda6392 & Lambda6403 & Lambda6408 & Lambda6419 & Lambda6424 & Lambda6435 & Lambda6440 & Lambda6451 & Lambda6456 & Lambda3599 & Lambda6467 & Lambda6472 & Lambda6483 & Lambda6488 & Lambda6499 & Lambda6504 & Lambda6515 & Lambda6520 & Lambda6531 & Lambda6536 & Lambda6547 & Lambda6552 & Lambda6563 & Lambda6568 & Lambda6579 & Lambda6584 & Lambda6595 & Lambda6600 & Lambda6611 & Lambda6616 & Lambda6627 & Lambda6632 & Lambda6643 & Lambda6648 & Lambda6659 & Lambda6664 & Lambda6675 & Lambda6680 & Lambda6691 & Lambda6696 & Lambda6707 & Lambda6712 & Lambda6723 & Lambda6728 & Lambda6739 & Lambda6744 & Lambda6755 & Lambda6760 & Lambda6771 & Lambda6776 & Lambda6787 & Lambda6792 & Lambda4094 & Lambda6803 & Lambda6808 & Lambda3599 & Lambda6822 & Lambda6827 & Lambda3596 & Lambda3599 & Lambda6840 & Lambda6845 --> PgSelect2969
+    Lambda6804{{"Lambda[6804∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6809{{"Lambda[6809∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6821{{"Lambda[6821∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6826{{"Lambda[6826∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6838{{"Lambda[6838∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6843{{"Lambda[6843∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6855{{"Lambda[6855∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6860{{"Lambda[6860∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6872{{"Lambda[6872∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6877{{"Lambda[6877∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6889{{"Lambda[6889∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6894{{"Lambda[6894∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6906{{"Lambda[6906∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6911{{"Lambda[6911∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6923{{"Lambda[6923∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6928{{"Lambda[6928∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6940{{"Lambda[6940∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6945{{"Lambda[6945∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6957{{"Lambda[6957∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6962{{"Lambda[6962∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6974{{"Lambda[6974∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6979{{"Lambda[6979∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6991{{"Lambda[6991∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda6996{{"Lambda[6996∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda7008{{"Lambda[7008∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda7013{{"Lambda[7013∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda7028{{"Lambda[7028∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda7033{{"Lambda[7033∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda7047{{"Lambda[7047∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda7052{{"Lambda[7052∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant7053 & Access3600 & Lambda6481 & Lambda6486 & Lambda6498 & Lambda6503 & Lambda6515 & Lambda6520 & Lambda6532 & Lambda6537 & Lambda6549 & Lambda6554 & Lambda6566 & Lambda6571 & Lambda6583 & Lambda6588 & Lambda6600 & Lambda6605 & Lambda6617 & Lambda6622 & Lambda6634 & Lambda6639 & Access3600 & Lambda6651 & Lambda6656 & Lambda6668 & Lambda6673 & Lambda6685 & Lambda6690 & Lambda6702 & Lambda6707 & Lambda6719 & Lambda6724 & Lambda6736 & Lambda6741 & Lambda6753 & Lambda6758 & Lambda6770 & Lambda6775 & Lambda6787 & Lambda6792 & Lambda6804 & Lambda6809 & Lambda6821 & Lambda6826 & Lambda6838 & Lambda6843 & Lambda6855 & Lambda6860 & Lambda6872 & Lambda6877 & Lambda6889 & Lambda6894 & Lambda6906 & Lambda6911 & Lambda6923 & Lambda6928 & Lambda6940 & Lambda6945 & Lambda6957 & Lambda6962 & Lambda6974 & Lambda6979 & Lambda6991 & Lambda6996 & Access4126 & Lambda7008 & Lambda7013 & Access3600 & Lambda7028 & Lambda7033 & Lambda3596 & Access3600 & Lambda7047 & Lambda7052 --> PgSelect2969
     PgSelect627[["PgSelect[627∈0] ➊<br />ᐸtypesᐳ"]]:::plan
-    Lambda4127{{"Lambda[4127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4132{{"Lambda[4132∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4143{{"Lambda[4143∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4148{{"Lambda[4148∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4159{{"Lambda[4159∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4164{{"Lambda[4164∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4175{{"Lambda[4175∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4180{{"Lambda[4180∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4191{{"Lambda[4191∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4196{{"Lambda[4196∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4207{{"Lambda[4207∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4161{{"Lambda[4161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4166{{"Lambda[4166∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4178{{"Lambda[4178∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4183{{"Lambda[4183∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4195{{"Lambda[4195∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4200{{"Lambda[4200∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda4212{{"Lambda[4212∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4223{{"Lambda[4223∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4228{{"Lambda[4228∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4239{{"Lambda[4239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4244{{"Lambda[4244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4255{{"Lambda[4255∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4260{{"Lambda[4260∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4271{{"Lambda[4271∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4276{{"Lambda[4276∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4287{{"Lambda[4287∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4292{{"Lambda[4292∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant6846 & Lambda3599 & Lambda4127 & Lambda4132 & Lambda3599 & Lambda4143 & Lambda4148 & Lambda3599 & Lambda4159 & Lambda4164 & Lambda4175 & Lambda4180 & Lambda4191 & Lambda4196 & Lambda3599 & Lambda4207 & Lambda4212 & Lambda3599 & Lambda4223 & Lambda4228 & Lambda4239 & Lambda4244 & Lambda4255 & Lambda4260 & Lambda3599 & Lambda4271 & Lambda4276 & Lambda3596 & Lambda3599 & Lambda4287 & Lambda4292 --> PgSelect627
+    Lambda4217{{"Lambda[4217∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4229{{"Lambda[4229∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4234{{"Lambda[4234∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4246{{"Lambda[4246∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4251{{"Lambda[4251∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4263{{"Lambda[4263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4268{{"Lambda[4268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4280{{"Lambda[4280∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4285{{"Lambda[4285∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4297{{"Lambda[4297∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4302{{"Lambda[4302∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4314{{"Lambda[4314∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4319{{"Lambda[4319∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4331{{"Lambda[4331∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4336{{"Lambda[4336∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant7053 & Access3600 & Lambda4161 & Lambda4166 & Access3600 & Lambda4178 & Lambda4183 & Access3600 & Lambda4195 & Lambda4200 & Lambda4212 & Lambda4217 & Lambda4229 & Lambda4234 & Access3600 & Lambda4246 & Lambda4251 & Access3600 & Lambda4263 & Lambda4268 & Lambda4280 & Lambda4285 & Lambda4297 & Lambda4302 & Access3600 & Lambda4314 & Lambda4319 & Lambda3596 & Access3600 & Lambda4331 & Lambda4336 --> PgSelect627
     PgSelect827[["PgSelect[827∈0] ➊<br />ᐸtypesᐳ"]]:::plan
     Access825{{"Access[825∈0] ➊<br />ᐸ824.1ᐳ"}}:::plan
-    Lambda4301{{"Lambda[4301∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4306{{"Lambda[4306∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4317{{"Lambda[4317∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4322{{"Lambda[4322∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4333{{"Lambda[4333∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4338{{"Lambda[4338∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4349{{"Lambda[4349∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4354{{"Lambda[4354∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4365{{"Lambda[4365∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4370{{"Lambda[4370∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4381{{"Lambda[4381∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4386{{"Lambda[4386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4346{{"Lambda[4346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4351{{"Lambda[4351∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4363{{"Lambda[4363∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4368{{"Lambda[4368∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4380{{"Lambda[4380∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4385{{"Lambda[4385∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda4397{{"Lambda[4397∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda4402{{"Lambda[4402∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4413{{"Lambda[4413∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4418{{"Lambda[4418∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4429{{"Lambda[4429∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4434{{"Lambda[4434∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4445{{"Lambda[4445∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4450{{"Lambda[4450∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4461{{"Lambda[4461∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4466{{"Lambda[4466∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4414{{"Lambda[4414∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4419{{"Lambda[4419∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4431{{"Lambda[4431∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4436{{"Lambda[4436∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4448{{"Lambda[4448∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4453{{"Lambda[4453∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4465{{"Lambda[4465∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4470{{"Lambda[4470∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4482{{"Lambda[4482∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4487{{"Lambda[4487∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4499{{"Lambda[4499∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4504{{"Lambda[4504∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4516{{"Lambda[4516∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4521{{"Lambda[4521∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object12 -->|rejectNull| PgSelect827
-    Access825 & Lambda3599 & Lambda4301 & Lambda4306 & Lambda3599 & Lambda4317 & Lambda4322 & Lambda3599 & Lambda4333 & Lambda4338 & Lambda4349 & Lambda4354 & Lambda4365 & Lambda4370 & Lambda3599 & Lambda4381 & Lambda4386 & Lambda3599 & Lambda4397 & Lambda4402 & Lambda4413 & Lambda4418 & Lambda4429 & Lambda4434 & Lambda3599 & Lambda4445 & Lambda4450 & Lambda3596 & Lambda3599 & Lambda4461 & Lambda4466 --> PgSelect827
+    Access825 & Access3600 & Lambda4346 & Lambda4351 & Access3600 & Lambda4363 & Lambda4368 & Access3600 & Lambda4380 & Lambda4385 & Lambda4397 & Lambda4402 & Lambda4414 & Lambda4419 & Access3600 & Lambda4431 & Lambda4436 & Access3600 & Lambda4448 & Lambda4453 & Lambda4465 & Lambda4470 & Lambda4482 & Lambda4487 & Access3600 & Lambda4499 & Lambda4504 & Lambda3596 & Access3600 & Lambda4516 & Lambda4521 --> PgSelect827
     PgSelect1319[["PgSelect[1319∈0] ➊<br />ᐸtype_functionᐳ"]]:::plan
-    Lambda4901{{"Lambda[4901∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4906{{"Lambda[4906∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4917{{"Lambda[4917∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4922{{"Lambda[4922∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4933{{"Lambda[4933∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4938{{"Lambda[4938∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4949{{"Lambda[4949∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4954{{"Lambda[4954∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4965{{"Lambda[4965∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4970{{"Lambda[4970∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4981{{"Lambda[4981∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda4986{{"Lambda[4986∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4997{{"Lambda[4997∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5002{{"Lambda[5002∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5013{{"Lambda[5013∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5018{{"Lambda[5018∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5029{{"Lambda[5029∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5034{{"Lambda[5034∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5045{{"Lambda[5045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5050{{"Lambda[5050∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5061{{"Lambda[5061∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5066{{"Lambda[5066∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Constant6846 & Lambda3599 & Lambda4901 & Lambda4906 & Lambda3599 & Lambda4917 & Lambda4922 & Lambda3599 & Lambda4933 & Lambda4938 & Lambda4949 & Lambda4954 & Lambda4965 & Lambda4970 & Lambda3599 & Lambda4981 & Lambda4986 & Lambda3599 & Lambda4997 & Lambda5002 & Lambda5013 & Lambda5018 & Lambda5029 & Lambda5034 & Lambda3599 & Lambda5045 & Lambda5050 & Lambda3596 & Lambda3599 & Lambda5061 & Lambda5066 --> PgSelect1319
-    PgSelect9[["PgSelect[9∈0] ➊<br />ᐸtypesᐳ"]]:::plan
-    Lambda3604{{"Lambda[3604∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3609{{"Lambda[3609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3620{{"Lambda[3620∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3625{{"Lambda[3625∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3636{{"Lambda[3636∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3641{{"Lambda[3641∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3652{{"Lambda[3652∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3657{{"Lambda[3657∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3668{{"Lambda[3668∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3673{{"Lambda[3673∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3684{{"Lambda[3684∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3689{{"Lambda[3689∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3700{{"Lambda[3700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3705{{"Lambda[3705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3716{{"Lambda[3716∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3721{{"Lambda[3721∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3732{{"Lambda[3732∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3737{{"Lambda[3737∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3748{{"Lambda[3748∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3753{{"Lambda[3753∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3764{{"Lambda[3764∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3769{{"Lambda[3769∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Lambda3599 & Lambda3604 & Lambda3609 & Lambda3599 & Lambda3620 & Lambda3625 & Lambda3599 & Lambda3636 & Lambda3641 & Lambda3652 & Lambda3657 & Lambda3668 & Lambda3673 & Lambda3599 & Lambda3684 & Lambda3689 & Lambda3599 & Lambda3700 & Lambda3705 & Lambda3716 & Lambda3721 & Lambda3732 & Lambda3737 & Lambda3599 & Lambda3748 & Lambda3753 & Lambda3596 & Lambda3599 & Lambda3764 & Lambda3769 --> PgSelect9
-    PgSelect1515[["PgSelect[1515∈0] ➊<br />ᐸtype_function_listᐳ"]]:::plan
-    Lambda5075{{"Lambda[5075∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5080{{"Lambda[5080∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5091{{"Lambda[5091∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5096{{"Lambda[5096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5107{{"Lambda[5107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5112{{"Lambda[5112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5123{{"Lambda[5123∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5128{{"Lambda[5128∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda4991{{"Lambda[4991∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5003{{"Lambda[5003∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5008{{"Lambda[5008∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5020{{"Lambda[5020∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5025{{"Lambda[5025∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5037{{"Lambda[5037∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5042{{"Lambda[5042∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5054{{"Lambda[5054∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5059{{"Lambda[5059∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5071{{"Lambda[5071∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5076{{"Lambda[5076∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5088{{"Lambda[5088∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5093{{"Lambda[5093∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5105{{"Lambda[5105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5110{{"Lambda[5110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5122{{"Lambda[5122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5127{{"Lambda[5127∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda5139{{"Lambda[5139∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda5144{{"Lambda[5144∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5155{{"Lambda[5155∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5160{{"Lambda[5160∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5156{{"Lambda[5156∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5161{{"Lambda[5161∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Constant7053 & Access3600 & Lambda4986 & Lambda4991 & Access3600 & Lambda5003 & Lambda5008 & Access3600 & Lambda5020 & Lambda5025 & Lambda5037 & Lambda5042 & Lambda5054 & Lambda5059 & Access3600 & Lambda5071 & Lambda5076 & Access3600 & Lambda5088 & Lambda5093 & Lambda5105 & Lambda5110 & Lambda5122 & Lambda5127 & Access3600 & Lambda5139 & Lambda5144 & Lambda3596 & Access3600 & Lambda5156 & Lambda5161 --> PgSelect1319
+    PgSelect9[["PgSelect[9∈0] ➊<br />ᐸtypesᐳ"]]:::plan
+    Lambda3605{{"Lambda[3605∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3610{{"Lambda[3610∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3622{{"Lambda[3622∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3627{{"Lambda[3627∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3639{{"Lambda[3639∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3644{{"Lambda[3644∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3656{{"Lambda[3656∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3661{{"Lambda[3661∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3673{{"Lambda[3673∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3678{{"Lambda[3678∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3690{{"Lambda[3690∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3695{{"Lambda[3695∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3707{{"Lambda[3707∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3712{{"Lambda[3712∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3724{{"Lambda[3724∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3729{{"Lambda[3729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3741{{"Lambda[3741∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3746{{"Lambda[3746∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3758{{"Lambda[3758∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3763{{"Lambda[3763∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3775{{"Lambda[3775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda3780{{"Lambda[3780∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Access3600 & Lambda3605 & Lambda3610 & Access3600 & Lambda3622 & Lambda3627 & Access3600 & Lambda3639 & Lambda3644 & Lambda3656 & Lambda3661 & Lambda3673 & Lambda3678 & Access3600 & Lambda3690 & Lambda3695 & Access3600 & Lambda3707 & Lambda3712 & Lambda3724 & Lambda3729 & Lambda3741 & Lambda3746 & Access3600 & Lambda3758 & Lambda3763 & Lambda3596 & Access3600 & Lambda3775 & Lambda3780 --> PgSelect9
+    PgSelect1515[["PgSelect[1515∈0] ➊<br />ᐸtype_function_listᐳ"]]:::plan
     Lambda5171{{"Lambda[5171∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Lambda5176{{"Lambda[5176∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5187{{"Lambda[5187∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5192{{"Lambda[5192∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5203{{"Lambda[5203∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5208{{"Lambda[5208∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5219{{"Lambda[5219∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5224{{"Lambda[5224∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5235{{"Lambda[5235∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5240{{"Lambda[5240∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Lambda3599 & Lambda5075 & Lambda5080 & Lambda3599 & Lambda5091 & Lambda5096 & Lambda3599 & Lambda5107 & Lambda5112 & Lambda5123 & Lambda5128 & Lambda5139 & Lambda5144 & Lambda3599 & Lambda5155 & Lambda5160 & Lambda3599 & Lambda5171 & Lambda5176 & Lambda5187 & Lambda5192 & Lambda5203 & Lambda5208 & Lambda3599 & Lambda5219 & Lambda5224 & Lambda3596 & Lambda3599 & Lambda5235 & Lambda5240 --> PgSelect1515
-    Object3603{{"Object[3603∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3600{{"Constant[3600∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3601{{"Constant[3601∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant3602{{"Constant[3602∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
-    Lambda3596 & Constant3600 & Constant3601 & Constant3602 --> Object3603
-    Object3619{{"Object[3619∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3616{{"Constant[3616∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3617{{"Constant[3617∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant3616 & Constant3617 & Constant3602 --> Object3619
-    Object3635{{"Object[3635∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3632{{"Constant[3632∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3633{{"Constant[3633∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3634{{"Constant[3634∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
-    Lambda3596 & Constant3632 & Constant3633 & Constant3634 --> Object3635
-    Object3651{{"Object[3651∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3648{{"Constant[3648∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3649{{"Constant[3649∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant3648 & Constant3649 & Constant3634 --> Object3651
-    Object3667{{"Object[3667∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3664{{"Constant[3664∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3665{{"Constant[3665∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant3664 & Constant3665 & Constant3634 --> Object3667
-    Object3683{{"Object[3683∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3680{{"Constant[3680∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3681{{"Constant[3681∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant3682{{"Constant[3682∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
-    Lambda3596 & Constant3680 & Constant3681 & Constant3682 --> Object3683
-    Object3699{{"Object[3699∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3696{{"Constant[3696∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3697{{"Constant[3697∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant3696 & Constant3697 & Constant3634 --> Object3699
-    Object3715{{"Object[3715∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3712{{"Constant[3712∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3713{{"Constant[3713∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant3712 & Constant3713 & Constant3634 --> Object3715
-    Object3731{{"Object[3731∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3728{{"Constant[3728∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3729{{"Constant[3729∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant3728 & Constant3729 & Constant3634 --> Object3731
-    Object3747{{"Object[3747∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3744{{"Constant[3744∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3745{{"Constant[3745∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant3744 & Constant3745 & Constant3682 --> Object3747
-    Object3763{{"Object[3763∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant3760{{"Constant[3760∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant3761{{"Constant[3761∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Constant3762{{"Constant[3762∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
-    Lambda3596 & Constant3760 & Constant3761 & Constant3762 --> Object3763
-    Object4126{{"Object[4126∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4123{{"Constant[4123∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4124{{"Constant[4124∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4123 & Constant4124 & Constant3602 --> Object4126
-    Object4142{{"Object[4142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4139{{"Constant[4139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4140{{"Constant[4140∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4139 & Constant4140 & Constant3602 --> Object4142
-    Object4158{{"Object[4158∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4155{{"Constant[4155∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4156{{"Constant[4156∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4155 & Constant4156 & Constant3634 --> Object4158
-    Object4174{{"Object[4174∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4171{{"Constant[4171∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4172{{"Constant[4172∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4171 & Constant4172 & Constant3634 --> Object4174
-    Object4190{{"Object[4190∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4187{{"Constant[4187∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4188{{"Constant[4188∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4187 & Constant4188 & Constant3634 --> Object4190
-    Object4206{{"Object[4206∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4203{{"Constant[4203∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4204{{"Constant[4204∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4203 & Constant4204 & Constant3682 --> Object4206
-    Object4222{{"Object[4222∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4219{{"Constant[4219∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4220{{"Constant[4220∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4219 & Constant4220 & Constant3634 --> Object4222
-    Object4238{{"Object[4238∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4235{{"Constant[4235∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4236{{"Constant[4236∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4235 & Constant4236 & Constant3634 --> Object4238
-    Object4254{{"Object[4254∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4251{{"Constant[4251∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4252{{"Constant[4252∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4251 & Constant4252 & Constant3634 --> Object4254
-    Object4270{{"Object[4270∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4267{{"Constant[4267∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4268{{"Constant[4268∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4267 & Constant4268 & Constant3682 --> Object4270
-    Object4286{{"Object[4286∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4283{{"Constant[4283∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4284{{"Constant[4284∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda3596 & Constant4283 & Constant4284 & Constant3762 --> Object4286
-    Object4300{{"Object[4300∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4297{{"Constant[4297∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4298{{"Constant[4298∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4297 & Constant4298 & Constant3602 --> Object4300
-    Object4316{{"Object[4316∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4313{{"Constant[4313∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4314{{"Constant[4314∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4313 & Constant4314 & Constant3602 --> Object4316
-    Object4332{{"Object[4332∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4329{{"Constant[4329∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4330{{"Constant[4330∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4329 & Constant4330 & Constant3634 --> Object4332
-    Object4348{{"Object[4348∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4345{{"Constant[4345∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4346{{"Constant[4346∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4345 & Constant4346 & Constant3634 --> Object4348
-    Object4364{{"Object[4364∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4361{{"Constant[4361∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4362{{"Constant[4362∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4361 & Constant4362 & Constant3634 --> Object4364
-    Object4380{{"Object[4380∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4377{{"Constant[4377∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4378{{"Constant[4378∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4377 & Constant4378 & Constant3682 --> Object4380
+    Lambda5188{{"Lambda[5188∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5193{{"Lambda[5193∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5205{{"Lambda[5205∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5210{{"Lambda[5210∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5222{{"Lambda[5222∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5227{{"Lambda[5227∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5239{{"Lambda[5239∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5244{{"Lambda[5244∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5256{{"Lambda[5256∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5261{{"Lambda[5261∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5273{{"Lambda[5273∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5278{{"Lambda[5278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5290{{"Lambda[5290∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5295{{"Lambda[5295∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5307{{"Lambda[5307∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5312{{"Lambda[5312∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5324{{"Lambda[5324∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5329{{"Lambda[5329∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5341{{"Lambda[5341∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda5346{{"Lambda[5346∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object12 & Access3600 & Lambda5171 & Lambda5176 & Access3600 & Lambda5188 & Lambda5193 & Access3600 & Lambda5205 & Lambda5210 & Lambda5222 & Lambda5227 & Lambda5239 & Lambda5244 & Access3600 & Lambda5256 & Lambda5261 & Access3600 & Lambda5273 & Lambda5278 & Lambda5290 & Lambda5295 & Lambda5307 & Lambda5312 & Access3600 & Lambda5324 & Lambda5329 & Lambda3596 & Access3600 & Lambda5341 & Lambda5346 --> PgSelect1515
+    Object3604{{"Object[3604∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3601{{"Constant[3601∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3602{{"Constant[3602∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Constant3603{{"Constant[3603∈0] ➊<br />ᐸRecordCodec(post)ᐳ"}}:::plan
+    Lambda3596 & Constant3601 & Constant3602 & Constant3603 --> Object3604
+    Object3621{{"Object[3621∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3618{{"Constant[3618∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3619{{"Constant[3619∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant3618 & Constant3619 & Constant3603 --> Object3621
+    Object3638{{"Object[3638∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3635{{"Constant[3635∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3636{{"Constant[3636∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Constant3637{{"Constant[3637∈0] ➊<br />ᐸRecordCodec(compoundType)ᐳ"}}:::plan
+    Lambda3596 & Constant3635 & Constant3636 & Constant3637 --> Object3638
+    Object3655{{"Object[3655∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3652{{"Constant[3652∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3653{{"Constant[3653∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3652 & Constant3653 & Constant3637 --> Object3655
+    Object3672{{"Object[3672∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3669{{"Constant[3669∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3670{{"Constant[3670∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3669 & Constant3670 & Constant3637 --> Object3672
+    Object3689{{"Object[3689∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3686{{"Constant[3686∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3687{{"Constant[3687∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Constant3688{{"Constant[3688∈0] ➊<br />ᐸRecordCodec(nestedCompoundType)ᐳ"}}:::plan
+    Lambda3596 & Constant3686 & Constant3687 & Constant3688 --> Object3689
+    Object3706{{"Object[3706∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3703{{"Constant[3703∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3704{{"Constant[3704∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3703 & Constant3704 & Constant3637 --> Object3706
+    Object3723{{"Object[3723∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3720{{"Constant[3720∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3721{{"Constant[3721∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3720 & Constant3721 & Constant3637 --> Object3723
+    Object3740{{"Object[3740∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3737{{"Constant[3737∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3738{{"Constant[3738∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3737 & Constant3738 & Constant3637 --> Object3740
+    Object3757{{"Object[3757∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3754{{"Constant[3754∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3755{{"Constant[3755∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3754 & Constant3755 & Constant3688 --> Object3757
+    Object3774{{"Object[3774∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3771{{"Constant[3771∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant3772{{"Constant[3772∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Constant3773{{"Constant[3773∈0] ➊<br />ᐸRecordCodec(types)ᐳ"}}:::plan
+    Lambda3596 & Constant3771 & Constant3772 & Constant3773 --> Object3774
+    Object3789{{"Object[3789∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3786{{"Constant[3786∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3787{{"Constant[3787∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant3786 & Constant3787 & Constant3603 --> Object3789
+    Object3806{{"Object[3806∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3803{{"Constant[3803∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3804{{"Constant[3804∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant3803 & Constant3804 & Constant3603 --> Object3806
+    Object3823{{"Object[3823∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3820{{"Constant[3820∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3821{{"Constant[3821∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3820 & Constant3821 & Constant3637 --> Object3823
+    Object3840{{"Object[3840∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3837{{"Constant[3837∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3838{{"Constant[3838∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3837 & Constant3838 & Constant3637 --> Object3840
+    Object3857{{"Object[3857∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3854{{"Constant[3854∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3855{{"Constant[3855∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3854 & Constant3855 & Constant3637 --> Object3857
+    Object3874{{"Object[3874∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3871{{"Constant[3871∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3872{{"Constant[3872∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3871 & Constant3872 & Constant3688 --> Object3874
+    Object3891{{"Object[3891∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3888{{"Constant[3888∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3889{{"Constant[3889∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3888 & Constant3889 & Constant3637 --> Object3891
+    Object3908{{"Object[3908∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3905{{"Constant[3905∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3906{{"Constant[3906∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3905 & Constant3906 & Constant3637 --> Object3908
+    Object3925{{"Object[3925∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3922{{"Constant[3922∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3923{{"Constant[3923∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3922 & Constant3923 & Constant3637 --> Object3925
+    Object3942{{"Object[3942∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3939{{"Constant[3939∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3940{{"Constant[3940∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3939 & Constant3940 & Constant3688 --> Object3942
+    Object3959{{"Object[3959∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3956{{"Constant[3956∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3957{{"Constant[3957∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant3956 & Constant3957 & Constant3603 --> Object3959
+    Object3976{{"Object[3976∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3973{{"Constant[3973∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3974{{"Constant[3974∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant3973 & Constant3974 & Constant3603 --> Object3976
+    Object3993{{"Object[3993∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant3990{{"Constant[3990∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant3991{{"Constant[3991∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant3990 & Constant3991 & Constant3637 --> Object3993
+    Object4010{{"Object[4010∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4007{{"Constant[4007∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4008{{"Constant[4008∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4007 & Constant4008 & Constant3637 --> Object4010
+    Object4027{{"Object[4027∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4024{{"Constant[4024∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4025{{"Constant[4025∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4024 & Constant4025 & Constant3637 --> Object4027
+    Object4044{{"Object[4044∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4041{{"Constant[4041∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4042{{"Constant[4042∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4041 & Constant4042 & Constant3688 --> Object4044
+    Object4061{{"Object[4061∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4058{{"Constant[4058∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4059{{"Constant[4059∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4058 & Constant4059 & Constant3637 --> Object4061
+    Object4078{{"Object[4078∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4075{{"Constant[4075∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4076{{"Constant[4076∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4075 & Constant4076 & Constant3637 --> Object4078
+    Object4095{{"Object[4095∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4092{{"Constant[4092∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4093{{"Constant[4093∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4092 & Constant4093 & Constant3637 --> Object4095
+    Object4112{{"Object[4112∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4109{{"Constant[4109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4110{{"Constant[4110∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4109 & Constant4110 & Constant3688 --> Object4112
+    Object4130{{"Object[4130∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4127{{"Constant[4127∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Lambda3596 & Constant4127 & Constant3772 & Constant3773 --> Object4130
+    Object4145{{"Object[4145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4142{{"Constant[4142∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda3596 & Constant4142 & Constant3772 & Constant3773 --> Object4145
+    Object4160{{"Object[4160∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4157{{"Constant[4157∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4158{{"Constant[4158∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4157 & Constant4158 & Constant3603 --> Object4160
+    Object4177{{"Object[4177∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4174{{"Constant[4174∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4175{{"Constant[4175∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4174 & Constant4175 & Constant3603 --> Object4177
+    Object4194{{"Object[4194∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4191{{"Constant[4191∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4192{{"Constant[4192∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4191 & Constant4192 & Constant3637 --> Object4194
+    Object4211{{"Object[4211∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4208{{"Constant[4208∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4209{{"Constant[4209∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4208 & Constant4209 & Constant3637 --> Object4211
+    Object4228{{"Object[4228∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4225{{"Constant[4225∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4226{{"Constant[4226∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4225 & Constant4226 & Constant3637 --> Object4228
+    Object4245{{"Object[4245∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4242{{"Constant[4242∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4243{{"Constant[4243∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4242 & Constant4243 & Constant3688 --> Object4245
+    Object4262{{"Object[4262∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4259{{"Constant[4259∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4260{{"Constant[4260∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4259 & Constant4260 & Constant3637 --> Object4262
+    Object4279{{"Object[4279∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4276{{"Constant[4276∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4277{{"Constant[4277∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4276 & Constant4277 & Constant3637 --> Object4279
+    Object4296{{"Object[4296∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4293{{"Constant[4293∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4294{{"Constant[4294∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4293 & Constant4294 & Constant3637 --> Object4296
+    Object4313{{"Object[4313∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4310{{"Constant[4310∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4311{{"Constant[4311∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4310 & Constant4311 & Constant3688 --> Object4313
+    Object4330{{"Object[4330∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4327{{"Constant[4327∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4328{{"Constant[4328∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda3596 & Constant4327 & Constant4328 & Constant3773 --> Object4330
+    Object4345{{"Object[4345∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4342{{"Constant[4342∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4343{{"Constant[4343∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4342 & Constant4343 & Constant3603 --> Object4345
+    Object4362{{"Object[4362∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4359{{"Constant[4359∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4360{{"Constant[4360∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4359 & Constant4360 & Constant3603 --> Object4362
+    Object4379{{"Object[4379∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4376{{"Constant[4376∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4377{{"Constant[4377∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4376 & Constant4377 & Constant3637 --> Object4379
     Object4396{{"Object[4396∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4393{{"Constant[4393∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
     Constant4394{{"Constant[4394∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4393 & Constant4394 & Constant3634 --> Object4396
-    Object4412{{"Object[4412∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4409{{"Constant[4409∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4410{{"Constant[4410∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4409 & Constant4410 & Constant3634 --> Object4412
-    Object4428{{"Object[4428∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4425{{"Constant[4425∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4426{{"Constant[4426∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4425 & Constant4426 & Constant3634 --> Object4428
-    Object4444{{"Object[4444∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4441{{"Constant[4441∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4442{{"Constant[4442∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4441 & Constant4442 & Constant3682 --> Object4444
-    Object4460{{"Object[4460∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4457{{"Constant[4457∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4458{{"Constant[4458∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda3596 & Constant4457 & Constant4458 & Constant3762 --> Object4460
-    Object4474{{"Object[4474∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4471{{"Constant[4471∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4472{{"Constant[4472∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
-    Constant4473{{"Constant[4473∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
-    Lambda3596 & Constant4471 & Constant4472 & Constant4473 --> Object4474
-    Object4488{{"Object[4488∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4485{{"Constant[4485∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4486{{"Constant[4486∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
-    Constant4487{{"Constant[4487∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
-    Lambda3596 & Constant4485 & Constant4486 & Constant4487 --> Object4488
-    Object4502{{"Object[4502∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4499{{"Constant[4499∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4500{{"Constant[4500∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
-    Constant4501{{"Constant[4501∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
-    Lambda3596 & Constant4499 & Constant4500 & Constant4501 --> Object4502
-    Object4516{{"Object[4516∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4513{{"Constant[4513∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4514{{"Constant[4514∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
-    Constant4515{{"Constant[4515∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
-    Lambda3596 & Constant4513 & Constant4514 & Constant4515 --> Object4516
+    Lambda3596 & Constant4393 & Constant4394 & Constant3637 --> Object4396
+    Object4413{{"Object[4413∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4410{{"Constant[4410∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4411{{"Constant[4411∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4410 & Constant4411 & Constant3637 --> Object4413
+    Object4430{{"Object[4430∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4427{{"Constant[4427∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4428{{"Constant[4428∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4427 & Constant4428 & Constant3688 --> Object4430
+    Object4447{{"Object[4447∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4444{{"Constant[4444∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4445{{"Constant[4445∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4444 & Constant4445 & Constant3637 --> Object4447
+    Object4464{{"Object[4464∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4461{{"Constant[4461∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4462{{"Constant[4462∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4461 & Constant4462 & Constant3637 --> Object4464
+    Object4481{{"Object[4481∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4478{{"Constant[4478∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4479{{"Constant[4479∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4478 & Constant4479 & Constant3637 --> Object4481
+    Object4498{{"Object[4498∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4495{{"Constant[4495∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4496{{"Constant[4496∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4495 & Constant4496 & Constant3688 --> Object4498
+    Object4515{{"Object[4515∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4512{{"Constant[4512∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4513{{"Constant[4513∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda3596 & Constant4512 & Constant4513 & Constant3773 --> Object4515
     Object4530{{"Object[4530∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant4527{{"Constant[4527∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4528{{"Constant[4528∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
-    Constant4529{{"Constant[4529∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
+    Constant4528{{"Constant[4528∈0] ➊<br />ᐸsql.identifier(”inputs”)ᐳ"}}:::plan
+    Constant4529{{"Constant[4529∈0] ➊<br />ᐸRecordCodec(inputs)ᐳ"}}:::plan
     Lambda3596 & Constant4527 & Constant4528 & Constant4529 --> Object4530
-    Object4544{{"Object[4544∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4541{{"Constant[4541∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4542{{"Constant[4542∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
-    Constant4543{{"Constant[4543∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
-    Lambda3596 & Constant4541 & Constant4542 & Constant4543 --> Object4544
-    Object4558{{"Object[4558∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4555{{"Constant[4555∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4556{{"Constant[4556∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant4557{{"Constant[4557∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda3596 & Constant4555 & Constant4556 & Constant4557 --> Object4558
-    Object4572{{"Object[4572∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4569{{"Constant[4569∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4570{{"Constant[4570∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant4571{{"Constant[4571∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda3596 & Constant4569 & Constant4570 & Constant4571 --> Object4572
-    Object4586{{"Object[4586∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4583{{"Constant[4583∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4584{{"Constant[4584∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4583 & Constant4584 & Constant3602 --> Object4586
-    Object4600{{"Object[4600∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4597{{"Constant[4597∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4598{{"Constant[4598∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4597 & Constant4598 & Constant3602 --> Object4600
-    Object4616{{"Object[4616∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4613{{"Constant[4613∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4614{{"Constant[4614∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4613 & Constant4614 & Constant3602 --> Object4616
-    Object4632{{"Object[4632∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4629{{"Constant[4629∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4630{{"Constant[4630∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4629 & Constant4630 & Constant3634 --> Object4632
-    Object4648{{"Object[4648∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4645{{"Constant[4645∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4646{{"Constant[4646∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4645 & Constant4646 & Constant3634 --> Object4648
-    Object4664{{"Object[4664∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4661{{"Constant[4661∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4662{{"Constant[4662∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4661 & Constant4662 & Constant3634 --> Object4664
-    Object4680{{"Object[4680∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4677{{"Constant[4677∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4678{{"Constant[4678∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4677 & Constant4678 & Constant3682 --> Object4680
-    Object4696{{"Object[4696∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4693{{"Constant[4693∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4694{{"Constant[4694∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4693 & Constant4694 & Constant3634 --> Object4696
-    Object4712{{"Object[4712∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4709{{"Constant[4709∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4710{{"Constant[4710∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4709 & Constant4710 & Constant3634 --> Object4712
-    Object4728{{"Object[4728∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4725{{"Constant[4725∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4726{{"Constant[4726∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4725 & Constant4726 & Constant3634 --> Object4728
-    Object4744{{"Object[4744∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4741{{"Constant[4741∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4742{{"Constant[4742∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4741 & Constant4742 & Constant3682 --> Object4744
-    Object4760{{"Object[4760∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4757{{"Constant[4757∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4758{{"Constant[4758∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda3596 & Constant4757 & Constant4758 & Constant3762 --> Object4760
-    Object4774{{"Object[4774∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4771{{"Constant[4771∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4772{{"Constant[4772∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
-    Constant4773{{"Constant[4773∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
-    Lambda3596 & Constant4771 & Constant4772 & Constant4773 --> Object4774
-    Object4788{{"Object[4788∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4785{{"Constant[4785∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4786{{"Constant[4786∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
-    Constant4787{{"Constant[4787∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
-    Lambda3596 & Constant4785 & Constant4786 & Constant4787 --> Object4788
-    Object4802{{"Object[4802∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4799{{"Constant[4799∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4800{{"Constant[4800∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
-    Constant4801{{"Constant[4801∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
-    Lambda3596 & Constant4799 & Constant4800 & Constant4801 --> Object4802
-    Object4816{{"Object[4816∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4813{{"Constant[4813∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4814{{"Constant[4814∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
-    Constant4815{{"Constant[4815∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
-    Lambda3596 & Constant4813 & Constant4814 & Constant4815 --> Object4816
-    Object4830{{"Object[4830∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4827{{"Constant[4827∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4828{{"Constant[4828∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
-    Constant4829{{"Constant[4829∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
-    Lambda3596 & Constant4827 & Constant4828 & Constant4829 --> Object4830
-    Object4844{{"Object[4844∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4841{{"Constant[4841∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4842{{"Constant[4842∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
-    Constant4843{{"Constant[4843∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
-    Lambda3596 & Constant4841 & Constant4842 & Constant4843 --> Object4844
-    Object4858{{"Object[4858∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4855{{"Constant[4855∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4856{{"Constant[4856∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
-    Constant4857{{"Constant[4857∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
-    Lambda3596 & Constant4855 & Constant4856 & Constant4857 --> Object4858
-    Object4872{{"Object[4872∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4869{{"Constant[4869∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4870{{"Constant[4870∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
-    Constant4871{{"Constant[4871∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
-    Lambda3596 & Constant4869 & Constant4870 & Constant4871 --> Object4872
-    Object4886{{"Object[4886∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4883{{"Constant[4883∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4884{{"Constant[4884∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
-    Constant4885{{"Constant[4885∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
-    Lambda3596 & Constant4883 & Constant4884 & Constant4885 --> Object4886
-    Object4900{{"Object[4900∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4897{{"Constant[4897∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4898{{"Constant[4898∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4897 & Constant4898 & Constant3602 --> Object4900
-    Object4916{{"Object[4916∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4913{{"Constant[4913∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4914{{"Constant[4914∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant4913 & Constant4914 & Constant3602 --> Object4916
-    Object4932{{"Object[4932∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4929{{"Constant[4929∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4930{{"Constant[4930∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4929 & Constant4930 & Constant3634 --> Object4932
-    Object4948{{"Object[4948∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4945{{"Constant[4945∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4946{{"Constant[4946∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4945 & Constant4946 & Constant3634 --> Object4948
-    Object4964{{"Object[4964∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4961{{"Constant[4961∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4962{{"Constant[4962∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4961 & Constant4962 & Constant3634 --> Object4964
-    Object4980{{"Object[4980∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4977{{"Constant[4977∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4978{{"Constant[4978∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4977 & Constant4978 & Constant3682 --> Object4980
-    Object4996{{"Object[4996∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant4993{{"Constant[4993∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4994{{"Constant[4994∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant4993 & Constant4994 & Constant3634 --> Object4996
-    Object5012{{"Object[5012∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5009{{"Constant[5009∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5010{{"Constant[5010∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5009 & Constant5010 & Constant3634 --> Object5012
-    Object5028{{"Object[5028∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5025{{"Constant[5025∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5026{{"Constant[5026∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5025 & Constant5026 & Constant3634 --> Object5028
-    Object5044{{"Object[5044∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5041{{"Constant[5041∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5042{{"Constant[5042∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5041 & Constant5042 & Constant3682 --> Object5044
-    Object5060{{"Object[5060∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5057{{"Constant[5057∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5058{{"Constant[5058∈0] ➊<br />ᐸsql.identifier(”type_function”)ᐳ"}}:::plan
-    Lambda3596 & Constant5057 & Constant5058 & Constant3762 --> Object5060
-    Object5074{{"Object[5074∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5071{{"Constant[5071∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5072{{"Constant[5072∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant5071 & Constant5072 & Constant3602 --> Object5074
-    Object5090{{"Object[5090∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5087{{"Constant[5087∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5088{{"Constant[5088∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant5087 & Constant5088 & Constant3602 --> Object5090
-    Object5106{{"Object[5106∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5103{{"Constant[5103∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5104{{"Constant[5104∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5103 & Constant5104 & Constant3634 --> Object5106
-    Object5122{{"Object[5122∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5119{{"Constant[5119∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5120{{"Constant[5120∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5119 & Constant5120 & Constant3634 --> Object5122
+    Object4545{{"Object[4545∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4542{{"Constant[4542∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4543{{"Constant[4543∈0] ➊<br />ᐸsql.identifier(”patchs”)ᐳ"}}:::plan
+    Constant4544{{"Constant[4544∈0] ➊<br />ᐸRecordCodec(patchs)ᐳ"}}:::plan
+    Lambda3596 & Constant4542 & Constant4543 & Constant4544 --> Object4545
+    Object4560{{"Object[4560∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4557{{"Constant[4557∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4558{{"Constant[4558∈0] ➊<br />ᐸsql.identifier(”reserved”)ᐳ"}}:::plan
+    Constant4559{{"Constant[4559∈0] ➊<br />ᐸRecordCodec(reserved)ᐳ"}}:::plan
+    Lambda3596 & Constant4557 & Constant4558 & Constant4559 --> Object4560
+    Object4575{{"Object[4575∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4572{{"Constant[4572∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4573{{"Constant[4573∈0] ➊<br />ᐸsql.identifier(”reserved_patchs”)ᐳ"}}:::plan
+    Constant4574{{"Constant[4574∈0] ➊<br />ᐸRecordCodec(reservedPatchs)ᐳ"}}:::plan
+    Lambda3596 & Constant4572 & Constant4573 & Constant4574 --> Object4575
+    Object4590{{"Object[4590∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4587{{"Constant[4587∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4588{{"Constant[4588∈0] ➊<br />ᐸsql.identifier(”reserved_input”)ᐳ"}}:::plan
+    Constant4589{{"Constant[4589∈0] ➊<br />ᐸRecordCodec(reservedInput)ᐳ"}}:::plan
+    Lambda3596 & Constant4587 & Constant4588 & Constant4589 --> Object4590
+    Object4605{{"Object[4605∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4602{{"Constant[4602∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4603{{"Constant[4603∈0] ➊<br />ᐸsql.identifier(”default_value”)ᐳ"}}:::plan
+    Constant4604{{"Constant[4604∈0] ➊<br />ᐸRecordCodec(defaultValue)ᐳ"}}:::plan
+    Lambda3596 & Constant4602 & Constant4603 & Constant4604 --> Object4605
+    Object4620{{"Object[4620∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4617{{"Constant[4617∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4618{{"Constant[4618∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant4619{{"Constant[4619∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda3596 & Constant4617 & Constant4618 & Constant4619 --> Object4620
+    Object4635{{"Object[4635∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4632{{"Constant[4632∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4633{{"Constant[4633∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant4634{{"Constant[4634∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda3596 & Constant4632 & Constant4633 & Constant4634 --> Object4635
+    Object4650{{"Object[4650∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4647{{"Constant[4647∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4648{{"Constant[4648∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4647 & Constant4648 & Constant3603 --> Object4650
+    Object4665{{"Object[4665∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4662{{"Constant[4662∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4663{{"Constant[4663∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4662 & Constant4663 & Constant3603 --> Object4665
+    Object4682{{"Object[4682∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4679{{"Constant[4679∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4680{{"Constant[4680∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4679 & Constant4680 & Constant3603 --> Object4682
+    Object4699{{"Object[4699∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4696{{"Constant[4696∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4697{{"Constant[4697∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4696 & Constant4697 & Constant3637 --> Object4699
+    Object4716{{"Object[4716∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4713{{"Constant[4713∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4714{{"Constant[4714∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4713 & Constant4714 & Constant3637 --> Object4716
+    Object4733{{"Object[4733∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4730{{"Constant[4730∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4731{{"Constant[4731∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4730 & Constant4731 & Constant3637 --> Object4733
+    Object4750{{"Object[4750∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4747{{"Constant[4747∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4748{{"Constant[4748∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4747 & Constant4748 & Constant3688 --> Object4750
+    Object4767{{"Object[4767∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4764{{"Constant[4764∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4765{{"Constant[4765∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4764 & Constant4765 & Constant3637 --> Object4767
+    Object4784{{"Object[4784∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4781{{"Constant[4781∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4782{{"Constant[4782∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4781 & Constant4782 & Constant3637 --> Object4784
+    Object4801{{"Object[4801∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4798{{"Constant[4798∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4799{{"Constant[4799∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4798 & Constant4799 & Constant3637 --> Object4801
+    Object4818{{"Object[4818∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4815{{"Constant[4815∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4816{{"Constant[4816∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant4815 & Constant4816 & Constant3688 --> Object4818
+    Object4835{{"Object[4835∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4832{{"Constant[4832∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4833{{"Constant[4833∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda3596 & Constant4832 & Constant4833 & Constant3773 --> Object4835
+    Object4850{{"Object[4850∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4847{{"Constant[4847∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4848{{"Constant[4848∈0] ➊<br />ᐸsql.identifier(”person_secret”)ᐳ"}}:::plan
+    Constant4849{{"Constant[4849∈0] ➊<br />ᐸRecordCodec(personSecret)ᐳ"}}:::plan
+    Lambda3596 & Constant4847 & Constant4848 & Constant4849 --> Object4850
+    Object4865{{"Object[4865∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4862{{"Constant[4862∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4863{{"Constant[4863∈0] ➊<br />ᐸsql.identifier(”left_arm”)ᐳ"}}:::plan
+    Constant4864{{"Constant[4864∈0] ➊<br />ᐸRecordCodec(leftArm)ᐳ"}}:::plan
+    Lambda3596 & Constant4862 & Constant4863 & Constant4864 --> Object4865
+    Object4880{{"Object[4880∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4877{{"Constant[4877∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4878{{"Constant[4878∈0] ➊<br />ᐸsql.identifier(”my_table”)ᐳ"}}:::plan
+    Constant4879{{"Constant[4879∈0] ➊<br />ᐸRecordCodec(myTable)ᐳ"}}:::plan
+    Lambda3596 & Constant4877 & Constant4878 & Constant4879 --> Object4880
+    Object4895{{"Object[4895∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4892{{"Constant[4892∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4893{{"Constant[4893∈0] ➊<br />ᐸsql.identifier(”view_table”)ᐳ"}}:::plan
+    Constant4894{{"Constant[4894∈0] ➊<br />ᐸRecordCodec(viewTable)ᐳ"}}:::plan
+    Lambda3596 & Constant4892 & Constant4893 & Constant4894 --> Object4895
+    Object4910{{"Object[4910∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4907{{"Constant[4907∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4908{{"Constant[4908∈0] ➊<br />ᐸsql.identifier(”similar_table_1”)ᐳ"}}:::plan
+    Constant4909{{"Constant[4909∈0] ➊<br />ᐸRecordCodec(similarTable1)ᐳ"}}:::plan
+    Lambda3596 & Constant4907 & Constant4908 & Constant4909 --> Object4910
+    Object4925{{"Object[4925∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4922{{"Constant[4922∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4923{{"Constant[4923∈0] ➊<br />ᐸsql.identifier(”similar_table_2”)ᐳ"}}:::plan
+    Constant4924{{"Constant[4924∈0] ➊<br />ᐸRecordCodec(similarTable2)ᐳ"}}:::plan
+    Lambda3596 & Constant4922 & Constant4923 & Constant4924 --> Object4925
+    Object4940{{"Object[4940∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4937{{"Constant[4937∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4938{{"Constant[4938∈0] ➊<br />ᐸsql.identifier(”null_test_record”)ᐳ"}}:::plan
+    Constant4939{{"Constant[4939∈0] ➊<br />ᐸRecordCodec(nullTestRecord)ᐳ"}}:::plan
+    Lambda3596 & Constant4937 & Constant4938 & Constant4939 --> Object4940
+    Object4955{{"Object[4955∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4952{{"Constant[4952∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4953{{"Constant[4953∈0] ➊<br />ᐸsql.identifier(”issue756”)ᐳ"}}:::plan
+    Constant4954{{"Constant[4954∈0] ➊<br />ᐸRecordCodec(issue756)ᐳ"}}:::plan
+    Lambda3596 & Constant4952 & Constant4953 & Constant4954 --> Object4955
+    Object4970{{"Object[4970∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4967{{"Constant[4967∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4968{{"Constant[4968∈0] ➊<br />ᐸsql.identifier(”lists”)ᐳ"}}:::plan
+    Constant4969{{"Constant[4969∈0] ➊<br />ᐸRecordCodec(lists)ᐳ"}}:::plan
+    Lambda3596 & Constant4967 & Constant4968 & Constant4969 --> Object4970
+    Object4985{{"Object[4985∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4982{{"Constant[4982∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant4983{{"Constant[4983∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4982 & Constant4983 & Constant3603 --> Object4985
+    Object5002{{"Object[5002∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant4999{{"Constant[4999∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5000{{"Constant[5000∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant4999 & Constant5000 & Constant3603 --> Object5002
+    Object5019{{"Object[5019∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5016{{"Constant[5016∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5017{{"Constant[5017∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5016 & Constant5017 & Constant3637 --> Object5019
+    Object5036{{"Object[5036∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5033{{"Constant[5033∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5034{{"Constant[5034∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5033 & Constant5034 & Constant3637 --> Object5036
+    Object5053{{"Object[5053∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5050{{"Constant[5050∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5051{{"Constant[5051∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5050 & Constant5051 & Constant3637 --> Object5053
+    Object5070{{"Object[5070∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5067{{"Constant[5067∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5068{{"Constant[5068∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5067 & Constant5068 & Constant3688 --> Object5070
+    Object5087{{"Object[5087∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5084{{"Constant[5084∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5085{{"Constant[5085∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5084 & Constant5085 & Constant3637 --> Object5087
+    Object5104{{"Object[5104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5101{{"Constant[5101∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5102{{"Constant[5102∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5101 & Constant5102 & Constant3637 --> Object5104
+    Object5121{{"Object[5121∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5118{{"Constant[5118∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5119{{"Constant[5119∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5118 & Constant5119 & Constant3637 --> Object5121
     Object5138{{"Object[5138∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant5135{{"Constant[5135∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5136{{"Constant[5136∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5135 & Constant5136 & Constant3634 --> Object5138
-    Object5154{{"Object[5154∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5151{{"Constant[5151∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5152{{"Constant[5152∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5151 & Constant5152 & Constant3682 --> Object5154
+    Constant5136{{"Constant[5136∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5135 & Constant5136 & Constant3688 --> Object5138
+    Object5155{{"Object[5155∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5152{{"Constant[5152∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5153{{"Constant[5153∈0] ➊<br />ᐸsql.identifier(”type_function”)ᐳ"}}:::plan
+    Lambda3596 & Constant5152 & Constant5153 & Constant3773 --> Object5155
     Object5170{{"Object[5170∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant5167{{"Constant[5167∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5168{{"Constant[5168∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5167 & Constant5168 & Constant3634 --> Object5170
-    Object5186{{"Object[5186∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5183{{"Constant[5183∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5184{{"Constant[5184∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5183 & Constant5184 & Constant3634 --> Object5186
-    Object5202{{"Object[5202∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5199{{"Constant[5199∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5200{{"Constant[5200∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5199 & Constant5200 & Constant3634 --> Object5202
-    Object5218{{"Object[5218∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5215{{"Constant[5215∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5216{{"Constant[5216∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5215 & Constant5216 & Constant3682 --> Object5218
-    Object5234{{"Object[5234∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5231{{"Constant[5231∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5232{{"Constant[5232∈0] ➊<br />ᐸsql.identifier(”type_function_list”)ᐳ"}}:::plan
-    Lambda3596 & Constant5231 & Constant5232 & Constant3762 --> Object5234
-    Object5589{{"Object[5589∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5586{{"Constant[5586∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5587{{"Constant[5587∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant5586 & Constant5587 & Constant3602 --> Object5589
-    Object5605{{"Object[5605∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5602{{"Constant[5602∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5603{{"Constant[5603∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant5602 & Constant5603 & Constant3602 --> Object5605
-    Object5621{{"Object[5621∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5618{{"Constant[5618∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5619{{"Constant[5619∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5618 & Constant5619 & Constant3634 --> Object5621
+    Constant5168{{"Constant[5168∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5167 & Constant5168 & Constant3603 --> Object5170
+    Object5187{{"Object[5187∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5184{{"Constant[5184∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5185{{"Constant[5185∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5184 & Constant5185 & Constant3603 --> Object5187
+    Object5204{{"Object[5204∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5201{{"Constant[5201∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5202{{"Constant[5202∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5201 & Constant5202 & Constant3637 --> Object5204
+    Object5221{{"Object[5221∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5218{{"Constant[5218∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5219{{"Constant[5219∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5218 & Constant5219 & Constant3637 --> Object5221
+    Object5238{{"Object[5238∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5235{{"Constant[5235∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5236{{"Constant[5236∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5235 & Constant5236 & Constant3637 --> Object5238
+    Object5255{{"Object[5255∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5252{{"Constant[5252∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5253{{"Constant[5253∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5252 & Constant5253 & Constant3688 --> Object5255
+    Object5272{{"Object[5272∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5269{{"Constant[5269∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5270{{"Constant[5270∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5269 & Constant5270 & Constant3637 --> Object5272
+    Object5289{{"Object[5289∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5286{{"Constant[5286∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5287{{"Constant[5287∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5286 & Constant5287 & Constant3637 --> Object5289
+    Object5306{{"Object[5306∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5303{{"Constant[5303∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5304{{"Constant[5304∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5303 & Constant5304 & Constant3637 --> Object5306
+    Object5323{{"Object[5323∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5320{{"Constant[5320∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5321{{"Constant[5321∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5320 & Constant5321 & Constant3688 --> Object5323
+    Object5340{{"Object[5340∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5337{{"Constant[5337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5338{{"Constant[5338∈0] ➊<br />ᐸsql.identifier(”type_function_list”)ᐳ"}}:::plan
+    Lambda3596 & Constant5337 & Constant5338 & Constant3773 --> Object5340
+    Object5355{{"Object[5355∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5352{{"Constant[5352∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5353{{"Constant[5353∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5352 & Constant5353 & Constant3603 --> Object5355
+    Object5370{{"Object[5370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5367{{"Constant[5367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5368{{"Constant[5368∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5367 & Constant5368 & Constant3603 --> Object5370
+    Object5385{{"Object[5385∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5382{{"Constant[5382∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5383{{"Constant[5383∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5382 & Constant5383 & Constant3637 --> Object5385
+    Object5402{{"Object[5402∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5399{{"Constant[5399∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5400{{"Constant[5400∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5399 & Constant5400 & Constant3637 --> Object5402
+    Object5419{{"Object[5419∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5416{{"Constant[5416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5417{{"Constant[5417∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5416 & Constant5417 & Constant3637 --> Object5419
+    Object5436{{"Object[5436∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5433{{"Constant[5433∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5434{{"Constant[5434∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5433 & Constant5434 & Constant3688 --> Object5436
+    Object5453{{"Object[5453∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5450{{"Constant[5450∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5451{{"Constant[5451∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5450 & Constant5451 & Constant3637 --> Object5453
+    Object5470{{"Object[5470∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5467{{"Constant[5467∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5468{{"Constant[5468∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5467 & Constant5468 & Constant3637 --> Object5470
+    Object5487{{"Object[5487∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5484{{"Constant[5484∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5485{{"Constant[5485∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5484 & Constant5485 & Constant3637 --> Object5487
+    Object5504{{"Object[5504∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5501{{"Constant[5501∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5502{{"Constant[5502∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5501 & Constant5502 & Constant3688 --> Object5504
+    Object5522{{"Object[5522∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5519{{"Constant[5519∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5520{{"Constant[5520∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5519 & Constant5520 & Constant3603 --> Object5522
+    Object5537{{"Object[5537∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5534{{"Constant[5534∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5535{{"Constant[5535∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5534 & Constant5535 & Constant3603 --> Object5537
+    Object5552{{"Object[5552∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5549{{"Constant[5549∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5550{{"Constant[5550∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5549 & Constant5550 & Constant3637 --> Object5552
+    Object5569{{"Object[5569∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5566{{"Constant[5566∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5567{{"Constant[5567∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5566 & Constant5567 & Constant3637 --> Object5569
+    Object5586{{"Object[5586∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5583{{"Constant[5583∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5584{{"Constant[5584∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5583 & Constant5584 & Constant3637 --> Object5586
+    Object5603{{"Object[5603∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5600{{"Constant[5600∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5601{{"Constant[5601∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5600 & Constant5601 & Constant3688 --> Object5603
+    Object5620{{"Object[5620∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5617{{"Constant[5617∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5618{{"Constant[5618∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5617 & Constant5618 & Constant3637 --> Object5620
     Object5637{{"Object[5637∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant5634{{"Constant[5634∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
     Constant5635{{"Constant[5635∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5634 & Constant5635 & Constant3634 --> Object5637
-    Object5653{{"Object[5653∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5650{{"Constant[5650∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5651{{"Constant[5651∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5650 & Constant5651 & Constant3634 --> Object5653
-    Object5669{{"Object[5669∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5666{{"Constant[5666∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5667{{"Constant[5667∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5666 & Constant5667 & Constant3682 --> Object5669
-    Object5685{{"Object[5685∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5682{{"Constant[5682∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5683{{"Constant[5683∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5682 & Constant5683 & Constant3634 --> Object5685
-    Object5701{{"Object[5701∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5698{{"Constant[5698∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5699{{"Constant[5699∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5698 & Constant5699 & Constant3634 --> Object5701
-    Object5717{{"Object[5717∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5714{{"Constant[5714∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5715{{"Constant[5715∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5714 & Constant5715 & Constant3634 --> Object5717
-    Object5733{{"Object[5733∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5730{{"Constant[5730∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5731{{"Constant[5731∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5730 & Constant5731 & Constant3682 --> Object5733
-    Object5749{{"Object[5749∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5746{{"Constant[5746∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5747{{"Constant[5747∈0] ➊<br />ᐸsql.identifier(”person_type_function”)ᐳ"}}:::plan
-    Lambda3596 & Constant5746 & Constant5747 & Constant3762 --> Object5749
-    Object5765{{"Object[5765∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5762{{"Constant[5762∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5763{{"Constant[5763∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant5762 & Constant5763 & Constant3602 --> Object5765
-    Object5781{{"Object[5781∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5778{{"Constant[5778∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5779{{"Constant[5779∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant5778 & Constant5779 & Constant3602 --> Object5781
-    Object5797{{"Object[5797∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5794{{"Constant[5794∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5795{{"Constant[5795∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5794 & Constant5795 & Constant3634 --> Object5797
-    Object5813{{"Object[5813∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5810{{"Constant[5810∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5811{{"Constant[5811∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5810 & Constant5811 & Constant3634 --> Object5813
-    Object5829{{"Object[5829∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5826{{"Constant[5826∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5827{{"Constant[5827∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5826 & Constant5827 & Constant3634 --> Object5829
-    Object5845{{"Object[5845∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5842{{"Constant[5842∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5843{{"Constant[5843∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5842 & Constant5843 & Constant3682 --> Object5845
-    Object5861{{"Object[5861∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5858{{"Constant[5858∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5859{{"Constant[5859∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5858 & Constant5859 & Constant3634 --> Object5861
-    Object5877{{"Object[5877∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5874{{"Constant[5874∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5875{{"Constant[5875∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5874 & Constant5875 & Constant3634 --> Object5877
-    Object5893{{"Object[5893∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5890{{"Constant[5890∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5891{{"Constant[5891∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5890 & Constant5891 & Constant3634 --> Object5893
-    Object5909{{"Object[5909∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5906{{"Constant[5906∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5907{{"Constant[5907∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5906 & Constant5907 & Constant3682 --> Object5909
-    Object5925{{"Object[5925∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5922{{"Constant[5922∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5923{{"Constant[5923∈0] ➊<br />ᐸsql.identifier(”person_type_function_list”)ᐳ"}}:::plan
-    Lambda3596 & Constant5922 & Constant5923 & Constant3762 --> Object5925
-    Object5972{{"Object[5972∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5969{{"Constant[5969∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5970{{"Constant[5970∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5969 & Constant5970 & Constant3634 --> Object5972
-    Object5988{{"Object[5988∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant5985{{"Constant[5985∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5986{{"Constant[5986∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant5985 & Constant5986 & Constant3634 --> Object5988
-    Object6004{{"Object[6004∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6001{{"Constant[6001∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6002{{"Constant[6002∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6001 & Constant6002 & Constant3634 --> Object6004
-    Object6020{{"Object[6020∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6017{{"Constant[6017∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6018{{"Constant[6018∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6017 & Constant6018 & Constant3682 --> Object6020
-    Object6036{{"Object[6036∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6033{{"Constant[6033∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6034{{"Constant[6034∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6033 & Constant6034 & Constant3634 --> Object6036
-    Object6052{{"Object[6052∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6049{{"Constant[6049∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6050{{"Constant[6050∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6049 & Constant6050 & Constant3634 --> Object6052
-    Object6068{{"Object[6068∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6065{{"Constant[6065∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6066{{"Constant[6066∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6065 & Constant6066 & Constant3634 --> Object6068
-    Object6084{{"Object[6084∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6081{{"Constant[6081∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6082{{"Constant[6082∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6081 & Constant6082 & Constant3682 --> Object6084
-    Object6129{{"Object[6129∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6126{{"Constant[6126∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6127{{"Constant[6127∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6126 & Constant6127 & Constant3634 --> Object6129
-    Object6145{{"Object[6145∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6142{{"Constant[6142∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6143{{"Constant[6143∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6142 & Constant6143 & Constant3634 --> Object6145
-    Object6161{{"Object[6161∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6158{{"Constant[6158∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6159{{"Constant[6159∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6158 & Constant6159 & Constant3634 --> Object6161
-    Object6177{{"Object[6177∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6174{{"Constant[6174∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6175{{"Constant[6175∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6174 & Constant6175 & Constant3682 --> Object6177
+    Lambda3596 & Constant5634 & Constant5635 & Constant3637 --> Object5637
+    Object5654{{"Object[5654∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5651{{"Constant[5651∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5652{{"Constant[5652∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5651 & Constant5652 & Constant3637 --> Object5654
+    Object5671{{"Object[5671∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5668{{"Constant[5668∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5669{{"Constant[5669∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5668 & Constant5669 & Constant3688 --> Object5671
+    Object5688{{"Object[5688∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5685{{"Constant[5685∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5686{{"Constant[5686∈0] ➊<br />ᐸsql.identifier(”type_function_connection”)ᐳ"}}:::plan
+    Lambda3596 & Constant5685 & Constant5686 & Constant3773 --> Object5688
+    Object5703{{"Object[5703∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5700{{"Constant[5700∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda3596 & Constant5700 & Constant5686 & Constant3773 --> Object5703
+    Object5718{{"Object[5718∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5715{{"Constant[5715∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5716{{"Constant[5716∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5715 & Constant5716 & Constant3603 --> Object5718
+    Object5735{{"Object[5735∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5732{{"Constant[5732∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5733{{"Constant[5733∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5732 & Constant5733 & Constant3603 --> Object5735
+    Object5752{{"Object[5752∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5749{{"Constant[5749∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5750{{"Constant[5750∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5749 & Constant5750 & Constant3637 --> Object5752
+    Object5769{{"Object[5769∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5766{{"Constant[5766∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5767{{"Constant[5767∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5766 & Constant5767 & Constant3637 --> Object5769
+    Object5786{{"Object[5786∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5783{{"Constant[5783∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5784{{"Constant[5784∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5783 & Constant5784 & Constant3637 --> Object5786
+    Object5803{{"Object[5803∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5800{{"Constant[5800∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5801{{"Constant[5801∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5800 & Constant5801 & Constant3688 --> Object5803
+    Object5820{{"Object[5820∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5817{{"Constant[5817∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5818{{"Constant[5818∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5817 & Constant5818 & Constant3637 --> Object5820
+    Object5837{{"Object[5837∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5834{{"Constant[5834∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5835{{"Constant[5835∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5834 & Constant5835 & Constant3637 --> Object5837
+    Object5854{{"Object[5854∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5851{{"Constant[5851∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5852{{"Constant[5852∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5851 & Constant5852 & Constant3637 --> Object5854
+    Object5871{{"Object[5871∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5868{{"Constant[5868∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5869{{"Constant[5869∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5868 & Constant5869 & Constant3688 --> Object5871
+    Object5888{{"Object[5888∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5885{{"Constant[5885∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5886{{"Constant[5886∈0] ➊<br />ᐸsql.identifier(”person_type_function”)ᐳ"}}:::plan
+    Lambda3596 & Constant5885 & Constant5886 & Constant3773 --> Object5888
+    Object5905{{"Object[5905∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5902{{"Constant[5902∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5903{{"Constant[5903∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5902 & Constant5903 & Constant3603 --> Object5905
+    Object5922{{"Object[5922∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5919{{"Constant[5919∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5920{{"Constant[5920∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant5919 & Constant5920 & Constant3603 --> Object5922
+    Object5939{{"Object[5939∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5936{{"Constant[5936∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5937{{"Constant[5937∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5936 & Constant5937 & Constant3637 --> Object5939
+    Object5956{{"Object[5956∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5953{{"Constant[5953∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5954{{"Constant[5954∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5953 & Constant5954 & Constant3637 --> Object5956
+    Object5973{{"Object[5973∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5970{{"Constant[5970∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5971{{"Constant[5971∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5970 & Constant5971 & Constant3637 --> Object5973
+    Object5990{{"Object[5990∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant5987{{"Constant[5987∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant5988{{"Constant[5988∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant5987 & Constant5988 & Constant3688 --> Object5990
+    Object6007{{"Object[6007∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6004{{"Constant[6004∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6005{{"Constant[6005∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6004 & Constant6005 & Constant3637 --> Object6007
+    Object6024{{"Object[6024∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6021{{"Constant[6021∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6022{{"Constant[6022∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6021 & Constant6022 & Constant3637 --> Object6024
+    Object6041{{"Object[6041∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6038{{"Constant[6038∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6039{{"Constant[6039∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6038 & Constant6039 & Constant3637 --> Object6041
+    Object6058{{"Object[6058∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6055{{"Constant[6055∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6056{{"Constant[6056∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6055 & Constant6056 & Constant3688 --> Object6058
+    Object6075{{"Object[6075∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6072{{"Constant[6072∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6073{{"Constant[6073∈0] ➊<br />ᐸsql.identifier(”person_type_function_list”)ᐳ"}}:::plan
+    Lambda3596 & Constant6072 & Constant6073 & Constant3773 --> Object6075
+    Object6095{{"Object[6095∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6092{{"Constant[6092∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6093{{"Constant[6093∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6092 & Constant6093 & Constant3603 --> Object6095
+    Object6110{{"Object[6110∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6107{{"Constant[6107∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6108{{"Constant[6108∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6107 & Constant6108 & Constant3603 --> Object6110
+    Object6125{{"Object[6125∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6122{{"Constant[6122∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6123{{"Constant[6123∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6122 & Constant6123 & Constant3637 --> Object6125
+    Object6142{{"Object[6142∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6139{{"Constant[6139∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6140{{"Constant[6140∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6139 & Constant6140 & Constant3637 --> Object6142
+    Object6159{{"Object[6159∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6156{{"Constant[6156∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6157{{"Constant[6157∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6156 & Constant6157 & Constant3637 --> Object6159
+    Object6176{{"Object[6176∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6173{{"Constant[6173∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6174{{"Constant[6174∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6173 & Constant6174 & Constant3688 --> Object6176
     Object6193{{"Object[6193∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant6190{{"Constant[6190∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
     Constant6191{{"Constant[6191∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6190 & Constant6191 & Constant3634 --> Object6193
-    Object6209{{"Object[6209∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6206{{"Constant[6206∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6207{{"Constant[6207∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6206 & Constant6207 & Constant3634 --> Object6209
-    Object6225{{"Object[6225∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6222{{"Constant[6222∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6223{{"Constant[6223∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6222 & Constant6223 & Constant3634 --> Object6225
-    Object6241{{"Object[6241∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6238{{"Constant[6238∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6239{{"Constant[6239∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6238 & Constant6239 & Constant3682 --> Object6241
-    Object6257{{"Object[6257∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6254{{"Constant[6254∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6255{{"Constant[6255∈0] ➊<br />ᐸsql.identifier(”person_type_function_connection”)ᐳ"}}:::plan
-    Lambda3596 & Constant6254 & Constant6255 & Constant3762 --> Object6257
-    Object6275{{"Object[6275∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6272{{"Constant[6272∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda3596 & Constant6272 & Constant6255 & Constant3762 --> Object6275
+    Lambda3596 & Constant6190 & Constant6191 & Constant3637 --> Object6193
+    Object6210{{"Object[6210∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6207{{"Constant[6207∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6208{{"Constant[6208∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6207 & Constant6208 & Constant3637 --> Object6210
+    Object6227{{"Object[6227∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6224{{"Constant[6224∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6225{{"Constant[6225∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6224 & Constant6225 & Constant3637 --> Object6227
+    Object6244{{"Object[6244∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6241{{"Constant[6241∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6242{{"Constant[6242∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6241 & Constant6242 & Constant3688 --> Object6244
+    Object6262{{"Object[6262∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6259{{"Constant[6259∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6260{{"Constant[6260∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6259 & Constant6260 & Constant3603 --> Object6262
+    Object6277{{"Object[6277∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6274{{"Constant[6274∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6275{{"Constant[6275∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6274 & Constant6275 & Constant3603 --> Object6277
     Object6292{{"Object[6292∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant6289{{"Constant[6289∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6290{{"Constant[6290∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda3596 & Constant6289 & Constant6290 & Constant4571 --> Object6292
-    Object6306{{"Object[6306∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6303{{"Constant[6303∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6304{{"Constant[6304∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6303 & Constant6304 & Constant3602 --> Object6306
-    Object6322{{"Object[6322∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6319{{"Constant[6319∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6320{{"Constant[6320∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6319 & Constant6320 & Constant3602 --> Object6322
-    Object6338{{"Object[6338∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6335{{"Constant[6335∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6336{{"Constant[6336∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6335 & Constant6336 & Constant3634 --> Object6338
-    Object6354{{"Object[6354∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6351{{"Constant[6351∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6352{{"Constant[6352∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6351 & Constant6352 & Constant3634 --> Object6354
-    Object6370{{"Object[6370∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6367{{"Constant[6367∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6368{{"Constant[6368∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6367 & Constant6368 & Constant3634 --> Object6370
-    Object6386{{"Object[6386∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6383{{"Constant[6383∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6384{{"Constant[6384∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6383 & Constant6384 & Constant3682 --> Object6386
-    Object6402{{"Object[6402∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6399{{"Constant[6399∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6400{{"Constant[6400∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6399 & Constant6400 & Constant3634 --> Object6402
-    Object6418{{"Object[6418∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6415{{"Constant[6415∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6416{{"Constant[6416∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6415 & Constant6416 & Constant3634 --> Object6418
-    Object6434{{"Object[6434∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6431{{"Constant[6431∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6432{{"Constant[6432∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6431 & Constant6432 & Constant3634 --> Object6434
-    Object6450{{"Object[6450∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6447{{"Constant[6447∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6448{{"Constant[6448∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6447 & Constant6448 & Constant3682 --> Object6450
-    Object6466{{"Object[6466∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6463{{"Constant[6463∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6464{{"Constant[6464∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda3596 & Constant6463 & Constant6464 & Constant3762 --> Object6466
-    Object6482{{"Object[6482∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6479{{"Constant[6479∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6480{{"Constant[6480∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6479 & Constant6480 & Constant3602 --> Object6482
-    Object6498{{"Object[6498∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6495{{"Constant[6495∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6496{{"Constant[6496∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6495 & Constant6496 & Constant3602 --> Object6498
+    Constant6290{{"Constant[6290∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6289 & Constant6290 & Constant3637 --> Object6292
+    Object6309{{"Object[6309∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6306{{"Constant[6306∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6307{{"Constant[6307∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6306 & Constant6307 & Constant3637 --> Object6309
+    Object6326{{"Object[6326∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6323{{"Constant[6323∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6324{{"Constant[6324∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6323 & Constant6324 & Constant3637 --> Object6326
+    Object6343{{"Object[6343∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6340{{"Constant[6340∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6341{{"Constant[6341∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6340 & Constant6341 & Constant3688 --> Object6343
+    Object6360{{"Object[6360∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6357{{"Constant[6357∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6358{{"Constant[6358∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6357 & Constant6358 & Constant3637 --> Object6360
+    Object6377{{"Object[6377∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6374{{"Constant[6374∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6375{{"Constant[6375∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6374 & Constant6375 & Constant3637 --> Object6377
+    Object6394{{"Object[6394∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6391{{"Constant[6391∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6392{{"Constant[6392∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6391 & Constant6392 & Constant3637 --> Object6394
+    Object6411{{"Object[6411∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6408{{"Constant[6408∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6409{{"Constant[6409∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6408 & Constant6409 & Constant3688 --> Object6411
+    Object6428{{"Object[6428∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6425{{"Constant[6425∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6426{{"Constant[6426∈0] ➊<br />ᐸsql.identifier(”person_type_function_connection”)ᐳ"}}:::plan
+    Lambda3596 & Constant6425 & Constant6426 & Constant3773 --> Object6428
+    Object6447{{"Object[6447∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6444{{"Constant[6444∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda3596 & Constant6444 & Constant6426 & Constant3773 --> Object6447
+    Object6465{{"Object[6465∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6462{{"Constant[6462∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6463{{"Constant[6463∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda3596 & Constant6462 & Constant6463 & Constant4634 --> Object6465
+    Object6480{{"Object[6480∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6477{{"Constant[6477∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6478{{"Constant[6478∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6477 & Constant6478 & Constant3603 --> Object6480
+    Object6497{{"Object[6497∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6494{{"Constant[6494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6495{{"Constant[6495∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6494 & Constant6495 & Constant3603 --> Object6497
     Object6514{{"Object[6514∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant6511{{"Constant[6511∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
     Constant6512{{"Constant[6512∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6511 & Constant6512 & Constant3634 --> Object6514
-    Object6530{{"Object[6530∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6527{{"Constant[6527∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6528{{"Constant[6528∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6527 & Constant6528 & Constant3634 --> Object6530
-    Object6546{{"Object[6546∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6543{{"Constant[6543∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6544{{"Constant[6544∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6543 & Constant6544 & Constant3634 --> Object6546
-    Object6562{{"Object[6562∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6559{{"Constant[6559∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6560{{"Constant[6560∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6559 & Constant6560 & Constant3682 --> Object6562
-    Object6578{{"Object[6578∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6575{{"Constant[6575∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6576{{"Constant[6576∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6575 & Constant6576 & Constant3634 --> Object6578
-    Object6594{{"Object[6594∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6591{{"Constant[6591∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6592{{"Constant[6592∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6591 & Constant6592 & Constant3634 --> Object6594
-    Object6610{{"Object[6610∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6607{{"Constant[6607∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6608{{"Constant[6608∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6607 & Constant6608 & Constant3634 --> Object6610
-    Object6626{{"Object[6626∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6623{{"Constant[6623∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6624{{"Constant[6624∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6623 & Constant6624 & Constant3682 --> Object6626
-    Object6642{{"Object[6642∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6639{{"Constant[6639∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6640{{"Constant[6640∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6639 & Constant6640 & Constant3602 --> Object6642
-    Object6658{{"Object[6658∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6655{{"Constant[6655∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6656{{"Constant[6656∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6655 & Constant6656 & Constant3602 --> Object6658
-    Object6674{{"Object[6674∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6671{{"Constant[6671∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6672{{"Constant[6672∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6671 & Constant6672 & Constant3634 --> Object6674
-    Object6690{{"Object[6690∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6687{{"Constant[6687∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6688{{"Constant[6688∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6687 & Constant6688 & Constant3634 --> Object6690
-    Object6706{{"Object[6706∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6703{{"Constant[6703∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6704{{"Constant[6704∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6703 & Constant6704 & Constant3634 --> Object6706
-    Object6722{{"Object[6722∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6719{{"Constant[6719∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6720{{"Constant[6720∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6719 & Constant6720 & Constant3682 --> Object6722
-    Object6738{{"Object[6738∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6735{{"Constant[6735∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6736{{"Constant[6736∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6735 & Constant6736 & Constant3634 --> Object6738
-    Object6754{{"Object[6754∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6751{{"Constant[6751∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6752{{"Constant[6752∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6751 & Constant6752 & Constant3634 --> Object6754
-    Object6770{{"Object[6770∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6767{{"Constant[6767∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6768{{"Constant[6768∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6767 & Constant6768 & Constant3634 --> Object6770
+    Lambda3596 & Constant6511 & Constant6512 & Constant3637 --> Object6514
+    Object6531{{"Object[6531∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6528{{"Constant[6528∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6529{{"Constant[6529∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6528 & Constant6529 & Constant3637 --> Object6531
+    Object6548{{"Object[6548∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6545{{"Constant[6545∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6546{{"Constant[6546∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6545 & Constant6546 & Constant3637 --> Object6548
+    Object6565{{"Object[6565∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6562{{"Constant[6562∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6563{{"Constant[6563∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6562 & Constant6563 & Constant3688 --> Object6565
+    Object6582{{"Object[6582∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6579{{"Constant[6579∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6580{{"Constant[6580∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6579 & Constant6580 & Constant3637 --> Object6582
+    Object6599{{"Object[6599∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6596{{"Constant[6596∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6597{{"Constant[6597∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6596 & Constant6597 & Constant3637 --> Object6599
+    Object6616{{"Object[6616∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6613{{"Constant[6613∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6614{{"Constant[6614∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6613 & Constant6614 & Constant3637 --> Object6616
+    Object6633{{"Object[6633∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6630{{"Constant[6630∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6631{{"Constant[6631∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6630 & Constant6631 & Constant3688 --> Object6633
+    Object6650{{"Object[6650∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6647{{"Constant[6647∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6648{{"Constant[6648∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda3596 & Constant6647 & Constant6648 & Constant3773 --> Object6650
+    Object6667{{"Object[6667∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6664{{"Constant[6664∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6665{{"Constant[6665∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6664 & Constant6665 & Constant3603 --> Object6667
+    Object6684{{"Object[6684∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6681{{"Constant[6681∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6682{{"Constant[6682∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6681 & Constant6682 & Constant3603 --> Object6684
+    Object6701{{"Object[6701∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6698{{"Constant[6698∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6699{{"Constant[6699∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6698 & Constant6699 & Constant3637 --> Object6701
+    Object6718{{"Object[6718∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6715{{"Constant[6715∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6716{{"Constant[6716∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6715 & Constant6716 & Constant3637 --> Object6718
+    Object6735{{"Object[6735∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6732{{"Constant[6732∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6733{{"Constant[6733∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6732 & Constant6733 & Constant3637 --> Object6735
+    Object6752{{"Object[6752∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6749{{"Constant[6749∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6750{{"Constant[6750∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6749 & Constant6750 & Constant3688 --> Object6752
+    Object6769{{"Object[6769∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6766{{"Constant[6766∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6767{{"Constant[6767∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6766 & Constant6767 & Constant3637 --> Object6769
     Object6786{{"Object[6786∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
     Constant6783{{"Constant[6783∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6784{{"Constant[6784∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Lambda3596 & Constant6783 & Constant6784 & Constant3682 --> Object6786
-    Object6802{{"Object[6802∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6799{{"Constant[6799∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant6800{{"Constant[6800∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
-    Lambda3596 & Constant6799 & Constant6800 & Constant3762 --> Object6802
-    Object6821{{"Object[6821∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6818{{"Constant[6818∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Lambda3596 & Constant6818 & Constant6800 & Constant3762 --> Object6821
-    Object6839{{"Object[6839∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant6836{{"Constant[6836∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6837{{"Constant[6837∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Lambda3596 & Constant6836 & Constant6837 & Constant3602 --> Object6839
+    Constant6784{{"Constant[6784∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6783 & Constant6784 & Constant3637 --> Object6786
+    Object6803{{"Object[6803∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6800{{"Constant[6800∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6801{{"Constant[6801∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6800 & Constant6801 & Constant3637 --> Object6803
+    Object6820{{"Object[6820∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6817{{"Constant[6817∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6818{{"Constant[6818∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6817 & Constant6818 & Constant3688 --> Object6820
+    Object6837{{"Object[6837∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6834{{"Constant[6834∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6835{{"Constant[6835∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6834 & Constant6835 & Constant3603 --> Object6837
+    Object6854{{"Object[6854∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6851{{"Constant[6851∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6852{{"Constant[6852∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant6851 & Constant6852 & Constant3603 --> Object6854
+    Object6871{{"Object[6871∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6868{{"Constant[6868∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6869{{"Constant[6869∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6868 & Constant6869 & Constant3637 --> Object6871
+    Object6888{{"Object[6888∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6885{{"Constant[6885∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6886{{"Constant[6886∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6885 & Constant6886 & Constant3637 --> Object6888
+    Object6905{{"Object[6905∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6902{{"Constant[6902∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6903{{"Constant[6903∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6902 & Constant6903 & Constant3637 --> Object6905
+    Object6922{{"Object[6922∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6919{{"Constant[6919∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6920{{"Constant[6920∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6919 & Constant6920 & Constant3688 --> Object6922
+    Object6939{{"Object[6939∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6936{{"Constant[6936∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6937{{"Constant[6937∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6936 & Constant6937 & Constant3637 --> Object6939
+    Object6956{{"Object[6956∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6953{{"Constant[6953∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6954{{"Constant[6954∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6953 & Constant6954 & Constant3637 --> Object6956
+    Object6973{{"Object[6973∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6970{{"Constant[6970∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6971{{"Constant[6971∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6970 & Constant6971 & Constant3637 --> Object6973
+    Object6990{{"Object[6990∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant6987{{"Constant[6987∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant6988{{"Constant[6988∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
+    Lambda3596 & Constant6987 & Constant6988 & Constant3688 --> Object6990
+    Object7007{{"Object[7007∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant7004{{"Constant[7004∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
+    Constant7005{{"Constant[7005∈0] ➊<br />ᐸsql.identifier(”types”)ᐳ"}}:::plan
+    Lambda3596 & Constant7004 & Constant7005 & Constant3773 --> Object7007
+    Object7027{{"Object[7027∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant7024{{"Constant[7024∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Lambda3596 & Constant7024 & Constant7005 & Constant3773 --> Object7027
+    Object7046{{"Object[7046∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant7043{{"Constant[7043∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant7044{{"Constant[7044∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
+    Lambda3596 & Constant7043 & Constant7044 & Constant3603 --> Object7046
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
@@ -957,8 +1146,8 @@ graph TD
     PgSelectSingle630{{"PgSelectSingle[630∈0] ➊<br />ᐸtypesᐳ"}}:::plan
     First629 --> PgSelectSingle630
     Lambda824{{"Lambda[824∈0] ➊<br />ᐸspecifier_Type_base64JSONᐳ"}}:::plan
-    Constant6847{{"Constant[6847∈0] ➊<br />ᐸ'WyJ0eXBlcyIsMTFd'ᐳ"}}:::plan
-    Constant6847 --> Lambda824
+    Constant7054{{"Constant[7054∈0] ➊<br />ᐸ'WyJ0eXBlcyIsMTFd'ᐳ"}}:::plan
+    Constant7054 --> Lambda824
     Lambda824 --> Access825
     First829{{"First[829∈0] ➊"}}:::plan
     PgSelect827 --> First829
@@ -967,7 +1156,7 @@ graph TD
     Node1024{{"Node[1024∈0] ➊"}}:::plan
     Lambda1025{{"Lambda[1025∈0] ➊<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
     Lambda1025 --> Node1024
-    Constant6847 --> Lambda1025
+    Constant7054 --> Lambda1025
     First1321{{"First[1321∈0] ➊"}}:::plan
     PgSelect1319 --> First1321
     PgSelectSingle1322{{"PgSelectSingle[1322∈0] ➊<br />ᐸtype_functionᐳ"}}:::plan
@@ -976,795 +1165,815 @@ graph TD
     PgSelect2139 --> First2141
     PgSelectSingle2142{{"PgSelectSingle[2142∈0] ➊<br />ᐸpersonᐳ"}}:::plan
     First2141 --> PgSelectSingle2142
+    PgPageInfo2946{{"PgPageInfo[2946∈0] ➊"}}:::plan
+    Connection2543{{"Connection[2543∈0] ➊<br />ᐸ2541ᐳ"}}:::plan
+    Connection2543 --> PgPageInfo2946
     First2971{{"First[2971∈0] ➊"}}:::plan
     PgSelect2969 --> First2971
     PgSelectSingle2972{{"PgSelectSingle[2972∈0] ➊<br />ᐸpostᐳ"}}:::plan
     First2971 --> PgSelectSingle2972
-    Constant6851{{"Constant[6851∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant6851 --> Lambda3596
-    Constant6852{{"Constant[6852∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant6852 --> Lambda3599
-    Object3603 --> Lambda3604
-    Constant6854{{"Constant[6854∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6854 --> Lambda3609
-    Object3619 --> Lambda3620
-    Constant6855{{"Constant[6855∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6855 --> Lambda3625
-    Object3635 --> Lambda3636
-    Constant6856{{"Constant[6856∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6856 --> Lambda3641
-    Object3651 --> Lambda3652
-    Constant6857{{"Constant[6857∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6857 --> Lambda3657
-    Object3667 --> Lambda3668
-    Constant6858{{"Constant[6858∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6858 --> Lambda3673
-    Object3683 --> Lambda3684
-    Constant6859{{"Constant[6859∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6859 --> Lambda3689
-    Object3699 --> Lambda3700
-    Constant6860{{"Constant[6860∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6860 --> Lambda3705
-    Object3715 --> Lambda3716
-    Constant6861{{"Constant[6861∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6861 --> Lambda3721
-    Object3731 --> Lambda3732
-    Constant6862{{"Constant[6862∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6862 --> Lambda3737
-    Object3747 --> Lambda3748
-    Constant6863{{"Constant[6863∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6863 --> Lambda3753
-    Object3763 --> Lambda3764
-    Constant6864{{"Constant[6864∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant6864 --> Lambda3769
-    Constant6853{{"Constant[6853∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant6853 --> Lambda4094
-    Object4126 --> Lambda4127
-    Constant6887{{"Constant[6887∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6887 --> Lambda4132
-    Object4142 --> Lambda4143
-    Constant6888{{"Constant[6888∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6888 --> Lambda4148
-    Object4158 --> Lambda4159
-    Constant6889{{"Constant[6889∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6889 --> Lambda4164
-    Object4174 --> Lambda4175
-    Constant6890{{"Constant[6890∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6890 --> Lambda4180
-    Object4190 --> Lambda4191
-    Constant6891{{"Constant[6891∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6891 --> Lambda4196
-    Object4206 --> Lambda4207
-    Constant6892{{"Constant[6892∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6892 --> Lambda4212
-    Object4222 --> Lambda4223
-    Constant6893{{"Constant[6893∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6893 --> Lambda4228
-    Object4238 --> Lambda4239
-    Constant6894{{"Constant[6894∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6894 --> Lambda4244
-    Object4254 --> Lambda4255
-    Constant6895{{"Constant[6895∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6895 --> Lambda4260
-    Object4270 --> Lambda4271
-    Constant6896{{"Constant[6896∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6896 --> Lambda4276
-    Object4286 --> Lambda4287
-    Constant6897{{"Constant[6897∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant6897 --> Lambda4292
-    Object4300 --> Lambda4301
-    Constant6898{{"Constant[6898∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6898 --> Lambda4306
-    Object4316 --> Lambda4317
-    Constant6899{{"Constant[6899∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6899 --> Lambda4322
-    Object4332 --> Lambda4333
-    Constant6900{{"Constant[6900∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6900 --> Lambda4338
-    Object4348 --> Lambda4349
-    Constant6901{{"Constant[6901∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6901 --> Lambda4354
-    Object4364 --> Lambda4365
-    Constant6902{{"Constant[6902∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6902 --> Lambda4370
-    Object4380 --> Lambda4381
-    Constant6903{{"Constant[6903∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6903 --> Lambda4386
+    PgPageInfo3572{{"PgPageInfo[3572∈0] ➊"}}:::plan
+    Connection3177{{"Connection[3177∈0] ➊<br />ᐸ3175ᐳ"}}:::plan
+    Connection3177 --> PgPageInfo3572
+    Constant7058{{"Constant[7058∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant7058 --> Lambda3596
+    Lambda3599{{"Lambda[3599∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant7059{{"Constant[7059∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant7059 --> Lambda3599
+    Lambda3599 --> Access3600
+    Object3604 --> Lambda3605
+    Constant7061{{"Constant[7061∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7061 --> Lambda3610
+    Object3621 --> Lambda3622
+    Constant7062{{"Constant[7062∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7062 --> Lambda3627
+    Object3638 --> Lambda3639
+    Constant7063{{"Constant[7063∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7063 --> Lambda3644
+    Object3655 --> Lambda3656
+    Constant7064{{"Constant[7064∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7064 --> Lambda3661
+    Object3672 --> Lambda3673
+    Constant7065{{"Constant[7065∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7065 --> Lambda3678
+    Object3689 --> Lambda3690
+    Constant7066{{"Constant[7066∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7066 --> Lambda3695
+    Object3706 --> Lambda3707
+    Constant7067{{"Constant[7067∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7067 --> Lambda3712
+    Object3723 --> Lambda3724
+    Constant7068{{"Constant[7068∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7068 --> Lambda3729
+    Object3740 --> Lambda3741
+    Constant7069{{"Constant[7069∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7069 --> Lambda3746
+    Object3757 --> Lambda3758
+    Constant7070{{"Constant[7070∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7070 --> Lambda3763
+    Object3774 --> Lambda3775
+    Constant7071{{"Constant[7071∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant7071 --> Lambda3780
+    Lambda3790{{"Lambda[3790∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3789 --> Lambda3790
+    Lambda3795{{"Lambda[3795∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7072{{"Constant[7072∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7072 --> Lambda3795
+    Lambda3807{{"Lambda[3807∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3806 --> Lambda3807
+    Lambda3812{{"Lambda[3812∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7073{{"Constant[7073∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7073 --> Lambda3812
+    Lambda3824{{"Lambda[3824∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3823 --> Lambda3824
+    Lambda3829{{"Lambda[3829∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7074{{"Constant[7074∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7074 --> Lambda3829
+    Lambda3841{{"Lambda[3841∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3840 --> Lambda3841
+    Lambda3846{{"Lambda[3846∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7075{{"Constant[7075∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7075 --> Lambda3846
+    Lambda3858{{"Lambda[3858∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3857 --> Lambda3858
+    Lambda3863{{"Lambda[3863∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7076{{"Constant[7076∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7076 --> Lambda3863
+    Lambda3875{{"Lambda[3875∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3874 --> Lambda3875
+    Lambda3880{{"Lambda[3880∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7077{{"Constant[7077∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7077 --> Lambda3880
+    Lambda3892{{"Lambda[3892∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3891 --> Lambda3892
+    Lambda3897{{"Lambda[3897∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7078{{"Constant[7078∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7078 --> Lambda3897
+    Lambda3909{{"Lambda[3909∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3908 --> Lambda3909
+    Lambda3914{{"Lambda[3914∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7079{{"Constant[7079∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7079 --> Lambda3914
+    Lambda3926{{"Lambda[3926∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3925 --> Lambda3926
+    Lambda3931{{"Lambda[3931∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7080{{"Constant[7080∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7080 --> Lambda3931
+    Lambda3943{{"Lambda[3943∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3942 --> Lambda3943
+    Lambda3948{{"Lambda[3948∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7081{{"Constant[7081∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7081 --> Lambda3948
+    Lambda3960{{"Lambda[3960∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3959 --> Lambda3960
+    Lambda3965{{"Lambda[3965∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7082{{"Constant[7082∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7082 --> Lambda3965
+    Lambda3977{{"Lambda[3977∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3976 --> Lambda3977
+    Lambda3982{{"Lambda[3982∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7083{{"Constant[7083∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7083 --> Lambda3982
+    Lambda3994{{"Lambda[3994∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object3993 --> Lambda3994
+    Lambda3999{{"Lambda[3999∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7084{{"Constant[7084∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7084 --> Lambda3999
+    Lambda4011{{"Lambda[4011∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4010 --> Lambda4011
+    Lambda4016{{"Lambda[4016∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7085{{"Constant[7085∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7085 --> Lambda4016
+    Lambda4028{{"Lambda[4028∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4027 --> Lambda4028
+    Lambda4033{{"Lambda[4033∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7086{{"Constant[7086∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7086 --> Lambda4033
+    Lambda4045{{"Lambda[4045∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4044 --> Lambda4045
+    Lambda4050{{"Lambda[4050∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7087{{"Constant[7087∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7087 --> Lambda4050
+    Lambda4062{{"Lambda[4062∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4061 --> Lambda4062
+    Lambda4067{{"Lambda[4067∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7088{{"Constant[7088∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7088 --> Lambda4067
+    Lambda4079{{"Lambda[4079∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4078 --> Lambda4079
+    Lambda4084{{"Lambda[4084∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7089{{"Constant[7089∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7089 --> Lambda4084
+    Lambda4096{{"Lambda[4096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4095 --> Lambda4096
+    Lambda4101{{"Lambda[4101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7090{{"Constant[7090∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7090 --> Lambda4101
+    Lambda4113{{"Lambda[4113∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4112 --> Lambda4113
+    Lambda4118{{"Lambda[4118∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7091{{"Constant[7091∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7091 --> Lambda4118
+    Lambda4125{{"Lambda[4125∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant7060{{"Constant[7060∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant7060 --> Lambda4125
+    Lambda4125 --> Access4126
+    Lambda4131{{"Lambda[4131∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4130 --> Lambda4131
+    Lambda4136{{"Lambda[4136∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7092{{"Constant[7092∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant7092 --> Lambda4136
+    Lambda4146{{"Lambda[4146∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4145 --> Lambda4146
+    Lambda4151{{"Lambda[4151∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7093{{"Constant[7093∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant7093 --> Lambda4151
+    Object4160 --> Lambda4161
+    Constant7094{{"Constant[7094∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7094 --> Lambda4166
+    Object4177 --> Lambda4178
+    Constant7095{{"Constant[7095∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7095 --> Lambda4183
+    Object4194 --> Lambda4195
+    Constant7096{{"Constant[7096∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7096 --> Lambda4200
+    Object4211 --> Lambda4212
+    Constant7097{{"Constant[7097∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7097 --> Lambda4217
+    Object4228 --> Lambda4229
+    Constant7098{{"Constant[7098∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7098 --> Lambda4234
+    Object4245 --> Lambda4246
+    Constant7099{{"Constant[7099∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7099 --> Lambda4251
+    Object4262 --> Lambda4263
+    Constant7100{{"Constant[7100∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7100 --> Lambda4268
+    Object4279 --> Lambda4280
+    Constant7101{{"Constant[7101∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7101 --> Lambda4285
+    Object4296 --> Lambda4297
+    Constant7102{{"Constant[7102∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7102 --> Lambda4302
+    Object4313 --> Lambda4314
+    Constant7103{{"Constant[7103∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7103 --> Lambda4319
+    Object4330 --> Lambda4331
+    Constant7104{{"Constant[7104∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant7104 --> Lambda4336
+    Object4345 --> Lambda4346
+    Constant7105{{"Constant[7105∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7105 --> Lambda4351
+    Object4362 --> Lambda4363
+    Constant7106{{"Constant[7106∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7106 --> Lambda4368
+    Object4379 --> Lambda4380
+    Constant7107{{"Constant[7107∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7107 --> Lambda4385
     Object4396 --> Lambda4397
-    Constant6904{{"Constant[6904∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6904 --> Lambda4402
-    Object4412 --> Lambda4413
-    Constant6905{{"Constant[6905∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6905 --> Lambda4418
-    Object4428 --> Lambda4429
-    Constant6906{{"Constant[6906∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6906 --> Lambda4434
-    Object4444 --> Lambda4445
-    Constant6907{{"Constant[6907∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6907 --> Lambda4450
-    Object4460 --> Lambda4461
-    Constant6908{{"Constant[6908∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant6908 --> Lambda4466
-    Lambda4475{{"Lambda[4475∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4474 --> Lambda4475
-    Lambda4480{{"Lambda[4480∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6909{{"Constant[6909∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
-    Constant6909 --> Lambda4480
-    Lambda4489{{"Lambda[4489∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4488 --> Lambda4489
-    Lambda4494{{"Lambda[4494∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6910{{"Constant[6910∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
-    Constant6910 --> Lambda4494
-    Lambda4503{{"Lambda[4503∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4502 --> Lambda4503
-    Lambda4508{{"Lambda[4508∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6911{{"Constant[6911∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant6911 --> Lambda4508
-    Lambda4517{{"Lambda[4517∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4516 --> Lambda4517
-    Lambda4522{{"Lambda[4522∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6912{{"Constant[6912∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant6912 --> Lambda4522
+    Constant7108{{"Constant[7108∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7108 --> Lambda4402
+    Object4413 --> Lambda4414
+    Constant7109{{"Constant[7109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7109 --> Lambda4419
+    Object4430 --> Lambda4431
+    Constant7110{{"Constant[7110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7110 --> Lambda4436
+    Object4447 --> Lambda4448
+    Constant7111{{"Constant[7111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7111 --> Lambda4453
+    Object4464 --> Lambda4465
+    Constant7112{{"Constant[7112∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7112 --> Lambda4470
+    Object4481 --> Lambda4482
+    Constant7113{{"Constant[7113∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7113 --> Lambda4487
+    Object4498 --> Lambda4499
+    Constant7114{{"Constant[7114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7114 --> Lambda4504
+    Object4515 --> Lambda4516
+    Constant7115{{"Constant[7115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant7115 --> Lambda4521
     Lambda4531{{"Lambda[4531∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object4530 --> Lambda4531
     Lambda4536{{"Lambda[4536∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6913{{"Constant[6913∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
-    Constant6913 --> Lambda4536
-    Lambda4545{{"Lambda[4545∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4544 --> Lambda4545
-    Lambda4550{{"Lambda[4550∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6914{{"Constant[6914∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
-    Constant6914 --> Lambda4550
-    Lambda4559{{"Lambda[4559∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4558 --> Lambda4559
-    Lambda4564{{"Lambda[4564∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6915{{"Constant[6915∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant6915 --> Lambda4564
-    Lambda4573{{"Lambda[4573∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4572 --> Lambda4573
-    Lambda4578{{"Lambda[4578∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6916{{"Constant[6916∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant6916 --> Lambda4578
-    Lambda4587{{"Lambda[4587∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4586 --> Lambda4587
-    Lambda4592{{"Lambda[4592∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6917{{"Constant[6917∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6917 --> Lambda4592
-    Lambda4601{{"Lambda[4601∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4600 --> Lambda4601
+    Constant7116{{"Constant[7116∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”inputsᐳ"}}:::plan
+    Constant7116 --> Lambda4536
+    Lambda4546{{"Lambda[4546∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4545 --> Lambda4546
+    Lambda4551{{"Lambda[4551∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7117{{"Constant[7117∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”patchsᐳ"}}:::plan
+    Constant7117 --> Lambda4551
+    Lambda4561{{"Lambda[4561∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4560 --> Lambda4561
+    Lambda4566{{"Lambda[4566∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7118{{"Constant[7118∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant7118 --> Lambda4566
+    Lambda4576{{"Lambda[4576∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4575 --> Lambda4576
+    Lambda4581{{"Lambda[4581∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7119{{"Constant[7119∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant7119 --> Lambda4581
+    Lambda4591{{"Lambda[4591∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4590 --> Lambda4591
+    Lambda4596{{"Lambda[4596∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7120{{"Constant[7120∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”reservᐳ"}}:::plan
+    Constant7120 --> Lambda4596
     Lambda4606{{"Lambda[4606∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6918{{"Constant[6918∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6918 --> Lambda4606
-    Lambda4617{{"Lambda[4617∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4616 --> Lambda4617
-    Lambda4622{{"Lambda[4622∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6919{{"Constant[6919∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6919 --> Lambda4622
-    Lambda4633{{"Lambda[4633∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4632 --> Lambda4633
-    Lambda4638{{"Lambda[4638∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6920{{"Constant[6920∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6920 --> Lambda4638
-    Lambda4649{{"Lambda[4649∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4648 --> Lambda4649
-    Lambda4654{{"Lambda[4654∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6921{{"Constant[6921∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6921 --> Lambda4654
-    Lambda4665{{"Lambda[4665∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4664 --> Lambda4665
-    Lambda4670{{"Lambda[4670∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6922{{"Constant[6922∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6922 --> Lambda4670
-    Lambda4681{{"Lambda[4681∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4680 --> Lambda4681
-    Lambda4686{{"Lambda[4686∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6923{{"Constant[6923∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6923 --> Lambda4686
-    Lambda4697{{"Lambda[4697∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4696 --> Lambda4697
-    Lambda4702{{"Lambda[4702∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6924{{"Constant[6924∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6924 --> Lambda4702
-    Lambda4713{{"Lambda[4713∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4712 --> Lambda4713
-    Lambda4718{{"Lambda[4718∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6925{{"Constant[6925∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6925 --> Lambda4718
-    Lambda4729{{"Lambda[4729∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4728 --> Lambda4729
+    Object4605 --> Lambda4606
+    Lambda4611{{"Lambda[4611∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7121{{"Constant[7121∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”defaulᐳ"}}:::plan
+    Constant7121 --> Lambda4611
+    Lambda4621{{"Lambda[4621∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4620 --> Lambda4621
+    Lambda4626{{"Lambda[4626∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7122{{"Constant[7122∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant7122 --> Lambda4626
+    Lambda4636{{"Lambda[4636∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4635 --> Lambda4636
+    Lambda4641{{"Lambda[4641∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7123{{"Constant[7123∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7123 --> Lambda4641
+    Lambda4651{{"Lambda[4651∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4650 --> Lambda4651
+    Lambda4656{{"Lambda[4656∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7124{{"Constant[7124∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7124 --> Lambda4656
+    Lambda4666{{"Lambda[4666∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4665 --> Lambda4666
+    Lambda4671{{"Lambda[4671∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7125{{"Constant[7125∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7125 --> Lambda4671
+    Lambda4683{{"Lambda[4683∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4682 --> Lambda4683
+    Lambda4688{{"Lambda[4688∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7126{{"Constant[7126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7126 --> Lambda4688
+    Lambda4700{{"Lambda[4700∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4699 --> Lambda4700
+    Lambda4705{{"Lambda[4705∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7127{{"Constant[7127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7127 --> Lambda4705
+    Lambda4717{{"Lambda[4717∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4716 --> Lambda4717
+    Lambda4722{{"Lambda[4722∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7128{{"Constant[7128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7128 --> Lambda4722
     Lambda4734{{"Lambda[4734∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6926{{"Constant[6926∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6926 --> Lambda4734
-    Lambda4745{{"Lambda[4745∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4744 --> Lambda4745
-    Lambda4750{{"Lambda[4750∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6927{{"Constant[6927∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6927 --> Lambda4750
-    Lambda4761{{"Lambda[4761∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4760 --> Lambda4761
-    Lambda4766{{"Lambda[4766∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6928{{"Constant[6928∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant6928 --> Lambda4766
-    Lambda4775{{"Lambda[4775∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4774 --> Lambda4775
-    Lambda4780{{"Lambda[4780∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6929{{"Constant[6929∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant6929 --> Lambda4780
-    Lambda4789{{"Lambda[4789∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4788 --> Lambda4789
-    Lambda4794{{"Lambda[4794∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6930{{"Constant[6930∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
-    Constant6930 --> Lambda4794
-    Lambda4803{{"Lambda[4803∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4802 --> Lambda4803
-    Lambda4808{{"Lambda[4808∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6931{{"Constant[6931∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
-    Constant6931 --> Lambda4808
-    Lambda4817{{"Lambda[4817∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4816 --> Lambda4817
-    Lambda4822{{"Lambda[4822∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6932{{"Constant[6932∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
-    Constant6932 --> Lambda4822
-    Lambda4831{{"Lambda[4831∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4830 --> Lambda4831
+    Object4733 --> Lambda4734
+    Lambda4739{{"Lambda[4739∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7129{{"Constant[7129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7129 --> Lambda4739
+    Lambda4751{{"Lambda[4751∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4750 --> Lambda4751
+    Lambda4756{{"Lambda[4756∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7130{{"Constant[7130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7130 --> Lambda4756
+    Lambda4768{{"Lambda[4768∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4767 --> Lambda4768
+    Lambda4773{{"Lambda[4773∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7131{{"Constant[7131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7131 --> Lambda4773
+    Lambda4785{{"Lambda[4785∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4784 --> Lambda4785
+    Lambda4790{{"Lambda[4790∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7132{{"Constant[7132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7132 --> Lambda4790
+    Lambda4802{{"Lambda[4802∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4801 --> Lambda4802
+    Lambda4807{{"Lambda[4807∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7133{{"Constant[7133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7133 --> Lambda4807
+    Lambda4819{{"Lambda[4819∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4818 --> Lambda4819
+    Lambda4824{{"Lambda[4824∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7134{{"Constant[7134∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7134 --> Lambda4824
     Lambda4836{{"Lambda[4836∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6933{{"Constant[6933∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant6933 --> Lambda4836
-    Lambda4845{{"Lambda[4845∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4844 --> Lambda4845
-    Lambda4850{{"Lambda[4850∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6934{{"Constant[6934∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
-    Constant6934 --> Lambda4850
-    Lambda4859{{"Lambda[4859∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4858 --> Lambda4859
-    Lambda4864{{"Lambda[4864∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6935{{"Constant[6935∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
-    Constant6935 --> Lambda4864
-    Lambda4873{{"Lambda[4873∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4872 --> Lambda4873
-    Lambda4878{{"Lambda[4878∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6936{{"Constant[6936∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
-    Constant6936 --> Lambda4878
-    Lambda4887{{"Lambda[4887∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object4886 --> Lambda4887
-    Lambda4892{{"Lambda[4892∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6937{{"Constant[6937∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
-    Constant6937 --> Lambda4892
-    Object4900 --> Lambda4901
-    Constant6938{{"Constant[6938∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6938 --> Lambda4906
-    Object4916 --> Lambda4917
-    Constant6939{{"Constant[6939∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6939 --> Lambda4922
-    Object4932 --> Lambda4933
-    Constant6940{{"Constant[6940∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6940 --> Lambda4938
-    Object4948 --> Lambda4949
-    Constant6941{{"Constant[6941∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6941 --> Lambda4954
-    Object4964 --> Lambda4965
-    Constant6942{{"Constant[6942∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6942 --> Lambda4970
-    Object4980 --> Lambda4981
-    Constant6943{{"Constant[6943∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6943 --> Lambda4986
-    Object4996 --> Lambda4997
-    Constant6944{{"Constant[6944∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6944 --> Lambda5002
-    Object5012 --> Lambda5013
-    Constant6945{{"Constant[6945∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6945 --> Lambda5018
-    Object5028 --> Lambda5029
-    Constant6946{{"Constant[6946∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6946 --> Lambda5034
-    Object5044 --> Lambda5045
-    Constant6947{{"Constant[6947∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6947 --> Lambda5050
-    Object5060 --> Lambda5061
-    Constant6948{{"Constant[6948∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant6948 --> Lambda5066
-    Object5074 --> Lambda5075
-    Constant6949{{"Constant[6949∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6949 --> Lambda5080
-    Object5090 --> Lambda5091
-    Constant6950{{"Constant[6950∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6950 --> Lambda5096
-    Object5106 --> Lambda5107
-    Constant6951{{"Constant[6951∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6951 --> Lambda5112
-    Object5122 --> Lambda5123
-    Constant6952{{"Constant[6952∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6952 --> Lambda5128
+    Object4835 --> Lambda4836
+    Lambda4841{{"Lambda[4841∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7135{{"Constant[7135∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant7135 --> Lambda4841
+    Lambda4851{{"Lambda[4851∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4850 --> Lambda4851
+    Lambda4856{{"Lambda[4856∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7136{{"Constant[7136∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7136 --> Lambda4856
+    Lambda4866{{"Lambda[4866∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4865 --> Lambda4866
+    Lambda4871{{"Lambda[4871∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7137{{"Constant[7137∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”left_aᐳ"}}:::plan
+    Constant7137 --> Lambda4871
+    Lambda4881{{"Lambda[4881∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4880 --> Lambda4881
+    Lambda4886{{"Lambda[4886∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7138{{"Constant[7138∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”my_tabᐳ"}}:::plan
+    Constant7138 --> Lambda4886
+    Lambda4896{{"Lambda[4896∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4895 --> Lambda4896
+    Lambda4901{{"Lambda[4901∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7139{{"Constant[7139∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”view_tᐳ"}}:::plan
+    Constant7139 --> Lambda4901
+    Lambda4911{{"Lambda[4911∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4910 --> Lambda4911
+    Lambda4916{{"Lambda[4916∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7140{{"Constant[7140∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant7140 --> Lambda4916
+    Lambda4926{{"Lambda[4926∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4925 --> Lambda4926
+    Lambda4931{{"Lambda[4931∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7141{{"Constant[7141∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”similaᐳ"}}:::plan
+    Constant7141 --> Lambda4931
+    Lambda4941{{"Lambda[4941∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4940 --> Lambda4941
+    Lambda4946{{"Lambda[4946∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7142{{"Constant[7142∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”null_tᐳ"}}:::plan
+    Constant7142 --> Lambda4946
+    Lambda4956{{"Lambda[4956∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4955 --> Lambda4956
+    Lambda4961{{"Lambda[4961∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7143{{"Constant[7143∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”issue7ᐳ"}}:::plan
+    Constant7143 --> Lambda4961
+    Lambda4971{{"Lambda[4971∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object4970 --> Lambda4971
+    Lambda4976{{"Lambda[4976∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7144{{"Constant[7144∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”lists”ᐳ"}}:::plan
+    Constant7144 --> Lambda4976
+    Object4985 --> Lambda4986
+    Constant7145{{"Constant[7145∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7145 --> Lambda4991
+    Object5002 --> Lambda5003
+    Constant7146{{"Constant[7146∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7146 --> Lambda5008
+    Object5019 --> Lambda5020
+    Constant7147{{"Constant[7147∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7147 --> Lambda5025
+    Object5036 --> Lambda5037
+    Constant7148{{"Constant[7148∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7148 --> Lambda5042
+    Object5053 --> Lambda5054
+    Constant7149{{"Constant[7149∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7149 --> Lambda5059
+    Object5070 --> Lambda5071
+    Constant7150{{"Constant[7150∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7150 --> Lambda5076
+    Object5087 --> Lambda5088
+    Constant7151{{"Constant[7151∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7151 --> Lambda5093
+    Object5104 --> Lambda5105
+    Constant7152{{"Constant[7152∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7152 --> Lambda5110
+    Object5121 --> Lambda5122
+    Constant7153{{"Constant[7153∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7153 --> Lambda5127
     Object5138 --> Lambda5139
-    Constant6953{{"Constant[6953∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6953 --> Lambda5144
-    Object5154 --> Lambda5155
-    Constant6954{{"Constant[6954∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6954 --> Lambda5160
+    Constant7154{{"Constant[7154∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7154 --> Lambda5144
+    Object5155 --> Lambda5156
+    Constant7155{{"Constant[7155∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant7155 --> Lambda5161
     Object5170 --> Lambda5171
-    Constant6955{{"Constant[6955∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6955 --> Lambda5176
-    Object5186 --> Lambda5187
-    Constant6956{{"Constant[6956∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6956 --> Lambda5192
-    Object5202 --> Lambda5203
-    Constant6957{{"Constant[6957∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6957 --> Lambda5208
-    Object5218 --> Lambda5219
-    Constant6958{{"Constant[6958∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6958 --> Lambda5224
-    Object5234 --> Lambda5235
-    Constant6959{{"Constant[6959∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant6959 --> Lambda5240
-    Object5589 --> Lambda5590
-    Constant6982{{"Constant[6982∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6982 --> Lambda5595
-    Object5605 --> Lambda5606
-    Constant6983{{"Constant[6983∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6983 --> Lambda5611
-    Object5621 --> Lambda5622
-    Constant6984{{"Constant[6984∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6984 --> Lambda5627
+    Constant7156{{"Constant[7156∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7156 --> Lambda5176
+    Object5187 --> Lambda5188
+    Constant7157{{"Constant[7157∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7157 --> Lambda5193
+    Object5204 --> Lambda5205
+    Constant7158{{"Constant[7158∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7158 --> Lambda5210
+    Object5221 --> Lambda5222
+    Constant7159{{"Constant[7159∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7159 --> Lambda5227
+    Object5238 --> Lambda5239
+    Constant7160{{"Constant[7160∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7160 --> Lambda5244
+    Object5255 --> Lambda5256
+    Constant7161{{"Constant[7161∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7161 --> Lambda5261
+    Object5272 --> Lambda5273
+    Constant7162{{"Constant[7162∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7162 --> Lambda5278
+    Object5289 --> Lambda5290
+    Constant7163{{"Constant[7163∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7163 --> Lambda5295
+    Object5306 --> Lambda5307
+    Constant7164{{"Constant[7164∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7164 --> Lambda5312
+    Object5323 --> Lambda5324
+    Constant7165{{"Constant[7165∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7165 --> Lambda5329
+    Object5340 --> Lambda5341
+    Constant7166{{"Constant[7166∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant7166 --> Lambda5346
+    Lambda5356{{"Lambda[5356∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5355 --> Lambda5356
+    Lambda5361{{"Lambda[5361∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7167{{"Constant[7167∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7167 --> Lambda5361
+    Lambda5371{{"Lambda[5371∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5370 --> Lambda5371
+    Lambda5376{{"Lambda[5376∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7168{{"Constant[7168∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7168 --> Lambda5376
+    Lambda5386{{"Lambda[5386∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5385 --> Lambda5386
+    Lambda5391{{"Lambda[5391∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7169{{"Constant[7169∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7169 --> Lambda5391
+    Lambda5403{{"Lambda[5403∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5402 --> Lambda5403
+    Lambda5408{{"Lambda[5408∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7170{{"Constant[7170∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7170 --> Lambda5408
+    Lambda5420{{"Lambda[5420∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5419 --> Lambda5420
+    Lambda5425{{"Lambda[5425∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7171{{"Constant[7171∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7171 --> Lambda5425
+    Lambda5437{{"Lambda[5437∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5436 --> Lambda5437
+    Lambda5442{{"Lambda[5442∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7172{{"Constant[7172∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7172 --> Lambda5442
+    Lambda5454{{"Lambda[5454∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5453 --> Lambda5454
+    Lambda5459{{"Lambda[5459∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7173{{"Constant[7173∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7173 --> Lambda5459
+    Lambda5471{{"Lambda[5471∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5470 --> Lambda5471
+    Lambda5476{{"Lambda[5476∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7174{{"Constant[7174∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7174 --> Lambda5476
+    Lambda5488{{"Lambda[5488∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5487 --> Lambda5488
+    Lambda5493{{"Lambda[5493∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7175{{"Constant[7175∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7175 --> Lambda5493
+    Lambda5505{{"Lambda[5505∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5504 --> Lambda5505
+    Lambda5510{{"Lambda[5510∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7176{{"Constant[7176∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7176 --> Lambda5510
+    Lambda5523{{"Lambda[5523∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5522 --> Lambda5523
+    Lambda5528{{"Lambda[5528∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7177{{"Constant[7177∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7177 --> Lambda5528
+    Lambda5538{{"Lambda[5538∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5537 --> Lambda5538
+    Lambda5543{{"Lambda[5543∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7178{{"Constant[7178∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7178 --> Lambda5543
+    Lambda5553{{"Lambda[5553∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5552 --> Lambda5553
+    Lambda5558{{"Lambda[5558∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7179{{"Constant[7179∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7179 --> Lambda5558
+    Lambda5570{{"Lambda[5570∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5569 --> Lambda5570
+    Lambda5575{{"Lambda[5575∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7180{{"Constant[7180∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7180 --> Lambda5575
+    Lambda5587{{"Lambda[5587∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5586 --> Lambda5587
+    Lambda5592{{"Lambda[5592∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7181{{"Constant[7181∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7181 --> Lambda5592
+    Lambda5604{{"Lambda[5604∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5603 --> Lambda5604
+    Lambda5609{{"Lambda[5609∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7182{{"Constant[7182∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7182 --> Lambda5609
+    Lambda5621{{"Lambda[5621∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5620 --> Lambda5621
+    Lambda5626{{"Lambda[5626∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7183{{"Constant[7183∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7183 --> Lambda5626
+    Lambda5638{{"Lambda[5638∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
     Object5637 --> Lambda5638
-    Constant6985{{"Constant[6985∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6985 --> Lambda5643
-    Object5653 --> Lambda5654
-    Constant6986{{"Constant[6986∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6986 --> Lambda5659
-    Object5669 --> Lambda5670
-    Constant6987{{"Constant[6987∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6987 --> Lambda5675
-    Object5685 --> Lambda5686
-    Constant6988{{"Constant[6988∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6988 --> Lambda5691
-    Object5701 --> Lambda5702
-    Constant6989{{"Constant[6989∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6989 --> Lambda5707
-    Object5717 --> Lambda5718
-    Constant6990{{"Constant[6990∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6990 --> Lambda5723
-    Object5733 --> Lambda5734
-    Constant6991{{"Constant[6991∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6991 --> Lambda5739
-    Object5749 --> Lambda5750
-    Constant6992{{"Constant[6992∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant6992 --> Lambda5755
-    Object5765 --> Lambda5766
-    Constant6993{{"Constant[6993∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6993 --> Lambda5771
-    Object5781 --> Lambda5782
-    Constant6994{{"Constant[6994∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6994 --> Lambda5787
-    Object5797 --> Lambda5798
-    Constant6995{{"Constant[6995∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6995 --> Lambda5803
-    Object5813 --> Lambda5814
-    Constant6996{{"Constant[6996∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6996 --> Lambda5819
-    Object5829 --> Lambda5830
-    Constant6997{{"Constant[6997∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6997 --> Lambda5835
-    Object5845 --> Lambda5846
-    Constant6998{{"Constant[6998∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6998 --> Lambda5851
-    Object5861 --> Lambda5862
-    Constant6999{{"Constant[6999∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6999 --> Lambda5867
-    Object5877 --> Lambda5878
-    Constant7000{{"Constant[7000∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7000 --> Lambda5883
-    Object5893 --> Lambda5894
-    Constant7001{{"Constant[7001∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7001 --> Lambda5899
-    Object5909 --> Lambda5910
-    Constant7002{{"Constant[7002∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7002 --> Lambda5915
-    Object5925 --> Lambda5926
-    Constant7003{{"Constant[7003∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant7003 --> Lambda5931
-    Object5972 --> Lambda5973
-    Constant7006{{"Constant[7006∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7006 --> Lambda5978
-    Object5988 --> Lambda5989
-    Constant7007{{"Constant[7007∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7007 --> Lambda5994
-    Object6004 --> Lambda6005
-    Constant7008{{"Constant[7008∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7008 --> Lambda6010
-    Object6020 --> Lambda6021
-    Constant7009{{"Constant[7009∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7009 --> Lambda6026
-    Object6036 --> Lambda6037
-    Constant7010{{"Constant[7010∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7010 --> Lambda6042
-    Object6052 --> Lambda6053
-    Constant7011{{"Constant[7011∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7011 --> Lambda6058
-    Object6068 --> Lambda6069
-    Constant7012{{"Constant[7012∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7012 --> Lambda6074
-    Object6084 --> Lambda6085
-    Constant7013{{"Constant[7013∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7013 --> Lambda6090
-    Object6129 --> Lambda6130
-    Constant7016{{"Constant[7016∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7016 --> Lambda6135
-    Object6145 --> Lambda6146
-    Constant7017{{"Constant[7017∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7017 --> Lambda6151
-    Object6161 --> Lambda6162
-    Constant7018{{"Constant[7018∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7018 --> Lambda6167
-    Object6177 --> Lambda6178
-    Constant7019{{"Constant[7019∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7019 --> Lambda6183
+    Lambda5643{{"Lambda[5643∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7184{{"Constant[7184∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7184 --> Lambda5643
+    Lambda5655{{"Lambda[5655∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5654 --> Lambda5655
+    Lambda5660{{"Lambda[5660∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7185{{"Constant[7185∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7185 --> Lambda5660
+    Lambda5672{{"Lambda[5672∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5671 --> Lambda5672
+    Lambda5677{{"Lambda[5677∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7186{{"Constant[7186∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7186 --> Lambda5677
+    Lambda5689{{"Lambda[5689∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5688 --> Lambda5689
+    Lambda5694{{"Lambda[5694∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7187{{"Constant[7187∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant7187 --> Lambda5694
+    Lambda5704{{"Lambda[5704∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object5703 --> Lambda5704
+    Lambda5709{{"Lambda[5709∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7188{{"Constant[7188∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
+    Constant7188 --> Lambda5709
+    Object5718 --> Lambda5719
+    Constant7189{{"Constant[7189∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7189 --> Lambda5724
+    Object5735 --> Lambda5736
+    Constant7190{{"Constant[7190∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7190 --> Lambda5741
+    Object5752 --> Lambda5753
+    Constant7191{{"Constant[7191∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7191 --> Lambda5758
+    Object5769 --> Lambda5770
+    Constant7192{{"Constant[7192∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7192 --> Lambda5775
+    Object5786 --> Lambda5787
+    Constant7193{{"Constant[7193∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7193 --> Lambda5792
+    Object5803 --> Lambda5804
+    Constant7194{{"Constant[7194∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7194 --> Lambda5809
+    Object5820 --> Lambda5821
+    Constant7195{{"Constant[7195∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7195 --> Lambda5826
+    Object5837 --> Lambda5838
+    Constant7196{{"Constant[7196∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7196 --> Lambda5843
+    Object5854 --> Lambda5855
+    Constant7197{{"Constant[7197∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7197 --> Lambda5860
+    Object5871 --> Lambda5872
+    Constant7198{{"Constant[7198∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7198 --> Lambda5877
+    Object5888 --> Lambda5889
+    Constant7199{{"Constant[7199∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7199 --> Lambda5894
+    Object5905 --> Lambda5906
+    Constant7200{{"Constant[7200∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7200 --> Lambda5911
+    Object5922 --> Lambda5923
+    Constant7201{{"Constant[7201∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7201 --> Lambda5928
+    Object5939 --> Lambda5940
+    Constant7202{{"Constant[7202∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7202 --> Lambda5945
+    Object5956 --> Lambda5957
+    Constant7203{{"Constant[7203∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7203 --> Lambda5962
+    Object5973 --> Lambda5974
+    Constant7204{{"Constant[7204∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7204 --> Lambda5979
+    Object5990 --> Lambda5991
+    Constant7205{{"Constant[7205∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7205 --> Lambda5996
+    Object6007 --> Lambda6008
+    Constant7206{{"Constant[7206∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7206 --> Lambda6013
+    Object6024 --> Lambda6025
+    Constant7207{{"Constant[7207∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7207 --> Lambda6030
+    Object6041 --> Lambda6042
+    Constant7208{{"Constant[7208∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7208 --> Lambda6047
+    Object6058 --> Lambda6059
+    Constant7209{{"Constant[7209∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7209 --> Lambda6064
+    Object6075 --> Lambda6076
+    Constant7210{{"Constant[7210∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7210 --> Lambda6081
+    Lambda6096{{"Lambda[6096∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object6095 --> Lambda6096
+    Lambda6101{{"Lambda[6101∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7211{{"Constant[7211∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7211 --> Lambda6101
+    Lambda6111{{"Lambda[6111∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object6110 --> Lambda6111
+    Lambda6116{{"Lambda[6116∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7212{{"Constant[7212∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7212 --> Lambda6116
+    Object6125 --> Lambda6126
+    Constant7213{{"Constant[7213∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7213 --> Lambda6131
+    Object6142 --> Lambda6143
+    Constant7214{{"Constant[7214∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7214 --> Lambda6148
+    Object6159 --> Lambda6160
+    Constant7215{{"Constant[7215∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7215 --> Lambda6165
+    Object6176 --> Lambda6177
+    Constant7216{{"Constant[7216∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7216 --> Lambda6182
     Object6193 --> Lambda6194
-    Constant7020{{"Constant[7020∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7020 --> Lambda6199
-    Object6209 --> Lambda6210
-    Constant7021{{"Constant[7021∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7021 --> Lambda6215
-    Object6225 --> Lambda6226
-    Constant7022{{"Constant[7022∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7022 --> Lambda6231
-    Object6241 --> Lambda6242
-    Constant7023{{"Constant[7023∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7023 --> Lambda6247
-    Object6257 --> Lambda6258
-    Constant7024{{"Constant[7024∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant7024 --> Lambda6263
-    Object6275 --> Lambda6276
-    Constant7025{{"Constant[7025∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant7025 --> Lambda6281
+    Constant7217{{"Constant[7217∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7217 --> Lambda6199
+    Object6210 --> Lambda6211
+    Constant7218{{"Constant[7218∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7218 --> Lambda6216
+    Object6227 --> Lambda6228
+    Constant7219{{"Constant[7219∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7219 --> Lambda6233
+    Object6244 --> Lambda6245
+    Constant7220{{"Constant[7220∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7220 --> Lambda6250
+    Lambda6263{{"Lambda[6263∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object6262 --> Lambda6263
+    Lambda6268{{"Lambda[6268∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7221{{"Constant[7221∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7221 --> Lambda6268
+    Lambda6278{{"Lambda[6278∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object6277 --> Lambda6278
+    Lambda6283{{"Lambda[6283∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant7222{{"Constant[7222∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7222 --> Lambda6283
     Object6292 --> Lambda6293
-    Constant7026{{"Constant[7026∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant7026 --> Lambda6298
-    Object6306 --> Lambda6307
-    Constant7027{{"Constant[7027∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7027 --> Lambda6312
-    Object6322 --> Lambda6323
-    Constant7028{{"Constant[7028∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7028 --> Lambda6328
-    Object6338 --> Lambda6339
-    Constant7029{{"Constant[7029∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7029 --> Lambda6344
-    Object6354 --> Lambda6355
-    Constant7030{{"Constant[7030∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7030 --> Lambda6360
-    Object6370 --> Lambda6371
-    Constant7031{{"Constant[7031∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7031 --> Lambda6376
-    Object6386 --> Lambda6387
-    Constant7032{{"Constant[7032∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7032 --> Lambda6392
-    Object6402 --> Lambda6403
-    Constant7033{{"Constant[7033∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7033 --> Lambda6408
-    Object6418 --> Lambda6419
-    Constant7034{{"Constant[7034∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7034 --> Lambda6424
-    Object6434 --> Lambda6435
-    Constant7035{{"Constant[7035∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7035 --> Lambda6440
-    Object6450 --> Lambda6451
-    Constant7036{{"Constant[7036∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7036 --> Lambda6456
-    Object6466 --> Lambda6467
-    Constant7037{{"Constant[7037∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant7037 --> Lambda6472
-    Object6482 --> Lambda6483
-    Constant7038{{"Constant[7038∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7038 --> Lambda6488
-    Object6498 --> Lambda6499
-    Constant7039{{"Constant[7039∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7039 --> Lambda6504
+    Constant7223{{"Constant[7223∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7223 --> Lambda6298
+    Object6309 --> Lambda6310
+    Constant7224{{"Constant[7224∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7224 --> Lambda6315
+    Object6326 --> Lambda6327
+    Constant7225{{"Constant[7225∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7225 --> Lambda6332
+    Object6343 --> Lambda6344
+    Constant7226{{"Constant[7226∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7226 --> Lambda6349
+    Object6360 --> Lambda6361
+    Constant7227{{"Constant[7227∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7227 --> Lambda6366
+    Object6377 --> Lambda6378
+    Constant7228{{"Constant[7228∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7228 --> Lambda6383
+    Object6394 --> Lambda6395
+    Constant7229{{"Constant[7229∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7229 --> Lambda6400
+    Object6411 --> Lambda6412
+    Constant7230{{"Constant[7230∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7230 --> Lambda6417
+    Object6428 --> Lambda6429
+    Constant7231{{"Constant[7231∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7231 --> Lambda6434
+    Object6447 --> Lambda6448
+    Constant7232{{"Constant[7232∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7232 --> Lambda6453
+    Object6465 --> Lambda6466
+    Constant7233{{"Constant[7233∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant7233 --> Lambda6471
+    Object6480 --> Lambda6481
+    Constant7234{{"Constant[7234∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7234 --> Lambda6486
+    Object6497 --> Lambda6498
+    Constant7235{{"Constant[7235∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7235 --> Lambda6503
     Object6514 --> Lambda6515
-    Constant7040{{"Constant[7040∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7040 --> Lambda6520
-    Object6530 --> Lambda6531
-    Constant7041{{"Constant[7041∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7041 --> Lambda6536
-    Object6546 --> Lambda6547
-    Constant7042{{"Constant[7042∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7042 --> Lambda6552
-    Object6562 --> Lambda6563
-    Constant7043{{"Constant[7043∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7043 --> Lambda6568
-    Object6578 --> Lambda6579
-    Constant7044{{"Constant[7044∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7044 --> Lambda6584
-    Object6594 --> Lambda6595
-    Constant7045{{"Constant[7045∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7045 --> Lambda6600
-    Object6610 --> Lambda6611
-    Constant7046{{"Constant[7046∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7046 --> Lambda6616
-    Object6626 --> Lambda6627
-    Constant7047{{"Constant[7047∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7047 --> Lambda6632
-    Object6642 --> Lambda6643
-    Constant7048{{"Constant[7048∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7048 --> Lambda6648
-    Object6658 --> Lambda6659
-    Constant7049{{"Constant[7049∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7049 --> Lambda6664
-    Object6674 --> Lambda6675
-    Constant7050{{"Constant[7050∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7050 --> Lambda6680
-    Object6690 --> Lambda6691
-    Constant7051{{"Constant[7051∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7051 --> Lambda6696
-    Object6706 --> Lambda6707
-    Constant7052{{"Constant[7052∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7052 --> Lambda6712
-    Object6722 --> Lambda6723
-    Constant7053{{"Constant[7053∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7053 --> Lambda6728
-    Object6738 --> Lambda6739
-    Constant7054{{"Constant[7054∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7054 --> Lambda6744
-    Object6754 --> Lambda6755
-    Constant7055{{"Constant[7055∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7055 --> Lambda6760
-    Object6770 --> Lambda6771
-    Constant7056{{"Constant[7056∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7056 --> Lambda6776
+    Constant7236{{"Constant[7236∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7236 --> Lambda6520
+    Object6531 --> Lambda6532
+    Constant7237{{"Constant[7237∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7237 --> Lambda6537
+    Object6548 --> Lambda6549
+    Constant7238{{"Constant[7238∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7238 --> Lambda6554
+    Object6565 --> Lambda6566
+    Constant7239{{"Constant[7239∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7239 --> Lambda6571
+    Object6582 --> Lambda6583
+    Constant7240{{"Constant[7240∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7240 --> Lambda6588
+    Object6599 --> Lambda6600
+    Constant7241{{"Constant[7241∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7241 --> Lambda6605
+    Object6616 --> Lambda6617
+    Constant7242{{"Constant[7242∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7242 --> Lambda6622
+    Object6633 --> Lambda6634
+    Constant7243{{"Constant[7243∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7243 --> Lambda6639
+    Object6650 --> Lambda6651
+    Constant7244{{"Constant[7244∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant7244 --> Lambda6656
+    Object6667 --> Lambda6668
+    Constant7245{{"Constant[7245∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7245 --> Lambda6673
+    Object6684 --> Lambda6685
+    Constant7246{{"Constant[7246∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7246 --> Lambda6690
+    Object6701 --> Lambda6702
+    Constant7247{{"Constant[7247∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7247 --> Lambda6707
+    Object6718 --> Lambda6719
+    Constant7248{{"Constant[7248∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7248 --> Lambda6724
+    Object6735 --> Lambda6736
+    Constant7249{{"Constant[7249∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7249 --> Lambda6741
+    Object6752 --> Lambda6753
+    Constant7250{{"Constant[7250∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7250 --> Lambda6758
+    Object6769 --> Lambda6770
+    Constant7251{{"Constant[7251∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7251 --> Lambda6775
     Object6786 --> Lambda6787
-    Constant7057{{"Constant[7057∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant7057 --> Lambda6792
-    Object6802 --> Lambda6803
-    Constant7058{{"Constant[7058∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant7058 --> Lambda6808
-    Object6821 --> Lambda6822
-    Constant7059{{"Constant[7059∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant7059 --> Lambda6827
-    Object6839 --> Lambda6840
-    Constant7060{{"Constant[7060∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7060 --> Lambda6845
+    Constant7252{{"Constant[7252∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7252 --> Lambda6792
+    Object6803 --> Lambda6804
+    Constant7253{{"Constant[7253∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7253 --> Lambda6809
+    Object6820 --> Lambda6821
+    Constant7254{{"Constant[7254∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7254 --> Lambda6826
+    Object6837 --> Lambda6838
+    Constant7255{{"Constant[7255∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7255 --> Lambda6843
+    Object6854 --> Lambda6855
+    Constant7256{{"Constant[7256∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7256 --> Lambda6860
+    Object6871 --> Lambda6872
+    Constant7257{{"Constant[7257∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7257 --> Lambda6877
+    Object6888 --> Lambda6889
+    Constant7258{{"Constant[7258∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7258 --> Lambda6894
+    Object6905 --> Lambda6906
+    Constant7259{{"Constant[7259∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7259 --> Lambda6911
+    Object6922 --> Lambda6923
+    Constant7260{{"Constant[7260∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7260 --> Lambda6928
+    Object6939 --> Lambda6940
+    Constant7261{{"Constant[7261∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7261 --> Lambda6945
+    Object6956 --> Lambda6957
+    Constant7262{{"Constant[7262∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7262 --> Lambda6962
+    Object6973 --> Lambda6974
+    Constant7263{{"Constant[7263∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7263 --> Lambda6979
+    Object6990 --> Lambda6991
+    Constant7264{{"Constant[7264∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
+    Constant7264 --> Lambda6996
+    Object7007 --> Lambda7008
+    Constant7265{{"Constant[7265∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant7265 --> Lambda7013
+    Object7027 --> Lambda7028
+    Constant7266{{"Constant[7266∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
+    Constant7266 --> Lambda7033
+    Object7046 --> Lambda7047
+    Constant7267{{"Constant[7267∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant7267 --> Lambda7052
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Constant6{{"Constant[6∈0] ➊<br />ᐸundefinedᐳ"}}:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection1713{{"Connection[1713∈0] ➊<br />ᐸ1711ᐳ"}}:::plan
-    Connection2543{{"Connection[2543∈0] ➊<br />ᐸ2541ᐳ"}}:::plan
     Constant3594{{"Constant[3594∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant3597{{"Constant[3597∈0] ➊<br />ᐸfalseᐳ"}}:::plan
-    Constant3774{{"Constant[3774∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3775{{"Constant[3775∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant3790{{"Constant[3790∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3791{{"Constant[3791∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant3806{{"Constant[3806∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3807{{"Constant[3807∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3822{{"Constant[3822∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3823{{"Constant[3823∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3838{{"Constant[3838∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3839{{"Constant[3839∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3854{{"Constant[3854∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3855{{"Constant[3855∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant3870{{"Constant[3870∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3871{{"Constant[3871∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3886{{"Constant[3886∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3887{{"Constant[3887∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3902{{"Constant[3902∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3903{{"Constant[3903∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3918{{"Constant[3918∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3919{{"Constant[3919∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant3934{{"Constant[3934∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3935{{"Constant[3935∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant3950{{"Constant[3950∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3951{{"Constant[3951∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant3966{{"Constant[3966∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3967{{"Constant[3967∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3982{{"Constant[3982∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3983{{"Constant[3983∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant3998{{"Constant[3998∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant3999{{"Constant[3999∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant4014{{"Constant[4014∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4015{{"Constant[4015∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant4030{{"Constant[4030∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4031{{"Constant[4031∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant4046{{"Constant[4046∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4047{{"Constant[4047∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant4062{{"Constant[4062∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4063{{"Constant[4063∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant4078{{"Constant[4078∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant4079{{"Constant[4079∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant4092{{"Constant[4092∈0] ➊<br />ᐸtrueᐳ"}}:::plan
-    Constant4095{{"Constant[4095∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 266ᐳ"}}:::plan
-    Constant4109{{"Constant[4109∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5245{{"Constant[5245∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5246{{"Constant[5246∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant5259{{"Constant[5259∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5260{{"Constant[5260∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant5273{{"Constant[5273∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5274{{"Constant[5274∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5289{{"Constant[5289∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5290{{"Constant[5290∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5305{{"Constant[5305∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5306{{"Constant[5306∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5321{{"Constant[5321∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5322{{"Constant[5322∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant5337{{"Constant[5337∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5338{{"Constant[5338∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5353{{"Constant[5353∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5354{{"Constant[5354∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5369{{"Constant[5369∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5370{{"Constant[5370∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5385{{"Constant[5385∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5386{{"Constant[5386∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant5402{{"Constant[5402∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5403{{"Constant[5403∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant5416{{"Constant[5416∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5417{{"Constant[5417∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant5430{{"Constant[5430∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5431{{"Constant[5431∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5446{{"Constant[5446∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5447{{"Constant[5447∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5462{{"Constant[5462∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5463{{"Constant[5463∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5478{{"Constant[5478∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5479{{"Constant[5479∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant5494{{"Constant[5494∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5495{{"Constant[5495∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5510{{"Constant[5510∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5511{{"Constant[5511∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5526{{"Constant[5526∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5527{{"Constant[5527∈0] ➊<br />ᐸsql.identifier(”frmcdc_compound_type”)ᐳ"}}:::plan
-    Constant5542{{"Constant[5542∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5543{{"Constant[5543∈0] ➊<br />ᐸsql.identifier(”frmcdc_nested_compound_type”)ᐳ"}}:::plan
-    Constant5558{{"Constant[5558∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5559{{"Constant[5559∈0] ➊<br />ᐸsql.identifier(”type_function_connection”)ᐳ"}}:::plan
-    Constant5572{{"Constant[5572∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5941{{"Constant[5941∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5942{{"Constant[5942∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant5955{{"Constant[5955∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant5956{{"Constant[5956∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant6098{{"Constant[6098∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6099{{"Constant[6099∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant6112{{"Constant[6112∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant6113{{"Constant[6113∈0] ➊<br />ᐸsql.identifier(”post”)ᐳ"}}:::plan
-    Constant6865{{"Constant[6865∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6866{{"Constant[6866∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6867{{"Constant[6867∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6868{{"Constant[6868∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6869{{"Constant[6869∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6870{{"Constant[6870∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6871{{"Constant[6871∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6872{{"Constant[6872∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6873{{"Constant[6873∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6874{{"Constant[6874∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6875{{"Constant[6875∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6876{{"Constant[6876∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6877{{"Constant[6877∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6878{{"Constant[6878∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6879{{"Constant[6879∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6880{{"Constant[6880∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6881{{"Constant[6881∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6882{{"Constant[6882∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6883{{"Constant[6883∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6884{{"Constant[6884∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6885{{"Constant[6885∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    Constant6886{{"Constant[6886∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”types”ᐳ"}}:::plan
-    Constant6960{{"Constant[6960∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6961{{"Constant[6961∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6962{{"Constant[6962∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6963{{"Constant[6963∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6964{{"Constant[6964∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6965{{"Constant[6965∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6966{{"Constant[6966∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6967{{"Constant[6967∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6968{{"Constant[6968∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6969{{"Constant[6969∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6970{{"Constant[6970∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6971{{"Constant[6971∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant6972{{"Constant[6972∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6973{{"Constant[6973∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6974{{"Constant[6974∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6975{{"Constant[6975∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6976{{"Constant[6976∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6977{{"Constant[6977∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6978{{"Constant[6978∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6979{{"Constant[6979∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”frmcdcᐳ"}}:::plan
-    Constant6980{{"Constant[6980∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant6981{{"Constant[6981∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”type_fᐳ"}}:::plan
-    Constant7004{{"Constant[7004∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7005{{"Constant[7005∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7014{{"Constant[7014∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
-    Constant7015{{"Constant[7015∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”post”)ᐳ"}}:::plan
+    Constant4123{{"Constant[4123∈0] ➊<br />ᐸtrueᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸtypes+1ᐳ"]]:::plan
-    Lambda3778{{"Lambda[3778∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3783{{"Lambda[3783∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3794{{"Lambda[3794∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3799{{"Lambda[3799∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3810{{"Lambda[3810∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3815{{"Lambda[3815∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3826{{"Lambda[3826∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3831{{"Lambda[3831∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3842{{"Lambda[3842∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3847{{"Lambda[3847∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3858{{"Lambda[3858∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3863{{"Lambda[3863∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3874{{"Lambda[3874∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3879{{"Lambda[3879∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3890{{"Lambda[3890∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3895{{"Lambda[3895∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3906{{"Lambda[3906∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3911{{"Lambda[3911∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3922{{"Lambda[3922∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3927{{"Lambda[3927∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3938{{"Lambda[3938∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3943{{"Lambda[3943∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3954{{"Lambda[3954∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3959{{"Lambda[3959∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3970{{"Lambda[3970∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3975{{"Lambda[3975∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3986{{"Lambda[3986∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda3991{{"Lambda[3991∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4002{{"Lambda[4002∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4007{{"Lambda[4007∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4018{{"Lambda[4018∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4023{{"Lambda[4023∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4034{{"Lambda[4034∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4039{{"Lambda[4039∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4050{{"Lambda[4050∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4055{{"Lambda[4055∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4066{{"Lambda[4066∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4071{{"Lambda[4071∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4082{{"Lambda[4082∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4087{{"Lambda[4087∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4099{{"Lambda[4099∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4104{{"Lambda[4104∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda3599 & Lambda3778 & Lambda3783 & Lambda3599 & Lambda3794 & Lambda3799 & Lambda3599 & Lambda3810 & Lambda3815 & Lambda3826 & Lambda3831 & Lambda3842 & Lambda3847 & Lambda3599 & Lambda3858 & Lambda3863 & Lambda3599 & Lambda3874 & Lambda3879 & Lambda3890 & Lambda3895 & Lambda3906 & Lambda3911 & Lambda3599 & Lambda3922 & Lambda3927 & Lambda3599 & Lambda3938 & Lambda3943 & Lambda3599 & Lambda3954 & Lambda3959 & Lambda3599 & Lambda3970 & Lambda3975 & Lambda3986 & Lambda3991 & Lambda4002 & Lambda4007 & Lambda3599 & Lambda4018 & Lambda4023 & Lambda3599 & Lambda4034 & Lambda4039 & Lambda4050 & Lambda4055 & Lambda4066 & Lambda4071 & Lambda3599 & Lambda4082 & Lambda4087 & Lambda3596 & Lambda4094 & Lambda4099 & Lambda4104 --> PgSelect14
+    Object12 & Connection13 & Access3600 & Lambda3790 & Lambda3795 & Access3600 & Lambda3807 & Lambda3812 & Access3600 & Lambda3824 & Lambda3829 & Lambda3841 & Lambda3846 & Lambda3858 & Lambda3863 & Access3600 & Lambda3875 & Lambda3880 & Access3600 & Lambda3892 & Lambda3897 & Lambda3909 & Lambda3914 & Lambda3926 & Lambda3931 & Access3600 & Lambda3943 & Lambda3948 & Access3600 & Lambda3960 & Lambda3965 & Access3600 & Lambda3977 & Lambda3982 & Access3600 & Lambda3994 & Lambda3999 & Lambda4011 & Lambda4016 & Lambda4028 & Lambda4033 & Access3600 & Lambda4045 & Lambda4050 & Access3600 & Lambda4062 & Lambda4067 & Lambda4079 & Lambda4084 & Lambda4096 & Lambda4101 & Access3600 & Lambda4113 & Lambda4118 & Lambda3596 & Access4126 & Lambda4131 & Lambda4136 --> PgSelect14
     PgSelect403[["PgSelect[403∈1] ➊<br />ᐸtypes(aggregate)ᐳ"]]:::plan
-    Lambda4113{{"Lambda[4113∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda4118{{"Lambda[4118∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda3596 & Lambda3599 & Lambda4113 & Lambda4118 --> PgSelect403
+    Object12 & Connection13 & Lambda3596 & Access3600 & Lambda4146 & Lambda4151 --> PgSelect403
     Object416{{"Object[416∈1] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access411{{"Access[411∈1] ➊<br />ᐸ14.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access411 --> Object416
-    Object3777{{"Object[3777∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3774 & Constant3775 & Constant3602 --> Object3777
-    Object3793{{"Object[3793∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3790 & Constant3791 & Constant3602 --> Object3793
-    Object3809{{"Object[3809∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3806 & Constant3807 & Constant3634 --> Object3809
-    Object3825{{"Object[3825∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3822 & Constant3823 & Constant3634 --> Object3825
-    Object3841{{"Object[3841∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3838 & Constant3839 & Constant3634 --> Object3841
-    Object3857{{"Object[3857∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3854 & Constant3855 & Constant3682 --> Object3857
-    Object3873{{"Object[3873∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3870 & Constant3871 & Constant3634 --> Object3873
-    Object3889{{"Object[3889∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3886 & Constant3887 & Constant3634 --> Object3889
-    Object3905{{"Object[3905∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3902 & Constant3903 & Constant3634 --> Object3905
-    Object3921{{"Object[3921∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3918 & Constant3919 & Constant3682 --> Object3921
-    Object3937{{"Object[3937∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3934 & Constant3935 & Constant3602 --> Object3937
-    Object3953{{"Object[3953∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3950 & Constant3951 & Constant3602 --> Object3953
-    Object3969{{"Object[3969∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3966 & Constant3967 & Constant3634 --> Object3969
-    Object3985{{"Object[3985∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3982 & Constant3983 & Constant3634 --> Object3985
-    Object4001{{"Object[4001∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant3998 & Constant3999 & Constant3634 --> Object4001
-    Object4017{{"Object[4017∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4014 & Constant4015 & Constant3682 --> Object4017
-    Object4033{{"Object[4033∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4030 & Constant4031 & Constant3634 --> Object4033
-    Object4049{{"Object[4049∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4046 & Constant4047 & Constant3634 --> Object4049
-    Object4065{{"Object[4065∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4062 & Constant4063 & Constant3634 --> Object4065
-    Object4081{{"Object[4081∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4078 & Constant4079 & Constant3682 --> Object4081
-    Object4098{{"Object[4098∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4095 & Constant3761 & Constant3762 --> Object4098
-    Object4112{{"Object[4112∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant4109 & Constant3761 & Constant3762 --> Object4112
     Object412{{"Object[412∈1] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access411 --> Object412
     First404{{"First[404∈1] ➊"}}:::plan
@@ -1800,50 +2009,6 @@ graph TD
     PgClassExpression428{{"PgClassExpression[428∈1] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     PgSelectSingle426 --> PgClassExpression428
     PgClassExpression428 --> List429
-    Object3777 --> Lambda3778
-    Constant6865 --> Lambda3783
-    Object3793 --> Lambda3794
-    Constant6866 --> Lambda3799
-    Object3809 --> Lambda3810
-    Constant6867 --> Lambda3815
-    Object3825 --> Lambda3826
-    Constant6868 --> Lambda3831
-    Object3841 --> Lambda3842
-    Constant6869 --> Lambda3847
-    Object3857 --> Lambda3858
-    Constant6870 --> Lambda3863
-    Object3873 --> Lambda3874
-    Constant6871 --> Lambda3879
-    Object3889 --> Lambda3890
-    Constant6872 --> Lambda3895
-    Object3905 --> Lambda3906
-    Constant6873 --> Lambda3911
-    Object3921 --> Lambda3922
-    Constant6874 --> Lambda3927
-    Object3937 --> Lambda3938
-    Constant6875 --> Lambda3943
-    Object3953 --> Lambda3954
-    Constant6876 --> Lambda3959
-    Object3969 --> Lambda3970
-    Constant6877 --> Lambda3975
-    Object3985 --> Lambda3986
-    Constant6878 --> Lambda3991
-    Object4001 --> Lambda4002
-    Constant6879 --> Lambda4007
-    Object4017 --> Lambda4018
-    Constant6880 --> Lambda4023
-    Object4033 --> Lambda4034
-    Constant6881 --> Lambda4039
-    Object4049 --> Lambda4050
-    Constant6882 --> Lambda4055
-    Object4065 --> Lambda4066
-    Constant6883 --> Lambda4071
-    Object4081 --> Lambda4082
-    Constant6884 --> Lambda4087
-    Object4098 --> Lambda4099
-    Constant6885 --> Lambda4104
-    Object4112 --> Lambda4113
-    Constant6886 --> Lambda4118
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸtypesᐳ"}}:::plan
@@ -1913,8 +2078,8 @@ graph TD
     PgClassExpression81{{"PgClassExpression[81∈3]<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression81
     PgSelectSingle88{{"PgSelectSingle[88∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3816{{"RemapKeys[3816∈3]<br />ᐸ16:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys3816 --> PgSelectSingle88
+    RemapKeys3830{{"RemapKeys[3830∈3]<br />ᐸ16:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys3830 --> PgSelectSingle88
     PgClassExpression89{{"PgClassExpression[89∈3]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle88 --> PgClassExpression89
     PgClassExpression90{{"PgClassExpression[90∈3]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -1930,21 +2095,21 @@ graph TD
     PgClassExpression95{{"PgClassExpression[95∈3]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle88 --> PgClassExpression95
     PgSelectSingle100{{"PgSelectSingle[100∈3]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys3864{{"RemapKeys[3864∈3]<br />ᐸ16:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys3864 --> PgSelectSingle100
+    RemapKeys3881{{"RemapKeys[3881∈3]<br />ᐸ16:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys3881 --> PgSelectSingle100
     PgSelectSingle105{{"PgSelectSingle[105∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle100 --> PgSelectSingle105
     PgSelectSingle117{{"PgSelectSingle[117∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3848{{"RemapKeys[3848∈3]<br />ᐸ100:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys3848 --> PgSelectSingle117
+    RemapKeys3864{{"RemapKeys[3864∈3]<br />ᐸ100:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys3864 --> PgSelectSingle117
     PgClassExpression125{{"PgClassExpression[125∈3]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle100 --> PgClassExpression125
     PgSelectSingle130{{"PgSelectSingle[130∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3880{{"RemapKeys[3880∈3]<br />ᐸ16:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys3880 --> PgSelectSingle130
+    RemapKeys3898{{"RemapKeys[3898∈3]<br />ᐸ16:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys3898 --> PgSelectSingle130
     PgSelectSingle142{{"PgSelectSingle[142∈3]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys3928{{"RemapKeys[3928∈3]<br />ᐸ16:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys3928 --> PgSelectSingle142
+    RemapKeys3949{{"RemapKeys[3949∈3]<br />ᐸ16:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys3949 --> PgSelectSingle142
     PgClassExpression170{{"PgClassExpression[170∈3]<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression170
     PgClassExpression173{{"PgClassExpression[173∈3]<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -1980,20 +2145,20 @@ graph TD
     PgClassExpression192{{"PgClassExpression[192∈3]<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression192
     PgSelectSingle197{{"PgSelectSingle[197∈3]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys3800{{"RemapKeys[3800∈3]<br />ᐸ16:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys3800 --> PgSelectSingle197
+    RemapKeys3813{{"RemapKeys[3813∈3]<br />ᐸ16:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys3813 --> PgSelectSingle197
     PgSelectSingle203{{"PgSelectSingle[203∈3]<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle16 --> PgSelectSingle203
     PgClassExpression206{{"PgClassExpression[206∈3]<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression206
     PgClassExpression207{{"PgClassExpression[207∈3]<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression207
-    PgSelectSingle16 --> RemapKeys3800
-    PgSelectSingle16 --> RemapKeys3816
-    PgSelectSingle100 --> RemapKeys3848
-    PgSelectSingle16 --> RemapKeys3864
-    PgSelectSingle16 --> RemapKeys3880
-    PgSelectSingle16 --> RemapKeys3928
+    PgSelectSingle16 --> RemapKeys3813
+    PgSelectSingle16 --> RemapKeys3830
+    PgSelectSingle100 --> RemapKeys3864
+    PgSelectSingle16 --> RemapKeys3881
+    PgSelectSingle16 --> RemapKeys3898
+    PgSelectSingle16 --> RemapKeys3949
     __Item26[/"__Item[26∈4]<br />ᐸ25ᐳ"\]:::itemplan
     PgClassExpression25 ==> __Item26
     __Item30[/"__Item[30∈5]<br />ᐸ29ᐳ"\]:::itemplan
@@ -2049,11 +2214,11 @@ graph TD
     PgSelectSingle149{{"PgSelectSingle[149∈20]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle142 --> PgSelectSingle149
     PgSelectSingle161{{"PgSelectSingle[161∈20]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3912{{"RemapKeys[3912∈20]<br />ᐸ142:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys3912 --> PgSelectSingle161
+    RemapKeys3932{{"RemapKeys[3932∈20]<br />ᐸ142:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys3932 --> PgSelectSingle161
     PgClassExpression169{{"PgClassExpression[169∈20]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle142 --> PgClassExpression169
-    PgSelectSingle142 --> RemapKeys3912
+    PgSelectSingle142 --> RemapKeys3932
     PgClassExpression150{{"PgClassExpression[150∈21]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle149 --> PgClassExpression150
     PgClassExpression151{{"PgClassExpression[151∈21]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2163,8 +2328,8 @@ graph TD
     PgClassExpression275{{"PgClassExpression[275∈30]<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression275
     PgSelectSingle282{{"PgSelectSingle[282∈30]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3976{{"RemapKeys[3976∈30]<br />ᐸ16:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113}ᐳ"}}:::plan
-    RemapKeys3976 --> PgSelectSingle282
+    RemapKeys4000{{"RemapKeys[4000∈30]<br />ᐸ16:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113}ᐳ"}}:::plan
+    RemapKeys4000 --> PgSelectSingle282
     PgClassExpression283{{"PgClassExpression[283∈30]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle282 --> PgClassExpression283
     PgClassExpression284{{"PgClassExpression[284∈30]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2180,21 +2345,21 @@ graph TD
     PgClassExpression289{{"PgClassExpression[289∈30]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle282 --> PgClassExpression289
     PgSelectSingle294{{"PgSelectSingle[294∈30]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4024{{"RemapKeys[4024∈30]<br />ᐸ16:{”0”:114,”1”:115,”2”:116,”3”:117,”4”:118,”5”:119,”6”:120,”7”:121,”8”:122,”9”:123,”10”:124,”11”:125,”12”:126,”13”:127,”14”:128,”15”:129,”16”:130,”17”:131}ᐳ"}}:::plan
-    RemapKeys4024 --> PgSelectSingle294
+    RemapKeys4051{{"RemapKeys[4051∈30]<br />ᐸ16:{”0”:114,”1”:115,”2”:116,”3”:117,”4”:118,”5”:119,”6”:120,”7”:121,”8”:122,”9”:123,”10”:124,”11”:125,”12”:126,”13”:127,”14”:128,”15”:129,”16”:130,”17”:131}ᐳ"}}:::plan
+    RemapKeys4051 --> PgSelectSingle294
     PgSelectSingle299{{"PgSelectSingle[299∈30]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle294 --> PgSelectSingle299
     PgSelectSingle311{{"PgSelectSingle[311∈30]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4008{{"RemapKeys[4008∈30]<br />ᐸ294:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4008 --> PgSelectSingle311
+    RemapKeys4034{{"RemapKeys[4034∈30]<br />ᐸ294:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4034 --> PgSelectSingle311
     PgClassExpression319{{"PgClassExpression[319∈30]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle294 --> PgClassExpression319
     PgSelectSingle324{{"PgSelectSingle[324∈30]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4040{{"RemapKeys[4040∈30]<br />ᐸ16:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139}ᐳ"}}:::plan
-    RemapKeys4040 --> PgSelectSingle324
+    RemapKeys4068{{"RemapKeys[4068∈30]<br />ᐸ16:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139}ᐳ"}}:::plan
+    RemapKeys4068 --> PgSelectSingle324
     PgSelectSingle336{{"PgSelectSingle[336∈30]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4088{{"RemapKeys[4088∈30]<br />ᐸ16:{”0”:140,”1”:141,”2”:142,”3”:143,”4”:144,”5”:145,”6”:146,”7”:147,”8”:148,”9”:149,”10”:150,”11”:151,”12”:152,”13”:153,”14”:154,”15”:155,”16”:156,”17”:157}ᐳ"}}:::plan
-    RemapKeys4088 --> PgSelectSingle336
+    RemapKeys4119{{"RemapKeys[4119∈30]<br />ᐸ16:{”0”:140,”1”:141,”2”:142,”3”:143,”4”:144,”5”:145,”6”:146,”7”:147,”8”:148,”9”:149,”10”:150,”11”:151,”12”:152,”13”:153,”14”:154,”15”:155,”16”:156,”17”:157}ᐳ"}}:::plan
+    RemapKeys4119 --> PgSelectSingle336
     PgClassExpression364{{"PgClassExpression[364∈30]<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression364
     PgClassExpression367{{"PgClassExpression[367∈30]<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -2230,22 +2395,22 @@ graph TD
     PgClassExpression386{{"PgClassExpression[386∈30]<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression386
     PgSelectSingle391{{"PgSelectSingle[391∈30]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys3960{{"RemapKeys[3960∈30]<br />ᐸ16:{”0”:103,”1”:104}ᐳ"}}:::plan
-    RemapKeys3960 --> PgSelectSingle391
+    RemapKeys3983{{"RemapKeys[3983∈30]<br />ᐸ16:{”0”:103,”1”:104}ᐳ"}}:::plan
+    RemapKeys3983 --> PgSelectSingle391
     PgSelectSingle397{{"PgSelectSingle[397∈30]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys3944{{"RemapKeys[3944∈30]<br />ᐸ16:{”0”:101,”1”:102}ᐳ"}}:::plan
-    RemapKeys3944 --> PgSelectSingle397
+    RemapKeys3966{{"RemapKeys[3966∈30]<br />ᐸ16:{”0”:101,”1”:102}ᐳ"}}:::plan
+    RemapKeys3966 --> PgSelectSingle397
     PgClassExpression400{{"PgClassExpression[400∈30]<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression400
     PgClassExpression401{{"PgClassExpression[401∈30]<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression401
-    PgSelectSingle16 --> RemapKeys3944
-    PgSelectSingle16 --> RemapKeys3960
-    PgSelectSingle16 --> RemapKeys3976
-    PgSelectSingle294 --> RemapKeys4008
-    PgSelectSingle16 --> RemapKeys4024
-    PgSelectSingle16 --> RemapKeys4040
-    PgSelectSingle16 --> RemapKeys4088
+    PgSelectSingle16 --> RemapKeys3966
+    PgSelectSingle16 --> RemapKeys3983
+    PgSelectSingle16 --> RemapKeys4000
+    PgSelectSingle294 --> RemapKeys4034
+    PgSelectSingle16 --> RemapKeys4051
+    PgSelectSingle16 --> RemapKeys4068
+    PgSelectSingle16 --> RemapKeys4119
     __Item220[/"__Item[220∈31]<br />ᐸ219ᐳ"\]:::itemplan
     PgClassExpression219 ==> __Item220
     __Item224[/"__Item[224∈32]<br />ᐸ223ᐳ"\]:::itemplan
@@ -2301,11 +2466,11 @@ graph TD
     PgSelectSingle343{{"PgSelectSingle[343∈47]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle336 --> PgSelectSingle343
     PgSelectSingle355{{"PgSelectSingle[355∈47]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4072{{"RemapKeys[4072∈47]<br />ᐸ336:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4072 --> PgSelectSingle355
+    RemapKeys4102{{"RemapKeys[4102∈47]<br />ᐸ336:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4102 --> PgSelectSingle355
     PgClassExpression363{{"PgClassExpression[363∈47]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle336 --> PgClassExpression363
-    PgSelectSingle336 --> RemapKeys4072
+    PgSelectSingle336 --> RemapKeys4102
     PgClassExpression344{{"PgClassExpression[344∈48]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle343 --> PgClassExpression344
     PgClassExpression345{{"PgClassExpression[345∈48]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2419,8 +2584,8 @@ graph TD
     PgClassExpression498{{"PgClassExpression[498∈57]<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle433 --> PgClassExpression498
     PgSelectSingle505{{"PgSelectSingle[505∈57]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3642{{"RemapKeys[3642∈57]<br />ᐸ433:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys3642 --> PgSelectSingle505
+    RemapKeys3645{{"RemapKeys[3645∈57]<br />ᐸ433:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys3645 --> PgSelectSingle505
     PgClassExpression506{{"PgClassExpression[506∈57]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle505 --> PgClassExpression506
     PgClassExpression507{{"PgClassExpression[507∈57]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2436,21 +2601,21 @@ graph TD
     PgClassExpression512{{"PgClassExpression[512∈57]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle505 --> PgClassExpression512
     PgSelectSingle517{{"PgSelectSingle[517∈57]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys3690{{"RemapKeys[3690∈57]<br />ᐸ433:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys3690 --> PgSelectSingle517
+    RemapKeys3696{{"RemapKeys[3696∈57]<br />ᐸ433:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys3696 --> PgSelectSingle517
     PgSelectSingle522{{"PgSelectSingle[522∈57]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle517 --> PgSelectSingle522
     PgSelectSingle534{{"PgSelectSingle[534∈57]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3674{{"RemapKeys[3674∈57]<br />ᐸ517:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys3674 --> PgSelectSingle534
+    RemapKeys3679{{"RemapKeys[3679∈57]<br />ᐸ517:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys3679 --> PgSelectSingle534
     PgClassExpression542{{"PgClassExpression[542∈57]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle517 --> PgClassExpression542
     PgSelectSingle547{{"PgSelectSingle[547∈57]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3706{{"RemapKeys[3706∈57]<br />ᐸ433:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys3706 --> PgSelectSingle547
+    RemapKeys3713{{"RemapKeys[3713∈57]<br />ᐸ433:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys3713 --> PgSelectSingle547
     PgSelectSingle559{{"PgSelectSingle[559∈57]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys3754{{"RemapKeys[3754∈57]<br />ᐸ433:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys3754 --> PgSelectSingle559
+    RemapKeys3764{{"RemapKeys[3764∈57]<br />ᐸ433:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys3764 --> PgSelectSingle559
     PgClassExpression587{{"PgClassExpression[587∈57]<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle433 --> PgClassExpression587
     PgClassExpression590{{"PgClassExpression[590∈57]<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -2486,20 +2651,20 @@ graph TD
     PgClassExpression609{{"PgClassExpression[609∈57]<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle433 --> PgClassExpression609
     PgSelectSingle614{{"PgSelectSingle[614∈57]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys3626{{"RemapKeys[3626∈57]<br />ᐸ433:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys3626 --> PgSelectSingle614
+    RemapKeys3628{{"RemapKeys[3628∈57]<br />ᐸ433:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys3628 --> PgSelectSingle614
     PgSelectSingle620{{"PgSelectSingle[620∈57]<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle433 --> PgSelectSingle620
     PgClassExpression623{{"PgClassExpression[623∈57]<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle433 --> PgClassExpression623
     PgClassExpression624{{"PgClassExpression[624∈57]<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle433 --> PgClassExpression624
-    PgSelectSingle433 --> RemapKeys3626
-    PgSelectSingle433 --> RemapKeys3642
-    PgSelectSingle517 --> RemapKeys3674
-    PgSelectSingle433 --> RemapKeys3690
-    PgSelectSingle433 --> RemapKeys3706
-    PgSelectSingle433 --> RemapKeys3754
+    PgSelectSingle433 --> RemapKeys3628
+    PgSelectSingle433 --> RemapKeys3645
+    PgSelectSingle517 --> RemapKeys3679
+    PgSelectSingle433 --> RemapKeys3696
+    PgSelectSingle433 --> RemapKeys3713
+    PgSelectSingle433 --> RemapKeys3764
     __Item443[/"__Item[443∈58]<br />ᐸ442ᐳ"\]:::itemplan
     PgClassExpression442 ==> __Item443
     __Item447[/"__Item[447∈59]<br />ᐸ446ᐳ"\]:::itemplan
@@ -2555,11 +2720,11 @@ graph TD
     PgSelectSingle566{{"PgSelectSingle[566∈74]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle559 --> PgSelectSingle566
     PgSelectSingle578{{"PgSelectSingle[578∈74]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys3738{{"RemapKeys[3738∈74]<br />ᐸ559:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys3738 --> PgSelectSingle578
+    RemapKeys3747{{"RemapKeys[3747∈74]<br />ᐸ559:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys3747 --> PgSelectSingle578
     PgClassExpression586{{"PgClassExpression[586∈74]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle559 --> PgClassExpression586
-    PgSelectSingle559 --> RemapKeys3738
+    PgSelectSingle559 --> RemapKeys3747
     PgClassExpression567{{"PgClassExpression[567∈75]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle566 --> PgClassExpression567
     PgClassExpression568{{"PgClassExpression[568∈75]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2669,8 +2834,8 @@ graph TD
     PgClassExpression695{{"PgClassExpression[695∈84] ➊<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle630 --> PgClassExpression695
     PgSelectSingle702{{"PgSelectSingle[702∈84] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4165{{"RemapKeys[4165∈84] ➊<br />ᐸ630:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys4165 --> PgSelectSingle702
+    RemapKeys4201{{"RemapKeys[4201∈84] ➊<br />ᐸ630:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys4201 --> PgSelectSingle702
     PgClassExpression703{{"PgClassExpression[703∈84] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle702 --> PgClassExpression703
     PgClassExpression704{{"PgClassExpression[704∈84] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2686,21 +2851,21 @@ graph TD
     PgClassExpression709{{"PgClassExpression[709∈84] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle702 --> PgClassExpression709
     PgSelectSingle714{{"PgSelectSingle[714∈84] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4213{{"RemapKeys[4213∈84] ➊<br />ᐸ630:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys4213 --> PgSelectSingle714
+    RemapKeys4252{{"RemapKeys[4252∈84] ➊<br />ᐸ630:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys4252 --> PgSelectSingle714
     PgSelectSingle719{{"PgSelectSingle[719∈84] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle714 --> PgSelectSingle719
     PgSelectSingle731{{"PgSelectSingle[731∈84] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4197{{"RemapKeys[4197∈84] ➊<br />ᐸ714:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4197 --> PgSelectSingle731
+    RemapKeys4235{{"RemapKeys[4235∈84] ➊<br />ᐸ714:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4235 --> PgSelectSingle731
     PgClassExpression739{{"PgClassExpression[739∈84] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle714 --> PgClassExpression739
     PgSelectSingle744{{"PgSelectSingle[744∈84] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4229{{"RemapKeys[4229∈84] ➊<br />ᐸ630:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys4229 --> PgSelectSingle744
+    RemapKeys4269{{"RemapKeys[4269∈84] ➊<br />ᐸ630:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys4269 --> PgSelectSingle744
     PgSelectSingle756{{"PgSelectSingle[756∈84] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4277{{"RemapKeys[4277∈84] ➊<br />ᐸ630:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys4277 --> PgSelectSingle756
+    RemapKeys4320{{"RemapKeys[4320∈84] ➊<br />ᐸ630:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys4320 --> PgSelectSingle756
     PgClassExpression784{{"PgClassExpression[784∈84] ➊<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle630 --> PgClassExpression784
     PgClassExpression787{{"PgClassExpression[787∈84] ➊<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -2736,20 +2901,20 @@ graph TD
     PgClassExpression806{{"PgClassExpression[806∈84] ➊<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle630 --> PgClassExpression806
     PgSelectSingle811{{"PgSelectSingle[811∈84] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys4149{{"RemapKeys[4149∈84] ➊<br />ᐸ630:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys4149 --> PgSelectSingle811
+    RemapKeys4184{{"RemapKeys[4184∈84] ➊<br />ᐸ630:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys4184 --> PgSelectSingle811
     PgSelectSingle817{{"PgSelectSingle[817∈84] ➊<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle630 --> PgSelectSingle817
     PgClassExpression820{{"PgClassExpression[820∈84] ➊<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle630 --> PgClassExpression820
     PgClassExpression821{{"PgClassExpression[821∈84] ➊<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle630 --> PgClassExpression821
-    PgSelectSingle630 --> RemapKeys4149
-    PgSelectSingle630 --> RemapKeys4165
-    PgSelectSingle714 --> RemapKeys4197
-    PgSelectSingle630 --> RemapKeys4213
-    PgSelectSingle630 --> RemapKeys4229
-    PgSelectSingle630 --> RemapKeys4277
+    PgSelectSingle630 --> RemapKeys4184
+    PgSelectSingle630 --> RemapKeys4201
+    PgSelectSingle714 --> RemapKeys4235
+    PgSelectSingle630 --> RemapKeys4252
+    PgSelectSingle630 --> RemapKeys4269
+    PgSelectSingle630 --> RemapKeys4320
     __Item640[/"__Item[640∈85]<br />ᐸ639ᐳ"\]:::itemplan
     PgClassExpression639 ==> __Item640
     __Item644[/"__Item[644∈86]<br />ᐸ643ᐳ"\]:::itemplan
@@ -2805,11 +2970,11 @@ graph TD
     PgSelectSingle763{{"PgSelectSingle[763∈101] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle756 --> PgSelectSingle763
     PgSelectSingle775{{"PgSelectSingle[775∈101] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4261{{"RemapKeys[4261∈101] ➊<br />ᐸ756:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4261 --> PgSelectSingle775
+    RemapKeys4303{{"RemapKeys[4303∈101] ➊<br />ᐸ756:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4303 --> PgSelectSingle775
     PgClassExpression783{{"PgClassExpression[783∈101] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle756 --> PgClassExpression783
-    PgSelectSingle756 --> RemapKeys4261
+    PgSelectSingle756 --> RemapKeys4303
     PgClassExpression764{{"PgClassExpression[764∈102] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle763 --> PgClassExpression764
     PgClassExpression765{{"PgClassExpression[765∈102] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2919,8 +3084,8 @@ graph TD
     PgClassExpression895{{"PgClassExpression[895∈111] ➊<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle830 --> PgClassExpression895
     PgSelectSingle902{{"PgSelectSingle[902∈111] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4339{{"RemapKeys[4339∈111] ➊<br />ᐸ830:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys4339 --> PgSelectSingle902
+    RemapKeys4386{{"RemapKeys[4386∈111] ➊<br />ᐸ830:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys4386 --> PgSelectSingle902
     PgClassExpression903{{"PgClassExpression[903∈111] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle902 --> PgClassExpression903
     PgClassExpression904{{"PgClassExpression[904∈111] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -2936,21 +3101,21 @@ graph TD
     PgClassExpression909{{"PgClassExpression[909∈111] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle902 --> PgClassExpression909
     PgSelectSingle914{{"PgSelectSingle[914∈111] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4387{{"RemapKeys[4387∈111] ➊<br />ᐸ830:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys4387 --> PgSelectSingle914
+    RemapKeys4437{{"RemapKeys[4437∈111] ➊<br />ᐸ830:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys4437 --> PgSelectSingle914
     PgSelectSingle919{{"PgSelectSingle[919∈111] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle914 --> PgSelectSingle919
     PgSelectSingle931{{"PgSelectSingle[931∈111] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4371{{"RemapKeys[4371∈111] ➊<br />ᐸ914:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4371 --> PgSelectSingle931
+    RemapKeys4420{{"RemapKeys[4420∈111] ➊<br />ᐸ914:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4420 --> PgSelectSingle931
     PgClassExpression939{{"PgClassExpression[939∈111] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle914 --> PgClassExpression939
     PgSelectSingle944{{"PgSelectSingle[944∈111] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4403{{"RemapKeys[4403∈111] ➊<br />ᐸ830:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys4403 --> PgSelectSingle944
+    RemapKeys4454{{"RemapKeys[4454∈111] ➊<br />ᐸ830:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys4454 --> PgSelectSingle944
     PgSelectSingle956{{"PgSelectSingle[956∈111] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4451{{"RemapKeys[4451∈111] ➊<br />ᐸ830:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys4451 --> PgSelectSingle956
+    RemapKeys4505{{"RemapKeys[4505∈111] ➊<br />ᐸ830:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys4505 --> PgSelectSingle956
     PgClassExpression984{{"PgClassExpression[984∈111] ➊<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle830 --> PgClassExpression984
     PgClassExpression987{{"PgClassExpression[987∈111] ➊<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -2986,20 +3151,20 @@ graph TD
     PgClassExpression1006{{"PgClassExpression[1006∈111] ➊<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle830 --> PgClassExpression1006
     PgSelectSingle1011{{"PgSelectSingle[1011∈111] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys4323{{"RemapKeys[4323∈111] ➊<br />ᐸ830:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys4323 --> PgSelectSingle1011
+    RemapKeys4369{{"RemapKeys[4369∈111] ➊<br />ᐸ830:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys4369 --> PgSelectSingle1011
     PgSelectSingle1017{{"PgSelectSingle[1017∈111] ➊<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle830 --> PgSelectSingle1017
     PgClassExpression1020{{"PgClassExpression[1020∈111] ➊<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle830 --> PgClassExpression1020
     PgClassExpression1021{{"PgClassExpression[1021∈111] ➊<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle830 --> PgClassExpression1021
-    PgSelectSingle830 --> RemapKeys4323
-    PgSelectSingle830 --> RemapKeys4339
-    PgSelectSingle914 --> RemapKeys4371
-    PgSelectSingle830 --> RemapKeys4387
-    PgSelectSingle830 --> RemapKeys4403
-    PgSelectSingle830 --> RemapKeys4451
+    PgSelectSingle830 --> RemapKeys4369
+    PgSelectSingle830 --> RemapKeys4386
+    PgSelectSingle914 --> RemapKeys4420
+    PgSelectSingle830 --> RemapKeys4437
+    PgSelectSingle830 --> RemapKeys4454
+    PgSelectSingle830 --> RemapKeys4505
     __Item840[/"__Item[840∈112]<br />ᐸ839ᐳ"\]:::itemplan
     PgClassExpression839 ==> __Item840
     __Item844[/"__Item[844∈113]<br />ᐸ843ᐳ"\]:::itemplan
@@ -3055,11 +3220,11 @@ graph TD
     PgSelectSingle963{{"PgSelectSingle[963∈128] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle956 --> PgSelectSingle963
     PgSelectSingle975{{"PgSelectSingle[975∈128] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4435{{"RemapKeys[4435∈128] ➊<br />ᐸ956:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4435 --> PgSelectSingle975
+    RemapKeys4488{{"RemapKeys[4488∈128] ➊<br />ᐸ956:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4488 --> PgSelectSingle975
     PgClassExpression983{{"PgClassExpression[983∈128] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle956 --> PgClassExpression983
-    PgSelectSingle956 --> RemapKeys4435
+    PgSelectSingle956 --> RemapKeys4488
     PgClassExpression964{{"PgClassExpression[964∈129] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle963 --> PgClassExpression964
     PgClassExpression965{{"PgClassExpression[965∈129] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3105,65 +3270,65 @@ graph TD
     __Item1022[/"__Item[1022∈137]<br />ᐸ1021ᐳ"\]:::itemplan
     PgClassExpression1021 ==> __Item1022
     PgSelect1079[["PgSelect[1079∈138] ➊<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Access6848{{"Access[6848∈138] ➊<br />ᐸ1025.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access7055{{"Access[7055∈138] ➊<br />ᐸ1025.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
     Object12 -->|rejectNull| PgSelect1079
-    Access6848 & Lambda3599 & Lambda4601 & Lambda4606 & Lambda3599 & Lambda4617 & Lambda4622 & Lambda3599 & Lambda4633 & Lambda4638 & Lambda4649 & Lambda4654 & Lambda4665 & Lambda4670 & Lambda3599 & Lambda4681 & Lambda4686 & Lambda3599 & Lambda4697 & Lambda4702 & Lambda4713 & Lambda4718 & Lambda4729 & Lambda4734 & Lambda3599 & Lambda4745 & Lambda4750 & Lambda3596 & Lambda3599 & Lambda4761 & Lambda4766 --> PgSelect1079
+    Access7055 & Access3600 & Lambda4666 & Lambda4671 & Access3600 & Lambda4683 & Lambda4688 & Access3600 & Lambda4700 & Lambda4705 & Lambda4717 & Lambda4722 & Lambda4734 & Lambda4739 & Access3600 & Lambda4751 & Lambda4756 & Access3600 & Lambda4768 & Lambda4773 & Lambda4785 & Lambda4790 & Lambda4802 & Lambda4807 & Access3600 & Lambda4819 & Lambda4824 & Lambda3596 & Access3600 & Lambda4836 & Lambda4841 --> PgSelect1079
     PgSelect1064[["PgSelect[1064∈138] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access6849{{"Access[6849∈138] ➊<br />ᐸ1025.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
+    Access7056{{"Access[7056∈138] ➊<br />ᐸ1025.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1064
-    Access6848 -->|rejectNull| PgSelect1064
-    Access6849 & Lambda3596 & Lambda3599 & Lambda4559 & Lambda4564 --> PgSelect1064
+    Access7055 -->|rejectNull| PgSelect1064
+    Access7056 & Lambda3596 & Access3600 & Lambda4621 & Lambda4626 --> PgSelect1064
     PgSelect1030[["PgSelect[1030∈138] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object12 -->|rejectNull| PgSelect1030
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4475 & Lambda4480 --> PgSelect1030
+    Access7055 & Lambda3596 & Access3600 & Lambda4531 & Lambda4536 --> PgSelect1030
     PgSelect1037[["PgSelect[1037∈138] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object12 -->|rejectNull| PgSelect1037
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4489 & Lambda4494 --> PgSelect1037
+    Access7055 & Lambda3596 & Access3600 & Lambda4546 & Lambda4551 --> PgSelect1037
     PgSelect1042[["PgSelect[1042∈138] ➊<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
     Object12 -->|rejectNull| PgSelect1042
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4503 & Lambda4508 --> PgSelect1042
+    Access7055 & Lambda3596 & Access3600 & Lambda4561 & Lambda4566 --> PgSelect1042
     PgSelect1047[["PgSelect[1047∈138] ➊<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1047
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4517 & Lambda4522 --> PgSelect1047
+    Access7055 & Lambda3596 & Access3600 & Lambda4576 & Lambda4581 --> PgSelect1047
     PgSelect1052[["PgSelect[1052∈138] ➊<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1052
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4531 & Lambda4536 --> PgSelect1052
+    Access7055 & Lambda3596 & Access3600 & Lambda4591 & Lambda4596 --> PgSelect1052
     PgSelect1057[["PgSelect[1057∈138] ➊<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
     Object12 -->|rejectNull| PgSelect1057
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4545 & Lambda4550 --> PgSelect1057
+    Access7055 & Lambda3596 & Access3600 & Lambda4606 & Lambda4611 --> PgSelect1057
     PgSelect1069[["PgSelect[1069∈138] ➊<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
     Object12 -->|rejectNull| PgSelect1069
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4573 & Lambda4578 --> PgSelect1069
+    Access7055 & Lambda3596 & Access3600 & Lambda4636 & Lambda4641 --> PgSelect1069
     PgSelect1074[["PgSelect[1074∈138] ➊<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
     Object12 -->|rejectNull| PgSelect1074
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4587 & Lambda4592 --> PgSelect1074
+    Access7055 & Lambda3596 & Access3600 & Lambda4651 & Lambda4656 --> PgSelect1074
     PgSelect1274[["PgSelect[1274∈138] ➊<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
     Object12 -->|rejectNull| PgSelect1274
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4775 & Lambda4780 --> PgSelect1274
+    Access7055 & Lambda3596 & Access3600 & Lambda4851 & Lambda4856 --> PgSelect1274
     PgSelect1279[["PgSelect[1279∈138] ➊<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
     Object12 -->|rejectNull| PgSelect1279
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4789 & Lambda4794 --> PgSelect1279
+    Access7055 & Lambda3596 & Access3600 & Lambda4866 & Lambda4871 --> PgSelect1279
     PgSelect1284[["PgSelect[1284∈138] ➊<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1284
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4803 & Lambda4808 --> PgSelect1284
+    Access7055 & Lambda3596 & Access3600 & Lambda4881 & Lambda4886 --> PgSelect1284
     PgSelect1289[["PgSelect[1289∈138] ➊<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
     Object12 -->|rejectNull| PgSelect1289
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4817 & Lambda4822 --> PgSelect1289
+    Access7055 & Lambda3596 & Access3600 & Lambda4896 & Lambda4901 --> PgSelect1289
     PgSelect1294[["PgSelect[1294∈138] ➊<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
     Object12 -->|rejectNull| PgSelect1294
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4831 & Lambda4836 --> PgSelect1294
+    Access7055 & Lambda3596 & Access3600 & Lambda4911 & Lambda4916 --> PgSelect1294
     PgSelect1299[["PgSelect[1299∈138] ➊<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
     Object12 -->|rejectNull| PgSelect1299
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4845 & Lambda4850 --> PgSelect1299
+    Access7055 & Lambda3596 & Access3600 & Lambda4926 & Lambda4931 --> PgSelect1299
     PgSelect1304[["PgSelect[1304∈138] ➊<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
     Object12 -->|rejectNull| PgSelect1304
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4859 & Lambda4864 --> PgSelect1304
+    Access7055 & Lambda3596 & Access3600 & Lambda4941 & Lambda4946 --> PgSelect1304
     PgSelect1309[["PgSelect[1309∈138] ➊<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
     Object12 -->|rejectNull| PgSelect1309
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4873 & Lambda4878 --> PgSelect1309
+    Access7055 & Lambda3596 & Access3600 & Lambda4956 & Lambda4961 --> PgSelect1309
     PgSelect1314[["PgSelect[1314∈138] ➊<br />ᐸlistsᐳ<br />ᐳList"]]:::plan
     Object12 -->|rejectNull| PgSelect1314
-    Access6848 & Lambda3596 & Lambda3599 & Lambda4887 & Lambda4892 --> PgSelect1314
+    Access7055 & Lambda3596 & Access3600 & Lambda4971 & Lambda4976 --> PgSelect1314
     First1034{{"First[1034∈138] ➊"}}:::plan
     PgSelect1030 --> First1034
     PgSelectSingle1035{{"PgSelectSingle[1035∈138] ➊<br />ᐸinputsᐳ"}}:::plan
@@ -3269,8 +3434,8 @@ graph TD
     PgClassExpression1147{{"PgClassExpression[1147∈138] ➊<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle1082 --> PgClassExpression1147
     PgSelectSingle1152{{"PgSelectSingle[1152∈138] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4639{{"RemapKeys[4639∈138] ➊<br />ᐸ1082:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys4639 --> PgSelectSingle1152
+    RemapKeys4706{{"RemapKeys[4706∈138] ➊<br />ᐸ1082:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys4706 --> PgSelectSingle1152
     PgClassExpression1153{{"PgClassExpression[1153∈138] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1152 --> PgClassExpression1153
     PgClassExpression1154{{"PgClassExpression[1154∈138] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3286,21 +3451,21 @@ graph TD
     PgClassExpression1159{{"PgClassExpression[1159∈138] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1152 --> PgClassExpression1159
     PgSelectSingle1164{{"PgSelectSingle[1164∈138] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4687{{"RemapKeys[4687∈138] ➊<br />ᐸ1082:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys4687 --> PgSelectSingle1164
+    RemapKeys4757{{"RemapKeys[4757∈138] ➊<br />ᐸ1082:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys4757 --> PgSelectSingle1164
     PgSelectSingle1169{{"PgSelectSingle[1169∈138] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1164 --> PgSelectSingle1169
     PgSelectSingle1181{{"PgSelectSingle[1181∈138] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4671{{"RemapKeys[4671∈138] ➊<br />ᐸ1164:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4671 --> PgSelectSingle1181
+    RemapKeys4740{{"RemapKeys[4740∈138] ➊<br />ᐸ1164:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4740 --> PgSelectSingle1181
     PgClassExpression1189{{"PgClassExpression[1189∈138] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1164 --> PgClassExpression1189
     PgSelectSingle1194{{"PgSelectSingle[1194∈138] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4703{{"RemapKeys[4703∈138] ➊<br />ᐸ1082:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys4703 --> PgSelectSingle1194
+    RemapKeys4774{{"RemapKeys[4774∈138] ➊<br />ᐸ1082:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys4774 --> PgSelectSingle1194
     PgSelectSingle1206{{"PgSelectSingle[1206∈138] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4751{{"RemapKeys[4751∈138] ➊<br />ᐸ1082:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys4751 --> PgSelectSingle1206
+    RemapKeys4825{{"RemapKeys[4825∈138] ➊<br />ᐸ1082:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys4825 --> PgSelectSingle1206
     PgClassExpression1234{{"PgClassExpression[1234∈138] ➊<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle1082 --> PgClassExpression1234
     PgClassExpression1237{{"PgClassExpression[1237∈138] ➊<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -3336,8 +3501,8 @@ graph TD
     PgClassExpression1256{{"PgClassExpression[1256∈138] ➊<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle1082 --> PgClassExpression1256
     PgSelectSingle1261{{"PgSelectSingle[1261∈138] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys4623{{"RemapKeys[4623∈138] ➊<br />ᐸ1082:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys4623 --> PgSelectSingle1261
+    RemapKeys4689{{"RemapKeys[4689∈138] ➊<br />ᐸ1082:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys4689 --> PgSelectSingle1261
     PgSelectSingle1267{{"PgSelectSingle[1267∈138] ➊<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle1082 --> PgSelectSingle1267
     PgClassExpression1270{{"PgClassExpression[1270∈138] ➊<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
@@ -3380,14 +3545,14 @@ graph TD
     PgSelect1314 --> First1316
     PgSelectSingle1317{{"PgSelectSingle[1317∈138] ➊<br />ᐸlistsᐳ"}}:::plan
     First1316 --> PgSelectSingle1317
-    PgSelectSingle1082 --> RemapKeys4623
-    PgSelectSingle1082 --> RemapKeys4639
-    PgSelectSingle1164 --> RemapKeys4671
-    PgSelectSingle1082 --> RemapKeys4687
-    PgSelectSingle1082 --> RemapKeys4703
-    PgSelectSingle1082 --> RemapKeys4751
-    Lambda1025 --> Access6848
-    Lambda1025 --> Access6849
+    PgSelectSingle1082 --> RemapKeys4689
+    PgSelectSingle1082 --> RemapKeys4706
+    PgSelectSingle1164 --> RemapKeys4740
+    PgSelectSingle1082 --> RemapKeys4757
+    PgSelectSingle1082 --> RemapKeys4774
+    PgSelectSingle1082 --> RemapKeys4825
+    Lambda1025 --> Access7055
+    Lambda1025 --> Access7056
     __Item1092[/"__Item[1092∈139]<br />ᐸ1091ᐳ"\]:::itemplan
     PgClassExpression1091 ==> __Item1092
     __Item1096[/"__Item[1096∈140]<br />ᐸ1095ᐳ"\]:::itemplan
@@ -3443,11 +3608,11 @@ graph TD
     PgSelectSingle1213{{"PgSelectSingle[1213∈155] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1206 --> PgSelectSingle1213
     PgSelectSingle1225{{"PgSelectSingle[1225∈155] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4735{{"RemapKeys[4735∈155] ➊<br />ᐸ1206:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4735 --> PgSelectSingle1225
+    RemapKeys4808{{"RemapKeys[4808∈155] ➊<br />ᐸ1206:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys4808 --> PgSelectSingle1225
     PgClassExpression1233{{"PgClassExpression[1233∈155] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1206 --> PgClassExpression1233
-    PgSelectSingle1206 --> RemapKeys4735
+    PgSelectSingle1206 --> RemapKeys4808
     PgClassExpression1214{{"PgClassExpression[1214∈156] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1213 --> PgClassExpression1214
     PgClassExpression1215{{"PgClassExpression[1215∈156] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3557,8 +3722,8 @@ graph TD
     PgClassExpression1387{{"PgClassExpression[1387∈165] ➊<br />ᐸ__type_fun...__.”money”ᐳ"}}:::plan
     PgSelectSingle1322 --> PgClassExpression1387
     PgSelectSingle1394{{"PgSelectSingle[1394∈165] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4939{{"RemapKeys[4939∈165] ➊<br />ᐸ1322:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys4939 --> PgSelectSingle1394
+    RemapKeys5026{{"RemapKeys[5026∈165] ➊<br />ᐸ1322:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys5026 --> PgSelectSingle1394
     PgClassExpression1395{{"PgClassExpression[1395∈165] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1394 --> PgClassExpression1395
     PgClassExpression1396{{"PgClassExpression[1396∈165] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3574,21 +3739,21 @@ graph TD
     PgClassExpression1401{{"PgClassExpression[1401∈165] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1394 --> PgClassExpression1401
     PgSelectSingle1406{{"PgSelectSingle[1406∈165] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys4987{{"RemapKeys[4987∈165] ➊<br />ᐸ1322:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys4987 --> PgSelectSingle1406
+    RemapKeys5077{{"RemapKeys[5077∈165] ➊<br />ᐸ1322:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys5077 --> PgSelectSingle1406
     PgSelectSingle1411{{"PgSelectSingle[1411∈165] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1406 --> PgSelectSingle1411
     PgSelectSingle1423{{"PgSelectSingle[1423∈165] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys4971{{"RemapKeys[4971∈165] ➊<br />ᐸ1406:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys4971 --> PgSelectSingle1423
+    RemapKeys5060{{"RemapKeys[5060∈165] ➊<br />ᐸ1406:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5060 --> PgSelectSingle1423
     PgClassExpression1431{{"PgClassExpression[1431∈165] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1406 --> PgClassExpression1431
     PgSelectSingle1436{{"PgSelectSingle[1436∈165] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5003{{"RemapKeys[5003∈165] ➊<br />ᐸ1322:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys5003 --> PgSelectSingle1436
+    RemapKeys5094{{"RemapKeys[5094∈165] ➊<br />ᐸ1322:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys5094 --> PgSelectSingle1436
     PgSelectSingle1448{{"PgSelectSingle[1448∈165] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5051{{"RemapKeys[5051∈165] ➊<br />ᐸ1322:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys5051 --> PgSelectSingle1448
+    RemapKeys5145{{"RemapKeys[5145∈165] ➊<br />ᐸ1322:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys5145 --> PgSelectSingle1448
     PgClassExpression1476{{"PgClassExpression[1476∈165] ➊<br />ᐸ__type_fun...__.”point”ᐳ"}}:::plan
     PgSelectSingle1322 --> PgClassExpression1476
     PgClassExpression1479{{"PgClassExpression[1479∈165] ➊<br />ᐸ__type_fun...ablePoint”ᐳ"}}:::plan
@@ -3624,20 +3789,20 @@ graph TD
     PgClassExpression1498{{"PgClassExpression[1498∈165] ➊<br />ᐸ__type_fun...tea_array”ᐳ"}}:::plan
     PgSelectSingle1322 --> PgClassExpression1498
     PgSelectSingle1503{{"PgSelectSingle[1503∈165] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys4923{{"RemapKeys[4923∈165] ➊<br />ᐸ1322:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys4923 --> PgSelectSingle1503
+    RemapKeys5009{{"RemapKeys[5009∈165] ➊<br />ᐸ1322:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys5009 --> PgSelectSingle1503
     PgSelectSingle1509{{"PgSelectSingle[1509∈165] ➊<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle1322 --> PgSelectSingle1509
     PgClassExpression1512{{"PgClassExpression[1512∈165] ➊<br />ᐸ__type_fun...__.”ltree”ᐳ"}}:::plan
     PgSelectSingle1322 --> PgClassExpression1512
     PgClassExpression1513{{"PgClassExpression[1513∈165] ➊<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle1322 --> PgClassExpression1513
-    PgSelectSingle1322 --> RemapKeys4923
-    PgSelectSingle1322 --> RemapKeys4939
-    PgSelectSingle1406 --> RemapKeys4971
-    PgSelectSingle1322 --> RemapKeys4987
-    PgSelectSingle1322 --> RemapKeys5003
-    PgSelectSingle1322 --> RemapKeys5051
+    PgSelectSingle1322 --> RemapKeys5009
+    PgSelectSingle1322 --> RemapKeys5026
+    PgSelectSingle1406 --> RemapKeys5060
+    PgSelectSingle1322 --> RemapKeys5077
+    PgSelectSingle1322 --> RemapKeys5094
+    PgSelectSingle1322 --> RemapKeys5145
     __Item1332[/"__Item[1332∈166]<br />ᐸ1331ᐳ"\]:::itemplan
     PgClassExpression1331 ==> __Item1332
     __Item1336[/"__Item[1336∈167]<br />ᐸ1335ᐳ"\]:::itemplan
@@ -3693,11 +3858,11 @@ graph TD
     PgSelectSingle1455{{"PgSelectSingle[1455∈182] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1448 --> PgSelectSingle1455
     PgSelectSingle1467{{"PgSelectSingle[1467∈182] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5035{{"RemapKeys[5035∈182] ➊<br />ᐸ1448:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5035 --> PgSelectSingle1467
+    RemapKeys5128{{"RemapKeys[5128∈182] ➊<br />ᐸ1448:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5128 --> PgSelectSingle1467
     PgClassExpression1475{{"PgClassExpression[1475∈182] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1448 --> PgClassExpression1475
-    PgSelectSingle1448 --> RemapKeys5035
+    PgSelectSingle1448 --> RemapKeys5128
     PgClassExpression1456{{"PgClassExpression[1456∈183] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1455 --> PgClassExpression1456
     PgClassExpression1457{{"PgClassExpression[1457∈183] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3811,8 +3976,8 @@ graph TD
     PgClassExpression1583{{"PgClassExpression[1583∈193]<br />ᐸ__type_fun...__.”money”ᐳ"}}:::plan
     PgSelectSingle1518 --> PgClassExpression1583
     PgSelectSingle1590{{"PgSelectSingle[1590∈193]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5113{{"RemapKeys[5113∈193]<br />ᐸ1518:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys5113 --> PgSelectSingle1590
+    RemapKeys5211{{"RemapKeys[5211∈193]<br />ᐸ1518:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys5211 --> PgSelectSingle1590
     PgClassExpression1591{{"PgClassExpression[1591∈193]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1590 --> PgClassExpression1591
     PgClassExpression1592{{"PgClassExpression[1592∈193]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3828,21 +3993,21 @@ graph TD
     PgClassExpression1597{{"PgClassExpression[1597∈193]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1590 --> PgClassExpression1597
     PgSelectSingle1602{{"PgSelectSingle[1602∈193]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5161{{"RemapKeys[5161∈193]<br />ᐸ1518:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys5161 --> PgSelectSingle1602
+    RemapKeys5262{{"RemapKeys[5262∈193]<br />ᐸ1518:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys5262 --> PgSelectSingle1602
     PgSelectSingle1607{{"PgSelectSingle[1607∈193]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1602 --> PgSelectSingle1607
     PgSelectSingle1619{{"PgSelectSingle[1619∈193]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5145{{"RemapKeys[5145∈193]<br />ᐸ1602:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5145 --> PgSelectSingle1619
+    RemapKeys5245{{"RemapKeys[5245∈193]<br />ᐸ1602:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5245 --> PgSelectSingle1619
     PgClassExpression1627{{"PgClassExpression[1627∈193]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1602 --> PgClassExpression1627
     PgSelectSingle1632{{"PgSelectSingle[1632∈193]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5177{{"RemapKeys[5177∈193]<br />ᐸ1518:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys5177 --> PgSelectSingle1632
+    RemapKeys5279{{"RemapKeys[5279∈193]<br />ᐸ1518:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys5279 --> PgSelectSingle1632
     PgSelectSingle1644{{"PgSelectSingle[1644∈193]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5225{{"RemapKeys[5225∈193]<br />ᐸ1518:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys5225 --> PgSelectSingle1644
+    RemapKeys5330{{"RemapKeys[5330∈193]<br />ᐸ1518:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys5330 --> PgSelectSingle1644
     PgClassExpression1672{{"PgClassExpression[1672∈193]<br />ᐸ__type_fun...__.”point”ᐳ"}}:::plan
     PgSelectSingle1518 --> PgClassExpression1672
     PgClassExpression1675{{"PgClassExpression[1675∈193]<br />ᐸ__type_fun...ablePoint”ᐳ"}}:::plan
@@ -3878,20 +4043,20 @@ graph TD
     PgClassExpression1694{{"PgClassExpression[1694∈193]<br />ᐸ__type_fun...tea_array”ᐳ"}}:::plan
     PgSelectSingle1518 --> PgClassExpression1694
     PgSelectSingle1699{{"PgSelectSingle[1699∈193]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys5097{{"RemapKeys[5097∈193]<br />ᐸ1518:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys5097 --> PgSelectSingle1699
+    RemapKeys5194{{"RemapKeys[5194∈193]<br />ᐸ1518:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys5194 --> PgSelectSingle1699
     PgSelectSingle1705{{"PgSelectSingle[1705∈193]<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle1518 --> PgSelectSingle1705
     PgClassExpression1708{{"PgClassExpression[1708∈193]<br />ᐸ__type_fun...__.”ltree”ᐳ"}}:::plan
     PgSelectSingle1518 --> PgClassExpression1708
     PgClassExpression1709{{"PgClassExpression[1709∈193]<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle1518 --> PgClassExpression1709
-    PgSelectSingle1518 --> RemapKeys5097
-    PgSelectSingle1518 --> RemapKeys5113
-    PgSelectSingle1602 --> RemapKeys5145
-    PgSelectSingle1518 --> RemapKeys5161
-    PgSelectSingle1518 --> RemapKeys5177
-    PgSelectSingle1518 --> RemapKeys5225
+    PgSelectSingle1518 --> RemapKeys5194
+    PgSelectSingle1518 --> RemapKeys5211
+    PgSelectSingle1602 --> RemapKeys5245
+    PgSelectSingle1518 --> RemapKeys5262
+    PgSelectSingle1518 --> RemapKeys5279
+    PgSelectSingle1518 --> RemapKeys5330
     __Item1528[/"__Item[1528∈194]<br />ᐸ1527ᐳ"\]:::itemplan
     PgClassExpression1527 ==> __Item1528
     __Item1532[/"__Item[1532∈195]<br />ᐸ1531ᐳ"\]:::itemplan
@@ -3947,11 +4112,11 @@ graph TD
     PgSelectSingle1651{{"PgSelectSingle[1651∈210]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1644 --> PgSelectSingle1651
     PgSelectSingle1663{{"PgSelectSingle[1663∈210]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5209{{"RemapKeys[5209∈210]<br />ᐸ1644:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5209 --> PgSelectSingle1663
+    RemapKeys5313{{"RemapKeys[5313∈210]<br />ᐸ1644:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5313 --> PgSelectSingle1663
     PgClassExpression1671{{"PgClassExpression[1671∈210]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1644 --> PgClassExpression1671
-    PgSelectSingle1644 --> RemapKeys5209
+    PgSelectSingle1644 --> RemapKeys5313
     PgClassExpression1652{{"PgClassExpression[1652∈211]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1651 --> PgClassExpression1652
     PgClassExpression1653{{"PgClassExpression[1653∈211]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3997,92 +4162,12 @@ graph TD
     __Item1710[/"__Item[1710∈219]<br />ᐸ1709ᐳ"\]:::itemplan
     PgClassExpression1709 ==> __Item1710
     PgSelect1714[["PgSelect[1714∈220] ➊<br />ᐸtype_function_connection+1ᐳ"]]:::plan
-    Lambda5277{{"Lambda[5277∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5282{{"Lambda[5282∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5293{{"Lambda[5293∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5298{{"Lambda[5298∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5309{{"Lambda[5309∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5314{{"Lambda[5314∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5325{{"Lambda[5325∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5330{{"Lambda[5330∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5341{{"Lambda[5341∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5346{{"Lambda[5346∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5357{{"Lambda[5357∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5362{{"Lambda[5362∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5373{{"Lambda[5373∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5378{{"Lambda[5378∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5389{{"Lambda[5389∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5394{{"Lambda[5394∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5434{{"Lambda[5434∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5439{{"Lambda[5439∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5450{{"Lambda[5450∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5455{{"Lambda[5455∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5466{{"Lambda[5466∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5471{{"Lambda[5471∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5482{{"Lambda[5482∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5487{{"Lambda[5487∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5498{{"Lambda[5498∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5503{{"Lambda[5503∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5514{{"Lambda[5514∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5519{{"Lambda[5519∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5530{{"Lambda[5530∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5535{{"Lambda[5535∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5546{{"Lambda[5546∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5551{{"Lambda[5551∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5562{{"Lambda[5562∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5567{{"Lambda[5567∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection1713 & Lambda3599 & Lambda5277 & Lambda5282 & Lambda5293 & Lambda5298 & Lambda5309 & Lambda5314 & Lambda3599 & Lambda5325 & Lambda5330 & Lambda3599 & Lambda5341 & Lambda5346 & Lambda5357 & Lambda5362 & Lambda5373 & Lambda5378 & Lambda3599 & Lambda5389 & Lambda5394 & Lambda3599 & Lambda5434 & Lambda5439 & Lambda5450 & Lambda5455 & Lambda5466 & Lambda5471 & Lambda3599 & Lambda5482 & Lambda5487 & Lambda3599 & Lambda5498 & Lambda5503 & Lambda5514 & Lambda5519 & Lambda5530 & Lambda5535 & Lambda3599 & Lambda5546 & Lambda5551 & Lambda3596 & Lambda4094 & Lambda5562 & Lambda5567 --> PgSelect1714
+    Object12 & Connection1713 & Access3600 & Lambda5386 & Lambda5391 & Lambda5403 & Lambda5408 & Lambda5420 & Lambda5425 & Access3600 & Lambda5437 & Lambda5442 & Access3600 & Lambda5454 & Lambda5459 & Lambda5471 & Lambda5476 & Lambda5488 & Lambda5493 & Access3600 & Lambda5505 & Lambda5510 & Access3600 & Lambda5553 & Lambda5558 & Lambda5570 & Lambda5575 & Lambda5587 & Lambda5592 & Access3600 & Lambda5604 & Lambda5609 & Access3600 & Lambda5621 & Lambda5626 & Lambda5638 & Lambda5643 & Lambda5655 & Lambda5660 & Access3600 & Lambda5672 & Lambda5677 & Lambda3596 & Access4126 & Lambda5689 & Lambda5694 --> PgSelect1714
     PgSelect2111[["PgSelect[2111∈220] ➊<br />ᐸtype_function_connection(aggregate)ᐳ"]]:::plan
-    Lambda5576{{"Lambda[5576∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda5581{{"Lambda[5581∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection1713 & Lambda3596 & Lambda3599 & Lambda5576 & Lambda5581 --> PgSelect2111
+    Object12 & Connection1713 & Lambda3596 & Access3600 & Lambda5704 & Lambda5709 --> PgSelect2111
     Object2124{{"Object[2124∈220] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
     Access2119{{"Access[2119∈220] ➊<br />ᐸ1714.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access2119 --> Object2124
-    Object5248{{"Object[5248∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5245 & Constant5246 & Constant3602 --> Object5248
-    Object5262{{"Object[5262∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5259 & Constant5260 & Constant3602 --> Object5262
-    Object5276{{"Object[5276∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5273 & Constant5274 & Constant3634 --> Object5276
-    Object5292{{"Object[5292∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5289 & Constant5290 & Constant3634 --> Object5292
-    Object5308{{"Object[5308∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5305 & Constant5306 & Constant3634 --> Object5308
-    Object5324{{"Object[5324∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5321 & Constant5322 & Constant3682 --> Object5324
-    Object5340{{"Object[5340∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5337 & Constant5338 & Constant3634 --> Object5340
-    Object5356{{"Object[5356∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5353 & Constant5354 & Constant3634 --> Object5356
-    Object5372{{"Object[5372∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5369 & Constant5370 & Constant3634 --> Object5372
-    Object5388{{"Object[5388∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5385 & Constant5386 & Constant3682 --> Object5388
-    Object5405{{"Object[5405∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5402 & Constant5403 & Constant3602 --> Object5405
-    Object5419{{"Object[5419∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5416 & Constant5417 & Constant3602 --> Object5419
-    Object5433{{"Object[5433∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5430 & Constant5431 & Constant3634 --> Object5433
-    Object5449{{"Object[5449∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5446 & Constant5447 & Constant3634 --> Object5449
-    Object5465{{"Object[5465∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5462 & Constant5463 & Constant3634 --> Object5465
-    Object5481{{"Object[5481∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5478 & Constant5479 & Constant3682 --> Object5481
-    Object5497{{"Object[5497∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5494 & Constant5495 & Constant3634 --> Object5497
-    Object5513{{"Object[5513∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5510 & Constant5511 & Constant3634 --> Object5513
-    Object5529{{"Object[5529∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5526 & Constant5527 & Constant3634 --> Object5529
-    Object5545{{"Object[5545∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5542 & Constant5543 & Constant3682 --> Object5545
-    Object5561{{"Object[5561∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5558 & Constant5559 & Constant3762 --> Object5561
-    Object5575{{"Object[5575∈220] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5572 & Constant5559 & Constant3762 --> Object5575
     Object2120{{"Object[2120∈220] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access2119 --> Object2120
     __ListTransform1910[["__ListTransform[1910∈220] ➊<br />ᐸeach:1909ᐳ"]]:::plan
@@ -4120,68 +4205,16 @@ graph TD
     PgClassExpression2136{{"PgClassExpression[2136∈220] ➊<br />ᐸrow_number...tion by 1)ᐳ"}}:::plan
     PgSelectSingle2134 --> PgClassExpression2136
     PgClassExpression2136 --> List2137
-    Lambda5249{{"Lambda[5249∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5248 --> Lambda5249
-    Lambda5254{{"Lambda[5254∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6960 --> Lambda5254
-    Lambda5263{{"Lambda[5263∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5262 --> Lambda5263
-    Lambda5268{{"Lambda[5268∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6961 --> Lambda5268
-    Object5276 --> Lambda5277
-    Constant6962 --> Lambda5282
-    Object5292 --> Lambda5293
-    Constant6963 --> Lambda5298
-    Object5308 --> Lambda5309
-    Constant6964 --> Lambda5314
-    Object5324 --> Lambda5325
-    Constant6965 --> Lambda5330
-    Object5340 --> Lambda5341
-    Constant6966 --> Lambda5346
-    Object5356 --> Lambda5357
-    Constant6967 --> Lambda5362
-    Object5372 --> Lambda5373
-    Constant6968 --> Lambda5378
-    Object5388 --> Lambda5389
-    Constant6969 --> Lambda5394
-    Lambda5406{{"Lambda[5406∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5405 --> Lambda5406
-    Lambda5411{{"Lambda[5411∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6970 --> Lambda5411
-    Lambda5420{{"Lambda[5420∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5419 --> Lambda5420
-    Lambda5425{{"Lambda[5425∈220] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant6971 --> Lambda5425
-    Object5433 --> Lambda5434
-    Constant6972 --> Lambda5439
-    Object5449 --> Lambda5450
-    Constant6973 --> Lambda5455
-    Object5465 --> Lambda5466
-    Constant6974 --> Lambda5471
-    Object5481 --> Lambda5482
-    Constant6975 --> Lambda5487
-    Object5497 --> Lambda5498
-    Constant6976 --> Lambda5503
-    Object5513 --> Lambda5514
-    Constant6977 --> Lambda5519
-    Object5529 --> Lambda5530
-    Constant6978 --> Lambda5535
-    Object5545 --> Lambda5546
-    Constant6979 --> Lambda5551
-    Object5561 --> Lambda5562
-    Constant6980 --> Lambda5567
-    Object5575 --> Lambda5576
-    Constant6981 --> Lambda5581
     __Item1715[/"__Item[1715∈221]<br />ᐸ1714ᐳ"\]:::itemplan
     PgSelect1714 ==> __Item1715
     PgSelectSingle1716{{"PgSelectSingle[1716∈221]<br />ᐸtype_function_connectionᐳ"}}:::plan
     __Item1715 --> PgSelectSingle1716
     PgSelect1894[["PgSelect[1894∈222]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1718{{"PgClassExpression[1718∈222]<br />ᐸ__type_fun...”smallint”ᐳ"}}:::plan
-    Object12 & PgClassExpression1718 & Lambda3596 & Lambda3599 & Lambda5263 & Lambda5268 --> PgSelect1894
+    Object12 & PgClassExpression1718 & Lambda3596 & Access3600 & Lambda5371 & Lambda5376 --> PgSelect1894
     PgSelect1900[["PgSelect[1900∈222]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1717{{"PgClassExpression[1717∈222]<br />ᐸ__type_fun...ion__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression1717 & Lambda3596 & Lambda3599 & Lambda5249 & Lambda5254 --> PgSelect1900
+    Object12 & PgClassExpression1717 & Lambda3596 & Access3600 & Lambda5356 & Lambda5361 --> PgSelect1900
     PgSelectSingle1716 --> PgClassExpression1717
     PgSelectSingle1716 --> PgClassExpression1718
     PgClassExpression1719{{"PgClassExpression[1719∈222]<br />ᐸ__type_fun..._.”bigint”ᐳ"}}:::plan
@@ -4245,8 +4278,8 @@ graph TD
     PgClassExpression1781{{"PgClassExpression[1781∈222]<br />ᐸ__type_fun...__.”money”ᐳ"}}:::plan
     PgSelectSingle1716 --> PgClassExpression1781
     PgSelectSingle1788{{"PgSelectSingle[1788∈222]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5283{{"RemapKeys[5283∈222]<br />ᐸ1716:{”0”:26,”1”:27,”2”:28,”3”:29,”4”:30,”5”:31,”6”:32,”7”:33}ᐳ"}}:::plan
-    RemapKeys5283 --> PgSelectSingle1788
+    RemapKeys5392{{"RemapKeys[5392∈222]<br />ᐸ1716:{”0”:26,”1”:27,”2”:28,”3”:29,”4”:30,”5”:31,”6”:32,”7”:33}ᐳ"}}:::plan
+    RemapKeys5392 --> PgSelectSingle1788
     PgClassExpression1789{{"PgClassExpression[1789∈222]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1788 --> PgClassExpression1789
     PgClassExpression1790{{"PgClassExpression[1790∈222]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -4262,21 +4295,21 @@ graph TD
     PgClassExpression1795{{"PgClassExpression[1795∈222]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1788 --> PgClassExpression1795
     PgSelectSingle1800{{"PgSelectSingle[1800∈222]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5331{{"RemapKeys[5331∈222]<br />ᐸ1716:{”0”:34,”1”:35,”2”:36,”3”:37,”4”:38,”5”:39,”6”:40,”7”:41,”8”:42,”9”:43,”10”:44,”11”:45,”12”:46,”13”:47,”14”:48,”15”:49,”16”:50,”17”:51}ᐳ"}}:::plan
-    RemapKeys5331 --> PgSelectSingle1800
+    RemapKeys5443{{"RemapKeys[5443∈222]<br />ᐸ1716:{”0”:34,”1”:35,”2”:36,”3”:37,”4”:38,”5”:39,”6”:40,”7”:41,”8”:42,”9”:43,”10”:44,”11”:45,”12”:46,”13”:47,”14”:48,”15”:49,”16”:50,”17”:51}ᐳ"}}:::plan
+    RemapKeys5443 --> PgSelectSingle1800
     PgSelectSingle1805{{"PgSelectSingle[1805∈222]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1800 --> PgSelectSingle1805
     PgSelectSingle1817{{"PgSelectSingle[1817∈222]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5315{{"RemapKeys[5315∈222]<br />ᐸ1800:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5315 --> PgSelectSingle1817
+    RemapKeys5426{{"RemapKeys[5426∈222]<br />ᐸ1800:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5426 --> PgSelectSingle1817
     PgClassExpression1825{{"PgClassExpression[1825∈222]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1800 --> PgClassExpression1825
     PgSelectSingle1830{{"PgSelectSingle[1830∈222]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5347{{"RemapKeys[5347∈222]<br />ᐸ1716:{”0”:52,”1”:53,”2”:54,”3”:55,”4”:56,”5”:57,”6”:58,”7”:59}ᐳ"}}:::plan
-    RemapKeys5347 --> PgSelectSingle1830
+    RemapKeys5460{{"RemapKeys[5460∈222]<br />ᐸ1716:{”0”:52,”1”:53,”2”:54,”3”:55,”4”:56,”5”:57,”6”:58,”7”:59}ᐳ"}}:::plan
+    RemapKeys5460 --> PgSelectSingle1830
     PgSelectSingle1842{{"PgSelectSingle[1842∈222]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5395{{"RemapKeys[5395∈222]<br />ᐸ1716:{”0”:60,”1”:61,”2”:62,”3”:63,”4”:64,”5”:65,”6”:66,”7”:67,”8”:68,”9”:69,”10”:70,”11”:71,”12”:72,”13”:73,”14”:74,”15”:75,”16”:76,”17”:77}ᐳ"}}:::plan
-    RemapKeys5395 --> PgSelectSingle1842
+    RemapKeys5511{{"RemapKeys[5511∈222]<br />ᐸ1716:{”0”:60,”1”:61,”2”:62,”3”:63,”4”:64,”5”:65,”6”:66,”7”:67,”8”:68,”9”:69,”10”:70,”11”:71,”12”:72,”13”:73,”14”:74,”15”:75,”16”:76,”17”:77}ᐳ"}}:::plan
+    RemapKeys5511 --> PgSelectSingle1842
     PgClassExpression1870{{"PgClassExpression[1870∈222]<br />ᐸ__type_fun...__.”point”ᐳ"}}:::plan
     PgSelectSingle1716 --> PgClassExpression1870
     PgClassExpression1873{{"PgClassExpression[1873∈222]<br />ᐸ__type_fun...ablePoint”ᐳ"}}:::plan
@@ -4323,11 +4356,11 @@ graph TD
     PgSelectSingle1716 --> PgClassExpression1906
     PgClassExpression1907{{"PgClassExpression[1907∈222]<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle1716 --> PgClassExpression1907
-    PgSelectSingle1716 --> RemapKeys5283
-    PgSelectSingle1800 --> RemapKeys5315
-    PgSelectSingle1716 --> RemapKeys5331
-    PgSelectSingle1716 --> RemapKeys5347
-    PgSelectSingle1716 --> RemapKeys5395
+    PgSelectSingle1716 --> RemapKeys5392
+    PgSelectSingle1800 --> RemapKeys5426
+    PgSelectSingle1716 --> RemapKeys5443
+    PgSelectSingle1716 --> RemapKeys5460
+    PgSelectSingle1716 --> RemapKeys5511
     __Item1726[/"__Item[1726∈223]<br />ᐸ1725ᐳ"\]:::itemplan
     PgClassExpression1725 ==> __Item1726
     __Item1730[/"__Item[1730∈224]<br />ᐸ1729ᐳ"\]:::itemplan
@@ -4383,11 +4416,11 @@ graph TD
     PgSelectSingle1849{{"PgSelectSingle[1849∈239]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle1842 --> PgSelectSingle1849
     PgSelectSingle1861{{"PgSelectSingle[1861∈239]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5379{{"RemapKeys[5379∈239]<br />ᐸ1842:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5379 --> PgSelectSingle1861
+    RemapKeys5494{{"RemapKeys[5494∈239]<br />ᐸ1842:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5494 --> PgSelectSingle1861
     PgClassExpression1869{{"PgClassExpression[1869∈239]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1842 --> PgClassExpression1869
-    PgSelectSingle1842 --> RemapKeys5379
+    PgSelectSingle1842 --> RemapKeys5494
     PgClassExpression1850{{"PgClassExpression[1850∈240]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1849 --> PgClassExpression1850
     PgClassExpression1851{{"PgClassExpression[1851∈240]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -4436,18 +4469,18 @@ graph TD
     PgSelect1714 -.-> __Item1911
     PgSelectSingle1912{{"PgSelectSingle[1912∈249]<br />ᐸtype_function_connectionᐳ"}}:::plan
     __Item1911 --> PgSelectSingle1912
-    Edge5397{{"Edge[5397∈250]"}}:::plan
+    Edge5513{{"Edge[5513∈250]"}}:::plan
     PgSelectSingle1914{{"PgSelectSingle[1914∈250]<br />ᐸtype_function_connectionᐳ"}}:::plan
-    PgSelectSingle1914 & Connection1713 --> Edge5397
+    PgSelectSingle1914 & Connection1713 --> Edge5513
     __Item1913[/"__Item[1913∈250]<br />ᐸ1910ᐳ"\]:::itemplan
     __ListTransform1910 ==> __Item1913
     __Item1913 --> PgSelectSingle1914
     PgSelect2096[["PgSelect[2096∈252]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1920{{"PgClassExpression[1920∈252]<br />ᐸ__type_fun...”smallint”ᐳ"}}:::plan
-    Object12 & PgClassExpression1920 & Lambda3596 & Lambda3599 & Lambda5420 & Lambda5425 --> PgSelect2096
+    Object12 & PgClassExpression1920 & Lambda3596 & Access3600 & Lambda5538 & Lambda5543 --> PgSelect2096
     PgSelect2102[["PgSelect[2102∈252]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression1919{{"PgClassExpression[1919∈252]<br />ᐸ__type_fun...ion__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression1919 & Lambda3596 & Lambda3599 & Lambda5406 & Lambda5411 --> PgSelect2102
+    Object12 & PgClassExpression1919 & Lambda3596 & Access3600 & Lambda5523 & Lambda5528 --> PgSelect2102
     PgSelectSingle1914 --> PgClassExpression1919
     PgSelectSingle1914 --> PgClassExpression1920
     PgClassExpression1921{{"PgClassExpression[1921∈252]<br />ᐸ__type_fun..._.”bigint”ᐳ"}}:::plan
@@ -4511,8 +4544,8 @@ graph TD
     PgClassExpression1983{{"PgClassExpression[1983∈252]<br />ᐸ__type_fun...__.”money”ᐳ"}}:::plan
     PgSelectSingle1914 --> PgClassExpression1983
     PgSelectSingle1990{{"PgSelectSingle[1990∈252]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5440{{"RemapKeys[5440∈252]<br />ᐸ1914:{”0”:98,”1”:99,”2”:100,”3”:101,”4”:102,”5”:103,”6”:104,”7”:105}ᐳ"}}:::plan
-    RemapKeys5440 --> PgSelectSingle1990
+    RemapKeys5559{{"RemapKeys[5559∈252]<br />ᐸ1914:{”0”:98,”1”:99,”2”:100,”3”:101,”4”:102,”5”:103,”6”:104,”7”:105}ᐳ"}}:::plan
+    RemapKeys5559 --> PgSelectSingle1990
     PgClassExpression1991{{"PgClassExpression[1991∈252]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1990 --> PgClassExpression1991
     PgClassExpression1992{{"PgClassExpression[1992∈252]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -4528,21 +4561,21 @@ graph TD
     PgClassExpression1997{{"PgClassExpression[1997∈252]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1990 --> PgClassExpression1997
     PgSelectSingle2002{{"PgSelectSingle[2002∈252]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5488{{"RemapKeys[5488∈252]<br />ᐸ1914:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113,”8”:114,”9”:115,”10”:116,”11”:117,”12”:118,”13”:119,”14”:120,”15”:121,”16”:122,”17”:123}ᐳ"}}:::plan
-    RemapKeys5488 --> PgSelectSingle2002
+    RemapKeys5610{{"RemapKeys[5610∈252]<br />ᐸ1914:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113,”8”:114,”9”:115,”10”:116,”11”:117,”12”:118,”13”:119,”14”:120,”15”:121,”16”:122,”17”:123}ᐳ"}}:::plan
+    RemapKeys5610 --> PgSelectSingle2002
     PgSelectSingle2007{{"PgSelectSingle[2007∈252]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2002 --> PgSelectSingle2007
     PgSelectSingle2019{{"PgSelectSingle[2019∈252]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5472{{"RemapKeys[5472∈252]<br />ᐸ2002:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5472 --> PgSelectSingle2019
+    RemapKeys5593{{"RemapKeys[5593∈252]<br />ᐸ2002:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5593 --> PgSelectSingle2019
     PgClassExpression2027{{"PgClassExpression[2027∈252]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2002 --> PgClassExpression2027
     PgSelectSingle2032{{"PgSelectSingle[2032∈252]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5504{{"RemapKeys[5504∈252]<br />ᐸ1914:{”0”:124,”1”:125,”2”:126,”3”:127,”4”:128,”5”:129,”6”:130,”7”:131}ᐳ"}}:::plan
-    RemapKeys5504 --> PgSelectSingle2032
+    RemapKeys5627{{"RemapKeys[5627∈252]<br />ᐸ1914:{”0”:124,”1”:125,”2”:126,”3”:127,”4”:128,”5”:129,”6”:130,”7”:131}ᐳ"}}:::plan
+    RemapKeys5627 --> PgSelectSingle2032
     PgSelectSingle2044{{"PgSelectSingle[2044∈252]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5552{{"RemapKeys[5552∈252]<br />ᐸ1914:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139,”8”:140,”9”:141,”10”:142,”11”:143,”12”:144,”13”:145,”14”:146,”15”:147,”16”:148,”17”:149}ᐳ"}}:::plan
-    RemapKeys5552 --> PgSelectSingle2044
+    RemapKeys5678{{"RemapKeys[5678∈252]<br />ᐸ1914:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139,”8”:140,”9”:141,”10”:142,”11”:143,”12”:144,”13”:145,”14”:146,”15”:147,”16”:148,”17”:149}ᐳ"}}:::plan
+    RemapKeys5678 --> PgSelectSingle2044
     PgClassExpression2072{{"PgClassExpression[2072∈252]<br />ᐸ__type_fun...__.”point”ᐳ"}}:::plan
     PgSelectSingle1914 --> PgClassExpression2072
     PgClassExpression2075{{"PgClassExpression[2075∈252]<br />ᐸ__type_fun...ablePoint”ᐳ"}}:::plan
@@ -4589,11 +4622,11 @@ graph TD
     PgSelectSingle1914 --> PgClassExpression2108
     PgClassExpression2109{{"PgClassExpression[2109∈252]<br />ᐸ__type_fun...ree_array”ᐳ"}}:::plan
     PgSelectSingle1914 --> PgClassExpression2109
-    PgSelectSingle1914 --> RemapKeys5440
-    PgSelectSingle2002 --> RemapKeys5472
-    PgSelectSingle1914 --> RemapKeys5488
-    PgSelectSingle1914 --> RemapKeys5504
-    PgSelectSingle1914 --> RemapKeys5552
+    PgSelectSingle1914 --> RemapKeys5559
+    PgSelectSingle2002 --> RemapKeys5593
+    PgSelectSingle1914 --> RemapKeys5610
+    PgSelectSingle1914 --> RemapKeys5627
+    PgSelectSingle1914 --> RemapKeys5678
     __Item1928[/"__Item[1928∈253]<br />ᐸ1927ᐳ"\]:::itemplan
     PgClassExpression1927 ==> __Item1928
     __Item1932[/"__Item[1932∈254]<br />ᐸ1931ᐳ"\]:::itemplan
@@ -4649,11 +4682,11 @@ graph TD
     PgSelectSingle2051{{"PgSelectSingle[2051∈269]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2044 --> PgSelectSingle2051
     PgSelectSingle2063{{"PgSelectSingle[2063∈269]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5536{{"RemapKeys[5536∈269]<br />ᐸ2044:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5536 --> PgSelectSingle2063
+    RemapKeys5661{{"RemapKeys[5661∈269]<br />ᐸ2044:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5661 --> PgSelectSingle2063
     PgClassExpression2071{{"PgClassExpression[2071∈269]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2044 --> PgClassExpression2071
-    PgSelectSingle2044 --> RemapKeys5536
+    PgSelectSingle2044 --> RemapKeys5661
     PgClassExpression2052{{"PgClassExpression[2052∈270]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2051 --> PgClassExpression2052
     PgClassExpression2053{{"PgClassExpression[2053∈270]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -4698,49 +4731,39 @@ graph TD
     PgSelectSingle2105 --> PgClassExpression2107
     __Item2110[/"__Item[2110∈278]<br />ᐸ2109ᐳ"\]:::itemplan
     PgClassExpression2109 ==> __Item2110
-    Object5935{{"Object[5935∈279] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access5933{{"Access[5933∈279] ➊<br />ᐸ2141.101ᐳ"}}:::plan
-    Access5933 & Constant3594 & Constant3594 & Lambda3596 & Constant3597 --> Object5935
-    Object6266{{"Object[6266∈279] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access6264{{"Access[6264∈279] ➊<br />ᐸ2141.102ᐳ"}}:::plan
-    Access6264 & Constant3594 & Constant3594 & Lambda3596 & Constant4092 --> Object6266
-    Object6283{{"Object[6283∈279] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access6282{{"Access[6282∈279] ➊<br />ᐸ2141.103ᐳ"}}:::plan
-    Access6282 & Constant3594 & Constant3594 & Lambda3596 & Constant3597 --> Object6283
+    Object6085{{"Object[6085∈279] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access6083{{"Access[6083∈279] ➊<br />ᐸ2141.101ᐳ"}}:::plan
+    Access6083 & Constant3594 & Constant3594 & Lambda3596 & Constant3597 --> Object6085
+    Object6437{{"Object[6437∈279] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access6435{{"Access[6435∈279] ➊<br />ᐸ2141.102ᐳ"}}:::plan
+    Access6435 & Constant3594 & Constant3594 & Lambda3596 & Constant4123 --> Object6437
+    Object6455{{"Object[6455∈279] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access6454{{"Access[6454∈279] ➊<br />ᐸ2141.103ᐳ"}}:::plan
+    Access6454 & Constant3594 & Constant3594 & Lambda3596 & Constant3597 --> Object6455
     Object2954{{"Object[2954∈279] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access2949{{"Access[2949∈279] ➊<br />ᐸ6267.hasMoreᐳ"}}:::plan
+    Access2949{{"Access[2949∈279] ➊<br />ᐸ6438.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access2949 --> Object2954
-    Object5944{{"Object[5944∈279] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5941 & Constant5942 & Constant3602 --> Object5944
-    Object5958{{"Object[5958∈279] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant5955 & Constant5956 & Constant3602 --> Object5958
-    Object6101{{"Object[6101∈279] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant6098 & Constant6099 & Constant3602 --> Object6101
-    Object6115{{"Object[6115∈279] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda3596 & Constant6112 & Constant6113 & Constant3602 --> Object6115
     Object2950{{"Object[2950∈279] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access2949 --> Object2950
     PgSelectSingle2150{{"PgSelectSingle[2150∈279] ➊<br />ᐸperson_type_functionᐳ"}}:::plan
     PgSelectSingle2142 --> PgSelectSingle2150
     __ListTransform2740[["__ListTransform[2740∈279] ➊<br />ᐸeach:2739ᐳ"]]:::plan
-    Lambda6267{{"Lambda[6267∈279] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda6267 --> __ListTransform2740
+    Lambda6438{{"Lambda[6438∈279] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda6438 --> __ListTransform2740
     First2942{{"First[2942∈279] ➊"}}:::plan
-    Lambda6284{{"Lambda[6284∈279] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda6284 --> First2942
+    Lambda6456{{"Lambda[6456∈279] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda6456 --> First2942
     PgSelectSingle2943{{"PgSelectSingle[2943∈279] ➊<br />ᐸperson_type_function_connectionᐳ"}}:::plan
     First2942 --> PgSelectSingle2943
     PgClassExpression2944{{"PgClassExpression[2944∈279] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle2943 --> PgClassExpression2944
-    PgPageInfo2946{{"PgPageInfo[2946∈279] ➊"}}:::plan
-    Connection2543 --> PgPageInfo2946
-    Lambda6267 --> Access2949
+    Lambda6438 --> Access2949
     Lambda2951{{"Lambda[2951∈279] ➊<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object2950 --> Lambda2951
     Lambda2955{{"Lambda[2955∈279] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object2954 --> Lambda2955
     First2957{{"First[2957∈279] ➊"}}:::plan
-    Lambda6267 --> First2957
+    Lambda6438 --> First2957
     PgSelectSingle2958{{"PgSelectSingle[2958∈279] ➊<br />ᐸperson_type_function_connectionᐳ"}}:::plan
     First2957 --> PgSelectSingle2958
     PgCursor2959{{"PgCursor[2959∈279] ➊"}}:::plan
@@ -4750,7 +4773,7 @@ graph TD
     PgSelectSingle2958 --> PgClassExpression2960
     PgClassExpression2960 --> List2961
     Last2963{{"Last[2963∈279] ➊"}}:::plan
-    Lambda6267 --> Last2963
+    Lambda6438 --> Last2963
     PgSelectSingle2964{{"PgSelectSingle[2964∈279] ➊<br />ᐸperson_type_function_connectionᐳ"}}:::plan
     Last2963 --> PgSelectSingle2964
     PgCursor2965{{"PgCursor[2965∈279] ➊"}}:::plan
@@ -4759,29 +4782,13 @@ graph TD
     PgClassExpression2966{{"PgClassExpression[2966∈279] ➊<br />ᐸrow_number...tion by 1)ᐳ"}}:::plan
     PgSelectSingle2964 --> PgClassExpression2966
     PgClassExpression2966 --> List2967
-    First2141 --> Access5933
-    Lambda5936{{"Lambda[5936∈279] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Object5935 --> Lambda5936
-    Lambda5945{{"Lambda[5945∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5944 --> Lambda5945
-    Lambda5950{{"Lambda[5950∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant7004 --> Lambda5950
-    Lambda5959{{"Lambda[5959∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object5958 --> Lambda5959
-    Lambda5964{{"Lambda[5964∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant7005 --> Lambda5964
-    Lambda6102{{"Lambda[6102∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object6101 --> Lambda6102
-    Lambda6107{{"Lambda[6107∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant7014 --> Lambda6107
-    Lambda6116{{"Lambda[6116∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object6115 --> Lambda6116
-    Lambda6121{{"Lambda[6121∈279] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Constant7015 --> Lambda6121
-    First2141 --> Access6264
-    Object6266 --> Lambda6267
-    First2141 --> Access6282
-    Object6283 --> Lambda6284
+    First2141 --> Access6083
+    Lambda6086{{"Lambda[6086∈279] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Object6085 --> Lambda6086
+    First2141 --> Access6435
+    Object6437 --> Lambda6438
+    First2141 --> Access6454
+    Object6455 --> Lambda6456
     PgClassExpression2151{{"PgClassExpression[2151∈280] ➊<br />ᐸ__person_t...ion__.”id”ᐳ"}}:::plan
     PgSelectSingle2150 --> PgClassExpression2151
     PgClassExpression2152{{"PgClassExpression[2152∈280] ➊<br />ᐸ__person_t...”smallint”ᐳ"}}:::plan
@@ -4847,8 +4854,8 @@ graph TD
     PgClassExpression2215{{"PgClassExpression[2215∈280] ➊<br />ᐸ__person_t...__.”money”ᐳ"}}:::plan
     PgSelectSingle2150 --> PgClassExpression2215
     PgSelectSingle2222{{"PgSelectSingle[2222∈280] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5628{{"RemapKeys[5628∈280] ➊<br />ᐸ2150:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys5628 --> PgSelectSingle2222
+    RemapKeys5759{{"RemapKeys[5759∈280] ➊<br />ᐸ2150:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys5759 --> PgSelectSingle2222
     PgClassExpression2223{{"PgClassExpression[2223∈280] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2222 --> PgClassExpression2223
     PgClassExpression2224{{"PgClassExpression[2224∈280] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -4864,21 +4871,21 @@ graph TD
     PgClassExpression2229{{"PgClassExpression[2229∈280] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle2222 --> PgClassExpression2229
     PgSelectSingle2234{{"PgSelectSingle[2234∈280] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5676{{"RemapKeys[5676∈280] ➊<br />ᐸ2150:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys5676 --> PgSelectSingle2234
+    RemapKeys5810{{"RemapKeys[5810∈280] ➊<br />ᐸ2150:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys5810 --> PgSelectSingle2234
     PgSelectSingle2239{{"PgSelectSingle[2239∈280] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2234 --> PgSelectSingle2239
     PgSelectSingle2251{{"PgSelectSingle[2251∈280] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5660{{"RemapKeys[5660∈280] ➊<br />ᐸ2234:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5660 --> PgSelectSingle2251
+    RemapKeys5793{{"RemapKeys[5793∈280] ➊<br />ᐸ2234:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5793 --> PgSelectSingle2251
     PgClassExpression2259{{"PgClassExpression[2259∈280] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2234 --> PgClassExpression2259
     PgSelectSingle2264{{"PgSelectSingle[2264∈280] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5692{{"RemapKeys[5692∈280] ➊<br />ᐸ2150:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys5692 --> PgSelectSingle2264
+    RemapKeys5827{{"RemapKeys[5827∈280] ➊<br />ᐸ2150:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys5827 --> PgSelectSingle2264
     PgSelectSingle2276{{"PgSelectSingle[2276∈280] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5740{{"RemapKeys[5740∈280] ➊<br />ᐸ2150:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys5740 --> PgSelectSingle2276
+    RemapKeys5878{{"RemapKeys[5878∈280] ➊<br />ᐸ2150:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys5878 --> PgSelectSingle2276
     PgClassExpression2304{{"PgClassExpression[2304∈280] ➊<br />ᐸ__person_t...__.”point”ᐳ"}}:::plan
     PgSelectSingle2150 --> PgClassExpression2304
     PgClassExpression2307{{"PgClassExpression[2307∈280] ➊<br />ᐸ__person_t...ablePoint”ᐳ"}}:::plan
@@ -4914,20 +4921,20 @@ graph TD
     PgClassExpression2326{{"PgClassExpression[2326∈280] ➊<br />ᐸ__person_t...tea_array”ᐳ"}}:::plan
     PgSelectSingle2150 --> PgClassExpression2326
     PgSelectSingle2331{{"PgSelectSingle[2331∈280] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys5612{{"RemapKeys[5612∈280] ➊<br />ᐸ2150:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys5612 --> PgSelectSingle2331
+    RemapKeys5742{{"RemapKeys[5742∈280] ➊<br />ᐸ2150:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys5742 --> PgSelectSingle2331
     PgSelectSingle2337{{"PgSelectSingle[2337∈280] ➊<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle2150 --> PgSelectSingle2337
     PgClassExpression2340{{"PgClassExpression[2340∈280] ➊<br />ᐸ__person_t...__.”ltree”ᐳ"}}:::plan
     PgSelectSingle2150 --> PgClassExpression2340
     PgClassExpression2341{{"PgClassExpression[2341∈280] ➊<br />ᐸ__person_t...ree_array”ᐳ"}}:::plan
     PgSelectSingle2150 --> PgClassExpression2341
-    PgSelectSingle2150 --> RemapKeys5612
-    PgSelectSingle2150 --> RemapKeys5628
-    PgSelectSingle2234 --> RemapKeys5660
-    PgSelectSingle2150 --> RemapKeys5676
-    PgSelectSingle2150 --> RemapKeys5692
-    PgSelectSingle2150 --> RemapKeys5740
+    PgSelectSingle2150 --> RemapKeys5742
+    PgSelectSingle2150 --> RemapKeys5759
+    PgSelectSingle2234 --> RemapKeys5793
+    PgSelectSingle2150 --> RemapKeys5810
+    PgSelectSingle2150 --> RemapKeys5827
+    PgSelectSingle2150 --> RemapKeys5878
     __Item2160[/"__Item[2160∈281]<br />ᐸ2159ᐳ"\]:::itemplan
     PgClassExpression2159 ==> __Item2160
     __Item2164[/"__Item[2164∈282]<br />ᐸ2163ᐳ"\]:::itemplan
@@ -4983,11 +4990,11 @@ graph TD
     PgSelectSingle2283{{"PgSelectSingle[2283∈297] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2276 --> PgSelectSingle2283
     PgSelectSingle2295{{"PgSelectSingle[2295∈297] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5724{{"RemapKeys[5724∈297] ➊<br />ᐸ2276:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5724 --> PgSelectSingle2295
+    RemapKeys5861{{"RemapKeys[5861∈297] ➊<br />ᐸ2276:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5861 --> PgSelectSingle2295
     PgClassExpression2303{{"PgClassExpression[2303∈297] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2276 --> PgClassExpression2303
-    PgSelectSingle2276 --> RemapKeys5724
+    PgSelectSingle2276 --> RemapKeys5861
     PgClassExpression2284{{"PgClassExpression[2284∈298] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2283 --> PgClassExpression2284
     PgClassExpression2285{{"PgClassExpression[2285∈298] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5032,8 +5039,8 @@ graph TD
     PgSelectSingle2337 --> PgClassExpression2339
     __Item2342[/"__Item[2342∈306]<br />ᐸ2341ᐳ"\]:::itemplan
     PgClassExpression2341 ==> __Item2342
-    __Item2346[/"__Item[2346∈307]<br />ᐸ5936ᐳ"\]:::itemplan
-    Lambda5936 ==> __Item2346
+    __Item2346[/"__Item[2346∈307]<br />ᐸ6086ᐳ"\]:::itemplan
+    Lambda6086 ==> __Item2346
     PgSelectSingle2347{{"PgSelectSingle[2347∈307]<br />ᐸperson_type_function_listᐳ"}}:::plan
     __Item2346 --> PgSelectSingle2347
     PgClassExpression2348{{"PgClassExpression[2348∈308]<br />ᐸ__person_t...ist__.”id”ᐳ"}}:::plan
@@ -5101,8 +5108,8 @@ graph TD
     PgClassExpression2412{{"PgClassExpression[2412∈308]<br />ᐸ__person_t...__.”money”ᐳ"}}:::plan
     PgSelectSingle2347 --> PgClassExpression2412
     PgSelectSingle2419{{"PgSelectSingle[2419∈308]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5804{{"RemapKeys[5804∈308]<br />ᐸ2347:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys5804 --> PgSelectSingle2419
+    RemapKeys5946{{"RemapKeys[5946∈308]<br />ᐸ2347:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys5946 --> PgSelectSingle2419
     PgClassExpression2420{{"PgClassExpression[2420∈308]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2419 --> PgClassExpression2420
     PgClassExpression2421{{"PgClassExpression[2421∈308]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5118,21 +5125,21 @@ graph TD
     PgClassExpression2426{{"PgClassExpression[2426∈308]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle2419 --> PgClassExpression2426
     PgSelectSingle2431{{"PgSelectSingle[2431∈308]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5852{{"RemapKeys[5852∈308]<br />ᐸ2347:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys5852 --> PgSelectSingle2431
+    RemapKeys5997{{"RemapKeys[5997∈308]<br />ᐸ2347:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys5997 --> PgSelectSingle2431
     PgSelectSingle2436{{"PgSelectSingle[2436∈308]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2431 --> PgSelectSingle2436
     PgSelectSingle2448{{"PgSelectSingle[2448∈308]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5836{{"RemapKeys[5836∈308]<br />ᐸ2431:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5836 --> PgSelectSingle2448
+    RemapKeys5980{{"RemapKeys[5980∈308]<br />ᐸ2431:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys5980 --> PgSelectSingle2448
     PgClassExpression2456{{"PgClassExpression[2456∈308]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2431 --> PgClassExpression2456
     PgSelectSingle2461{{"PgSelectSingle[2461∈308]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5868{{"RemapKeys[5868∈308]<br />ᐸ2347:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys5868 --> PgSelectSingle2461
+    RemapKeys6014{{"RemapKeys[6014∈308]<br />ᐸ2347:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys6014 --> PgSelectSingle2461
     PgSelectSingle2473{{"PgSelectSingle[2473∈308]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys5916{{"RemapKeys[5916∈308]<br />ᐸ2347:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys5916 --> PgSelectSingle2473
+    RemapKeys6065{{"RemapKeys[6065∈308]<br />ᐸ2347:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys6065 --> PgSelectSingle2473
     PgClassExpression2501{{"PgClassExpression[2501∈308]<br />ᐸ__person_t...__.”point”ᐳ"}}:::plan
     PgSelectSingle2347 --> PgClassExpression2501
     PgClassExpression2504{{"PgClassExpression[2504∈308]<br />ᐸ__person_t...ablePoint”ᐳ"}}:::plan
@@ -5168,20 +5175,20 @@ graph TD
     PgClassExpression2523{{"PgClassExpression[2523∈308]<br />ᐸ__person_t...tea_array”ᐳ"}}:::plan
     PgSelectSingle2347 --> PgClassExpression2523
     PgSelectSingle2528{{"PgSelectSingle[2528∈308]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys5788{{"RemapKeys[5788∈308]<br />ᐸ2347:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys5788 --> PgSelectSingle2528
+    RemapKeys5929{{"RemapKeys[5929∈308]<br />ᐸ2347:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys5929 --> PgSelectSingle2528
     PgSelectSingle2534{{"PgSelectSingle[2534∈308]<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle2347 --> PgSelectSingle2534
     PgClassExpression2537{{"PgClassExpression[2537∈308]<br />ᐸ__person_t...__.”ltree”ᐳ"}}:::plan
     PgSelectSingle2347 --> PgClassExpression2537
     PgClassExpression2538{{"PgClassExpression[2538∈308]<br />ᐸ__person_t...ree_array”ᐳ"}}:::plan
     PgSelectSingle2347 --> PgClassExpression2538
-    PgSelectSingle2347 --> RemapKeys5788
-    PgSelectSingle2347 --> RemapKeys5804
-    PgSelectSingle2431 --> RemapKeys5836
-    PgSelectSingle2347 --> RemapKeys5852
-    PgSelectSingle2347 --> RemapKeys5868
-    PgSelectSingle2347 --> RemapKeys5916
+    PgSelectSingle2347 --> RemapKeys5929
+    PgSelectSingle2347 --> RemapKeys5946
+    PgSelectSingle2431 --> RemapKeys5980
+    PgSelectSingle2347 --> RemapKeys5997
+    PgSelectSingle2347 --> RemapKeys6014
+    PgSelectSingle2347 --> RemapKeys6065
     __Item2357[/"__Item[2357∈309]<br />ᐸ2356ᐳ"\]:::itemplan
     PgClassExpression2356 ==> __Item2357
     __Item2361[/"__Item[2361∈310]<br />ᐸ2360ᐳ"\]:::itemplan
@@ -5237,11 +5244,11 @@ graph TD
     PgSelectSingle2480{{"PgSelectSingle[2480∈325]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2473 --> PgSelectSingle2480
     PgSelectSingle2492{{"PgSelectSingle[2492∈325]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5900{{"RemapKeys[5900∈325]<br />ᐸ2473:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys5900 --> PgSelectSingle2492
+    RemapKeys6048{{"RemapKeys[6048∈325]<br />ᐸ2473:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6048 --> PgSelectSingle2492
     PgClassExpression2500{{"PgClassExpression[2500∈325]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2473 --> PgClassExpression2500
-    PgSelectSingle2473 --> RemapKeys5900
+    PgSelectSingle2473 --> RemapKeys6048
     PgClassExpression2481{{"PgClassExpression[2481∈326]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2480 --> PgClassExpression2481
     PgClassExpression2482{{"PgClassExpression[2482∈326]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5286,16 +5293,16 @@ graph TD
     PgSelectSingle2534 --> PgClassExpression2536
     __Item2539[/"__Item[2539∈334]<br />ᐸ2538ᐳ"\]:::itemplan
     PgClassExpression2538 ==> __Item2539
-    __Item2545[/"__Item[2545∈335]<br />ᐸ6267ᐳ"\]:::itemplan
-    Lambda6267 ==> __Item2545
+    __Item2545[/"__Item[2545∈335]<br />ᐸ6438ᐳ"\]:::itemplan
+    Lambda6438 ==> __Item2545
     PgSelectSingle2546{{"PgSelectSingle[2546∈335]<br />ᐸperson_type_function_connectionᐳ"}}:::plan
     __Item2545 --> PgSelectSingle2546
     PgSelect2724[["PgSelect[2724∈336]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression2548{{"PgClassExpression[2548∈336]<br />ᐸ__person_t...”smallint”ᐳ"}}:::plan
-    Object12 & PgClassExpression2548 & Lambda3596 & Lambda3599 & Lambda5959 & Lambda5964 --> PgSelect2724
+    Object12 & PgClassExpression2548 & Lambda3596 & Access3600 & Lambda6111 & Lambda6116 --> PgSelect2724
     PgSelect2730[["PgSelect[2730∈336]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression2547{{"PgClassExpression[2547∈336]<br />ᐸ__person_t...ion__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression2547 & Lambda3596 & Lambda3599 & Lambda5945 & Lambda5950 --> PgSelect2730
+    Object12 & PgClassExpression2547 & Lambda3596 & Access3600 & Lambda6096 & Lambda6101 --> PgSelect2730
     PgSelectSingle2546 --> PgClassExpression2547
     PgSelectSingle2546 --> PgClassExpression2548
     PgClassExpression2549{{"PgClassExpression[2549∈336]<br />ᐸ__person_t..._.”bigint”ᐳ"}}:::plan
@@ -5359,8 +5366,8 @@ graph TD
     PgClassExpression2611{{"PgClassExpression[2611∈336]<br />ᐸ__person_t...__.”money”ᐳ"}}:::plan
     PgSelectSingle2546 --> PgClassExpression2611
     PgSelectSingle2618{{"PgSelectSingle[2618∈336]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys5979{{"RemapKeys[5979∈336]<br />ᐸ2546:{”0”:26,”1”:27,”2”:28,”3”:29,”4”:30,”5”:31,”6”:32,”7”:33}ᐳ"}}:::plan
-    RemapKeys5979 --> PgSelectSingle2618
+    RemapKeys6132{{"RemapKeys[6132∈336]<br />ᐸ2546:{”0”:26,”1”:27,”2”:28,”3”:29,”4”:30,”5”:31,”6”:32,”7”:33}ᐳ"}}:::plan
+    RemapKeys6132 --> PgSelectSingle2618
     PgClassExpression2619{{"PgClassExpression[2619∈336]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2618 --> PgClassExpression2619
     PgClassExpression2620{{"PgClassExpression[2620∈336]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5376,21 +5383,21 @@ graph TD
     PgClassExpression2625{{"PgClassExpression[2625∈336]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle2618 --> PgClassExpression2625
     PgSelectSingle2630{{"PgSelectSingle[2630∈336]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6027{{"RemapKeys[6027∈336]<br />ᐸ2546:{”0”:34,”1”:35,”2”:36,”3”:37,”4”:38,”5”:39,”6”:40,”7”:41,”8”:42,”9”:43,”10”:44,”11”:45,”12”:46,”13”:47,”14”:48,”15”:49,”16”:50,”17”:51}ᐳ"}}:::plan
-    RemapKeys6027 --> PgSelectSingle2630
+    RemapKeys6183{{"RemapKeys[6183∈336]<br />ᐸ2546:{”0”:34,”1”:35,”2”:36,”3”:37,”4”:38,”5”:39,”6”:40,”7”:41,”8”:42,”9”:43,”10”:44,”11”:45,”12”:46,”13”:47,”14”:48,”15”:49,”16”:50,”17”:51}ᐳ"}}:::plan
+    RemapKeys6183 --> PgSelectSingle2630
     PgSelectSingle2635{{"PgSelectSingle[2635∈336]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2630 --> PgSelectSingle2635
     PgSelectSingle2647{{"PgSelectSingle[2647∈336]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6011{{"RemapKeys[6011∈336]<br />ᐸ2630:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6011 --> PgSelectSingle2647
+    RemapKeys6166{{"RemapKeys[6166∈336]<br />ᐸ2630:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6166 --> PgSelectSingle2647
     PgClassExpression2655{{"PgClassExpression[2655∈336]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2630 --> PgClassExpression2655
     PgSelectSingle2660{{"PgSelectSingle[2660∈336]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6043{{"RemapKeys[6043∈336]<br />ᐸ2546:{”0”:52,”1”:53,”2”:54,”3”:55,”4”:56,”5”:57,”6”:58,”7”:59}ᐳ"}}:::plan
-    RemapKeys6043 --> PgSelectSingle2660
+    RemapKeys6200{{"RemapKeys[6200∈336]<br />ᐸ2546:{”0”:52,”1”:53,”2”:54,”3”:55,”4”:56,”5”:57,”6”:58,”7”:59}ᐳ"}}:::plan
+    RemapKeys6200 --> PgSelectSingle2660
     PgSelectSingle2672{{"PgSelectSingle[2672∈336]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6091{{"RemapKeys[6091∈336]<br />ᐸ2546:{”0”:60,”1”:61,”2”:62,”3”:63,”4”:64,”5”:65,”6”:66,”7”:67,”8”:68,”9”:69,”10”:70,”11”:71,”12”:72,”13”:73,”14”:74,”15”:75,”16”:76,”17”:77}ᐳ"}}:::plan
-    RemapKeys6091 --> PgSelectSingle2672
+    RemapKeys6251{{"RemapKeys[6251∈336]<br />ᐸ2546:{”0”:60,”1”:61,”2”:62,”3”:63,”4”:64,”5”:65,”6”:66,”7”:67,”8”:68,”9”:69,”10”:70,”11”:71,”12”:72,”13”:73,”14”:74,”15”:75,”16”:76,”17”:77}ᐳ"}}:::plan
+    RemapKeys6251 --> PgSelectSingle2672
     PgClassExpression2700{{"PgClassExpression[2700∈336]<br />ᐸ__person_t...__.”point”ᐳ"}}:::plan
     PgSelectSingle2546 --> PgClassExpression2700
     PgClassExpression2703{{"PgClassExpression[2703∈336]<br />ᐸ__person_t...ablePoint”ᐳ"}}:::plan
@@ -5437,11 +5444,11 @@ graph TD
     PgSelectSingle2546 --> PgClassExpression2736
     PgClassExpression2737{{"PgClassExpression[2737∈336]<br />ᐸ__person_t...ree_array”ᐳ"}}:::plan
     PgSelectSingle2546 --> PgClassExpression2737
-    PgSelectSingle2546 --> RemapKeys5979
-    PgSelectSingle2630 --> RemapKeys6011
-    PgSelectSingle2546 --> RemapKeys6027
-    PgSelectSingle2546 --> RemapKeys6043
-    PgSelectSingle2546 --> RemapKeys6091
+    PgSelectSingle2546 --> RemapKeys6132
+    PgSelectSingle2630 --> RemapKeys6166
+    PgSelectSingle2546 --> RemapKeys6183
+    PgSelectSingle2546 --> RemapKeys6200
+    PgSelectSingle2546 --> RemapKeys6251
     __Item2556[/"__Item[2556∈337]<br />ᐸ2555ᐳ"\]:::itemplan
     PgClassExpression2555 ==> __Item2556
     __Item2560[/"__Item[2560∈338]<br />ᐸ2559ᐳ"\]:::itemplan
@@ -5497,11 +5504,11 @@ graph TD
     PgSelectSingle2679{{"PgSelectSingle[2679∈353]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2672 --> PgSelectSingle2679
     PgSelectSingle2691{{"PgSelectSingle[2691∈353]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6075{{"RemapKeys[6075∈353]<br />ᐸ2672:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6075 --> PgSelectSingle2691
+    RemapKeys6234{{"RemapKeys[6234∈353]<br />ᐸ2672:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6234 --> PgSelectSingle2691
     PgClassExpression2699{{"PgClassExpression[2699∈353]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2672 --> PgClassExpression2699
-    PgSelectSingle2672 --> RemapKeys6075
+    PgSelectSingle2672 --> RemapKeys6234
     PgClassExpression2680{{"PgClassExpression[2680∈354]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2679 --> PgClassExpression2680
     PgClassExpression2681{{"PgClassExpression[2681∈354]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5546,22 +5553,22 @@ graph TD
     PgSelectSingle2733 --> PgClassExpression2735
     __Item2738[/"__Item[2738∈362]<br />ᐸ2737ᐳ"\]:::itemplan
     PgClassExpression2737 ==> __Item2738
-    __Item2741[/"__Item[2741∈363]<br />ᐸ6267ᐳ"\]:::itemplan
-    Lambda6267 -.-> __Item2741
+    __Item2741[/"__Item[2741∈363]<br />ᐸ6438ᐳ"\]:::itemplan
+    Lambda6438 -.-> __Item2741
     PgSelectSingle2742{{"PgSelectSingle[2742∈363]<br />ᐸperson_type_function_connectionᐳ"}}:::plan
     __Item2741 --> PgSelectSingle2742
-    Edge6093{{"Edge[6093∈364]"}}:::plan
+    Edge6253{{"Edge[6253∈364]"}}:::plan
     PgSelectSingle2744{{"PgSelectSingle[2744∈364]<br />ᐸperson_type_function_connectionᐳ"}}:::plan
-    PgSelectSingle2744 & Connection2543 --> Edge6093
+    PgSelectSingle2744 & Connection2543 --> Edge6253
     __Item2743[/"__Item[2743∈364]<br />ᐸ2740ᐳ"\]:::itemplan
     __ListTransform2740 ==> __Item2743
     __Item2743 --> PgSelectSingle2744
     PgSelect2926[["PgSelect[2926∈366]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression2750{{"PgClassExpression[2750∈366]<br />ᐸ__person_t...”smallint”ᐳ"}}:::plan
-    Object12 & PgClassExpression2750 & Lambda3596 & Lambda3599 & Lambda6116 & Lambda6121 --> PgSelect2926
+    Object12 & PgClassExpression2750 & Lambda3596 & Access3600 & Lambda6278 & Lambda6283 --> PgSelect2926
     PgSelect2932[["PgSelect[2932∈366]<br />ᐸpostᐳ"]]:::plan
     PgClassExpression2749{{"PgClassExpression[2749∈366]<br />ᐸ__person_t...ion__.”id”ᐳ"}}:::plan
-    Object12 & PgClassExpression2749 & Lambda3596 & Lambda3599 & Lambda6102 & Lambda6107 --> PgSelect2932
+    Object12 & PgClassExpression2749 & Lambda3596 & Access3600 & Lambda6263 & Lambda6268 --> PgSelect2932
     PgSelectSingle2744 --> PgClassExpression2749
     PgSelectSingle2744 --> PgClassExpression2750
     PgClassExpression2751{{"PgClassExpression[2751∈366]<br />ᐸ__person_t..._.”bigint”ᐳ"}}:::plan
@@ -5625,8 +5632,8 @@ graph TD
     PgClassExpression2813{{"PgClassExpression[2813∈366]<br />ᐸ__person_t...__.”money”ᐳ"}}:::plan
     PgSelectSingle2744 --> PgClassExpression2813
     PgSelectSingle2820{{"PgSelectSingle[2820∈366]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6136{{"RemapKeys[6136∈366]<br />ᐸ2744:{”0”:98,”1”:99,”2”:100,”3”:101,”4”:102,”5”:103,”6”:104,”7”:105}ᐳ"}}:::plan
-    RemapKeys6136 --> PgSelectSingle2820
+    RemapKeys6299{{"RemapKeys[6299∈366]<br />ᐸ2744:{”0”:98,”1”:99,”2”:100,”3”:101,”4”:102,”5”:103,”6”:104,”7”:105}ᐳ"}}:::plan
+    RemapKeys6299 --> PgSelectSingle2820
     PgClassExpression2821{{"PgClassExpression[2821∈366]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2820 --> PgClassExpression2821
     PgClassExpression2822{{"PgClassExpression[2822∈366]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5642,21 +5649,21 @@ graph TD
     PgClassExpression2827{{"PgClassExpression[2827∈366]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle2820 --> PgClassExpression2827
     PgSelectSingle2832{{"PgSelectSingle[2832∈366]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6184{{"RemapKeys[6184∈366]<br />ᐸ2744:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113,”8”:114,”9”:115,”10”:116,”11”:117,”12”:118,”13”:119,”14”:120,”15”:121,”16”:122,”17”:123}ᐳ"}}:::plan
-    RemapKeys6184 --> PgSelectSingle2832
+    RemapKeys6350{{"RemapKeys[6350∈366]<br />ᐸ2744:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113,”8”:114,”9”:115,”10”:116,”11”:117,”12”:118,”13”:119,”14”:120,”15”:121,”16”:122,”17”:123}ᐳ"}}:::plan
+    RemapKeys6350 --> PgSelectSingle2832
     PgSelectSingle2837{{"PgSelectSingle[2837∈366]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2832 --> PgSelectSingle2837
     PgSelectSingle2849{{"PgSelectSingle[2849∈366]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6168{{"RemapKeys[6168∈366]<br />ᐸ2832:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6168 --> PgSelectSingle2849
+    RemapKeys6333{{"RemapKeys[6333∈366]<br />ᐸ2832:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6333 --> PgSelectSingle2849
     PgClassExpression2857{{"PgClassExpression[2857∈366]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2832 --> PgClassExpression2857
     PgSelectSingle2862{{"PgSelectSingle[2862∈366]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6200{{"RemapKeys[6200∈366]<br />ᐸ2744:{”0”:124,”1”:125,”2”:126,”3”:127,”4”:128,”5”:129,”6”:130,”7”:131}ᐳ"}}:::plan
-    RemapKeys6200 --> PgSelectSingle2862
+    RemapKeys6367{{"RemapKeys[6367∈366]<br />ᐸ2744:{”0”:124,”1”:125,”2”:126,”3”:127,”4”:128,”5”:129,”6”:130,”7”:131}ᐳ"}}:::plan
+    RemapKeys6367 --> PgSelectSingle2862
     PgSelectSingle2874{{"PgSelectSingle[2874∈366]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6248{{"RemapKeys[6248∈366]<br />ᐸ2744:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139,”8”:140,”9”:141,”10”:142,”11”:143,”12”:144,”13”:145,”14”:146,”15”:147,”16”:148,”17”:149}ᐳ"}}:::plan
-    RemapKeys6248 --> PgSelectSingle2874
+    RemapKeys6418{{"RemapKeys[6418∈366]<br />ᐸ2744:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139,”8”:140,”9”:141,”10”:142,”11”:143,”12”:144,”13”:145,”14”:146,”15”:147,”16”:148,”17”:149}ᐳ"}}:::plan
+    RemapKeys6418 --> PgSelectSingle2874
     PgClassExpression2902{{"PgClassExpression[2902∈366]<br />ᐸ__person_t...__.”point”ᐳ"}}:::plan
     PgSelectSingle2744 --> PgClassExpression2902
     PgClassExpression2905{{"PgClassExpression[2905∈366]<br />ᐸ__person_t...ablePoint”ᐳ"}}:::plan
@@ -5703,11 +5710,11 @@ graph TD
     PgSelectSingle2744 --> PgClassExpression2938
     PgClassExpression2939{{"PgClassExpression[2939∈366]<br />ᐸ__person_t...ree_array”ᐳ"}}:::plan
     PgSelectSingle2744 --> PgClassExpression2939
-    PgSelectSingle2744 --> RemapKeys6136
-    PgSelectSingle2832 --> RemapKeys6168
-    PgSelectSingle2744 --> RemapKeys6184
-    PgSelectSingle2744 --> RemapKeys6200
-    PgSelectSingle2744 --> RemapKeys6248
+    PgSelectSingle2744 --> RemapKeys6299
+    PgSelectSingle2832 --> RemapKeys6333
+    PgSelectSingle2744 --> RemapKeys6350
+    PgSelectSingle2744 --> RemapKeys6367
+    PgSelectSingle2744 --> RemapKeys6418
     __Item2758[/"__Item[2758∈367]<br />ᐸ2757ᐳ"\]:::itemplan
     PgClassExpression2757 ==> __Item2758
     __Item2762[/"__Item[2762∈368]<br />ᐸ2761ᐳ"\]:::itemplan
@@ -5763,11 +5770,11 @@ graph TD
     PgSelectSingle2881{{"PgSelectSingle[2881∈383]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle2874 --> PgSelectSingle2881
     PgSelectSingle2893{{"PgSelectSingle[2893∈383]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6232{{"RemapKeys[6232∈383]<br />ᐸ2874:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6232 --> PgSelectSingle2893
+    RemapKeys6401{{"RemapKeys[6401∈383]<br />ᐸ2874:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6401 --> PgSelectSingle2893
     PgClassExpression2901{{"PgClassExpression[2901∈383]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2874 --> PgClassExpression2901
-    PgSelectSingle2874 --> RemapKeys6232
+    PgSelectSingle2874 --> RemapKeys6401
     PgClassExpression2882{{"PgClassExpression[2882∈384]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2881 --> PgClassExpression2882
     PgClassExpression2883{{"PgClassExpression[2883∈384]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5812,14 +5819,14 @@ graph TD
     PgSelectSingle2935 --> PgClassExpression2937
     __Item2940[/"__Item[2940∈392]<br />ᐸ2939ᐳ"\]:::itemplan
     PgClassExpression2939 ==> __Item2940
-    Object6812{{"Object[6812∈393] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access6810{{"Access[6810∈393] ➊<br />ᐸ2971.101ᐳ"}}:::plan
-    Access6810 & Constant3594 & Constant3594 & Lambda3596 & Constant4092 --> Object6812
-    Object6830{{"Object[6830∈393] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
-    Access6828{{"Access[6828∈393] ➊<br />ᐸ2971.102ᐳ"}}:::plan
-    Access6828 & Constant3594 & Constant3594 & Lambda3596 & Constant3597 --> Object6830
+    Object7017{{"Object[7017∈393] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access7015{{"Access[7015∈393] ➊<br />ᐸ2971.101ᐳ"}}:::plan
+    Access7015 & Constant3594 & Constant3594 & Lambda3596 & Constant4123 --> Object7017
+    Object7036{{"Object[7036∈393] ➊<br />ᐸ{rows,first,last,shouldReverseOrder,fetchOneExtra}ᐳ"}}:::plan
+    Access7034{{"Access[7034∈393] ➊<br />ᐸ2971.102ᐳ"}}:::plan
+    Access7034 & Constant3594 & Constant3594 & Lambda3596 & Constant3597 --> Object7036
     Object3580{{"Object[3580∈393] ➊<br />ᐸ{first,last,offset,hasMore}ᐳ"}}:::plan
-    Access3575{{"Access[3575∈393] ➊<br />ᐸ6813.hasMoreᐳ"}}:::plan
+    Access3575{{"Access[3575∈393] ➊<br />ᐸ7018.hasMoreᐳ"}}:::plan
     Constant6 & Constant6 & Constant6 & Access3575 --> Object3580
     Object3576{{"Object[3576∈393] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant6 & Constant6 & Access3575 --> Object3576
@@ -5830,23 +5837,20 @@ graph TD
     PgSelectSingle2980{{"PgSelectSingle[2980∈393] ➊<br />ᐸtypesᐳ"}}:::plan
     PgSelectSingle2972 --> PgSelectSingle2980
     First3568{{"First[3568∈393] ➊"}}:::plan
-    Lambda6831{{"Lambda[6831∈393] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda6831 --> First3568
+    Lambda7037{{"Lambda[7037∈393] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda7037 --> First3568
     PgSelectSingle3569{{"PgSelectSingle[3569∈393] ➊<br />ᐸtypesᐳ"}}:::plan
     First3568 --> PgSelectSingle3569
     PgClassExpression3570{{"PgClassExpression[3570∈393] ➊<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle3569 --> PgClassExpression3570
-    PgPageInfo3572{{"PgPageInfo[3572∈393] ➊"}}:::plan
-    Connection3177{{"Connection[3177∈393] ➊<br />ᐸ3175ᐳ"}}:::plan
-    Connection3177 --> PgPageInfo3572
-    Lambda6813{{"Lambda[6813∈393] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
-    Lambda6813 --> Access3575
+    Lambda7018{{"Lambda[7018∈393] ➊<br />ᐸreverseIfNecessaryᐳ"}}:::plan
+    Lambda7018 --> Access3575
     Lambda3577{{"Lambda[3577∈393] ➊<br />ᐸhasNextPageCbᐳ"}}:::plan
     Object3576 --> Lambda3577
     Lambda3581{{"Lambda[3581∈393] ➊<br />ᐸhasPreviousPageCbᐳ"}}:::plan
     Object3580 --> Lambda3581
     First3583{{"First[3583∈393] ➊"}}:::plan
-    Lambda6813 --> First3583
+    Lambda7018 --> First3583
     PgSelectSingle3584{{"PgSelectSingle[3584∈393] ➊<br />ᐸtypesᐳ"}}:::plan
     First3583 --> PgSelectSingle3584
     PgCursor3585{{"PgCursor[3585∈393] ➊"}}:::plan
@@ -5856,7 +5860,7 @@ graph TD
     PgSelectSingle3584 --> PgClassExpression3586
     PgClassExpression3586 --> List3587
     Last3589{{"Last[3589∈393] ➊"}}:::plan
-    Lambda6813 --> Last3589
+    Lambda7018 --> Last3589
     PgSelectSingle3590{{"PgSelectSingle[3590∈393] ➊<br />ᐸtypesᐳ"}}:::plan
     Last3589 --> PgSelectSingle3590
     PgCursor3591{{"PgCursor[3591∈393] ➊"}}:::plan
@@ -5865,10 +5869,10 @@ graph TD
     PgClassExpression3592{{"PgClassExpression[3592∈393] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     PgSelectSingle3590 --> PgClassExpression3592
     PgClassExpression3592 --> List3593
-    First2971 --> Access6810
-    Object6812 --> Lambda6813
-    First2971 --> Access6828
-    Object6830 --> Lambda6831
+    First2971 --> Access7015
+    Object7017 --> Lambda7018
+    First2971 --> Access7034
+    Object7036 --> Lambda7037
     PgClassExpression2981{{"PgClassExpression[2981∈394] ➊<br />ᐸ__types__.”id”ᐳ"}}:::plan
     PgSelectSingle2980 --> PgClassExpression2981
     PgClassExpression2982{{"PgClassExpression[2982∈394] ➊<br />ᐸ__types__.”smallint”ᐳ"}}:::plan
@@ -5934,8 +5938,8 @@ graph TD
     PgClassExpression3045{{"PgClassExpression[3045∈394] ➊<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle2980 --> PgClassExpression3045
     PgSelectSingle3052{{"PgSelectSingle[3052∈394] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6345{{"RemapKeys[6345∈394] ➊<br />ᐸ2980:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys6345 --> PgSelectSingle3052
+    RemapKeys6521{{"RemapKeys[6521∈394] ➊<br />ᐸ2980:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys6521 --> PgSelectSingle3052
     PgClassExpression3053{{"PgClassExpression[3053∈394] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3052 --> PgClassExpression3053
     PgClassExpression3054{{"PgClassExpression[3054∈394] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5951,21 +5955,21 @@ graph TD
     PgClassExpression3059{{"PgClassExpression[3059∈394] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle3052 --> PgClassExpression3059
     PgSelectSingle3064{{"PgSelectSingle[3064∈394] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6393{{"RemapKeys[6393∈394] ➊<br />ᐸ2980:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys6393 --> PgSelectSingle3064
+    RemapKeys6572{{"RemapKeys[6572∈394] ➊<br />ᐸ2980:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys6572 --> PgSelectSingle3064
     PgSelectSingle3069{{"PgSelectSingle[3069∈394] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle3064 --> PgSelectSingle3069
     PgSelectSingle3081{{"PgSelectSingle[3081∈394] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6377{{"RemapKeys[6377∈394] ➊<br />ᐸ3064:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6377 --> PgSelectSingle3081
+    RemapKeys6555{{"RemapKeys[6555∈394] ➊<br />ᐸ3064:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6555 --> PgSelectSingle3081
     PgClassExpression3089{{"PgClassExpression[3089∈394] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3064 --> PgClassExpression3089
     PgSelectSingle3094{{"PgSelectSingle[3094∈394] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6409{{"RemapKeys[6409∈394] ➊<br />ᐸ2980:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys6409 --> PgSelectSingle3094
+    RemapKeys6589{{"RemapKeys[6589∈394] ➊<br />ᐸ2980:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys6589 --> PgSelectSingle3094
     PgSelectSingle3106{{"PgSelectSingle[3106∈394] ➊<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6457{{"RemapKeys[6457∈394] ➊<br />ᐸ2980:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys6457 --> PgSelectSingle3106
+    RemapKeys6640{{"RemapKeys[6640∈394] ➊<br />ᐸ2980:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys6640 --> PgSelectSingle3106
     PgClassExpression3134{{"PgClassExpression[3134∈394] ➊<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle2980 --> PgClassExpression3134
     PgClassExpression3137{{"PgClassExpression[3137∈394] ➊<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -6001,20 +6005,20 @@ graph TD
     PgClassExpression3156{{"PgClassExpression[3156∈394] ➊<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle2980 --> PgClassExpression3156
     PgSelectSingle3161{{"PgSelectSingle[3161∈394] ➊<br />ᐸpostᐳ"}}:::plan
-    RemapKeys6329{{"RemapKeys[6329∈394] ➊<br />ᐸ2980:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys6329 --> PgSelectSingle3161
+    RemapKeys6504{{"RemapKeys[6504∈394] ➊<br />ᐸ2980:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys6504 --> PgSelectSingle3161
     PgSelectSingle3167{{"PgSelectSingle[3167∈394] ➊<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle2980 --> PgSelectSingle3167
     PgClassExpression3170{{"PgClassExpression[3170∈394] ➊<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle2980 --> PgClassExpression3170
     PgClassExpression3171{{"PgClassExpression[3171∈394] ➊<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle2980 --> PgClassExpression3171
-    PgSelectSingle2980 --> RemapKeys6329
-    PgSelectSingle2980 --> RemapKeys6345
-    PgSelectSingle3064 --> RemapKeys6377
-    PgSelectSingle2980 --> RemapKeys6393
-    PgSelectSingle2980 --> RemapKeys6409
-    PgSelectSingle2980 --> RemapKeys6457
+    PgSelectSingle2980 --> RemapKeys6504
+    PgSelectSingle2980 --> RemapKeys6521
+    PgSelectSingle3064 --> RemapKeys6555
+    PgSelectSingle2980 --> RemapKeys6572
+    PgSelectSingle2980 --> RemapKeys6589
+    PgSelectSingle2980 --> RemapKeys6640
     __Item2990[/"__Item[2990∈395]<br />ᐸ2989ᐳ"\]:::itemplan
     PgClassExpression2989 ==> __Item2990
     __Item2994[/"__Item[2994∈396]<br />ᐸ2993ᐳ"\]:::itemplan
@@ -6070,11 +6074,11 @@ graph TD
     PgSelectSingle3113{{"PgSelectSingle[3113∈411] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle3106 --> PgSelectSingle3113
     PgSelectSingle3125{{"PgSelectSingle[3125∈411] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6441{{"RemapKeys[6441∈411] ➊<br />ᐸ3106:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6441 --> PgSelectSingle3125
+    RemapKeys6623{{"RemapKeys[6623∈411] ➊<br />ᐸ3106:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6623 --> PgSelectSingle3125
     PgClassExpression3133{{"PgClassExpression[3133∈411] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3106 --> PgClassExpression3133
-    PgSelectSingle3106 --> RemapKeys6441
+    PgSelectSingle3106 --> RemapKeys6623
     PgClassExpression3114{{"PgClassExpression[3114∈412] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3113 --> PgClassExpression3114
     PgClassExpression3115{{"PgClassExpression[3115∈412] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6119,8 +6123,8 @@ graph TD
     PgSelectSingle3167 --> PgClassExpression3169
     __Item3172[/"__Item[3172∈420]<br />ᐸ3171ᐳ"\]:::itemplan
     PgClassExpression3171 ==> __Item3172
-    __Item3179[/"__Item[3179∈421]<br />ᐸ6813ᐳ"\]:::itemplan
-    Lambda6813 ==> __Item3179
+    __Item3179[/"__Item[3179∈421]<br />ᐸ7018ᐳ"\]:::itemplan
+    Lambda7018 ==> __Item3179
     PgSelectSingle3180{{"PgSelectSingle[3180∈421]<br />ᐸtypesᐳ"}}:::plan
     __Item3179 --> PgSelectSingle3180
     PgClassExpression3181{{"PgClassExpression[3181∈422]<br />ᐸ__types__.”id”ᐳ"}}:::plan
@@ -6188,8 +6192,8 @@ graph TD
     PgClassExpression3245{{"PgClassExpression[3245∈422]<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3245
     PgSelectSingle3252{{"PgSelectSingle[3252∈422]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6521{{"RemapKeys[6521∈422]<br />ᐸ3180:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
-    RemapKeys6521 --> PgSelectSingle3252
+    RemapKeys6708{{"RemapKeys[6708∈422]<br />ᐸ3180:{”0”:30,”1”:31,”2”:32,”3”:33,”4”:34,”5”:35,”6”:36,”7”:37}ᐳ"}}:::plan
+    RemapKeys6708 --> PgSelectSingle3252
     PgClassExpression3253{{"PgClassExpression[3253∈422]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3252 --> PgClassExpression3253
     PgClassExpression3254{{"PgClassExpression[3254∈422]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6205,21 +6209,21 @@ graph TD
     PgClassExpression3259{{"PgClassExpression[3259∈422]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle3252 --> PgClassExpression3259
     PgSelectSingle3264{{"PgSelectSingle[3264∈422]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6569{{"RemapKeys[6569∈422]<br />ᐸ3180:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
-    RemapKeys6569 --> PgSelectSingle3264
+    RemapKeys6759{{"RemapKeys[6759∈422]<br />ᐸ3180:{”0”:38,”1”:39,”2”:40,”3”:41,”4”:42,”5”:43,”6”:44,”7”:45,”8”:46,”9”:47,”10”:48,”11”:49,”12”:50,”13”:51,”14”:52,”15”:53,”16”:54,”17”:55}ᐳ"}}:::plan
+    RemapKeys6759 --> PgSelectSingle3264
     PgSelectSingle3269{{"PgSelectSingle[3269∈422]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle3264 --> PgSelectSingle3269
     PgSelectSingle3281{{"PgSelectSingle[3281∈422]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6553{{"RemapKeys[6553∈422]<br />ᐸ3264:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6553 --> PgSelectSingle3281
+    RemapKeys6742{{"RemapKeys[6742∈422]<br />ᐸ3264:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6742 --> PgSelectSingle3281
     PgClassExpression3289{{"PgClassExpression[3289∈422]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3289
     PgSelectSingle3294{{"PgSelectSingle[3294∈422]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6585{{"RemapKeys[6585∈422]<br />ᐸ3180:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
-    RemapKeys6585 --> PgSelectSingle3294
+    RemapKeys6776{{"RemapKeys[6776∈422]<br />ᐸ3180:{”0”:56,”1”:57,”2”:58,”3”:59,”4”:60,”5”:61,”6”:62,”7”:63}ᐳ"}}:::plan
+    RemapKeys6776 --> PgSelectSingle3294
     PgSelectSingle3306{{"PgSelectSingle[3306∈422]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6633{{"RemapKeys[6633∈422]<br />ᐸ3180:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
-    RemapKeys6633 --> PgSelectSingle3306
+    RemapKeys6827{{"RemapKeys[6827∈422]<br />ᐸ3180:{”0”:64,”1”:65,”2”:66,”3”:67,”4”:68,”5”:69,”6”:70,”7”:71,”8”:72,”9”:73,”10”:74,”11”:75,”12”:76,”13”:77,”14”:78,”15”:79,”16”:80,”17”:81}ᐳ"}}:::plan
+    RemapKeys6827 --> PgSelectSingle3306
     PgClassExpression3334{{"PgClassExpression[3334∈422]<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3334
     PgClassExpression3337{{"PgClassExpression[3337∈422]<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -6255,20 +6259,20 @@ graph TD
     PgClassExpression3356{{"PgClassExpression[3356∈422]<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3356
     PgSelectSingle3361{{"PgSelectSingle[3361∈422]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys6505{{"RemapKeys[6505∈422]<br />ᐸ3180:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys6505 --> PgSelectSingle3361
+    RemapKeys6691{{"RemapKeys[6691∈422]<br />ᐸ3180:{”0”:3,”1”:4}ᐳ"}}:::plan
+    RemapKeys6691 --> PgSelectSingle3361
     PgSelectSingle3367{{"PgSelectSingle[3367∈422]<br />ᐸpostᐳ"}}:::plan
     PgSelectSingle3180 --> PgSelectSingle3367
     PgClassExpression3370{{"PgClassExpression[3370∈422]<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3370
     PgClassExpression3371{{"PgClassExpression[3371∈422]<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3371
-    PgSelectSingle3180 --> RemapKeys6505
-    PgSelectSingle3180 --> RemapKeys6521
-    PgSelectSingle3264 --> RemapKeys6553
-    PgSelectSingle3180 --> RemapKeys6569
-    PgSelectSingle3180 --> RemapKeys6585
-    PgSelectSingle3180 --> RemapKeys6633
+    PgSelectSingle3180 --> RemapKeys6691
+    PgSelectSingle3180 --> RemapKeys6708
+    PgSelectSingle3264 --> RemapKeys6742
+    PgSelectSingle3180 --> RemapKeys6759
+    PgSelectSingle3180 --> RemapKeys6776
+    PgSelectSingle3180 --> RemapKeys6827
     __Item3190[/"__Item[3190∈423]<br />ᐸ3189ᐳ"\]:::itemplan
     PgClassExpression3189 ==> __Item3190
     __Item3194[/"__Item[3194∈424]<br />ᐸ3193ᐳ"\]:::itemplan
@@ -6324,11 +6328,11 @@ graph TD
     PgSelectSingle3313{{"PgSelectSingle[3313∈439]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle3306 --> PgSelectSingle3313
     PgSelectSingle3325{{"PgSelectSingle[3325∈439]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6617{{"RemapKeys[6617∈439]<br />ᐸ3306:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6617 --> PgSelectSingle3325
+    RemapKeys6810{{"RemapKeys[6810∈439]<br />ᐸ3306:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6810 --> PgSelectSingle3325
     PgClassExpression3333{{"PgClassExpression[3333∈439]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3306 --> PgClassExpression3333
-    PgSelectSingle3306 --> RemapKeys6617
+    PgSelectSingle3306 --> RemapKeys6810
     PgClassExpression3314{{"PgClassExpression[3314∈440]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3313 --> PgClassExpression3314
     PgClassExpression3315{{"PgClassExpression[3315∈440]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6438,8 +6442,8 @@ graph TD
     PgClassExpression3439{{"PgClassExpression[3439∈449]<br />ᐸ__types__.”money”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3439
     PgSelectSingle3446{{"PgSelectSingle[3446∈449]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6681{{"RemapKeys[6681∈449]<br />ᐸ3180:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113}ᐳ"}}:::plan
-    RemapKeys6681 --> PgSelectSingle3446
+    RemapKeys6878{{"RemapKeys[6878∈449]<br />ᐸ3180:{”0”:106,”1”:107,”2”:108,”3”:109,”4”:110,”5”:111,”6”:112,”7”:113}ᐳ"}}:::plan
+    RemapKeys6878 --> PgSelectSingle3446
     PgClassExpression3447{{"PgClassExpression[3447∈449]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3446 --> PgClassExpression3447
     PgClassExpression3448{{"PgClassExpression[3448∈449]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6455,21 +6459,21 @@ graph TD
     PgClassExpression3453{{"PgClassExpression[3453∈449]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle3446 --> PgClassExpression3453
     PgSelectSingle3458{{"PgSelectSingle[3458∈449]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6729{{"RemapKeys[6729∈449]<br />ᐸ3180:{”0”:114,”1”:115,”2”:116,”3”:117,”4”:118,”5”:119,”6”:120,”7”:121,”8”:122,”9”:123,”10”:124,”11”:125,”12”:126,”13”:127,”14”:128,”15”:129,”16”:130,”17”:131}ᐳ"}}:::plan
-    RemapKeys6729 --> PgSelectSingle3458
+    RemapKeys6929{{"RemapKeys[6929∈449]<br />ᐸ3180:{”0”:114,”1”:115,”2”:116,”3”:117,”4”:118,”5”:119,”6”:120,”7”:121,”8”:122,”9”:123,”10”:124,”11”:125,”12”:126,”13”:127,”14”:128,”15”:129,”16”:130,”17”:131}ᐳ"}}:::plan
+    RemapKeys6929 --> PgSelectSingle3458
     PgSelectSingle3463{{"PgSelectSingle[3463∈449]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle3458 --> PgSelectSingle3463
     PgSelectSingle3475{{"PgSelectSingle[3475∈449]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6713{{"RemapKeys[6713∈449]<br />ᐸ3458:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6713 --> PgSelectSingle3475
+    RemapKeys6912{{"RemapKeys[6912∈449]<br />ᐸ3458:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6912 --> PgSelectSingle3475
     PgClassExpression3483{{"PgClassExpression[3483∈449]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3458 --> PgClassExpression3483
     PgSelectSingle3488{{"PgSelectSingle[3488∈449]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6745{{"RemapKeys[6745∈449]<br />ᐸ3180:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139}ᐳ"}}:::plan
-    RemapKeys6745 --> PgSelectSingle3488
+    RemapKeys6946{{"RemapKeys[6946∈449]<br />ᐸ3180:{”0”:132,”1”:133,”2”:134,”3”:135,”4”:136,”5”:137,”6”:138,”7”:139}ᐳ"}}:::plan
+    RemapKeys6946 --> PgSelectSingle3488
     PgSelectSingle3500{{"PgSelectSingle[3500∈449]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys6793{{"RemapKeys[6793∈449]<br />ᐸ3180:{”0”:140,”1”:141,”2”:142,”3”:143,”4”:144,”5”:145,”6”:146,”7”:147,”8”:148,”9”:149,”10”:150,”11”:151,”12”:152,”13”:153,”14”:154,”15”:155,”16”:156,”17”:157}ᐳ"}}:::plan
-    RemapKeys6793 --> PgSelectSingle3500
+    RemapKeys6997{{"RemapKeys[6997∈449]<br />ᐸ3180:{”0”:140,”1”:141,”2”:142,”3”:143,”4”:144,”5”:145,”6”:146,”7”:147,”8”:148,”9”:149,”10”:150,”11”:151,”12”:152,”13”:153,”14”:154,”15”:155,”16”:156,”17”:157}ᐳ"}}:::plan
+    RemapKeys6997 --> PgSelectSingle3500
     PgClassExpression3528{{"PgClassExpression[3528∈449]<br />ᐸ__types__.”point”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3528
     PgClassExpression3531{{"PgClassExpression[3531∈449]<br />ᐸ__types__....ablePoint”ᐳ"}}:::plan
@@ -6505,22 +6509,22 @@ graph TD
     PgClassExpression3550{{"PgClassExpression[3550∈449]<br />ᐸ__types__.”bytea_array”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3550
     PgSelectSingle3555{{"PgSelectSingle[3555∈449]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys6665{{"RemapKeys[6665∈449]<br />ᐸ3180:{”0”:103,”1”:104}ᐳ"}}:::plan
-    RemapKeys6665 --> PgSelectSingle3555
+    RemapKeys6861{{"RemapKeys[6861∈449]<br />ᐸ3180:{”0”:103,”1”:104}ᐳ"}}:::plan
+    RemapKeys6861 --> PgSelectSingle3555
     PgSelectSingle3561{{"PgSelectSingle[3561∈449]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys6649{{"RemapKeys[6649∈449]<br />ᐸ3180:{”0”:101,”1”:102}ᐳ"}}:::plan
-    RemapKeys6649 --> PgSelectSingle3561
+    RemapKeys6844{{"RemapKeys[6844∈449]<br />ᐸ3180:{”0”:101,”1”:102}ᐳ"}}:::plan
+    RemapKeys6844 --> PgSelectSingle3561
     PgClassExpression3564{{"PgClassExpression[3564∈449]<br />ᐸ__types__.”ltree”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3564
     PgClassExpression3565{{"PgClassExpression[3565∈449]<br />ᐸ__types__.”ltree_array”ᐳ"}}:::plan
     PgSelectSingle3180 --> PgClassExpression3565
-    PgSelectSingle3180 --> RemapKeys6649
-    PgSelectSingle3180 --> RemapKeys6665
-    PgSelectSingle3180 --> RemapKeys6681
-    PgSelectSingle3458 --> RemapKeys6713
-    PgSelectSingle3180 --> RemapKeys6729
-    PgSelectSingle3180 --> RemapKeys6745
-    PgSelectSingle3180 --> RemapKeys6793
+    PgSelectSingle3180 --> RemapKeys6844
+    PgSelectSingle3180 --> RemapKeys6861
+    PgSelectSingle3180 --> RemapKeys6878
+    PgSelectSingle3458 --> RemapKeys6912
+    PgSelectSingle3180 --> RemapKeys6929
+    PgSelectSingle3180 --> RemapKeys6946
+    PgSelectSingle3180 --> RemapKeys6997
     __Item3384[/"__Item[3384∈450]<br />ᐸ3383ᐳ"\]:::itemplan
     PgClassExpression3383 ==> __Item3384
     __Item3388[/"__Item[3388∈451]<br />ᐸ3387ᐳ"\]:::itemplan
@@ -6576,11 +6580,11 @@ graph TD
     PgSelectSingle3507{{"PgSelectSingle[3507∈466]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle3500 --> PgSelectSingle3507
     PgSelectSingle3519{{"PgSelectSingle[3519∈466]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys6777{{"RemapKeys[6777∈466]<br />ᐸ3500:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
-    RemapKeys6777 --> PgSelectSingle3519
+    RemapKeys6980{{"RemapKeys[6980∈466]<br />ᐸ3500:{”0”:8,”1”:9,”2”:10,”3”:11,”4”:12,”5”:13,”6”:14,”7”:15}ᐳ"}}:::plan
+    RemapKeys6980 --> PgSelectSingle3519
     PgClassExpression3527{{"PgClassExpression[3527∈466]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3500 --> PgClassExpression3527
-    PgSelectSingle3500 --> RemapKeys6777
+    PgSelectSingle3500 --> RemapKeys6980
     PgClassExpression3508{{"PgClassExpression[3508∈467]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3507 --> PgClassExpression3508
     PgClassExpression3509{{"PgClassExpression[3509∈467]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6629,18 +6633,18 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/types"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 10, 11, 13, 1713, 2543, 3594, 3597, 3600, 3601, 3602, 3616, 3617, 3632, 3633, 3634, 3648, 3649, 3664, 3665, 3680, 3681, 3682, 3696, 3697, 3712, 3713, 3728, 3729, 3744, 3745, 3760, 3761, 3762, 3774, 3775, 3790, 3791, 3806, 3807, 3822, 3823, 3838, 3839, 3854, 3855, 3870, 3871, 3886, 3887, 3902, 3903, 3918, 3919, 3934, 3935, 3950, 3951, 3966, 3967, 3982, 3983, 3998, 3999, 4014, 4015, 4030, 4031, 4046, 4047, 4062, 4063, 4078, 4079, 4092, 4095, 4109, 4123, 4124, 4139, 4140, 4155, 4156, 4171, 4172, 4187, 4188, 4203, 4204, 4219, 4220, 4235, 4236, 4251, 4252, 4267, 4268, 4283, 4284, 4297, 4298, 4313, 4314, 4329, 4330, 4345, 4346, 4361, 4362, 4377, 4378, 4393, 4394, 4409, 4410, 4425, 4426, 4441, 4442, 4457, 4458, 4471, 4472, 4473, 4485, 4486, 4487, 4499, 4500, 4501, 4513, 4514, 4515, 4527, 4528, 4529, 4541, 4542, 4543, 4555, 4556, 4557, 4569, 4570, 4571, 4583, 4584, 4597, 4598, 4613, 4614, 4629, 4630, 4645, 4646, 4661, 4662, 4677, 4678, 4693, 4694, 4709, 4710, 4725, 4726, 4741, 4742, 4757, 4758, 4771, 4772, 4773, 4785, 4786, 4787, 4799, 4800, 4801, 4813, 4814, 4815, 4827, 4828, 4829, 4841, 4842, 4843, 4855, 4856, 4857, 4869, 4870, 4871, 4883, 4884, 4885, 4897, 4898, 4913, 4914, 4929, 4930, 4945, 4946, 4961, 4962, 4977, 4978, 4993, 4994, 5009, 5010, 5025, 5026, 5041, 5042, 5057, 5058, 5071, 5072, 5087, 5088, 5103, 5104, 5119, 5120, 5135, 5136, 5151, 5152, 5167, 5168, 5183, 5184, 5199, 5200, 5215, 5216, 5231, 5232, 5245, 5246, 5259, 5260, 5273, 5274, 5289, 5290, 5305, 5306, 5321, 5322, 5337, 5338, 5353, 5354, 5369, 5370, 5385, 5386, 5402, 5403, 5416, 5417, 5430, 5431, 5446, 5447, 5462, 5463, 5478, 5479, 5494, 5495, 5510, 5511, 5526, 5527, 5542, 5543, 5558, 5559, 5572, 5586, 5587, 5602, 5603, 5618, 5619, 5634, 5635, 5650, 5651, 5666, 5667, 5682, 5683, 5698, 5699, 5714, 5715, 5730, 5731, 5746, 5747, 5762, 5763, 5778, 5779, 5794, 5795, 5810, 5811, 5826, 5827, 5842, 5843, 5858, 5859, 5874, 5875, 5890, 5891, 5906, 5907, 5922, 5923, 5941, 5942, 5955, 5956, 5969, 5970, 5985, 5986, 6001, 6002, 6017, 6018, 6033, 6034, 6049, 6050, 6065, 6066, 6081, 6082, 6098, 6099, 6112, 6113, 6126, 6127, 6142, 6143, 6158, 6159, 6174, 6175, 6190, 6191, 6206, 6207, 6222, 6223, 6238, 6239, 6254, 6255, 6272, 6289, 6290, 6303, 6304, 6319, 6320, 6335, 6336, 6351, 6352, 6367, 6368, 6383, 6384, 6399, 6400, 6415, 6416, 6431, 6432, 6447, 6448, 6463, 6464, 6479, 6480, 6495, 6496, 6511, 6512, 6527, 6528, 6543, 6544, 6559, 6560, 6575, 6576, 6591, 6592, 6607, 6608, 6623, 6624, 6639, 6640, 6655, 6656, 6671, 6672, 6687, 6688, 6703, 6704, 6719, 6720, 6735, 6736, 6751, 6752, 6767, 6768, 6783, 6784, 6799, 6800, 6818, 6836, 6837, 6846, 6847, 6850, 6851, 6852, 6853, 6854, 6855, 6856, 6857, 6858, 6859, 6860, 6861, 6862, 6863, 6864, 6865, 6866, 6867, 6868, 6869, 6870, 6871, 6872, 6873, 6874, 6875, 6876, 6877, 6878, 6879, 6880, 6881, 6882, 6883, 6884, 6885, 6886, 6887, 6888, 6889, 6890, 6891, 6892, 6893, 6894, 6895, 6896, 6897, 6898, 6899, 6900, 6901, 6902, 6903, 6904, 6905, 6906, 6907, 6908, 6909, 6910, 6911, 6912, 6913, 6914, 6915, 6916, 6917, 6918, 6919, 6920, 6921, 6922, 6923, 6924, 6925, 6926, 6927, 6928, 6929, 6930, 6931, 6932, 6933, 6934, 6935, 6936, 6937, 6938, 6939, 6940, 6941, 6942, 6943, 6944, 6945, 6946, 6947, 6948, 6949, 6950, 6951, 6952, 6953, 6954, 6955, 6956, 6957, 6958, 6959, 6960, 6961, 6962, 6963, 6964, 6965, 6966, 6967, 6968, 6969, 6970, 6971, 6972, 6973, 6974, 6975, 6976, 6977, 6978, 6979, 6980, 6981, 6982, 6983, 6984, 6985, 6986, 6987, 6988, 6989, 6990, 6991, 6992, 6993, 6994, 6995, 6996, 6997, 6998, 6999, 7000, 7001, 7002, 7003, 7004, 7005, 7006, 7007, 7008, 7009, 7010, 7011, 7012, 7013, 7014, 7015, 7016, 7017, 7018, 7019, 7020, 7021, 7022, 7023, 7024, 7025, 7026, 7027, 7028, 7029, 7030, 7031, 7032, 7033, 7034, 7035, 7036, 7037, 7038, 7039, 7040, 7041, 7042, 7043, 7044, 7045, 7046, 7047, 7048, 7049, 7050, 7051, 7052, 7053, 7054, 7055, 7056, 7057, 7058, 7059, 7060, 12, 824, 825, 1025, 3596, 3599, 3603, 3604, 3609, 3619, 3620, 3625, 3635, 3636, 3641, 3651, 3652, 3657, 3667, 3668, 3673, 3683, 3684, 3689, 3699, 3700, 3705, 3715, 3716, 3721, 3731, 3732, 3737, 3747, 3748, 3753, 3763, 3764, 3769, 4094, 4126, 4127, 4132, 4142, 4143, 4148, 4158, 4159, 4164, 4174, 4175, 4180, 4190, 4191, 4196, 4206, 4207, 4212, 4222, 4223, 4228, 4238, 4239, 4244, 4254, 4255, 4260, 4270, 4271, 4276, 4286, 4287, 4292, 4300, 4301, 4306, 4316, 4317, 4322, 4332, 4333, 4338, 4348, 4349, 4354, 4364, 4365, 4370, 4380, 4381, 4386, 4396, 4397, 4402, 4412, 4413, 4418, 4428, 4429, 4434, 4444, 4445, 4450, 4460, 4461, 4466, 4474, 4475, 4480, 4488, 4489, 4494, 4502, 4503, 4508, 4516, 4517, 4522, 4530, 4531, 4536, 4544, 4545, 4550, 4558, 4559, 4564, 4572, 4573, 4578, 4586, 4587, 4592, 4600, 4601, 4606, 4616, 4617, 4622, 4632, 4633, 4638, 4648, 4649, 4654, 4664, 4665, 4670, 4680, 4681, 4686, 4696, 4697, 4702, 4712, 4713, 4718, 4728, 4729, 4734, 4744, 4745, 4750, 4760, 4761, 4766, 4774, 4775, 4780, 4788, 4789, 4794, 4802, 4803, 4808, 4816, 4817, 4822, 4830, 4831, 4836, 4844, 4845, 4850, 4858, 4859, 4864, 4872, 4873, 4878, 4886, 4887, 4892, 4900, 4901, 4906, 4916, 4917, 4922, 4932, 4933, 4938, 4948, 4949, 4954, 4964, 4965, 4970, 4980, 4981, 4986, 4996, 4997, 5002, 5012, 5013, 5018, 5028, 5029, 5034, 5044, 5045, 5050, 5060, 5061, 5066, 5074, 5075, 5080, 5090, 5091, 5096, 5106, 5107, 5112, 5122, 5123, 5128, 5138, 5139, 5144, 5154, 5155, 5160, 5170, 5171, 5176, 5186, 5187, 5192, 5202, 5203, 5208, 5218, 5219, 5224, 5234, 5235, 5240, 5589, 5590, 5595, 5605, 5606, 5611, 5621, 5622, 5627, 5637, 5638, 5643, 5653, 5654, 5659, 5669, 5670, 5675, 5685, 5686, 5691, 5701, 5702, 5707, 5717, 5718, 5723, 5733, 5734, 5739, 5749, 5750, 5755, 5765, 5766, 5771, 5781, 5782, 5787, 5797, 5798, 5803, 5813, 5814, 5819, 5829, 5830, 5835, 5845, 5846, 5851, 5861, 5862, 5867, 5877, 5878, 5883, 5893, 5894, 5899, 5909, 5910, 5915, 5925, 5926, 5931, 5972, 5973, 5978, 5988, 5989, 5994, 6004, 6005, 6010, 6020, 6021, 6026, 6036, 6037, 6042, 6052, 6053, 6058, 6068, 6069, 6074, 6084, 6085, 6090, 6129, 6130, 6135, 6145, 6146, 6151, 6161, 6162, 6167, 6177, 6178, 6183, 6193, 6194, 6199, 6209, 6210, 6215, 6225, 6226, 6231, 6241, 6242, 6247, 6257, 6258, 6263, 6275, 6276, 6281, 6292, 6293, 6298, 6306, 6307, 6312, 6322, 6323, 6328, 6338, 6339, 6344, 6354, 6355, 6360, 6370, 6371, 6376, 6386, 6387, 6392, 6402, 6403, 6408, 6418, 6419, 6424, 6434, 6435, 6440, 6450, 6451, 6456, 6466, 6467, 6472, 6482, 6483, 6488, 6498, 6499, 6504, 6514, 6515, 6520, 6530, 6531, 6536, 6546, 6547, 6552, 6562, 6563, 6568, 6578, 6579, 6584, 6594, 6595, 6600, 6610, 6611, 6616, 6626, 6627, 6632, 6642, 6643, 6648, 6658, 6659, 6664, 6674, 6675, 6680, 6690, 6691, 6696, 6706, 6707, 6712, 6722, 6723, 6728, 6738, 6739, 6744, 6754, 6755, 6760, 6770, 6771, 6776, 6786, 6787, 6792, 6802, 6803, 6808, 6821, 6822, 6827, 6839, 6840, 6845, 1024<br />2: 9, 627, 827, 1319, 1515, 2139, 2969<br />ᐳ: 629, 630, 829, 830, 1321, 1322, 2141, 2142, 2971, 2972"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 10, 11, 13, 1713, 2543, 3177, 3594, 3597, 3601, 3602, 3603, 3618, 3619, 3635, 3636, 3637, 3652, 3653, 3669, 3670, 3686, 3687, 3688, 3703, 3704, 3720, 3721, 3737, 3738, 3754, 3755, 3771, 3772, 3773, 3786, 3787, 3803, 3804, 3820, 3821, 3837, 3838, 3854, 3855, 3871, 3872, 3888, 3889, 3905, 3906, 3922, 3923, 3939, 3940, 3956, 3957, 3973, 3974, 3990, 3991, 4007, 4008, 4024, 4025, 4041, 4042, 4058, 4059, 4075, 4076, 4092, 4093, 4109, 4110, 4123, 4127, 4142, 4157, 4158, 4174, 4175, 4191, 4192, 4208, 4209, 4225, 4226, 4242, 4243, 4259, 4260, 4276, 4277, 4293, 4294, 4310, 4311, 4327, 4328, 4342, 4343, 4359, 4360, 4376, 4377, 4393, 4394, 4410, 4411, 4427, 4428, 4444, 4445, 4461, 4462, 4478, 4479, 4495, 4496, 4512, 4513, 4527, 4528, 4529, 4542, 4543, 4544, 4557, 4558, 4559, 4572, 4573, 4574, 4587, 4588, 4589, 4602, 4603, 4604, 4617, 4618, 4619, 4632, 4633, 4634, 4647, 4648, 4662, 4663, 4679, 4680, 4696, 4697, 4713, 4714, 4730, 4731, 4747, 4748, 4764, 4765, 4781, 4782, 4798, 4799, 4815, 4816, 4832, 4833, 4847, 4848, 4849, 4862, 4863, 4864, 4877, 4878, 4879, 4892, 4893, 4894, 4907, 4908, 4909, 4922, 4923, 4924, 4937, 4938, 4939, 4952, 4953, 4954, 4967, 4968, 4969, 4982, 4983, 4999, 5000, 5016, 5017, 5033, 5034, 5050, 5051, 5067, 5068, 5084, 5085, 5101, 5102, 5118, 5119, 5135, 5136, 5152, 5153, 5167, 5168, 5184, 5185, 5201, 5202, 5218, 5219, 5235, 5236, 5252, 5253, 5269, 5270, 5286, 5287, 5303, 5304, 5320, 5321, 5337, 5338, 5352, 5353, 5367, 5368, 5382, 5383, 5399, 5400, 5416, 5417, 5433, 5434, 5450, 5451, 5467, 5468, 5484, 5485, 5501, 5502, 5519, 5520, 5534, 5535, 5549, 5550, 5566, 5567, 5583, 5584, 5600, 5601, 5617, 5618, 5634, 5635, 5651, 5652, 5668, 5669, 5685, 5686, 5700, 5715, 5716, 5732, 5733, 5749, 5750, 5766, 5767, 5783, 5784, 5800, 5801, 5817, 5818, 5834, 5835, 5851, 5852, 5868, 5869, 5885, 5886, 5902, 5903, 5919, 5920, 5936, 5937, 5953, 5954, 5970, 5971, 5987, 5988, 6004, 6005, 6021, 6022, 6038, 6039, 6055, 6056, 6072, 6073, 6092, 6093, 6107, 6108, 6122, 6123, 6139, 6140, 6156, 6157, 6173, 6174, 6190, 6191, 6207, 6208, 6224, 6225, 6241, 6242, 6259, 6260, 6274, 6275, 6289, 6290, 6306, 6307, 6323, 6324, 6340, 6341, 6357, 6358, 6374, 6375, 6391, 6392, 6408, 6409, 6425, 6426, 6444, 6462, 6463, 6477, 6478, 6494, 6495, 6511, 6512, 6528, 6529, 6545, 6546, 6562, 6563, 6579, 6580, 6596, 6597, 6613, 6614, 6630, 6631, 6647, 6648, 6664, 6665, 6681, 6682, 6698, 6699, 6715, 6716, 6732, 6733, 6749, 6750, 6766, 6767, 6783, 6784, 6800, 6801, 6817, 6818, 6834, 6835, 6851, 6852, 6868, 6869, 6885, 6886, 6902, 6903, 6919, 6920, 6936, 6937, 6953, 6954, 6970, 6971, 6987, 6988, 7004, 7005, 7024, 7043, 7044, 7053, 7054, 7057, 7058, 7059, 7060, 7061, 7062, 7063, 7064, 7065, 7066, 7067, 7068, 7069, 7070, 7071, 7072, 7073, 7074, 7075, 7076, 7077, 7078, 7079, 7080, 7081, 7082, 7083, 7084, 7085, 7086, 7087, 7088, 7089, 7090, 7091, 7092, 7093, 7094, 7095, 7096, 7097, 7098, 7099, 7100, 7101, 7102, 7103, 7104, 7105, 7106, 7107, 7108, 7109, 7110, 7111, 7112, 7113, 7114, 7115, 7116, 7117, 7118, 7119, 7120, 7121, 7122, 7123, 7124, 7125, 7126, 7127, 7128, 7129, 7130, 7131, 7132, 7133, 7134, 7135, 7136, 7137, 7138, 7139, 7140, 7141, 7142, 7143, 7144, 7145, 7146, 7147, 7148, 7149, 7150, 7151, 7152, 7153, 7154, 7155, 7156, 7157, 7158, 7159, 7160, 7161, 7162, 7163, 7164, 7165, 7166, 7167, 7168, 7169, 7170, 7171, 7172, 7173, 7174, 7175, 7176, 7177, 7178, 7179, 7180, 7181, 7182, 7183, 7184, 7185, 7186, 7187, 7188, 7189, 7190, 7191, 7192, 7193, 7194, 7195, 7196, 7197, 7198, 7199, 7200, 7201, 7202, 7203, 7204, 7205, 7206, 7207, 7208, 7209, 7210, 7211, 7212, 7213, 7214, 7215, 7216, 7217, 7218, 7219, 7220, 7221, 7222, 7223, 7224, 7225, 7226, 7227, 7228, 7229, 7230, 7231, 7232, 7233, 7234, 7235, 7236, 7237, 7238, 7239, 7240, 7241, 7242, 7243, 7244, 7245, 7246, 7247, 7248, 7249, 7250, 7251, 7252, 7253, 7254, 7255, 7256, 7257, 7258, 7259, 7260, 7261, 7262, 7263, 7264, 7265, 7266, 7267, 12, 824, 825, 1025, 2946, 3572, 3596, 3599, 3600, 3604, 3605, 3610, 3621, 3622, 3627, 3638, 3639, 3644, 3655, 3656, 3661, 3672, 3673, 3678, 3689, 3690, 3695, 3706, 3707, 3712, 3723, 3724, 3729, 3740, 3741, 3746, 3757, 3758, 3763, 3774, 3775, 3780, 3789, 3790, 3795, 3806, 3807, 3812, 3823, 3824, 3829, 3840, 3841, 3846, 3857, 3858, 3863, 3874, 3875, 3880, 3891, 3892, 3897, 3908, 3909, 3914, 3925, 3926, 3931, 3942, 3943, 3948, 3959, 3960, 3965, 3976, 3977, 3982, 3993, 3994, 3999, 4010, 4011, 4016, 4027, 4028, 4033, 4044, 4045, 4050, 4061, 4062, 4067, 4078, 4079, 4084, 4095, 4096, 4101, 4112, 4113, 4118, 4125, 4126, 4130, 4131, 4136, 4145, 4146, 4151, 4160, 4161, 4166, 4177, 4178, 4183, 4194, 4195, 4200, 4211, 4212, 4217, 4228, 4229, 4234, 4245, 4246, 4251, 4262, 4263, 4268, 4279, 4280, 4285, 4296, 4297, 4302, 4313, 4314, 4319, 4330, 4331, 4336, 4345, 4346, 4351, 4362, 4363, 4368, 4379, 4380, 4385, 4396, 4397, 4402, 4413, 4414, 4419, 4430, 4431, 4436, 4447, 4448, 4453, 4464, 4465, 4470, 4481, 4482, 4487, 4498, 4499, 4504, 4515, 4516, 4521, 4530, 4531, 4536, 4545, 4546, 4551, 4560, 4561, 4566, 4575, 4576, 4581, 4590, 4591, 4596, 4605, 4606, 4611, 4620, 4621, 4626, 4635, 4636, 4641, 4650, 4651, 4656, 4665, 4666, 4671, 4682, 4683, 4688, 4699, 4700, 4705, 4716, 4717, 4722, 4733, 4734, 4739, 4750, 4751, 4756, 4767, 4768, 4773, 4784, 4785, 4790, 4801, 4802, 4807, 4818, 4819, 4824, 4835, 4836, 4841, 4850, 4851, 4856, 4865, 4866, 4871, 4880, 4881, 4886, 4895, 4896, 4901, 4910, 4911, 4916, 4925, 4926, 4931, 4940, 4941, 4946, 4955, 4956, 4961, 4970, 4971, 4976, 4985, 4986, 4991, 5002, 5003, 5008, 5019, 5020, 5025, 5036, 5037, 5042, 5053, 5054, 5059, 5070, 5071, 5076, 5087, 5088, 5093, 5104, 5105, 5110, 5121, 5122, 5127, 5138, 5139, 5144, 5155, 5156, 5161, 5170, 5171, 5176, 5187, 5188, 5193, 5204, 5205, 5210, 5221, 5222, 5227, 5238, 5239, 5244, 5255, 5256, 5261, 5272, 5273, 5278, 5289, 5290, 5295, 5306, 5307, 5312, 5323, 5324, 5329, 5340, 5341, 5346, 5355, 5356, 5361, 5370, 5371, 5376, 5385, 5386, 5391, 5402, 5403, 5408, 5419, 5420, 5425, 5436, 5437, 5442, 5453, 5454, 5459, 5470, 5471, 5476, 5487, 5488, 5493, 5504, 5505, 5510, 5522, 5523, 5528, 5537, 5538, 5543, 5552, 5553, 5558, 5569, 5570, 5575, 5586, 5587, 5592, 5603, 5604, 5609, 5620, 5621, 5626, 5637, 5638, 5643, 5654, 5655, 5660, 5671, 5672, 5677, 5688, 5689, 5694, 5703, 5704, 5709, 5718, 5719, 5724, 5735, 5736, 5741, 5752, 5753, 5758, 5769, 5770, 5775, 5786, 5787, 5792, 5803, 5804, 5809, 5820, 5821, 5826, 5837, 5838, 5843, 5854, 5855, 5860, 5871, 5872, 5877, 5888, 5889, 5894, 5905, 5906, 5911, 5922, 5923, 5928, 5939, 5940, 5945, 5956, 5957, 5962, 5973, 5974, 5979, 5990, 5991, 5996, 6007, 6008, 6013, 6024, 6025, 6030, 6041, 6042, 6047, 6058, 6059, 6064, 6075, 6076, 6081, 6095, 6096, 6101, 6110, 6111, 6116, 6125, 6126, 6131, 6142, 6143, 6148, 6159, 6160, 6165, 6176, 6177, 6182, 6193, 6194, 6199, 6210, 6211, 6216, 6227, 6228, 6233, 6244, 6245, 6250, 6262, 6263, 6268, 6277, 6278, 6283, 6292, 6293, 6298, 6309, 6310, 6315, 6326, 6327, 6332, 6343, 6344, 6349, 6360, 6361, 6366, 6377, 6378, 6383, 6394, 6395, 6400, 6411, 6412, 6417, 6428, 6429, 6434, 6447, 6448, 6453, 6465, 6466, 6471, 6480, 6481, 6486, 6497, 6498, 6503, 6514, 6515, 6520, 6531, 6532, 6537, 6548, 6549, 6554, 6565, 6566, 6571, 6582, 6583, 6588, 6599, 6600, 6605, 6616, 6617, 6622, 6633, 6634, 6639, 6650, 6651, 6656, 6667, 6668, 6673, 6684, 6685, 6690, 6701, 6702, 6707, 6718, 6719, 6724, 6735, 6736, 6741, 6752, 6753, 6758, 6769, 6770, 6775, 6786, 6787, 6792, 6803, 6804, 6809, 6820, 6821, 6826, 6837, 6838, 6843, 6854, 6855, 6860, 6871, 6872, 6877, 6888, 6889, 6894, 6905, 6906, 6911, 6922, 6923, 6928, 6939, 6940, 6945, 6956, 6957, 6962, 6973, 6974, 6979, 6990, 6991, 6996, 7007, 7008, 7013, 7027, 7028, 7033, 7046, 7047, 7052, 1024<br />2: 9, 627, 827, 1319, 1515, 2139, 2969<br />ᐳ: 629, 630, 829, 830, 1321, 1322, 2141, 2142, 2971, 2972"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Constant6,PgSelect9,Access10,Access11,Object12,Connection13,PgSelect627,First629,PgSelectSingle630,Lambda824,Access825,PgSelect827,First829,PgSelectSingle830,Node1024,Lambda1025,PgSelect1319,First1321,PgSelectSingle1322,PgSelect1515,Connection1713,PgSelect2139,First2141,PgSelectSingle2142,Connection2543,PgSelect2969,First2971,PgSelectSingle2972,Constant3594,Lambda3596,Constant3597,Lambda3599,Constant3600,Constant3601,Constant3602,Object3603,Lambda3604,Lambda3609,Constant3616,Constant3617,Object3619,Lambda3620,Lambda3625,Constant3632,Constant3633,Constant3634,Object3635,Lambda3636,Lambda3641,Constant3648,Constant3649,Object3651,Lambda3652,Lambda3657,Constant3664,Constant3665,Object3667,Lambda3668,Lambda3673,Constant3680,Constant3681,Constant3682,Object3683,Lambda3684,Lambda3689,Constant3696,Constant3697,Object3699,Lambda3700,Lambda3705,Constant3712,Constant3713,Object3715,Lambda3716,Lambda3721,Constant3728,Constant3729,Object3731,Lambda3732,Lambda3737,Constant3744,Constant3745,Object3747,Lambda3748,Lambda3753,Constant3760,Constant3761,Constant3762,Object3763,Lambda3764,Lambda3769,Constant3774,Constant3775,Constant3790,Constant3791,Constant3806,Constant3807,Constant3822,Constant3823,Constant3838,Constant3839,Constant3854,Constant3855,Constant3870,Constant3871,Constant3886,Constant3887,Constant3902,Constant3903,Constant3918,Constant3919,Constant3934,Constant3935,Constant3950,Constant3951,Constant3966,Constant3967,Constant3982,Constant3983,Constant3998,Constant3999,Constant4014,Constant4015,Constant4030,Constant4031,Constant4046,Constant4047,Constant4062,Constant4063,Constant4078,Constant4079,Constant4092,Lambda4094,Constant4095,Constant4109,Constant4123,Constant4124,Object4126,Lambda4127,Lambda4132,Constant4139,Constant4140,Object4142,Lambda4143,Lambda4148,Constant4155,Constant4156,Object4158,Lambda4159,Lambda4164,Constant4171,Constant4172,Object4174,Lambda4175,Lambda4180,Constant4187,Constant4188,Object4190,Lambda4191,Lambda4196,Constant4203,Constant4204,Object4206,Lambda4207,Lambda4212,Constant4219,Constant4220,Object4222,Lambda4223,Lambda4228,Constant4235,Constant4236,Object4238,Lambda4239,Lambda4244,Constant4251,Constant4252,Object4254,Lambda4255,Lambda4260,Constant4267,Constant4268,Object4270,Lambda4271,Lambda4276,Constant4283,Constant4284,Object4286,Lambda4287,Lambda4292,Constant4297,Constant4298,Object4300,Lambda4301,Lambda4306,Constant4313,Constant4314,Object4316,Lambda4317,Lambda4322,Constant4329,Constant4330,Object4332,Lambda4333,Lambda4338,Constant4345,Constant4346,Object4348,Lambda4349,Lambda4354,Constant4361,Constant4362,Object4364,Lambda4365,Lambda4370,Constant4377,Constant4378,Object4380,Lambda4381,Lambda4386,Constant4393,Constant4394,Object4396,Lambda4397,Lambda4402,Constant4409,Constant4410,Object4412,Lambda4413,Lambda4418,Constant4425,Constant4426,Object4428,Lambda4429,Lambda4434,Constant4441,Constant4442,Object4444,Lambda4445,Lambda4450,Constant4457,Constant4458,Object4460,Lambda4461,Lambda4466,Constant4471,Constant4472,Constant4473,Object4474,Lambda4475,Lambda4480,Constant4485,Constant4486,Constant4487,Object4488,Lambda4489,Lambda4494,Constant4499,Constant4500,Constant4501,Object4502,Lambda4503,Lambda4508,Constant4513,Constant4514,Constant4515,Object4516,Lambda4517,Lambda4522,Constant4527,Constant4528,Constant4529,Object4530,Lambda4531,Lambda4536,Constant4541,Constant4542,Constant4543,Object4544,Lambda4545,Lambda4550,Constant4555,Constant4556,Constant4557,Object4558,Lambda4559,Lambda4564,Constant4569,Constant4570,Constant4571,Object4572,Lambda4573,Lambda4578,Constant4583,Constant4584,Object4586,Lambda4587,Lambda4592,Constant4597,Constant4598,Object4600,Lambda4601,Lambda4606,Constant4613,Constant4614,Object4616,Lambda4617,Lambda4622,Constant4629,Constant4630,Object4632,Lambda4633,Lambda4638,Constant4645,Constant4646,Object4648,Lambda4649,Lambda4654,Constant4661,Constant4662,Object4664,Lambda4665,Lambda4670,Constant4677,Constant4678,Object4680,Lambda4681,Lambda4686,Constant4693,Constant4694,Object4696,Lambda4697,Lambda4702,Constant4709,Constant4710,Object4712,Lambda4713,Lambda4718,Constant4725,Constant4726,Object4728,Lambda4729,Lambda4734,Constant4741,Constant4742,Object4744,Lambda4745,Lambda4750,Constant4757,Constant4758,Object4760,Lambda4761,Lambda4766,Constant4771,Constant4772,Constant4773,Object4774,Lambda4775,Lambda4780,Constant4785,Constant4786,Constant4787,Object4788,Lambda4789,Lambda4794,Constant4799,Constant4800,Constant4801,Object4802,Lambda4803,Lambda4808,Constant4813,Constant4814,Constant4815,Object4816,Lambda4817,Lambda4822,Constant4827,Constant4828,Constant4829,Object4830,Lambda4831,Lambda4836,Constant4841,Constant4842,Constant4843,Object4844,Lambda4845,Lambda4850,Constant4855,Constant4856,Constant4857,Object4858,Lambda4859,Lambda4864,Constant4869,Constant4870,Constant4871,Object4872,Lambda4873,Lambda4878,Constant4883,Constant4884,Constant4885,Object4886,Lambda4887,Lambda4892,Constant4897,Constant4898,Object4900,Lambda4901,Lambda4906,Constant4913,Constant4914,Object4916,Lambda4917,Lambda4922,Constant4929,Constant4930,Object4932,Lambda4933,Lambda4938,Constant4945,Constant4946,Object4948,Lambda4949,Lambda4954,Constant4961,Constant4962,Object4964,Lambda4965,Lambda4970,Constant4977,Constant4978,Object4980,Lambda4981,Lambda4986,Constant4993,Constant4994,Object4996,Lambda4997,Lambda5002,Constant5009,Constant5010,Object5012,Lambda5013,Lambda5018,Constant5025,Constant5026,Object5028,Lambda5029,Lambda5034,Constant5041,Constant5042,Object5044,Lambda5045,Lambda5050,Constant5057,Constant5058,Object5060,Lambda5061,Lambda5066,Constant5071,Constant5072,Object5074,Lambda5075,Lambda5080,Constant5087,Constant5088,Object5090,Lambda5091,Lambda5096,Constant5103,Constant5104,Object5106,Lambda5107,Lambda5112,Constant5119,Constant5120,Object5122,Lambda5123,Lambda5128,Constant5135,Constant5136,Object5138,Lambda5139,Lambda5144,Constant5151,Constant5152,Object5154,Lambda5155,Lambda5160,Constant5167,Constant5168,Object5170,Lambda5171,Lambda5176,Constant5183,Constant5184,Object5186,Lambda5187,Lambda5192,Constant5199,Constant5200,Object5202,Lambda5203,Lambda5208,Constant5215,Constant5216,Object5218,Lambda5219,Lambda5224,Constant5231,Constant5232,Object5234,Lambda5235,Lambda5240,Constant5245,Constant5246,Constant5259,Constant5260,Constant5273,Constant5274,Constant5289,Constant5290,Constant5305,Constant5306,Constant5321,Constant5322,Constant5337,Constant5338,Constant5353,Constant5354,Constant5369,Constant5370,Constant5385,Constant5386,Constant5402,Constant5403,Constant5416,Constant5417,Constant5430,Constant5431,Constant5446,Constant5447,Constant5462,Constant5463,Constant5478,Constant5479,Constant5494,Constant5495,Constant5510,Constant5511,Constant5526,Constant5527,Constant5542,Constant5543,Constant5558,Constant5559,Constant5572,Constant5586,Constant5587,Object5589,Lambda5590,Lambda5595,Constant5602,Constant5603,Object5605,Lambda5606,Lambda5611,Constant5618,Constant5619,Object5621,Lambda5622,Lambda5627,Constant5634,Constant5635,Object5637,Lambda5638,Lambda5643,Constant5650,Constant5651,Object5653,Lambda5654,Lambda5659,Constant5666,Constant5667,Object5669,Lambda5670,Lambda5675,Constant5682,Constant5683,Object5685,Lambda5686,Lambda5691,Constant5698,Constant5699,Object5701,Lambda5702,Lambda5707,Constant5714,Constant5715,Object5717,Lambda5718,Lambda5723,Constant5730,Constant5731,Object5733,Lambda5734,Lambda5739,Constant5746,Constant5747,Object5749,Lambda5750,Lambda5755,Constant5762,Constant5763,Object5765,Lambda5766,Lambda5771,Constant5778,Constant5779,Object5781,Lambda5782,Lambda5787,Constant5794,Constant5795,Object5797,Lambda5798,Lambda5803,Constant5810,Constant5811,Object5813,Lambda5814,Lambda5819,Constant5826,Constant5827,Object5829,Lambda5830,Lambda5835,Constant5842,Constant5843,Object5845,Lambda5846,Lambda5851,Constant5858,Constant5859,Object5861,Lambda5862,Lambda5867,Constant5874,Constant5875,Object5877,Lambda5878,Lambda5883,Constant5890,Constant5891,Object5893,Lambda5894,Lambda5899,Constant5906,Constant5907,Object5909,Lambda5910,Lambda5915,Constant5922,Constant5923,Object5925,Lambda5926,Lambda5931,Constant5941,Constant5942,Constant5955,Constant5956,Constant5969,Constant5970,Object5972,Lambda5973,Lambda5978,Constant5985,Constant5986,Object5988,Lambda5989,Lambda5994,Constant6001,Constant6002,Object6004,Lambda6005,Lambda6010,Constant6017,Constant6018,Object6020,Lambda6021,Lambda6026,Constant6033,Constant6034,Object6036,Lambda6037,Lambda6042,Constant6049,Constant6050,Object6052,Lambda6053,Lambda6058,Constant6065,Constant6066,Object6068,Lambda6069,Lambda6074,Constant6081,Constant6082,Object6084,Lambda6085,Lambda6090,Constant6098,Constant6099,Constant6112,Constant6113,Constant6126,Constant6127,Object6129,Lambda6130,Lambda6135,Constant6142,Constant6143,Object6145,Lambda6146,Lambda6151,Constant6158,Constant6159,Object6161,Lambda6162,Lambda6167,Constant6174,Constant6175,Object6177,Lambda6178,Lambda6183,Constant6190,Constant6191,Object6193,Lambda6194,Lambda6199,Constant6206,Constant6207,Object6209,Lambda6210,Lambda6215,Constant6222,Constant6223,Object6225,Lambda6226,Lambda6231,Constant6238,Constant6239,Object6241,Lambda6242,Lambda6247,Constant6254,Constant6255,Object6257,Lambda6258,Lambda6263,Constant6272,Object6275,Lambda6276,Lambda6281,Constant6289,Constant6290,Object6292,Lambda6293,Lambda6298,Constant6303,Constant6304,Object6306,Lambda6307,Lambda6312,Constant6319,Constant6320,Object6322,Lambda6323,Lambda6328,Constant6335,Constant6336,Object6338,Lambda6339,Lambda6344,Constant6351,Constant6352,Object6354,Lambda6355,Lambda6360,Constant6367,Constant6368,Object6370,Lambda6371,Lambda6376,Constant6383,Constant6384,Object6386,Lambda6387,Lambda6392,Constant6399,Constant6400,Object6402,Lambda6403,Lambda6408,Constant6415,Constant6416,Object6418,Lambda6419,Lambda6424,Constant6431,Constant6432,Object6434,Lambda6435,Lambda6440,Constant6447,Constant6448,Object6450,Lambda6451,Lambda6456,Constant6463,Constant6464,Object6466,Lambda6467,Lambda6472,Constant6479,Constant6480,Object6482,Lambda6483,Lambda6488,Constant6495,Constant6496,Object6498,Lambda6499,Lambda6504,Constant6511,Constant6512,Object6514,Lambda6515,Lambda6520,Constant6527,Constant6528,Object6530,Lambda6531,Lambda6536,Constant6543,Constant6544,Object6546,Lambda6547,Lambda6552,Constant6559,Constant6560,Object6562,Lambda6563,Lambda6568,Constant6575,Constant6576,Object6578,Lambda6579,Lambda6584,Constant6591,Constant6592,Object6594,Lambda6595,Lambda6600,Constant6607,Constant6608,Object6610,Lambda6611,Lambda6616,Constant6623,Constant6624,Object6626,Lambda6627,Lambda6632,Constant6639,Constant6640,Object6642,Lambda6643,Lambda6648,Constant6655,Constant6656,Object6658,Lambda6659,Lambda6664,Constant6671,Constant6672,Object6674,Lambda6675,Lambda6680,Constant6687,Constant6688,Object6690,Lambda6691,Lambda6696,Constant6703,Constant6704,Object6706,Lambda6707,Lambda6712,Constant6719,Constant6720,Object6722,Lambda6723,Lambda6728,Constant6735,Constant6736,Object6738,Lambda6739,Lambda6744,Constant6751,Constant6752,Object6754,Lambda6755,Lambda6760,Constant6767,Constant6768,Object6770,Lambda6771,Lambda6776,Constant6783,Constant6784,Object6786,Lambda6787,Lambda6792,Constant6799,Constant6800,Object6802,Lambda6803,Lambda6808,Constant6818,Object6821,Lambda6822,Lambda6827,Constant6836,Constant6837,Object6839,Lambda6840,Lambda6845,Constant6846,Constant6847,Constant6850,Constant6851,Constant6852,Constant6853,Constant6854,Constant6855,Constant6856,Constant6857,Constant6858,Constant6859,Constant6860,Constant6861,Constant6862,Constant6863,Constant6864,Constant6865,Constant6866,Constant6867,Constant6868,Constant6869,Constant6870,Constant6871,Constant6872,Constant6873,Constant6874,Constant6875,Constant6876,Constant6877,Constant6878,Constant6879,Constant6880,Constant6881,Constant6882,Constant6883,Constant6884,Constant6885,Constant6886,Constant6887,Constant6888,Constant6889,Constant6890,Constant6891,Constant6892,Constant6893,Constant6894,Constant6895,Constant6896,Constant6897,Constant6898,Constant6899,Constant6900,Constant6901,Constant6902,Constant6903,Constant6904,Constant6905,Constant6906,Constant6907,Constant6908,Constant6909,Constant6910,Constant6911,Constant6912,Constant6913,Constant6914,Constant6915,Constant6916,Constant6917,Constant6918,Constant6919,Constant6920,Constant6921,Constant6922,Constant6923,Constant6924,Constant6925,Constant6926,Constant6927,Constant6928,Constant6929,Constant6930,Constant6931,Constant6932,Constant6933,Constant6934,Constant6935,Constant6936,Constant6937,Constant6938,Constant6939,Constant6940,Constant6941,Constant6942,Constant6943,Constant6944,Constant6945,Constant6946,Constant6947,Constant6948,Constant6949,Constant6950,Constant6951,Constant6952,Constant6953,Constant6954,Constant6955,Constant6956,Constant6957,Constant6958,Constant6959,Constant6960,Constant6961,Constant6962,Constant6963,Constant6964,Constant6965,Constant6966,Constant6967,Constant6968,Constant6969,Constant6970,Constant6971,Constant6972,Constant6973,Constant6974,Constant6975,Constant6976,Constant6977,Constant6978,Constant6979,Constant6980,Constant6981,Constant6982,Constant6983,Constant6984,Constant6985,Constant6986,Constant6987,Constant6988,Constant6989,Constant6990,Constant6991,Constant6992,Constant6993,Constant6994,Constant6995,Constant6996,Constant6997,Constant6998,Constant6999,Constant7000,Constant7001,Constant7002,Constant7003,Constant7004,Constant7005,Constant7006,Constant7007,Constant7008,Constant7009,Constant7010,Constant7011,Constant7012,Constant7013,Constant7014,Constant7015,Constant7016,Constant7017,Constant7018,Constant7019,Constant7020,Constant7021,Constant7022,Constant7023,Constant7024,Constant7025,Constant7026,Constant7027,Constant7028,Constant7029,Constant7030,Constant7031,Constant7032,Constant7033,Constant7034,Constant7035,Constant7036,Constant7037,Constant7038,Constant7039,Constant7040,Constant7041,Constant7042,Constant7043,Constant7044,Constant7045,Constant7046,Constant7047,Constant7048,Constant7049,Constant7050,Constant7051,Constant7052,Constant7053,Constant7054,Constant7055,Constant7056,Constant7057,Constant7058,Constant7059,Constant7060 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 3599, 3596, 4094, 6, 3774, 3775, 3602, 6865, 3790, 3791, 6866, 3806, 3807, 3634, 6867, 3822, 3823, 6868, 3838, 3839, 6869, 3854, 3855, 3682, 6870, 3870, 3871, 6871, 3886, 3887, 6872, 3902, 3903, 6873, 3918, 3919, 6874, 3934, 3935, 6875, 3950, 3951, 6876, 3966, 3967, 6877, 3982, 3983, 6878, 3998, 3999, 6879, 4014, 4015, 6880, 4030, 4031, 6881, 4046, 4047, 6882, 4062, 4063, 6883, 4078, 4079, 6884, 4095, 3761, 3762, 6885, 4109, 6886<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 408, 3777, 3783, 3793, 3799, 3809, 3815, 3825, 3831, 3841, 3847, 3857, 3863, 3873, 3879, 3889, 3895, 3905, 3911, 3921, 3927, 3937, 3943, 3953, 3959, 3969, 3975, 3985, 3991, 4001, 4007, 4017, 4023, 4033, 4039, 4049, 4055, 4065, 4071, 4081, 4087, 4098, 4104, 4112, 4118, 3778, 3794, 3810, 3826, 3842, 3858, 3874, 3890, 3906, 3922, 3938, 3954, 3970, 3986, 4002, 4018, 4034, 4050, 4066, 4082, 4099, 4113<br />2: PgSelect[14], PgSelect[403]<br />ᐳ: 404, 405, 406, 411, 412, 413, 416, 417, 419, 420, 422, 423, 425, 426, 428, 429, 421, 427"):::bucket
+    class Bucket0,__Value2,__Value4,Constant6,PgSelect9,Access10,Access11,Object12,Connection13,PgSelect627,First629,PgSelectSingle630,Lambda824,Access825,PgSelect827,First829,PgSelectSingle830,Node1024,Lambda1025,PgSelect1319,First1321,PgSelectSingle1322,PgSelect1515,Connection1713,PgSelect2139,First2141,PgSelectSingle2142,Connection2543,PgPageInfo2946,PgSelect2969,First2971,PgSelectSingle2972,Connection3177,PgPageInfo3572,Constant3594,Lambda3596,Constant3597,Lambda3599,Access3600,Constant3601,Constant3602,Constant3603,Object3604,Lambda3605,Lambda3610,Constant3618,Constant3619,Object3621,Lambda3622,Lambda3627,Constant3635,Constant3636,Constant3637,Object3638,Lambda3639,Lambda3644,Constant3652,Constant3653,Object3655,Lambda3656,Lambda3661,Constant3669,Constant3670,Object3672,Lambda3673,Lambda3678,Constant3686,Constant3687,Constant3688,Object3689,Lambda3690,Lambda3695,Constant3703,Constant3704,Object3706,Lambda3707,Lambda3712,Constant3720,Constant3721,Object3723,Lambda3724,Lambda3729,Constant3737,Constant3738,Object3740,Lambda3741,Lambda3746,Constant3754,Constant3755,Object3757,Lambda3758,Lambda3763,Constant3771,Constant3772,Constant3773,Object3774,Lambda3775,Lambda3780,Constant3786,Constant3787,Object3789,Lambda3790,Lambda3795,Constant3803,Constant3804,Object3806,Lambda3807,Lambda3812,Constant3820,Constant3821,Object3823,Lambda3824,Lambda3829,Constant3837,Constant3838,Object3840,Lambda3841,Lambda3846,Constant3854,Constant3855,Object3857,Lambda3858,Lambda3863,Constant3871,Constant3872,Object3874,Lambda3875,Lambda3880,Constant3888,Constant3889,Object3891,Lambda3892,Lambda3897,Constant3905,Constant3906,Object3908,Lambda3909,Lambda3914,Constant3922,Constant3923,Object3925,Lambda3926,Lambda3931,Constant3939,Constant3940,Object3942,Lambda3943,Lambda3948,Constant3956,Constant3957,Object3959,Lambda3960,Lambda3965,Constant3973,Constant3974,Object3976,Lambda3977,Lambda3982,Constant3990,Constant3991,Object3993,Lambda3994,Lambda3999,Constant4007,Constant4008,Object4010,Lambda4011,Lambda4016,Constant4024,Constant4025,Object4027,Lambda4028,Lambda4033,Constant4041,Constant4042,Object4044,Lambda4045,Lambda4050,Constant4058,Constant4059,Object4061,Lambda4062,Lambda4067,Constant4075,Constant4076,Object4078,Lambda4079,Lambda4084,Constant4092,Constant4093,Object4095,Lambda4096,Lambda4101,Constant4109,Constant4110,Object4112,Lambda4113,Lambda4118,Constant4123,Lambda4125,Access4126,Constant4127,Object4130,Lambda4131,Lambda4136,Constant4142,Object4145,Lambda4146,Lambda4151,Constant4157,Constant4158,Object4160,Lambda4161,Lambda4166,Constant4174,Constant4175,Object4177,Lambda4178,Lambda4183,Constant4191,Constant4192,Object4194,Lambda4195,Lambda4200,Constant4208,Constant4209,Object4211,Lambda4212,Lambda4217,Constant4225,Constant4226,Object4228,Lambda4229,Lambda4234,Constant4242,Constant4243,Object4245,Lambda4246,Lambda4251,Constant4259,Constant4260,Object4262,Lambda4263,Lambda4268,Constant4276,Constant4277,Object4279,Lambda4280,Lambda4285,Constant4293,Constant4294,Object4296,Lambda4297,Lambda4302,Constant4310,Constant4311,Object4313,Lambda4314,Lambda4319,Constant4327,Constant4328,Object4330,Lambda4331,Lambda4336,Constant4342,Constant4343,Object4345,Lambda4346,Lambda4351,Constant4359,Constant4360,Object4362,Lambda4363,Lambda4368,Constant4376,Constant4377,Object4379,Lambda4380,Lambda4385,Constant4393,Constant4394,Object4396,Lambda4397,Lambda4402,Constant4410,Constant4411,Object4413,Lambda4414,Lambda4419,Constant4427,Constant4428,Object4430,Lambda4431,Lambda4436,Constant4444,Constant4445,Object4447,Lambda4448,Lambda4453,Constant4461,Constant4462,Object4464,Lambda4465,Lambda4470,Constant4478,Constant4479,Object4481,Lambda4482,Lambda4487,Constant4495,Constant4496,Object4498,Lambda4499,Lambda4504,Constant4512,Constant4513,Object4515,Lambda4516,Lambda4521,Constant4527,Constant4528,Constant4529,Object4530,Lambda4531,Lambda4536,Constant4542,Constant4543,Constant4544,Object4545,Lambda4546,Lambda4551,Constant4557,Constant4558,Constant4559,Object4560,Lambda4561,Lambda4566,Constant4572,Constant4573,Constant4574,Object4575,Lambda4576,Lambda4581,Constant4587,Constant4588,Constant4589,Object4590,Lambda4591,Lambda4596,Constant4602,Constant4603,Constant4604,Object4605,Lambda4606,Lambda4611,Constant4617,Constant4618,Constant4619,Object4620,Lambda4621,Lambda4626,Constant4632,Constant4633,Constant4634,Object4635,Lambda4636,Lambda4641,Constant4647,Constant4648,Object4650,Lambda4651,Lambda4656,Constant4662,Constant4663,Object4665,Lambda4666,Lambda4671,Constant4679,Constant4680,Object4682,Lambda4683,Lambda4688,Constant4696,Constant4697,Object4699,Lambda4700,Lambda4705,Constant4713,Constant4714,Object4716,Lambda4717,Lambda4722,Constant4730,Constant4731,Object4733,Lambda4734,Lambda4739,Constant4747,Constant4748,Object4750,Lambda4751,Lambda4756,Constant4764,Constant4765,Object4767,Lambda4768,Lambda4773,Constant4781,Constant4782,Object4784,Lambda4785,Lambda4790,Constant4798,Constant4799,Object4801,Lambda4802,Lambda4807,Constant4815,Constant4816,Object4818,Lambda4819,Lambda4824,Constant4832,Constant4833,Object4835,Lambda4836,Lambda4841,Constant4847,Constant4848,Constant4849,Object4850,Lambda4851,Lambda4856,Constant4862,Constant4863,Constant4864,Object4865,Lambda4866,Lambda4871,Constant4877,Constant4878,Constant4879,Object4880,Lambda4881,Lambda4886,Constant4892,Constant4893,Constant4894,Object4895,Lambda4896,Lambda4901,Constant4907,Constant4908,Constant4909,Object4910,Lambda4911,Lambda4916,Constant4922,Constant4923,Constant4924,Object4925,Lambda4926,Lambda4931,Constant4937,Constant4938,Constant4939,Object4940,Lambda4941,Lambda4946,Constant4952,Constant4953,Constant4954,Object4955,Lambda4956,Lambda4961,Constant4967,Constant4968,Constant4969,Object4970,Lambda4971,Lambda4976,Constant4982,Constant4983,Object4985,Lambda4986,Lambda4991,Constant4999,Constant5000,Object5002,Lambda5003,Lambda5008,Constant5016,Constant5017,Object5019,Lambda5020,Lambda5025,Constant5033,Constant5034,Object5036,Lambda5037,Lambda5042,Constant5050,Constant5051,Object5053,Lambda5054,Lambda5059,Constant5067,Constant5068,Object5070,Lambda5071,Lambda5076,Constant5084,Constant5085,Object5087,Lambda5088,Lambda5093,Constant5101,Constant5102,Object5104,Lambda5105,Lambda5110,Constant5118,Constant5119,Object5121,Lambda5122,Lambda5127,Constant5135,Constant5136,Object5138,Lambda5139,Lambda5144,Constant5152,Constant5153,Object5155,Lambda5156,Lambda5161,Constant5167,Constant5168,Object5170,Lambda5171,Lambda5176,Constant5184,Constant5185,Object5187,Lambda5188,Lambda5193,Constant5201,Constant5202,Object5204,Lambda5205,Lambda5210,Constant5218,Constant5219,Object5221,Lambda5222,Lambda5227,Constant5235,Constant5236,Object5238,Lambda5239,Lambda5244,Constant5252,Constant5253,Object5255,Lambda5256,Lambda5261,Constant5269,Constant5270,Object5272,Lambda5273,Lambda5278,Constant5286,Constant5287,Object5289,Lambda5290,Lambda5295,Constant5303,Constant5304,Object5306,Lambda5307,Lambda5312,Constant5320,Constant5321,Object5323,Lambda5324,Lambda5329,Constant5337,Constant5338,Object5340,Lambda5341,Lambda5346,Constant5352,Constant5353,Object5355,Lambda5356,Lambda5361,Constant5367,Constant5368,Object5370,Lambda5371,Lambda5376,Constant5382,Constant5383,Object5385,Lambda5386,Lambda5391,Constant5399,Constant5400,Object5402,Lambda5403,Lambda5408,Constant5416,Constant5417,Object5419,Lambda5420,Lambda5425,Constant5433,Constant5434,Object5436,Lambda5437,Lambda5442,Constant5450,Constant5451,Object5453,Lambda5454,Lambda5459,Constant5467,Constant5468,Object5470,Lambda5471,Lambda5476,Constant5484,Constant5485,Object5487,Lambda5488,Lambda5493,Constant5501,Constant5502,Object5504,Lambda5505,Lambda5510,Constant5519,Constant5520,Object5522,Lambda5523,Lambda5528,Constant5534,Constant5535,Object5537,Lambda5538,Lambda5543,Constant5549,Constant5550,Object5552,Lambda5553,Lambda5558,Constant5566,Constant5567,Object5569,Lambda5570,Lambda5575,Constant5583,Constant5584,Object5586,Lambda5587,Lambda5592,Constant5600,Constant5601,Object5603,Lambda5604,Lambda5609,Constant5617,Constant5618,Object5620,Lambda5621,Lambda5626,Constant5634,Constant5635,Object5637,Lambda5638,Lambda5643,Constant5651,Constant5652,Object5654,Lambda5655,Lambda5660,Constant5668,Constant5669,Object5671,Lambda5672,Lambda5677,Constant5685,Constant5686,Object5688,Lambda5689,Lambda5694,Constant5700,Object5703,Lambda5704,Lambda5709,Constant5715,Constant5716,Object5718,Lambda5719,Lambda5724,Constant5732,Constant5733,Object5735,Lambda5736,Lambda5741,Constant5749,Constant5750,Object5752,Lambda5753,Lambda5758,Constant5766,Constant5767,Object5769,Lambda5770,Lambda5775,Constant5783,Constant5784,Object5786,Lambda5787,Lambda5792,Constant5800,Constant5801,Object5803,Lambda5804,Lambda5809,Constant5817,Constant5818,Object5820,Lambda5821,Lambda5826,Constant5834,Constant5835,Object5837,Lambda5838,Lambda5843,Constant5851,Constant5852,Object5854,Lambda5855,Lambda5860,Constant5868,Constant5869,Object5871,Lambda5872,Lambda5877,Constant5885,Constant5886,Object5888,Lambda5889,Lambda5894,Constant5902,Constant5903,Object5905,Lambda5906,Lambda5911,Constant5919,Constant5920,Object5922,Lambda5923,Lambda5928,Constant5936,Constant5937,Object5939,Lambda5940,Lambda5945,Constant5953,Constant5954,Object5956,Lambda5957,Lambda5962,Constant5970,Constant5971,Object5973,Lambda5974,Lambda5979,Constant5987,Constant5988,Object5990,Lambda5991,Lambda5996,Constant6004,Constant6005,Object6007,Lambda6008,Lambda6013,Constant6021,Constant6022,Object6024,Lambda6025,Lambda6030,Constant6038,Constant6039,Object6041,Lambda6042,Lambda6047,Constant6055,Constant6056,Object6058,Lambda6059,Lambda6064,Constant6072,Constant6073,Object6075,Lambda6076,Lambda6081,Constant6092,Constant6093,Object6095,Lambda6096,Lambda6101,Constant6107,Constant6108,Object6110,Lambda6111,Lambda6116,Constant6122,Constant6123,Object6125,Lambda6126,Lambda6131,Constant6139,Constant6140,Object6142,Lambda6143,Lambda6148,Constant6156,Constant6157,Object6159,Lambda6160,Lambda6165,Constant6173,Constant6174,Object6176,Lambda6177,Lambda6182,Constant6190,Constant6191,Object6193,Lambda6194,Lambda6199,Constant6207,Constant6208,Object6210,Lambda6211,Lambda6216,Constant6224,Constant6225,Object6227,Lambda6228,Lambda6233,Constant6241,Constant6242,Object6244,Lambda6245,Lambda6250,Constant6259,Constant6260,Object6262,Lambda6263,Lambda6268,Constant6274,Constant6275,Object6277,Lambda6278,Lambda6283,Constant6289,Constant6290,Object6292,Lambda6293,Lambda6298,Constant6306,Constant6307,Object6309,Lambda6310,Lambda6315,Constant6323,Constant6324,Object6326,Lambda6327,Lambda6332,Constant6340,Constant6341,Object6343,Lambda6344,Lambda6349,Constant6357,Constant6358,Object6360,Lambda6361,Lambda6366,Constant6374,Constant6375,Object6377,Lambda6378,Lambda6383,Constant6391,Constant6392,Object6394,Lambda6395,Lambda6400,Constant6408,Constant6409,Object6411,Lambda6412,Lambda6417,Constant6425,Constant6426,Object6428,Lambda6429,Lambda6434,Constant6444,Object6447,Lambda6448,Lambda6453,Constant6462,Constant6463,Object6465,Lambda6466,Lambda6471,Constant6477,Constant6478,Object6480,Lambda6481,Lambda6486,Constant6494,Constant6495,Object6497,Lambda6498,Lambda6503,Constant6511,Constant6512,Object6514,Lambda6515,Lambda6520,Constant6528,Constant6529,Object6531,Lambda6532,Lambda6537,Constant6545,Constant6546,Object6548,Lambda6549,Lambda6554,Constant6562,Constant6563,Object6565,Lambda6566,Lambda6571,Constant6579,Constant6580,Object6582,Lambda6583,Lambda6588,Constant6596,Constant6597,Object6599,Lambda6600,Lambda6605,Constant6613,Constant6614,Object6616,Lambda6617,Lambda6622,Constant6630,Constant6631,Object6633,Lambda6634,Lambda6639,Constant6647,Constant6648,Object6650,Lambda6651,Lambda6656,Constant6664,Constant6665,Object6667,Lambda6668,Lambda6673,Constant6681,Constant6682,Object6684,Lambda6685,Lambda6690,Constant6698,Constant6699,Object6701,Lambda6702,Lambda6707,Constant6715,Constant6716,Object6718,Lambda6719,Lambda6724,Constant6732,Constant6733,Object6735,Lambda6736,Lambda6741,Constant6749,Constant6750,Object6752,Lambda6753,Lambda6758,Constant6766,Constant6767,Object6769,Lambda6770,Lambda6775,Constant6783,Constant6784,Object6786,Lambda6787,Lambda6792,Constant6800,Constant6801,Object6803,Lambda6804,Lambda6809,Constant6817,Constant6818,Object6820,Lambda6821,Lambda6826,Constant6834,Constant6835,Object6837,Lambda6838,Lambda6843,Constant6851,Constant6852,Object6854,Lambda6855,Lambda6860,Constant6868,Constant6869,Object6871,Lambda6872,Lambda6877,Constant6885,Constant6886,Object6888,Lambda6889,Lambda6894,Constant6902,Constant6903,Object6905,Lambda6906,Lambda6911,Constant6919,Constant6920,Object6922,Lambda6923,Lambda6928,Constant6936,Constant6937,Object6939,Lambda6940,Lambda6945,Constant6953,Constant6954,Object6956,Lambda6957,Lambda6962,Constant6970,Constant6971,Object6973,Lambda6974,Lambda6979,Constant6987,Constant6988,Object6990,Lambda6991,Lambda6996,Constant7004,Constant7005,Object7007,Lambda7008,Lambda7013,Constant7024,Object7027,Lambda7028,Lambda7033,Constant7043,Constant7044,Object7046,Lambda7047,Lambda7052,Constant7053,Constant7054,Constant7057,Constant7058,Constant7059,Constant7060,Constant7061,Constant7062,Constant7063,Constant7064,Constant7065,Constant7066,Constant7067,Constant7068,Constant7069,Constant7070,Constant7071,Constant7072,Constant7073,Constant7074,Constant7075,Constant7076,Constant7077,Constant7078,Constant7079,Constant7080,Constant7081,Constant7082,Constant7083,Constant7084,Constant7085,Constant7086,Constant7087,Constant7088,Constant7089,Constant7090,Constant7091,Constant7092,Constant7093,Constant7094,Constant7095,Constant7096,Constant7097,Constant7098,Constant7099,Constant7100,Constant7101,Constant7102,Constant7103,Constant7104,Constant7105,Constant7106,Constant7107,Constant7108,Constant7109,Constant7110,Constant7111,Constant7112,Constant7113,Constant7114,Constant7115,Constant7116,Constant7117,Constant7118,Constant7119,Constant7120,Constant7121,Constant7122,Constant7123,Constant7124,Constant7125,Constant7126,Constant7127,Constant7128,Constant7129,Constant7130,Constant7131,Constant7132,Constant7133,Constant7134,Constant7135,Constant7136,Constant7137,Constant7138,Constant7139,Constant7140,Constant7141,Constant7142,Constant7143,Constant7144,Constant7145,Constant7146,Constant7147,Constant7148,Constant7149,Constant7150,Constant7151,Constant7152,Constant7153,Constant7154,Constant7155,Constant7156,Constant7157,Constant7158,Constant7159,Constant7160,Constant7161,Constant7162,Constant7163,Constant7164,Constant7165,Constant7166,Constant7167,Constant7168,Constant7169,Constant7170,Constant7171,Constant7172,Constant7173,Constant7174,Constant7175,Constant7176,Constant7177,Constant7178,Constant7179,Constant7180,Constant7181,Constant7182,Constant7183,Constant7184,Constant7185,Constant7186,Constant7187,Constant7188,Constant7189,Constant7190,Constant7191,Constant7192,Constant7193,Constant7194,Constant7195,Constant7196,Constant7197,Constant7198,Constant7199,Constant7200,Constant7201,Constant7202,Constant7203,Constant7204,Constant7205,Constant7206,Constant7207,Constant7208,Constant7209,Constant7210,Constant7211,Constant7212,Constant7213,Constant7214,Constant7215,Constant7216,Constant7217,Constant7218,Constant7219,Constant7220,Constant7221,Constant7222,Constant7223,Constant7224,Constant7225,Constant7226,Constant7227,Constant7228,Constant7229,Constant7230,Constant7231,Constant7232,Constant7233,Constant7234,Constant7235,Constant7236,Constant7237,Constant7238,Constant7239,Constant7240,Constant7241,Constant7242,Constant7243,Constant7244,Constant7245,Constant7246,Constant7247,Constant7248,Constant7249,Constant7250,Constant7251,Constant7252,Constant7253,Constant7254,Constant7255,Constant7256,Constant7257,Constant7258,Constant7259,Constant7260,Constant7261,Constant7262,Constant7263,Constant7264,Constant7265,Constant7266,Constant7267 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 3600, 3790, 3795, 3807, 3812, 3824, 3829, 3841, 3846, 3858, 3863, 3875, 3880, 3892, 3897, 3909, 3914, 3926, 3931, 3943, 3948, 3960, 3965, 3977, 3982, 3994, 3999, 4011, 4016, 4028, 4033, 4045, 4050, 4062, 4067, 4079, 4084, 4096, 4101, 4113, 4118, 3596, 4126, 4131, 4136, 4146, 4151, 6<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,PgSelect403,First404,PgSelectSingle405,PgClassExpression406,PgPageInfo408,Access411,Object412,Lambda413,Object416,Lambda417,First419,PgSelectSingle420,PgCursor421,PgClassExpression422,List423,Last425,PgSelectSingle426,PgCursor427,PgClassExpression428,List429,Object3777,Lambda3778,Lambda3783,Object3793,Lambda3794,Lambda3799,Object3809,Lambda3810,Lambda3815,Object3825,Lambda3826,Lambda3831,Object3841,Lambda3842,Lambda3847,Object3857,Lambda3858,Lambda3863,Object3873,Lambda3874,Lambda3879,Object3889,Lambda3890,Lambda3895,Object3905,Lambda3906,Lambda3911,Object3921,Lambda3922,Lambda3927,Object3937,Lambda3938,Lambda3943,Object3953,Lambda3954,Lambda3959,Object3969,Lambda3970,Lambda3975,Object3985,Lambda3986,Lambda3991,Object4001,Lambda4002,Lambda4007,Object4017,Lambda4018,Lambda4023,Object4033,Lambda4034,Lambda4039,Object4049,Lambda4050,Lambda4055,Object4065,Lambda4066,Lambda4071,Object4081,Lambda4082,Lambda4087,Object4098,Lambda4099,Lambda4104,Object4112,Lambda4113,Lambda4118 bucket1
+    class Bucket1,PgSelect14,PgSelect403,First404,PgSelectSingle405,PgClassExpression406,PgPageInfo408,Access411,Object412,Lambda413,Object416,Lambda417,First419,PgSelectSingle420,PgCursor421,PgClassExpression422,List423,Last425,PgSelectSingle426,PgCursor427,PgClassExpression428,List429 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸtypesᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression27,PgClassExpression28,PgClassExpression29,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression40,Access41,Access44,PgClassExpression47,Access48,Access51,PgClassExpression54,Access55,Access58,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgClassExpression66,PgClassExpression73,PgClassExpression81,PgSelectSingle88,PgClassExpression89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,PgClassExpression95,PgSelectSingle100,PgSelectSingle105,PgSelectSingle117,PgClassExpression125,PgSelectSingle130,PgSelectSingle142,PgClassExpression170,PgClassExpression173,PgClassExpression176,PgClassExpression177,PgClassExpression178,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression186,PgClassExpression187,PgClassExpression189,PgClassExpression191,PgClassExpression192,PgSelectSingle197,PgSelectSingle203,PgClassExpression206,PgClassExpression207,RemapKeys3800,RemapKeys3816,RemapKeys3848,RemapKeys3864,RemapKeys3880,RemapKeys3928 bucket3
+    class Bucket3,PgClassExpression17,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression27,PgClassExpression28,PgClassExpression29,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression40,Access41,Access44,PgClassExpression47,Access48,Access51,PgClassExpression54,Access55,Access58,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgClassExpression66,PgClassExpression73,PgClassExpression81,PgSelectSingle88,PgClassExpression89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,PgClassExpression95,PgSelectSingle100,PgSelectSingle105,PgSelectSingle117,PgClassExpression125,PgSelectSingle130,PgSelectSingle142,PgClassExpression170,PgClassExpression173,PgClassExpression176,PgClassExpression177,PgClassExpression178,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression186,PgClassExpression187,PgClassExpression189,PgClassExpression191,PgClassExpression192,PgSelectSingle197,PgSelectSingle203,PgClassExpression206,PgClassExpression207,RemapKeys3813,RemapKeys3830,RemapKeys3864,RemapKeys3881,RemapKeys3898,RemapKeys3949 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ25ᐳ[26]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item26 bucket4
@@ -6691,7 +6695,7 @@ graph TD
     class Bucket19,PgClassExpression131,PgClassExpression132,PgClassExpression133,PgClassExpression134,PgClassExpression135,PgClassExpression136,PgClassExpression137 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 142<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_nestedCompoundTypeᐳ[142]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgSelectSingle149,PgSelectSingle161,PgClassExpression169,RemapKeys3912 bucket20
+    class Bucket20,PgSelectSingle149,PgSelectSingle161,PgClassExpression169,RemapKeys3932 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 149<br /><br />ROOT PgSelectSingle{20}ᐸfrmcdc_compoundTypeᐳ[149]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156 bucket21
@@ -6721,7 +6725,7 @@ graph TD
     class Bucket29,__Item208 bucket29
     Bucket30("Bucket 30 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸtypesᐳ[16]"):::bucket
     classDef bucket30 stroke:#3cb371
-    class Bucket30,PgClassExpression211,PgClassExpression212,PgClassExpression213,PgClassExpression214,PgClassExpression215,PgClassExpression216,PgClassExpression217,PgClassExpression218,PgClassExpression219,PgClassExpression221,PgClassExpression222,PgClassExpression223,PgClassExpression225,PgClassExpression226,PgClassExpression227,PgClassExpression234,Access235,Access238,PgClassExpression241,Access242,Access245,PgClassExpression248,Access249,Access252,PgClassExpression255,PgClassExpression256,PgClassExpression257,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression267,PgClassExpression275,PgSelectSingle282,PgClassExpression283,PgClassExpression284,PgClassExpression285,PgClassExpression286,PgClassExpression287,PgClassExpression288,PgClassExpression289,PgSelectSingle294,PgSelectSingle299,PgSelectSingle311,PgClassExpression319,PgSelectSingle324,PgSelectSingle336,PgClassExpression364,PgClassExpression367,PgClassExpression370,PgClassExpression371,PgClassExpression372,PgClassExpression373,PgClassExpression374,PgClassExpression375,PgClassExpression376,PgClassExpression377,PgClassExpression378,PgClassExpression379,PgClassExpression380,PgClassExpression381,PgClassExpression383,PgClassExpression385,PgClassExpression386,PgSelectSingle391,PgSelectSingle397,PgClassExpression400,PgClassExpression401,RemapKeys3944,RemapKeys3960,RemapKeys3976,RemapKeys4008,RemapKeys4024,RemapKeys4040,RemapKeys4088 bucket30
+    class Bucket30,PgClassExpression211,PgClassExpression212,PgClassExpression213,PgClassExpression214,PgClassExpression215,PgClassExpression216,PgClassExpression217,PgClassExpression218,PgClassExpression219,PgClassExpression221,PgClassExpression222,PgClassExpression223,PgClassExpression225,PgClassExpression226,PgClassExpression227,PgClassExpression234,Access235,Access238,PgClassExpression241,Access242,Access245,PgClassExpression248,Access249,Access252,PgClassExpression255,PgClassExpression256,PgClassExpression257,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression267,PgClassExpression275,PgSelectSingle282,PgClassExpression283,PgClassExpression284,PgClassExpression285,PgClassExpression286,PgClassExpression287,PgClassExpression288,PgClassExpression289,PgSelectSingle294,PgSelectSingle299,PgSelectSingle311,PgClassExpression319,PgSelectSingle324,PgSelectSingle336,PgClassExpression364,PgClassExpression367,PgClassExpression370,PgClassExpression371,PgClassExpression372,PgClassExpression373,PgClassExpression374,PgClassExpression375,PgClassExpression376,PgClassExpression377,PgClassExpression378,PgClassExpression379,PgClassExpression380,PgClassExpression381,PgClassExpression383,PgClassExpression385,PgClassExpression386,PgSelectSingle391,PgSelectSingle397,PgClassExpression400,PgClassExpression401,RemapKeys3966,RemapKeys3983,RemapKeys4000,RemapKeys4034,RemapKeys4051,RemapKeys4068,RemapKeys4119 bucket30
     Bucket31("Bucket 31 (listItem)<br /><br />ROOT __Item{31}ᐸ219ᐳ[220]"):::bucket
     classDef bucket31 stroke:#a52a2a
     class Bucket31,__Item220 bucket31
@@ -6772,7 +6776,7 @@ graph TD
     class Bucket46,PgClassExpression325,PgClassExpression326,PgClassExpression327,PgClassExpression328,PgClassExpression329,PgClassExpression330,PgClassExpression331 bucket46
     Bucket47("Bucket 47 (nullableBoundary)<br />Deps: 336<br /><br />ROOT PgSelectSingle{30}ᐸfrmcdc_nestedCompoundTypeᐳ[336]"):::bucket
     classDef bucket47 stroke:#3cb371
-    class Bucket47,PgSelectSingle343,PgSelectSingle355,PgClassExpression363,RemapKeys4072 bucket47
+    class Bucket47,PgSelectSingle343,PgSelectSingle355,PgClassExpression363,RemapKeys4102 bucket47
     Bucket48("Bucket 48 (nullableBoundary)<br />Deps: 343<br /><br />ROOT PgSelectSingle{47}ᐸfrmcdc_compoundTypeᐳ[343]"):::bucket
     classDef bucket48 stroke:#a52a2a
     class Bucket48,PgClassExpression344,PgClassExpression345,PgClassExpression346,PgClassExpression347,PgClassExpression348,PgClassExpression349,PgClassExpression350 bucket48
@@ -6802,7 +6806,7 @@ graph TD
     class Bucket56,__Item402 bucket56
     Bucket57("Bucket 57 (listItem)<br /><br />ROOT __Item{57}ᐸ9ᐳ[432]"):::bucket
     classDef bucket57 stroke:#ff1493
-    class Bucket57,__Item432,PgSelectSingle433,PgClassExpression434,PgClassExpression435,PgClassExpression436,PgClassExpression437,PgClassExpression438,PgClassExpression439,PgClassExpression440,PgClassExpression441,PgClassExpression442,PgClassExpression444,PgClassExpression445,PgClassExpression446,PgClassExpression448,PgClassExpression449,PgClassExpression450,PgClassExpression457,Access458,Access461,PgClassExpression464,Access465,Access468,PgClassExpression471,Access472,Access475,PgClassExpression478,PgClassExpression479,PgClassExpression480,PgClassExpression481,PgClassExpression482,PgClassExpression483,PgClassExpression490,PgClassExpression498,PgSelectSingle505,PgClassExpression506,PgClassExpression507,PgClassExpression508,PgClassExpression509,PgClassExpression510,PgClassExpression511,PgClassExpression512,PgSelectSingle517,PgSelectSingle522,PgSelectSingle534,PgClassExpression542,PgSelectSingle547,PgSelectSingle559,PgClassExpression587,PgClassExpression590,PgClassExpression593,PgClassExpression594,PgClassExpression595,PgClassExpression596,PgClassExpression597,PgClassExpression598,PgClassExpression599,PgClassExpression600,PgClassExpression601,PgClassExpression602,PgClassExpression603,PgClassExpression604,PgClassExpression606,PgClassExpression608,PgClassExpression609,PgSelectSingle614,PgSelectSingle620,PgClassExpression623,PgClassExpression624,RemapKeys3626,RemapKeys3642,RemapKeys3674,RemapKeys3690,RemapKeys3706,RemapKeys3754 bucket57
+    class Bucket57,__Item432,PgSelectSingle433,PgClassExpression434,PgClassExpression435,PgClassExpression436,PgClassExpression437,PgClassExpression438,PgClassExpression439,PgClassExpression440,PgClassExpression441,PgClassExpression442,PgClassExpression444,PgClassExpression445,PgClassExpression446,PgClassExpression448,PgClassExpression449,PgClassExpression450,PgClassExpression457,Access458,Access461,PgClassExpression464,Access465,Access468,PgClassExpression471,Access472,Access475,PgClassExpression478,PgClassExpression479,PgClassExpression480,PgClassExpression481,PgClassExpression482,PgClassExpression483,PgClassExpression490,PgClassExpression498,PgSelectSingle505,PgClassExpression506,PgClassExpression507,PgClassExpression508,PgClassExpression509,PgClassExpression510,PgClassExpression511,PgClassExpression512,PgSelectSingle517,PgSelectSingle522,PgSelectSingle534,PgClassExpression542,PgSelectSingle547,PgSelectSingle559,PgClassExpression587,PgClassExpression590,PgClassExpression593,PgClassExpression594,PgClassExpression595,PgClassExpression596,PgClassExpression597,PgClassExpression598,PgClassExpression599,PgClassExpression600,PgClassExpression601,PgClassExpression602,PgClassExpression603,PgClassExpression604,PgClassExpression606,PgClassExpression608,PgClassExpression609,PgSelectSingle614,PgSelectSingle620,PgClassExpression623,PgClassExpression624,RemapKeys3628,RemapKeys3645,RemapKeys3679,RemapKeys3696,RemapKeys3713,RemapKeys3764 bucket57
     Bucket58("Bucket 58 (listItem)<br /><br />ROOT __Item{58}ᐸ442ᐳ[443]"):::bucket
     classDef bucket58 stroke:#808000
     class Bucket58,__Item443 bucket58
@@ -6853,7 +6857,7 @@ graph TD
     class Bucket73,PgClassExpression548,PgClassExpression549,PgClassExpression550,PgClassExpression551,PgClassExpression552,PgClassExpression553,PgClassExpression554 bucket73
     Bucket74("Bucket 74 (nullableBoundary)<br />Deps: 559<br /><br />ROOT PgSelectSingle{57}ᐸfrmcdc_nestedCompoundTypeᐳ[559]"):::bucket
     classDef bucket74 stroke:#ff1493
-    class Bucket74,PgSelectSingle566,PgSelectSingle578,PgClassExpression586,RemapKeys3738 bucket74
+    class Bucket74,PgSelectSingle566,PgSelectSingle578,PgClassExpression586,RemapKeys3747 bucket74
     Bucket75("Bucket 75 (nullableBoundary)<br />Deps: 566<br /><br />ROOT PgSelectSingle{74}ᐸfrmcdc_compoundTypeᐳ[566]"):::bucket
     classDef bucket75 stroke:#808000
     class Bucket75,PgClassExpression567,PgClassExpression568,PgClassExpression569,PgClassExpression570,PgClassExpression571,PgClassExpression572,PgClassExpression573 bucket75
@@ -6883,7 +6887,7 @@ graph TD
     class Bucket83,__Item625 bucket83
     Bucket84("Bucket 84 (nullableBoundary)<br />Deps: 630<br /><br />ROOT PgSelectSingleᐸtypesᐳ[630]"):::bucket
     classDef bucket84 stroke:#f5deb3
-    class Bucket84,PgClassExpression631,PgClassExpression632,PgClassExpression633,PgClassExpression634,PgClassExpression635,PgClassExpression636,PgClassExpression637,PgClassExpression638,PgClassExpression639,PgClassExpression641,PgClassExpression642,PgClassExpression643,PgClassExpression645,PgClassExpression646,PgClassExpression647,PgClassExpression654,Access655,Access658,PgClassExpression661,Access662,Access665,PgClassExpression668,Access669,Access672,PgClassExpression675,PgClassExpression676,PgClassExpression677,PgClassExpression678,PgClassExpression679,PgClassExpression680,PgClassExpression687,PgClassExpression695,PgSelectSingle702,PgClassExpression703,PgClassExpression704,PgClassExpression705,PgClassExpression706,PgClassExpression707,PgClassExpression708,PgClassExpression709,PgSelectSingle714,PgSelectSingle719,PgSelectSingle731,PgClassExpression739,PgSelectSingle744,PgSelectSingle756,PgClassExpression784,PgClassExpression787,PgClassExpression790,PgClassExpression791,PgClassExpression792,PgClassExpression793,PgClassExpression794,PgClassExpression795,PgClassExpression796,PgClassExpression797,PgClassExpression798,PgClassExpression799,PgClassExpression800,PgClassExpression801,PgClassExpression803,PgClassExpression805,PgClassExpression806,PgSelectSingle811,PgSelectSingle817,PgClassExpression820,PgClassExpression821,RemapKeys4149,RemapKeys4165,RemapKeys4197,RemapKeys4213,RemapKeys4229,RemapKeys4277 bucket84
+    class Bucket84,PgClassExpression631,PgClassExpression632,PgClassExpression633,PgClassExpression634,PgClassExpression635,PgClassExpression636,PgClassExpression637,PgClassExpression638,PgClassExpression639,PgClassExpression641,PgClassExpression642,PgClassExpression643,PgClassExpression645,PgClassExpression646,PgClassExpression647,PgClassExpression654,Access655,Access658,PgClassExpression661,Access662,Access665,PgClassExpression668,Access669,Access672,PgClassExpression675,PgClassExpression676,PgClassExpression677,PgClassExpression678,PgClassExpression679,PgClassExpression680,PgClassExpression687,PgClassExpression695,PgSelectSingle702,PgClassExpression703,PgClassExpression704,PgClassExpression705,PgClassExpression706,PgClassExpression707,PgClassExpression708,PgClassExpression709,PgSelectSingle714,PgSelectSingle719,PgSelectSingle731,PgClassExpression739,PgSelectSingle744,PgSelectSingle756,PgClassExpression784,PgClassExpression787,PgClassExpression790,PgClassExpression791,PgClassExpression792,PgClassExpression793,PgClassExpression794,PgClassExpression795,PgClassExpression796,PgClassExpression797,PgClassExpression798,PgClassExpression799,PgClassExpression800,PgClassExpression801,PgClassExpression803,PgClassExpression805,PgClassExpression806,PgSelectSingle811,PgSelectSingle817,PgClassExpression820,PgClassExpression821,RemapKeys4184,RemapKeys4201,RemapKeys4235,RemapKeys4252,RemapKeys4269,RemapKeys4320 bucket84
     Bucket85("Bucket 85 (listItem)<br /><br />ROOT __Item{85}ᐸ639ᐳ[640]"):::bucket
     classDef bucket85 stroke:#696969
     class Bucket85,__Item640 bucket85
@@ -6934,7 +6938,7 @@ graph TD
     class Bucket100,PgClassExpression745,PgClassExpression746,PgClassExpression747,PgClassExpression748,PgClassExpression749,PgClassExpression750,PgClassExpression751 bucket100
     Bucket101("Bucket 101 (nullableBoundary)<br />Deps: 756<br /><br />ROOT PgSelectSingle{84}ᐸfrmcdc_nestedCompoundTypeᐳ[756]"):::bucket
     classDef bucket101 stroke:#f5deb3
-    class Bucket101,PgSelectSingle763,PgSelectSingle775,PgClassExpression783,RemapKeys4261 bucket101
+    class Bucket101,PgSelectSingle763,PgSelectSingle775,PgClassExpression783,RemapKeys4303 bucket101
     Bucket102("Bucket 102 (nullableBoundary)<br />Deps: 763<br /><br />ROOT PgSelectSingle{101}ᐸfrmcdc_compoundTypeᐳ[763]"):::bucket
     classDef bucket102 stroke:#696969
     class Bucket102,PgClassExpression764,PgClassExpression765,PgClassExpression766,PgClassExpression767,PgClassExpression768,PgClassExpression769,PgClassExpression770 bucket102
@@ -6964,7 +6968,7 @@ graph TD
     class Bucket110,__Item822 bucket110
     Bucket111("Bucket 111 (nullableBoundary)<br />Deps: 830<br /><br />ROOT PgSelectSingleᐸtypesᐳ[830]"):::bucket
     classDef bucket111 stroke:#ff0000
-    class Bucket111,PgClassExpression831,PgClassExpression832,PgClassExpression833,PgClassExpression834,PgClassExpression835,PgClassExpression836,PgClassExpression837,PgClassExpression838,PgClassExpression839,PgClassExpression841,PgClassExpression842,PgClassExpression843,PgClassExpression845,PgClassExpression846,PgClassExpression847,PgClassExpression854,Access855,Access858,PgClassExpression861,Access862,Access865,PgClassExpression868,Access869,Access872,PgClassExpression875,PgClassExpression876,PgClassExpression877,PgClassExpression878,PgClassExpression879,PgClassExpression880,PgClassExpression887,PgClassExpression895,PgSelectSingle902,PgClassExpression903,PgClassExpression904,PgClassExpression905,PgClassExpression906,PgClassExpression907,PgClassExpression908,PgClassExpression909,PgSelectSingle914,PgSelectSingle919,PgSelectSingle931,PgClassExpression939,PgSelectSingle944,PgSelectSingle956,PgClassExpression984,PgClassExpression987,PgClassExpression990,PgClassExpression991,PgClassExpression992,PgClassExpression993,PgClassExpression994,PgClassExpression995,PgClassExpression996,PgClassExpression997,PgClassExpression998,PgClassExpression999,PgClassExpression1000,PgClassExpression1001,PgClassExpression1003,PgClassExpression1005,PgClassExpression1006,PgSelectSingle1011,PgSelectSingle1017,PgClassExpression1020,PgClassExpression1021,RemapKeys4323,RemapKeys4339,RemapKeys4371,RemapKeys4387,RemapKeys4403,RemapKeys4451 bucket111
+    class Bucket111,PgClassExpression831,PgClassExpression832,PgClassExpression833,PgClassExpression834,PgClassExpression835,PgClassExpression836,PgClassExpression837,PgClassExpression838,PgClassExpression839,PgClassExpression841,PgClassExpression842,PgClassExpression843,PgClassExpression845,PgClassExpression846,PgClassExpression847,PgClassExpression854,Access855,Access858,PgClassExpression861,Access862,Access865,PgClassExpression868,Access869,Access872,PgClassExpression875,PgClassExpression876,PgClassExpression877,PgClassExpression878,PgClassExpression879,PgClassExpression880,PgClassExpression887,PgClassExpression895,PgSelectSingle902,PgClassExpression903,PgClassExpression904,PgClassExpression905,PgClassExpression906,PgClassExpression907,PgClassExpression908,PgClassExpression909,PgSelectSingle914,PgSelectSingle919,PgSelectSingle931,PgClassExpression939,PgSelectSingle944,PgSelectSingle956,PgClassExpression984,PgClassExpression987,PgClassExpression990,PgClassExpression991,PgClassExpression992,PgClassExpression993,PgClassExpression994,PgClassExpression995,PgClassExpression996,PgClassExpression997,PgClassExpression998,PgClassExpression999,PgClassExpression1000,PgClassExpression1001,PgClassExpression1003,PgClassExpression1005,PgClassExpression1006,PgSelectSingle1011,PgSelectSingle1017,PgClassExpression1020,PgClassExpression1021,RemapKeys4369,RemapKeys4386,RemapKeys4420,RemapKeys4437,RemapKeys4454,RemapKeys4505 bucket111
     Bucket112("Bucket 112 (listItem)<br /><br />ROOT __Item{112}ᐸ839ᐳ[840]"):::bucket
     classDef bucket112 stroke:#ffff00
     class Bucket112,__Item840 bucket112
@@ -7015,7 +7019,7 @@ graph TD
     class Bucket127,PgClassExpression945,PgClassExpression946,PgClassExpression947,PgClassExpression948,PgClassExpression949,PgClassExpression950,PgClassExpression951 bucket127
     Bucket128("Bucket 128 (nullableBoundary)<br />Deps: 956<br /><br />ROOT PgSelectSingle{111}ᐸfrmcdc_nestedCompoundTypeᐳ[956]"):::bucket
     classDef bucket128 stroke:#ff0000
-    class Bucket128,PgSelectSingle963,PgSelectSingle975,PgClassExpression983,RemapKeys4435 bucket128
+    class Bucket128,PgSelectSingle963,PgSelectSingle975,PgClassExpression983,RemapKeys4488 bucket128
     Bucket129("Bucket 129 (nullableBoundary)<br />Deps: 963<br /><br />ROOT PgSelectSingle{128}ᐸfrmcdc_compoundTypeᐳ[963]"):::bucket
     classDef bucket129 stroke:#ffff00
     class Bucket129,PgClassExpression964,PgClassExpression965,PgClassExpression966,PgClassExpression967,PgClassExpression968,PgClassExpression969,PgClassExpression970 bucket129
@@ -7043,9 +7047,9 @@ graph TD
     Bucket137("Bucket 137 (listItem)<br /><br />ROOT __Item{137}ᐸ1021ᐳ[1022]"):::bucket
     classDef bucket137 stroke:#00bfff
     class Bucket137,__Item1022 bucket137
-    Bucket138("Bucket 138 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 12, 3596, 3599, 4475, 4480, 4489, 4494, 4503, 4508, 4517, 4522, 4531, 4536, 4545, 4550, 4559, 4564, 4573, 4578, 4587, 4592, 4601, 4606, 4617, 4622, 4633, 4638, 4649, 4654, 4665, 4670, 4681, 4686, 4697, 4702, 4713, 4718, 4729, 4734, 4745, 4750, 4761, 4766, 4775, 4780, 4789, 4794, 4803, 4808, 4817, 4822, 4831, 4836, 4845, 4850, 4859, 4864, 4873, 4878, 4887, 4892, 1025, 1024, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Access[6848], Access[6849]<br />2: 1030, 1037, 1042, 1047, 1052, 1057, 1064, 1069, 1074, 1079, 1274, 1279, 1284, 1289, 1294, 1299, 1304, 1309, 1314<br />ᐳ: 1034, 1035, 1039, 1040, 1044, 1045, 1049, 1050, 1054, 1055, 1059, 1060, 1066, 1067, 1071, 1072, 1076, 1077, 1081, 1082, 1083, 1084, 1085, 1086, 1087, 1088, 1089, 1090, 1091, 1093, 1094, 1095, 1097, 1098, 1099, 1106, 1107, 1110, 1113, 1114, 1117, 1120, 1121, 1124, 1127, 1128, 1129, 1130, 1131, 1132, 1139, 1147, 1234, 1237, 1240, 1241, 1242, 1243, 1244, 1245, 1246, 1247, 1248, 1249, 1250, 1251, 1253, 1255, 1256, 1267, 1270, 1271, 1276, 1277, 1281, 1282, 1286, 1287, 1291, 1292, 1296, 1297, 1301, 1302, 1306, 1307, 1311, 1312, 1316, 1317, 4623, 4639, 4687, 4703, 4751, 1152, 1153, 1154, 1155, 1156, 1157, 1158, 1159, 1164, 1169, 1189, 1194, 1206, 1261, 4671, 1181"):::bucket
+    Bucket138("Bucket 138 (polymorphic)<br />Query,Input,Patch,Reserved,ReservedPatchRecord,ReservedInputRecord,DefaultValue,CompoundKey,Person,Post,Type,PersonSecret,LeftArm,MyTable,ViewTable,SimilarTable1,SimilarTable2,NullTestRecord,Issue756,List<br />Deps: 12, 3596, 3600, 4531, 4536, 4546, 4551, 4561, 4566, 4576, 4581, 4591, 4596, 4606, 4611, 4621, 4626, 4636, 4641, 4651, 4656, 4666, 4671, 4683, 4688, 4700, 4705, 4717, 4722, 4734, 4739, 4751, 4756, 4768, 4773, 4785, 4790, 4802, 4807, 4819, 4824, 4836, 4841, 4851, 4856, 4866, 4871, 4881, 4886, 4896, 4901, 4911, 4916, 4926, 4931, 4941, 4946, 4956, 4961, 4971, 4976, 1025, 1024, 4<br />ᐳQuery<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList<br /><br />1: <br />ᐳ: Access[7055], Access[7056]<br />2: 1030, 1037, 1042, 1047, 1052, 1057, 1064, 1069, 1074, 1079, 1274, 1279, 1284, 1289, 1294, 1299, 1304, 1309, 1314<br />ᐳ: 1034, 1035, 1039, 1040, 1044, 1045, 1049, 1050, 1054, 1055, 1059, 1060, 1066, 1067, 1071, 1072, 1076, 1077, 1081, 1082, 1083, 1084, 1085, 1086, 1087, 1088, 1089, 1090, 1091, 1093, 1094, 1095, 1097, 1098, 1099, 1106, 1107, 1110, 1113, 1114, 1117, 1120, 1121, 1124, 1127, 1128, 1129, 1130, 1131, 1132, 1139, 1147, 1234, 1237, 1240, 1241, 1242, 1243, 1244, 1245, 1246, 1247, 1248, 1249, 1250, 1251, 1253, 1255, 1256, 1267, 1270, 1271, 1276, 1277, 1281, 1282, 1286, 1287, 1291, 1292, 1296, 1297, 1301, 1302, 1306, 1307, 1311, 1312, 1316, 1317, 4689, 4706, 4757, 4774, 4825, 1152, 1153, 1154, 1155, 1156, 1157, 1158, 1159, 1164, 1169, 1189, 1194, 1206, 1261, 4740, 1181"):::bucket
     classDef bucket138 stroke:#7f007f
-    class Bucket138,PgSelect1030,First1034,PgSelectSingle1035,PgSelect1037,First1039,PgSelectSingle1040,PgSelect1042,First1044,PgSelectSingle1045,PgSelect1047,First1049,PgSelectSingle1050,PgSelect1052,First1054,PgSelectSingle1055,PgSelect1057,First1059,PgSelectSingle1060,PgSelect1064,First1066,PgSelectSingle1067,PgSelect1069,First1071,PgSelectSingle1072,PgSelect1074,First1076,PgSelectSingle1077,PgSelect1079,First1081,PgSelectSingle1082,PgClassExpression1083,PgClassExpression1084,PgClassExpression1085,PgClassExpression1086,PgClassExpression1087,PgClassExpression1088,PgClassExpression1089,PgClassExpression1090,PgClassExpression1091,PgClassExpression1093,PgClassExpression1094,PgClassExpression1095,PgClassExpression1097,PgClassExpression1098,PgClassExpression1099,PgClassExpression1106,Access1107,Access1110,PgClassExpression1113,Access1114,Access1117,PgClassExpression1120,Access1121,Access1124,PgClassExpression1127,PgClassExpression1128,PgClassExpression1129,PgClassExpression1130,PgClassExpression1131,PgClassExpression1132,PgClassExpression1139,PgClassExpression1147,PgSelectSingle1152,PgClassExpression1153,PgClassExpression1154,PgClassExpression1155,PgClassExpression1156,PgClassExpression1157,PgClassExpression1158,PgClassExpression1159,PgSelectSingle1164,PgSelectSingle1169,PgSelectSingle1181,PgClassExpression1189,PgSelectSingle1194,PgSelectSingle1206,PgClassExpression1234,PgClassExpression1237,PgClassExpression1240,PgClassExpression1241,PgClassExpression1242,PgClassExpression1243,PgClassExpression1244,PgClassExpression1245,PgClassExpression1246,PgClassExpression1247,PgClassExpression1248,PgClassExpression1249,PgClassExpression1250,PgClassExpression1251,PgClassExpression1253,PgClassExpression1255,PgClassExpression1256,PgSelectSingle1261,PgSelectSingle1267,PgClassExpression1270,PgClassExpression1271,PgSelect1274,First1276,PgSelectSingle1277,PgSelect1279,First1281,PgSelectSingle1282,PgSelect1284,First1286,PgSelectSingle1287,PgSelect1289,First1291,PgSelectSingle1292,PgSelect1294,First1296,PgSelectSingle1297,PgSelect1299,First1301,PgSelectSingle1302,PgSelect1304,First1306,PgSelectSingle1307,PgSelect1309,First1311,PgSelectSingle1312,PgSelect1314,First1316,PgSelectSingle1317,RemapKeys4623,RemapKeys4639,RemapKeys4671,RemapKeys4687,RemapKeys4703,RemapKeys4751,Access6848,Access6849 bucket138
+    class Bucket138,PgSelect1030,First1034,PgSelectSingle1035,PgSelect1037,First1039,PgSelectSingle1040,PgSelect1042,First1044,PgSelectSingle1045,PgSelect1047,First1049,PgSelectSingle1050,PgSelect1052,First1054,PgSelectSingle1055,PgSelect1057,First1059,PgSelectSingle1060,PgSelect1064,First1066,PgSelectSingle1067,PgSelect1069,First1071,PgSelectSingle1072,PgSelect1074,First1076,PgSelectSingle1077,PgSelect1079,First1081,PgSelectSingle1082,PgClassExpression1083,PgClassExpression1084,PgClassExpression1085,PgClassExpression1086,PgClassExpression1087,PgClassExpression1088,PgClassExpression1089,PgClassExpression1090,PgClassExpression1091,PgClassExpression1093,PgClassExpression1094,PgClassExpression1095,PgClassExpression1097,PgClassExpression1098,PgClassExpression1099,PgClassExpression1106,Access1107,Access1110,PgClassExpression1113,Access1114,Access1117,PgClassExpression1120,Access1121,Access1124,PgClassExpression1127,PgClassExpression1128,PgClassExpression1129,PgClassExpression1130,PgClassExpression1131,PgClassExpression1132,PgClassExpression1139,PgClassExpression1147,PgSelectSingle1152,PgClassExpression1153,PgClassExpression1154,PgClassExpression1155,PgClassExpression1156,PgClassExpression1157,PgClassExpression1158,PgClassExpression1159,PgSelectSingle1164,PgSelectSingle1169,PgSelectSingle1181,PgClassExpression1189,PgSelectSingle1194,PgSelectSingle1206,PgClassExpression1234,PgClassExpression1237,PgClassExpression1240,PgClassExpression1241,PgClassExpression1242,PgClassExpression1243,PgClassExpression1244,PgClassExpression1245,PgClassExpression1246,PgClassExpression1247,PgClassExpression1248,PgClassExpression1249,PgClassExpression1250,PgClassExpression1251,PgClassExpression1253,PgClassExpression1255,PgClassExpression1256,PgSelectSingle1261,PgSelectSingle1267,PgClassExpression1270,PgClassExpression1271,PgSelect1274,First1276,PgSelectSingle1277,PgSelect1279,First1281,PgSelectSingle1282,PgSelect1284,First1286,PgSelectSingle1287,PgSelect1289,First1291,PgSelectSingle1292,PgSelect1294,First1296,PgSelectSingle1297,PgSelect1299,First1301,PgSelectSingle1302,PgSelect1304,First1306,PgSelectSingle1307,PgSelect1309,First1311,PgSelectSingle1312,PgSelect1314,First1316,PgSelectSingle1317,RemapKeys4689,RemapKeys4706,RemapKeys4740,RemapKeys4757,RemapKeys4774,RemapKeys4825,Access7055,Access7056 bucket138
     Bucket139("Bucket 139 (listItem)<br /><br />ROOT __Item{139}ᐸ1091ᐳ[1092]"):::bucket
     classDef bucket139 stroke:#ffa500
     class Bucket139,__Item1092 bucket139
@@ -7096,7 +7100,7 @@ graph TD
     class Bucket154,PgClassExpression1195,PgClassExpression1196,PgClassExpression1197,PgClassExpression1198,PgClassExpression1199,PgClassExpression1200,PgClassExpression1201 bucket154
     Bucket155("Bucket 155 (nullableBoundary)<br />Deps: 1206<br /><br />ROOT PgSelectSingle{138}ᐸfrmcdc_nestedCompoundTypeᐳ[1206]"):::bucket
     classDef bucket155 stroke:#7f007f
-    class Bucket155,PgSelectSingle1213,PgSelectSingle1225,PgClassExpression1233,RemapKeys4735 bucket155
+    class Bucket155,PgSelectSingle1213,PgSelectSingle1225,PgClassExpression1233,RemapKeys4808 bucket155
     Bucket156("Bucket 156 (nullableBoundary)<br />Deps: 1213<br /><br />ROOT PgSelectSingle{155}ᐸfrmcdc_compoundTypeᐳ[1213]"):::bucket
     classDef bucket156 stroke:#ffa500
     class Bucket156,PgClassExpression1214,PgClassExpression1215,PgClassExpression1216,PgClassExpression1217,PgClassExpression1218,PgClassExpression1219,PgClassExpression1220 bucket156
@@ -7126,7 +7130,7 @@ graph TD
     class Bucket164,__Item1272 bucket164
     Bucket165("Bucket 165 (nullableBoundary)<br />Deps: 1322<br /><br />ROOT PgSelectSingleᐸtype_functionᐳ[1322]"):::bucket
     classDef bucket165 stroke:#4169e1
-    class Bucket165,PgClassExpression1323,PgClassExpression1324,PgClassExpression1325,PgClassExpression1326,PgClassExpression1327,PgClassExpression1328,PgClassExpression1329,PgClassExpression1330,PgClassExpression1331,PgClassExpression1333,PgClassExpression1334,PgClassExpression1335,PgClassExpression1337,PgClassExpression1338,PgClassExpression1339,PgClassExpression1346,Access1347,Access1350,PgClassExpression1353,Access1354,Access1357,PgClassExpression1360,Access1361,Access1364,PgClassExpression1367,PgClassExpression1368,PgClassExpression1369,PgClassExpression1370,PgClassExpression1371,PgClassExpression1372,PgClassExpression1379,PgClassExpression1387,PgSelectSingle1394,PgClassExpression1395,PgClassExpression1396,PgClassExpression1397,PgClassExpression1398,PgClassExpression1399,PgClassExpression1400,PgClassExpression1401,PgSelectSingle1406,PgSelectSingle1411,PgSelectSingle1423,PgClassExpression1431,PgSelectSingle1436,PgSelectSingle1448,PgClassExpression1476,PgClassExpression1479,PgClassExpression1482,PgClassExpression1483,PgClassExpression1484,PgClassExpression1485,PgClassExpression1486,PgClassExpression1487,PgClassExpression1488,PgClassExpression1489,PgClassExpression1490,PgClassExpression1491,PgClassExpression1492,PgClassExpression1493,PgClassExpression1495,PgClassExpression1497,PgClassExpression1498,PgSelectSingle1503,PgSelectSingle1509,PgClassExpression1512,PgClassExpression1513,RemapKeys4923,RemapKeys4939,RemapKeys4971,RemapKeys4987,RemapKeys5003,RemapKeys5051 bucket165
+    class Bucket165,PgClassExpression1323,PgClassExpression1324,PgClassExpression1325,PgClassExpression1326,PgClassExpression1327,PgClassExpression1328,PgClassExpression1329,PgClassExpression1330,PgClassExpression1331,PgClassExpression1333,PgClassExpression1334,PgClassExpression1335,PgClassExpression1337,PgClassExpression1338,PgClassExpression1339,PgClassExpression1346,Access1347,Access1350,PgClassExpression1353,Access1354,Access1357,PgClassExpression1360,Access1361,Access1364,PgClassExpression1367,PgClassExpression1368,PgClassExpression1369,PgClassExpression1370,PgClassExpression1371,PgClassExpression1372,PgClassExpression1379,PgClassExpression1387,PgSelectSingle1394,PgClassExpression1395,PgClassExpression1396,PgClassExpression1397,PgClassExpression1398,PgClassExpression1399,PgClassExpression1400,PgClassExpression1401,PgSelectSingle1406,PgSelectSingle1411,PgSelectSingle1423,PgClassExpression1431,PgSelectSingle1436,PgSelectSingle1448,PgClassExpression1476,PgClassExpression1479,PgClassExpression1482,PgClassExpression1483,PgClassExpression1484,PgClassExpression1485,PgClassExpression1486,PgClassExpression1487,PgClassExpression1488,PgClassExpression1489,PgClassExpression1490,PgClassExpression1491,PgClassExpression1492,PgClassExpression1493,PgClassExpression1495,PgClassExpression1497,PgClassExpression1498,PgSelectSingle1503,PgSelectSingle1509,PgClassExpression1512,PgClassExpression1513,RemapKeys5009,RemapKeys5026,RemapKeys5060,RemapKeys5077,RemapKeys5094,RemapKeys5145 bucket165
     Bucket166("Bucket 166 (listItem)<br /><br />ROOT __Item{166}ᐸ1331ᐳ[1332]"):::bucket
     classDef bucket166 stroke:#3cb371
     class Bucket166,__Item1332 bucket166
@@ -7177,7 +7181,7 @@ graph TD
     class Bucket181,PgClassExpression1437,PgClassExpression1438,PgClassExpression1439,PgClassExpression1440,PgClassExpression1441,PgClassExpression1442,PgClassExpression1443 bucket181
     Bucket182("Bucket 182 (nullableBoundary)<br />Deps: 1448<br /><br />ROOT PgSelectSingle{165}ᐸfrmcdc_nestedCompoundTypeᐳ[1448]"):::bucket
     classDef bucket182 stroke:#4169e1
-    class Bucket182,PgSelectSingle1455,PgSelectSingle1467,PgClassExpression1475,RemapKeys5035 bucket182
+    class Bucket182,PgSelectSingle1455,PgSelectSingle1467,PgClassExpression1475,RemapKeys5128 bucket182
     Bucket183("Bucket 183 (nullableBoundary)<br />Deps: 1455<br /><br />ROOT PgSelectSingle{182}ᐸfrmcdc_compoundTypeᐳ[1455]"):::bucket
     classDef bucket183 stroke:#3cb371
     class Bucket183,PgClassExpression1456,PgClassExpression1457,PgClassExpression1458,PgClassExpression1459,PgClassExpression1460,PgClassExpression1461,PgClassExpression1462 bucket183
@@ -7210,7 +7214,7 @@ graph TD
     class Bucket192,__Item1517,PgSelectSingle1518 bucket192
     Bucket193("Bucket 193 (nullableBoundary)<br />Deps: 1518<br /><br />ROOT PgSelectSingle{192}ᐸtype_function_listᐳ[1518]"):::bucket
     classDef bucket193 stroke:#ff1493
-    class Bucket193,PgClassExpression1519,PgClassExpression1520,PgClassExpression1521,PgClassExpression1522,PgClassExpression1523,PgClassExpression1524,PgClassExpression1525,PgClassExpression1526,PgClassExpression1527,PgClassExpression1529,PgClassExpression1530,PgClassExpression1531,PgClassExpression1533,PgClassExpression1534,PgClassExpression1535,PgClassExpression1542,Access1543,Access1546,PgClassExpression1549,Access1550,Access1553,PgClassExpression1556,Access1557,Access1560,PgClassExpression1563,PgClassExpression1564,PgClassExpression1565,PgClassExpression1566,PgClassExpression1567,PgClassExpression1568,PgClassExpression1575,PgClassExpression1583,PgSelectSingle1590,PgClassExpression1591,PgClassExpression1592,PgClassExpression1593,PgClassExpression1594,PgClassExpression1595,PgClassExpression1596,PgClassExpression1597,PgSelectSingle1602,PgSelectSingle1607,PgSelectSingle1619,PgClassExpression1627,PgSelectSingle1632,PgSelectSingle1644,PgClassExpression1672,PgClassExpression1675,PgClassExpression1678,PgClassExpression1679,PgClassExpression1680,PgClassExpression1681,PgClassExpression1682,PgClassExpression1683,PgClassExpression1684,PgClassExpression1685,PgClassExpression1686,PgClassExpression1687,PgClassExpression1688,PgClassExpression1689,PgClassExpression1691,PgClassExpression1693,PgClassExpression1694,PgSelectSingle1699,PgSelectSingle1705,PgClassExpression1708,PgClassExpression1709,RemapKeys5097,RemapKeys5113,RemapKeys5145,RemapKeys5161,RemapKeys5177,RemapKeys5225 bucket193
+    class Bucket193,PgClassExpression1519,PgClassExpression1520,PgClassExpression1521,PgClassExpression1522,PgClassExpression1523,PgClassExpression1524,PgClassExpression1525,PgClassExpression1526,PgClassExpression1527,PgClassExpression1529,PgClassExpression1530,PgClassExpression1531,PgClassExpression1533,PgClassExpression1534,PgClassExpression1535,PgClassExpression1542,Access1543,Access1546,PgClassExpression1549,Access1550,Access1553,PgClassExpression1556,Access1557,Access1560,PgClassExpression1563,PgClassExpression1564,PgClassExpression1565,PgClassExpression1566,PgClassExpression1567,PgClassExpression1568,PgClassExpression1575,PgClassExpression1583,PgSelectSingle1590,PgClassExpression1591,PgClassExpression1592,PgClassExpression1593,PgClassExpression1594,PgClassExpression1595,PgClassExpression1596,PgClassExpression1597,PgSelectSingle1602,PgSelectSingle1607,PgSelectSingle1619,PgClassExpression1627,PgSelectSingle1632,PgSelectSingle1644,PgClassExpression1672,PgClassExpression1675,PgClassExpression1678,PgClassExpression1679,PgClassExpression1680,PgClassExpression1681,PgClassExpression1682,PgClassExpression1683,PgClassExpression1684,PgClassExpression1685,PgClassExpression1686,PgClassExpression1687,PgClassExpression1688,PgClassExpression1689,PgClassExpression1691,PgClassExpression1693,PgClassExpression1694,PgSelectSingle1699,PgSelectSingle1705,PgClassExpression1708,PgClassExpression1709,RemapKeys5194,RemapKeys5211,RemapKeys5245,RemapKeys5262,RemapKeys5279,RemapKeys5330 bucket193
     Bucket194("Bucket 194 (listItem)<br /><br />ROOT __Item{194}ᐸ1527ᐳ[1528]"):::bucket
     classDef bucket194 stroke:#808000
     class Bucket194,__Item1528 bucket194
@@ -7261,7 +7265,7 @@ graph TD
     class Bucket209,PgClassExpression1633,PgClassExpression1634,PgClassExpression1635,PgClassExpression1636,PgClassExpression1637,PgClassExpression1638,PgClassExpression1639 bucket209
     Bucket210("Bucket 210 (nullableBoundary)<br />Deps: 1644<br /><br />ROOT PgSelectSingle{193}ᐸfrmcdc_nestedCompoundTypeᐳ[1644]"):::bucket
     classDef bucket210 stroke:#ff1493
-    class Bucket210,PgSelectSingle1651,PgSelectSingle1663,PgClassExpression1671,RemapKeys5209 bucket210
+    class Bucket210,PgSelectSingle1651,PgSelectSingle1663,PgClassExpression1671,RemapKeys5313 bucket210
     Bucket211("Bucket 211 (nullableBoundary)<br />Deps: 1651<br /><br />ROOT PgSelectSingle{210}ᐸfrmcdc_compoundTypeᐳ[1651]"):::bucket
     classDef bucket211 stroke:#808000
     class Bucket211,PgClassExpression1652,PgClassExpression1653,PgClassExpression1654,PgClassExpression1655,PgClassExpression1656,PgClassExpression1657,PgClassExpression1658 bucket211
@@ -7289,15 +7293,15 @@ graph TD
     Bucket219("Bucket 219 (listItem)<br /><br />ROOT __Item{219}ᐸ1709ᐳ[1710]"):::bucket
     classDef bucket219 stroke:#ff00ff
     class Bucket219,__Item1710 bucket219
-    Bucket220("Bucket 220 (nullableBoundary)<br />Deps: 12, 1713, 3599, 3596, 4094, 6, 5245, 5246, 3602, 6960, 5259, 5260, 6961, 5273, 5274, 3634, 6962, 5289, 5290, 6963, 5305, 5306, 6964, 5321, 5322, 3682, 6965, 5337, 5338, 6966, 5353, 5354, 6967, 5369, 5370, 6968, 5385, 5386, 6969, 5402, 5403, 6970, 5416, 5417, 6971, 5430, 5431, 6972, 5446, 5447, 6973, 5462, 5463, 6974, 5478, 5479, 6975, 5494, 5495, 6976, 5510, 5511, 6977, 5526, 5527, 6978, 5542, 5543, 6979, 5558, 5559, 3762, 6980, 5572, 6981<br /><br />ROOT Connectionᐸ1711ᐳ[1713]<br />1: <br />ᐳ: 2116, 5248, 5254, 5262, 5268, 5276, 5282, 5292, 5298, 5308, 5314, 5324, 5330, 5340, 5346, 5356, 5362, 5372, 5378, 5388, 5394, 5405, 5411, 5419, 5425, 5433, 5439, 5449, 5455, 5465, 5471, 5481, 5487, 5497, 5503, 5513, 5519, 5529, 5535, 5545, 5551, 5561, 5567, 5575, 5581, 5249, 5263, 5277, 5293, 5309, 5325, 5341, 5357, 5373, 5389, 5406, 5420, 5434, 5450, 5466, 5482, 5498, 5514, 5530, 5546, 5562, 5576<br />2: PgSelect[1714], PgSelect[2111]<br />ᐳ: 2112, 2113, 2114, 2119, 2120, 2121, 2124, 2125, 2127, 2128, 2130, 2131, 2133, 2134, 2136, 2137, 2129, 2135<br />3: __ListTransform[1910]"):::bucket
+    Bucket220("Bucket 220 (nullableBoundary)<br />Deps: 12, 1713, 3600, 5386, 5391, 5403, 5408, 5420, 5425, 5437, 5442, 5454, 5459, 5471, 5476, 5488, 5493, 5505, 5510, 5553, 5558, 5570, 5575, 5587, 5592, 5604, 5609, 5621, 5626, 5638, 5643, 5655, 5660, 5672, 5677, 3596, 4126, 5689, 5694, 5704, 5709, 6, 5371, 5376, 5356, 5361, 5538, 5543, 5523, 5528<br /><br />ROOT Connectionᐸ1711ᐳ[1713]<br />1: PgSelect[1714], PgSelect[2111]<br />ᐳ: 2116, 2112, 2113, 2114, 2119, 2120, 2121, 2124, 2125, 2127, 2128, 2130, 2131, 2133, 2134, 2136, 2137, 2129, 2135<br />2: __ListTransform[1910]"):::bucket
     classDef bucket220 stroke:#f5deb3
-    class Bucket220,PgSelect1714,__ListTransform1910,PgSelect2111,First2112,PgSelectSingle2113,PgClassExpression2114,PgPageInfo2116,Access2119,Object2120,Lambda2121,Object2124,Lambda2125,First2127,PgSelectSingle2128,PgCursor2129,PgClassExpression2130,List2131,Last2133,PgSelectSingle2134,PgCursor2135,PgClassExpression2136,List2137,Object5248,Lambda5249,Lambda5254,Object5262,Lambda5263,Lambda5268,Object5276,Lambda5277,Lambda5282,Object5292,Lambda5293,Lambda5298,Object5308,Lambda5309,Lambda5314,Object5324,Lambda5325,Lambda5330,Object5340,Lambda5341,Lambda5346,Object5356,Lambda5357,Lambda5362,Object5372,Lambda5373,Lambda5378,Object5388,Lambda5389,Lambda5394,Object5405,Lambda5406,Lambda5411,Object5419,Lambda5420,Lambda5425,Object5433,Lambda5434,Lambda5439,Object5449,Lambda5450,Lambda5455,Object5465,Lambda5466,Lambda5471,Object5481,Lambda5482,Lambda5487,Object5497,Lambda5498,Lambda5503,Object5513,Lambda5514,Lambda5519,Object5529,Lambda5530,Lambda5535,Object5545,Lambda5546,Lambda5551,Object5561,Lambda5562,Lambda5567,Object5575,Lambda5576,Lambda5581 bucket220
-    Bucket221("Bucket 221 (listItem)<br />Deps: 12, 3596, 3599, 5263, 5268, 5249, 5254<br /><br />ROOT __Item{221}ᐸ1714ᐳ[1715]"):::bucket
+    class Bucket220,PgSelect1714,__ListTransform1910,PgSelect2111,First2112,PgSelectSingle2113,PgClassExpression2114,PgPageInfo2116,Access2119,Object2120,Lambda2121,Object2124,Lambda2125,First2127,PgSelectSingle2128,PgCursor2129,PgClassExpression2130,List2131,Last2133,PgSelectSingle2134,PgCursor2135,PgClassExpression2136,List2137 bucket220
+    Bucket221("Bucket 221 (listItem)<br />Deps: 12, 3596, 3600, 5371, 5376, 5356, 5361<br /><br />ROOT __Item{221}ᐸ1714ᐳ[1715]"):::bucket
     classDef bucket221 stroke:#696969
     class Bucket221,__Item1715,PgSelectSingle1716 bucket221
-    Bucket222("Bucket 222 (nullableBoundary)<br />Deps: 1716, 12, 3596, 3599, 5263, 5268, 5249, 5254<br /><br />ROOT PgSelectSingle{221}ᐸtype_function_connectionᐳ[1716]<br />1: <br />ᐳ: 1717, 1718, 1719, 1720, 1721, 1722, 1723, 1724, 1725, 1727, 1728, 1729, 1731, 1732, 1733, 1740, 1747, 1754, 1761, 1762, 1763, 1764, 1765, 1766, 1773, 1781, 1870, 1873, 1876, 1877, 1878, 1879, 1880, 1881, 1882, 1883, 1884, 1885, 1886, 1887, 1889, 1891, 1892, 1906, 1907, 5283, 5331, 5347, 5395, 1741, 1744, 1748, 1751, 1755, 1758, 1788, 1789, 1790, 1791, 1792, 1793, 1794, 1795, 1800, 1805, 1825, 1830, 1842, 5315, 1817<br />2: PgSelect[1894], PgSelect[1900]<br />ᐳ: 1896, 1897, 1902, 1903"):::bucket
+    Bucket222("Bucket 222 (nullableBoundary)<br />Deps: 1716, 12, 3596, 3600, 5371, 5376, 5356, 5361<br /><br />ROOT PgSelectSingle{221}ᐸtype_function_connectionᐳ[1716]<br />1: <br />ᐳ: 1717, 1718, 1719, 1720, 1721, 1722, 1723, 1724, 1725, 1727, 1728, 1729, 1731, 1732, 1733, 1740, 1747, 1754, 1761, 1762, 1763, 1764, 1765, 1766, 1773, 1781, 1870, 1873, 1876, 1877, 1878, 1879, 1880, 1881, 1882, 1883, 1884, 1885, 1886, 1887, 1889, 1891, 1892, 1906, 1907, 5392, 5443, 5460, 5511, 1741, 1744, 1748, 1751, 1755, 1758, 1788, 1789, 1790, 1791, 1792, 1793, 1794, 1795, 1800, 1805, 1825, 1830, 1842, 5426, 1817<br />2: PgSelect[1894], PgSelect[1900]<br />ᐳ: 1896, 1897, 1902, 1903"):::bucket
     classDef bucket222 stroke:#00bfff
-    class Bucket222,PgClassExpression1717,PgClassExpression1718,PgClassExpression1719,PgClassExpression1720,PgClassExpression1721,PgClassExpression1722,PgClassExpression1723,PgClassExpression1724,PgClassExpression1725,PgClassExpression1727,PgClassExpression1728,PgClassExpression1729,PgClassExpression1731,PgClassExpression1732,PgClassExpression1733,PgClassExpression1740,Access1741,Access1744,PgClassExpression1747,Access1748,Access1751,PgClassExpression1754,Access1755,Access1758,PgClassExpression1761,PgClassExpression1762,PgClassExpression1763,PgClassExpression1764,PgClassExpression1765,PgClassExpression1766,PgClassExpression1773,PgClassExpression1781,PgSelectSingle1788,PgClassExpression1789,PgClassExpression1790,PgClassExpression1791,PgClassExpression1792,PgClassExpression1793,PgClassExpression1794,PgClassExpression1795,PgSelectSingle1800,PgSelectSingle1805,PgSelectSingle1817,PgClassExpression1825,PgSelectSingle1830,PgSelectSingle1842,PgClassExpression1870,PgClassExpression1873,PgClassExpression1876,PgClassExpression1877,PgClassExpression1878,PgClassExpression1879,PgClassExpression1880,PgClassExpression1881,PgClassExpression1882,PgClassExpression1883,PgClassExpression1884,PgClassExpression1885,PgClassExpression1886,PgClassExpression1887,PgClassExpression1889,PgClassExpression1891,PgClassExpression1892,PgSelect1894,First1896,PgSelectSingle1897,PgSelect1900,First1902,PgSelectSingle1903,PgClassExpression1906,PgClassExpression1907,RemapKeys5283,RemapKeys5315,RemapKeys5331,RemapKeys5347,RemapKeys5395 bucket222
+    class Bucket222,PgClassExpression1717,PgClassExpression1718,PgClassExpression1719,PgClassExpression1720,PgClassExpression1721,PgClassExpression1722,PgClassExpression1723,PgClassExpression1724,PgClassExpression1725,PgClassExpression1727,PgClassExpression1728,PgClassExpression1729,PgClassExpression1731,PgClassExpression1732,PgClassExpression1733,PgClassExpression1740,Access1741,Access1744,PgClassExpression1747,Access1748,Access1751,PgClassExpression1754,Access1755,Access1758,PgClassExpression1761,PgClassExpression1762,PgClassExpression1763,PgClassExpression1764,PgClassExpression1765,PgClassExpression1766,PgClassExpression1773,PgClassExpression1781,PgSelectSingle1788,PgClassExpression1789,PgClassExpression1790,PgClassExpression1791,PgClassExpression1792,PgClassExpression1793,PgClassExpression1794,PgClassExpression1795,PgSelectSingle1800,PgSelectSingle1805,PgSelectSingle1817,PgClassExpression1825,PgSelectSingle1830,PgSelectSingle1842,PgClassExpression1870,PgClassExpression1873,PgClassExpression1876,PgClassExpression1877,PgClassExpression1878,PgClassExpression1879,PgClassExpression1880,PgClassExpression1881,PgClassExpression1882,PgClassExpression1883,PgClassExpression1884,PgClassExpression1885,PgClassExpression1886,PgClassExpression1887,PgClassExpression1889,PgClassExpression1891,PgClassExpression1892,PgSelect1894,First1896,PgSelectSingle1897,PgSelect1900,First1902,PgSelectSingle1903,PgClassExpression1906,PgClassExpression1907,RemapKeys5392,RemapKeys5426,RemapKeys5443,RemapKeys5460,RemapKeys5511 bucket222
     Bucket223("Bucket 223 (listItem)<br /><br />ROOT __Item{223}ᐸ1725ᐳ[1726]"):::bucket
     classDef bucket223 stroke:#7f007f
     class Bucket223,__Item1726 bucket223
@@ -7348,7 +7352,7 @@ graph TD
     class Bucket238,PgClassExpression1831,PgClassExpression1832,PgClassExpression1833,PgClassExpression1834,PgClassExpression1835,PgClassExpression1836,PgClassExpression1837 bucket238
     Bucket239("Bucket 239 (nullableBoundary)<br />Deps: 1842<br /><br />ROOT PgSelectSingle{222}ᐸfrmcdc_nestedCompoundTypeᐳ[1842]"):::bucket
     classDef bucket239 stroke:#00bfff
-    class Bucket239,PgSelectSingle1849,PgSelectSingle1861,PgClassExpression1869,RemapKeys5379 bucket239
+    class Bucket239,PgSelectSingle1849,PgSelectSingle1861,PgClassExpression1869,RemapKeys5494 bucket239
     Bucket240("Bucket 240 (nullableBoundary)<br />Deps: 1849<br /><br />ROOT PgSelectSingle{239}ᐸfrmcdc_compoundTypeᐳ[1849]"):::bucket
     classDef bucket240 stroke:#7f007f
     class Bucket240,PgClassExpression1850,PgClassExpression1851,PgClassExpression1852,PgClassExpression1853,PgClassExpression1854,PgClassExpression1855,PgClassExpression1856 bucket240
@@ -7379,15 +7383,15 @@ graph TD
     Bucket249("Bucket 249 (subroutine)<br /><br />ROOT PgSelectSingle{249}ᐸtype_function_connectionᐳ[1912]"):::bucket
     classDef bucket249 stroke:#00ffff
     class Bucket249,__Item1911,PgSelectSingle1912 bucket249
-    Bucket250("Bucket 250 (listItem)<br />Deps: 1713, 12, 3596, 3599, 5420, 5425, 5406, 5411<br /><br />ROOT __Item{250}ᐸ1910ᐳ[1913]"):::bucket
+    Bucket250("Bucket 250 (listItem)<br />Deps: 1713, 12, 3596, 3600, 5538, 5543, 5523, 5528<br /><br />ROOT __Item{250}ᐸ1910ᐳ[1913]"):::bucket
     classDef bucket250 stroke:#4169e1
-    class Bucket250,__Item1913,PgSelectSingle1914,Edge5397 bucket250
-    Bucket251("Bucket 251 (nullableBoundary)<br />Deps: 5397, 1914, 12, 3596, 3599, 5420, 5425, 5406, 5411<br /><br />ROOT Edge{250}[5397]"):::bucket
+    class Bucket250,__Item1913,PgSelectSingle1914,Edge5513 bucket250
+    Bucket251("Bucket 251 (nullableBoundary)<br />Deps: 5513, 1914, 12, 3596, 3600, 5538, 5543, 5523, 5528<br /><br />ROOT Edge{250}[5513]"):::bucket
     classDef bucket251 stroke:#3cb371
     class Bucket251 bucket251
-    Bucket252("Bucket 252 (nullableBoundary)<br />Deps: 1914, 12, 3596, 3599, 5420, 5425, 5406, 5411<br /><br />ROOT PgSelectSingle{250}ᐸtype_function_connectionᐳ[1914]<br />1: <br />ᐳ: 1919, 1920, 1921, 1922, 1923, 1924, 1925, 1926, 1927, 1929, 1930, 1931, 1933, 1934, 1935, 1942, 1949, 1956, 1963, 1964, 1965, 1966, 1967, 1968, 1975, 1983, 2072, 2075, 2078, 2079, 2080, 2081, 2082, 2083, 2084, 2085, 2086, 2087, 2088, 2089, 2091, 2093, 2094, 2108, 2109, 5440, 5488, 5504, 5552, 1943, 1946, 1950, 1953, 1957, 1960, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 2002, 2007, 2027, 2032, 2044, 5472, 2019<br />2: PgSelect[2096], PgSelect[2102]<br />ᐳ: 2098, 2099, 2104, 2105"):::bucket
+    Bucket252("Bucket 252 (nullableBoundary)<br />Deps: 1914, 12, 3596, 3600, 5538, 5543, 5523, 5528<br /><br />ROOT PgSelectSingle{250}ᐸtype_function_connectionᐳ[1914]<br />1: <br />ᐳ: 1919, 1920, 1921, 1922, 1923, 1924, 1925, 1926, 1927, 1929, 1930, 1931, 1933, 1934, 1935, 1942, 1949, 1956, 1963, 1964, 1965, 1966, 1967, 1968, 1975, 1983, 2072, 2075, 2078, 2079, 2080, 2081, 2082, 2083, 2084, 2085, 2086, 2087, 2088, 2089, 2091, 2093, 2094, 2108, 2109, 5559, 5610, 5627, 5678, 1943, 1946, 1950, 1953, 1957, 1960, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 2002, 2007, 2027, 2032, 2044, 5593, 2019<br />2: PgSelect[2096], PgSelect[2102]<br />ᐳ: 2098, 2099, 2104, 2105"):::bucket
     classDef bucket252 stroke:#a52a2a
-    class Bucket252,PgClassExpression1919,PgClassExpression1920,PgClassExpression1921,PgClassExpression1922,PgClassExpression1923,PgClassExpression1924,PgClassExpression1925,PgClassExpression1926,PgClassExpression1927,PgClassExpression1929,PgClassExpression1930,PgClassExpression1931,PgClassExpression1933,PgClassExpression1934,PgClassExpression1935,PgClassExpression1942,Access1943,Access1946,PgClassExpression1949,Access1950,Access1953,PgClassExpression1956,Access1957,Access1960,PgClassExpression1963,PgClassExpression1964,PgClassExpression1965,PgClassExpression1966,PgClassExpression1967,PgClassExpression1968,PgClassExpression1975,PgClassExpression1983,PgSelectSingle1990,PgClassExpression1991,PgClassExpression1992,PgClassExpression1993,PgClassExpression1994,PgClassExpression1995,PgClassExpression1996,PgClassExpression1997,PgSelectSingle2002,PgSelectSingle2007,PgSelectSingle2019,PgClassExpression2027,PgSelectSingle2032,PgSelectSingle2044,PgClassExpression2072,PgClassExpression2075,PgClassExpression2078,PgClassExpression2079,PgClassExpression2080,PgClassExpression2081,PgClassExpression2082,PgClassExpression2083,PgClassExpression2084,PgClassExpression2085,PgClassExpression2086,PgClassExpression2087,PgClassExpression2088,PgClassExpression2089,PgClassExpression2091,PgClassExpression2093,PgClassExpression2094,PgSelect2096,First2098,PgSelectSingle2099,PgSelect2102,First2104,PgSelectSingle2105,PgClassExpression2108,PgClassExpression2109,RemapKeys5440,RemapKeys5472,RemapKeys5488,RemapKeys5504,RemapKeys5552 bucket252
+    class Bucket252,PgClassExpression1919,PgClassExpression1920,PgClassExpression1921,PgClassExpression1922,PgClassExpression1923,PgClassExpression1924,PgClassExpression1925,PgClassExpression1926,PgClassExpression1927,PgClassExpression1929,PgClassExpression1930,PgClassExpression1931,PgClassExpression1933,PgClassExpression1934,PgClassExpression1935,PgClassExpression1942,Access1943,Access1946,PgClassExpression1949,Access1950,Access1953,PgClassExpression1956,Access1957,Access1960,PgClassExpression1963,PgClassExpression1964,PgClassExpression1965,PgClassExpression1966,PgClassExpression1967,PgClassExpression1968,PgClassExpression1975,PgClassExpression1983,PgSelectSingle1990,PgClassExpression1991,PgClassExpression1992,PgClassExpression1993,PgClassExpression1994,PgClassExpression1995,PgClassExpression1996,PgClassExpression1997,PgSelectSingle2002,PgSelectSingle2007,PgSelectSingle2019,PgClassExpression2027,PgSelectSingle2032,PgSelectSingle2044,PgClassExpression2072,PgClassExpression2075,PgClassExpression2078,PgClassExpression2079,PgClassExpression2080,PgClassExpression2081,PgClassExpression2082,PgClassExpression2083,PgClassExpression2084,PgClassExpression2085,PgClassExpression2086,PgClassExpression2087,PgClassExpression2088,PgClassExpression2089,PgClassExpression2091,PgClassExpression2093,PgClassExpression2094,PgSelect2096,First2098,PgSelectSingle2099,PgSelect2102,First2104,PgSelectSingle2105,PgClassExpression2108,PgClassExpression2109,RemapKeys5559,RemapKeys5593,RemapKeys5610,RemapKeys5627,RemapKeys5678 bucket252
     Bucket253("Bucket 253 (listItem)<br /><br />ROOT __Item{253}ᐸ1927ᐳ[1928]"):::bucket
     classDef bucket253 stroke:#ff00ff
     class Bucket253,__Item1928 bucket253
@@ -7438,7 +7442,7 @@ graph TD
     class Bucket268,PgClassExpression2033,PgClassExpression2034,PgClassExpression2035,PgClassExpression2036,PgClassExpression2037,PgClassExpression2038,PgClassExpression2039 bucket268
     Bucket269("Bucket 269 (nullableBoundary)<br />Deps: 2044<br /><br />ROOT PgSelectSingle{252}ᐸfrmcdc_nestedCompoundTypeᐳ[2044]"):::bucket
     classDef bucket269 stroke:#a52a2a
-    class Bucket269,PgSelectSingle2051,PgSelectSingle2063,PgClassExpression2071,RemapKeys5536 bucket269
+    class Bucket269,PgSelectSingle2051,PgSelectSingle2063,PgClassExpression2071,RemapKeys5661 bucket269
     Bucket270("Bucket 270 (nullableBoundary)<br />Deps: 2051<br /><br />ROOT PgSelectSingle{269}ᐸfrmcdc_compoundTypeᐳ[2051]"):::bucket
     classDef bucket270 stroke:#ff00ff
     class Bucket270,PgClassExpression2052,PgClassExpression2053,PgClassExpression2054,PgClassExpression2055,PgClassExpression2056,PgClassExpression2057,PgClassExpression2058 bucket270
@@ -7466,12 +7470,12 @@ graph TD
     Bucket278("Bucket 278 (listItem)<br /><br />ROOT __Item{278}ᐸ2109ᐳ[2110]"):::bucket
     classDef bucket278 stroke:#ff1493
     class Bucket278,__Item2110 bucket278
-    Bucket279("Bucket 279 (nullableBoundary)<br />Deps: 2142, 2543, 6, 2141, 3594, 3596, 3597, 5941, 5942, 3602, 7004, 5955, 5956, 7005, 6098, 6099, 7014, 6112, 6113, 7015, 4092, 12, 3599<br /><br />ROOT PgSelectSingleᐸpersonᐳ[2142]<br />1: <br />ᐳ: 2150, 2946, 5933, 5944, 5950, 5958, 5964, 6101, 6107, 6115, 6121, 6264, 6282, 5935, 5936, 5945, 5959, 6102, 6116, 6266, 6267, 6283, 6284, 2942, 2943, 2944, 2949, 2950, 2951, 2954, 2955, 2957, 2958, 2960, 2961, 2963, 2964, 2966, 2967, 2959, 2965<br />2: __ListTransform[2740]"):::bucket
+    Bucket279("Bucket 279 (nullableBoundary)<br />Deps: 2142, 6, 2141, 3594, 3596, 3597, 4123, 12, 3600, 6111, 6116, 6096, 6101, 2543, 6278, 6283, 6263, 6268, 2946<br /><br />ROOT PgSelectSingleᐸpersonᐳ[2142]<br />1: <br />ᐳ: 2150, 6083, 6435, 6454, 6085, 6086, 6437, 6438, 6455, 6456, 2942, 2943, 2944, 2949, 2950, 2951, 2954, 2955, 2957, 2958, 2960, 2961, 2963, 2964, 2966, 2967, 2959, 2965<br />2: __ListTransform[2740]"):::bucket
     classDef bucket279 stroke:#808000
-    class Bucket279,PgSelectSingle2150,__ListTransform2740,First2942,PgSelectSingle2943,PgClassExpression2944,PgPageInfo2946,Access2949,Object2950,Lambda2951,Object2954,Lambda2955,First2957,PgSelectSingle2958,PgCursor2959,PgClassExpression2960,List2961,Last2963,PgSelectSingle2964,PgCursor2965,PgClassExpression2966,List2967,Access5933,Object5935,Lambda5936,Object5944,Lambda5945,Lambda5950,Object5958,Lambda5959,Lambda5964,Object6101,Lambda6102,Lambda6107,Object6115,Lambda6116,Lambda6121,Access6264,Object6266,Lambda6267,Access6282,Object6283,Lambda6284 bucket279
+    class Bucket279,PgSelectSingle2150,__ListTransform2740,First2942,PgSelectSingle2943,PgClassExpression2944,Access2949,Object2950,Lambda2951,Object2954,Lambda2955,First2957,PgSelectSingle2958,PgCursor2959,PgClassExpression2960,List2961,Last2963,PgSelectSingle2964,PgCursor2965,PgClassExpression2966,List2967,Access6083,Object6085,Lambda6086,Access6435,Object6437,Lambda6438,Access6454,Object6455,Lambda6456 bucket279
     Bucket280("Bucket 280 (nullableBoundary)<br />Deps: 2150<br /><br />ROOT PgSelectSingle{279}ᐸperson_type_functionᐳ[2150]"):::bucket
     classDef bucket280 stroke:#dda0dd
-    class Bucket280,PgClassExpression2151,PgClassExpression2152,PgClassExpression2153,PgClassExpression2154,PgClassExpression2155,PgClassExpression2156,PgClassExpression2157,PgClassExpression2158,PgClassExpression2159,PgClassExpression2161,PgClassExpression2162,PgClassExpression2163,PgClassExpression2165,PgClassExpression2166,PgClassExpression2167,PgClassExpression2174,Access2175,Access2178,PgClassExpression2181,Access2182,Access2185,PgClassExpression2188,Access2189,Access2192,PgClassExpression2195,PgClassExpression2196,PgClassExpression2197,PgClassExpression2198,PgClassExpression2199,PgClassExpression2200,PgClassExpression2207,PgClassExpression2215,PgSelectSingle2222,PgClassExpression2223,PgClassExpression2224,PgClassExpression2225,PgClassExpression2226,PgClassExpression2227,PgClassExpression2228,PgClassExpression2229,PgSelectSingle2234,PgSelectSingle2239,PgSelectSingle2251,PgClassExpression2259,PgSelectSingle2264,PgSelectSingle2276,PgClassExpression2304,PgClassExpression2307,PgClassExpression2310,PgClassExpression2311,PgClassExpression2312,PgClassExpression2313,PgClassExpression2314,PgClassExpression2315,PgClassExpression2316,PgClassExpression2317,PgClassExpression2318,PgClassExpression2319,PgClassExpression2320,PgClassExpression2321,PgClassExpression2323,PgClassExpression2325,PgClassExpression2326,PgSelectSingle2331,PgSelectSingle2337,PgClassExpression2340,PgClassExpression2341,RemapKeys5612,RemapKeys5628,RemapKeys5660,RemapKeys5676,RemapKeys5692,RemapKeys5740 bucket280
+    class Bucket280,PgClassExpression2151,PgClassExpression2152,PgClassExpression2153,PgClassExpression2154,PgClassExpression2155,PgClassExpression2156,PgClassExpression2157,PgClassExpression2158,PgClassExpression2159,PgClassExpression2161,PgClassExpression2162,PgClassExpression2163,PgClassExpression2165,PgClassExpression2166,PgClassExpression2167,PgClassExpression2174,Access2175,Access2178,PgClassExpression2181,Access2182,Access2185,PgClassExpression2188,Access2189,Access2192,PgClassExpression2195,PgClassExpression2196,PgClassExpression2197,PgClassExpression2198,PgClassExpression2199,PgClassExpression2200,PgClassExpression2207,PgClassExpression2215,PgSelectSingle2222,PgClassExpression2223,PgClassExpression2224,PgClassExpression2225,PgClassExpression2226,PgClassExpression2227,PgClassExpression2228,PgClassExpression2229,PgSelectSingle2234,PgSelectSingle2239,PgSelectSingle2251,PgClassExpression2259,PgSelectSingle2264,PgSelectSingle2276,PgClassExpression2304,PgClassExpression2307,PgClassExpression2310,PgClassExpression2311,PgClassExpression2312,PgClassExpression2313,PgClassExpression2314,PgClassExpression2315,PgClassExpression2316,PgClassExpression2317,PgClassExpression2318,PgClassExpression2319,PgClassExpression2320,PgClassExpression2321,PgClassExpression2323,PgClassExpression2325,PgClassExpression2326,PgSelectSingle2331,PgSelectSingle2337,PgClassExpression2340,PgClassExpression2341,RemapKeys5742,RemapKeys5759,RemapKeys5793,RemapKeys5810,RemapKeys5827,RemapKeys5878 bucket280
     Bucket281("Bucket 281 (listItem)<br /><br />ROOT __Item{281}ᐸ2159ᐳ[2160]"):::bucket
     classDef bucket281 stroke:#ff0000
     class Bucket281,__Item2160 bucket281
@@ -7522,7 +7526,7 @@ graph TD
     class Bucket296,PgClassExpression2265,PgClassExpression2266,PgClassExpression2267,PgClassExpression2268,PgClassExpression2269,PgClassExpression2270,PgClassExpression2271 bucket296
     Bucket297("Bucket 297 (nullableBoundary)<br />Deps: 2276<br /><br />ROOT PgSelectSingle{280}ᐸfrmcdc_nestedCompoundTypeᐳ[2276]"):::bucket
     classDef bucket297 stroke:#dda0dd
-    class Bucket297,PgSelectSingle2283,PgSelectSingle2295,PgClassExpression2303,RemapKeys5724 bucket297
+    class Bucket297,PgSelectSingle2283,PgSelectSingle2295,PgClassExpression2303,RemapKeys5861 bucket297
     Bucket298("Bucket 298 (nullableBoundary)<br />Deps: 2283<br /><br />ROOT PgSelectSingle{297}ᐸfrmcdc_compoundTypeᐳ[2283]"):::bucket
     classDef bucket298 stroke:#ff0000
     class Bucket298,PgClassExpression2284,PgClassExpression2285,PgClassExpression2286,PgClassExpression2287,PgClassExpression2288,PgClassExpression2289,PgClassExpression2290 bucket298
@@ -7550,12 +7554,12 @@ graph TD
     Bucket306("Bucket 306 (listItem)<br /><br />ROOT __Item{306}ᐸ2341ᐳ[2342]"):::bucket
     classDef bucket306 stroke:#696969
     class Bucket306,__Item2342 bucket306
-    Bucket307("Bucket 307 (listItem)<br /><br />ROOT __Item{307}ᐸ5936ᐳ[2346]"):::bucket
+    Bucket307("Bucket 307 (listItem)<br /><br />ROOT __Item{307}ᐸ6086ᐳ[2346]"):::bucket
     classDef bucket307 stroke:#00bfff
     class Bucket307,__Item2346,PgSelectSingle2347 bucket307
     Bucket308("Bucket 308 (nullableBoundary)<br />Deps: 2347<br /><br />ROOT PgSelectSingle{307}ᐸperson_type_function_listᐳ[2347]"):::bucket
     classDef bucket308 stroke:#7f007f
-    class Bucket308,PgClassExpression2348,PgClassExpression2349,PgClassExpression2350,PgClassExpression2351,PgClassExpression2352,PgClassExpression2353,PgClassExpression2354,PgClassExpression2355,PgClassExpression2356,PgClassExpression2358,PgClassExpression2359,PgClassExpression2360,PgClassExpression2362,PgClassExpression2363,PgClassExpression2364,PgClassExpression2371,Access2372,Access2375,PgClassExpression2378,Access2379,Access2382,PgClassExpression2385,Access2386,Access2389,PgClassExpression2392,PgClassExpression2393,PgClassExpression2394,PgClassExpression2395,PgClassExpression2396,PgClassExpression2397,PgClassExpression2404,PgClassExpression2412,PgSelectSingle2419,PgClassExpression2420,PgClassExpression2421,PgClassExpression2422,PgClassExpression2423,PgClassExpression2424,PgClassExpression2425,PgClassExpression2426,PgSelectSingle2431,PgSelectSingle2436,PgSelectSingle2448,PgClassExpression2456,PgSelectSingle2461,PgSelectSingle2473,PgClassExpression2501,PgClassExpression2504,PgClassExpression2507,PgClassExpression2508,PgClassExpression2509,PgClassExpression2510,PgClassExpression2511,PgClassExpression2512,PgClassExpression2513,PgClassExpression2514,PgClassExpression2515,PgClassExpression2516,PgClassExpression2517,PgClassExpression2518,PgClassExpression2520,PgClassExpression2522,PgClassExpression2523,PgSelectSingle2528,PgSelectSingle2534,PgClassExpression2537,PgClassExpression2538,RemapKeys5788,RemapKeys5804,RemapKeys5836,RemapKeys5852,RemapKeys5868,RemapKeys5916 bucket308
+    class Bucket308,PgClassExpression2348,PgClassExpression2349,PgClassExpression2350,PgClassExpression2351,PgClassExpression2352,PgClassExpression2353,PgClassExpression2354,PgClassExpression2355,PgClassExpression2356,PgClassExpression2358,PgClassExpression2359,PgClassExpression2360,PgClassExpression2362,PgClassExpression2363,PgClassExpression2364,PgClassExpression2371,Access2372,Access2375,PgClassExpression2378,Access2379,Access2382,PgClassExpression2385,Access2386,Access2389,PgClassExpression2392,PgClassExpression2393,PgClassExpression2394,PgClassExpression2395,PgClassExpression2396,PgClassExpression2397,PgClassExpression2404,PgClassExpression2412,PgSelectSingle2419,PgClassExpression2420,PgClassExpression2421,PgClassExpression2422,PgClassExpression2423,PgClassExpression2424,PgClassExpression2425,PgClassExpression2426,PgSelectSingle2431,PgSelectSingle2436,PgSelectSingle2448,PgClassExpression2456,PgSelectSingle2461,PgSelectSingle2473,PgClassExpression2501,PgClassExpression2504,PgClassExpression2507,PgClassExpression2508,PgClassExpression2509,PgClassExpression2510,PgClassExpression2511,PgClassExpression2512,PgClassExpression2513,PgClassExpression2514,PgClassExpression2515,PgClassExpression2516,PgClassExpression2517,PgClassExpression2518,PgClassExpression2520,PgClassExpression2522,PgClassExpression2523,PgSelectSingle2528,PgSelectSingle2534,PgClassExpression2537,PgClassExpression2538,RemapKeys5929,RemapKeys5946,RemapKeys5980,RemapKeys5997,RemapKeys6014,RemapKeys6065 bucket308
     Bucket309("Bucket 309 (listItem)<br /><br />ROOT __Item{309}ᐸ2356ᐳ[2357]"):::bucket
     classDef bucket309 stroke:#ffa500
     class Bucket309,__Item2357 bucket309
@@ -7606,7 +7610,7 @@ graph TD
     class Bucket324,PgClassExpression2462,PgClassExpression2463,PgClassExpression2464,PgClassExpression2465,PgClassExpression2466,PgClassExpression2467,PgClassExpression2468 bucket324
     Bucket325("Bucket 325 (nullableBoundary)<br />Deps: 2473<br /><br />ROOT PgSelectSingle{308}ᐸfrmcdc_nestedCompoundTypeᐳ[2473]"):::bucket
     classDef bucket325 stroke:#7f007f
-    class Bucket325,PgSelectSingle2480,PgSelectSingle2492,PgClassExpression2500,RemapKeys5900 bucket325
+    class Bucket325,PgSelectSingle2480,PgSelectSingle2492,PgClassExpression2500,RemapKeys6048 bucket325
     Bucket326("Bucket 326 (nullableBoundary)<br />Deps: 2480<br /><br />ROOT PgSelectSingle{325}ᐸfrmcdc_compoundTypeᐳ[2480]"):::bucket
     classDef bucket326 stroke:#ffa500
     class Bucket326,PgClassExpression2481,PgClassExpression2482,PgClassExpression2483,PgClassExpression2484,PgClassExpression2485,PgClassExpression2486,PgClassExpression2487 bucket326
@@ -7634,12 +7638,12 @@ graph TD
     Bucket334("Bucket 334 (listItem)<br /><br />ROOT __Item{334}ᐸ2538ᐳ[2539]"):::bucket
     classDef bucket334 stroke:#00ffff
     class Bucket334,__Item2539 bucket334
-    Bucket335("Bucket 335 (listItem)<br />Deps: 12, 3596, 3599, 5959, 5964, 5945, 5950<br /><br />ROOT __Item{335}ᐸ6267ᐳ[2545]"):::bucket
+    Bucket335("Bucket 335 (listItem)<br />Deps: 12, 3596, 3600, 6111, 6116, 6096, 6101<br /><br />ROOT __Item{335}ᐸ6438ᐳ[2545]"):::bucket
     classDef bucket335 stroke:#4169e1
     class Bucket335,__Item2545,PgSelectSingle2546 bucket335
-    Bucket336("Bucket 336 (nullableBoundary)<br />Deps: 2546, 12, 3596, 3599, 5959, 5964, 5945, 5950<br /><br />ROOT PgSelectSingle{335}ᐸperson_type_function_connectionᐳ[2546]<br />1: <br />ᐳ: 2547, 2548, 2549, 2550, 2551, 2552, 2553, 2554, 2555, 2557, 2558, 2559, 2561, 2562, 2563, 2570, 2577, 2584, 2591, 2592, 2593, 2594, 2595, 2596, 2603, 2611, 2700, 2703, 2706, 2707, 2708, 2709, 2710, 2711, 2712, 2713, 2714, 2715, 2716, 2717, 2719, 2721, 2722, 2736, 2737, 5979, 6027, 6043, 6091, 2571, 2574, 2578, 2581, 2585, 2588, 2618, 2619, 2620, 2621, 2622, 2623, 2624, 2625, 2630, 2635, 2655, 2660, 2672, 6011, 2647<br />2: PgSelect[2724], PgSelect[2730]<br />ᐳ: 2726, 2727, 2732, 2733"):::bucket
+    Bucket336("Bucket 336 (nullableBoundary)<br />Deps: 2546, 12, 3596, 3600, 6111, 6116, 6096, 6101<br /><br />ROOT PgSelectSingle{335}ᐸperson_type_function_connectionᐳ[2546]<br />1: <br />ᐳ: 2547, 2548, 2549, 2550, 2551, 2552, 2553, 2554, 2555, 2557, 2558, 2559, 2561, 2562, 2563, 2570, 2577, 2584, 2591, 2592, 2593, 2594, 2595, 2596, 2603, 2611, 2700, 2703, 2706, 2707, 2708, 2709, 2710, 2711, 2712, 2713, 2714, 2715, 2716, 2717, 2719, 2721, 2722, 2736, 2737, 6132, 6183, 6200, 6251, 2571, 2574, 2578, 2581, 2585, 2588, 2618, 2619, 2620, 2621, 2622, 2623, 2624, 2625, 2630, 2635, 2655, 2660, 2672, 6166, 2647<br />2: PgSelect[2724], PgSelect[2730]<br />ᐳ: 2726, 2727, 2732, 2733"):::bucket
     classDef bucket336 stroke:#3cb371
-    class Bucket336,PgClassExpression2547,PgClassExpression2548,PgClassExpression2549,PgClassExpression2550,PgClassExpression2551,PgClassExpression2552,PgClassExpression2553,PgClassExpression2554,PgClassExpression2555,PgClassExpression2557,PgClassExpression2558,PgClassExpression2559,PgClassExpression2561,PgClassExpression2562,PgClassExpression2563,PgClassExpression2570,Access2571,Access2574,PgClassExpression2577,Access2578,Access2581,PgClassExpression2584,Access2585,Access2588,PgClassExpression2591,PgClassExpression2592,PgClassExpression2593,PgClassExpression2594,PgClassExpression2595,PgClassExpression2596,PgClassExpression2603,PgClassExpression2611,PgSelectSingle2618,PgClassExpression2619,PgClassExpression2620,PgClassExpression2621,PgClassExpression2622,PgClassExpression2623,PgClassExpression2624,PgClassExpression2625,PgSelectSingle2630,PgSelectSingle2635,PgSelectSingle2647,PgClassExpression2655,PgSelectSingle2660,PgSelectSingle2672,PgClassExpression2700,PgClassExpression2703,PgClassExpression2706,PgClassExpression2707,PgClassExpression2708,PgClassExpression2709,PgClassExpression2710,PgClassExpression2711,PgClassExpression2712,PgClassExpression2713,PgClassExpression2714,PgClassExpression2715,PgClassExpression2716,PgClassExpression2717,PgClassExpression2719,PgClassExpression2721,PgClassExpression2722,PgSelect2724,First2726,PgSelectSingle2727,PgSelect2730,First2732,PgSelectSingle2733,PgClassExpression2736,PgClassExpression2737,RemapKeys5979,RemapKeys6011,RemapKeys6027,RemapKeys6043,RemapKeys6091 bucket336
+    class Bucket336,PgClassExpression2547,PgClassExpression2548,PgClassExpression2549,PgClassExpression2550,PgClassExpression2551,PgClassExpression2552,PgClassExpression2553,PgClassExpression2554,PgClassExpression2555,PgClassExpression2557,PgClassExpression2558,PgClassExpression2559,PgClassExpression2561,PgClassExpression2562,PgClassExpression2563,PgClassExpression2570,Access2571,Access2574,PgClassExpression2577,Access2578,Access2581,PgClassExpression2584,Access2585,Access2588,PgClassExpression2591,PgClassExpression2592,PgClassExpression2593,PgClassExpression2594,PgClassExpression2595,PgClassExpression2596,PgClassExpression2603,PgClassExpression2611,PgSelectSingle2618,PgClassExpression2619,PgClassExpression2620,PgClassExpression2621,PgClassExpression2622,PgClassExpression2623,PgClassExpression2624,PgClassExpression2625,PgSelectSingle2630,PgSelectSingle2635,PgSelectSingle2647,PgClassExpression2655,PgSelectSingle2660,PgSelectSingle2672,PgClassExpression2700,PgClassExpression2703,PgClassExpression2706,PgClassExpression2707,PgClassExpression2708,PgClassExpression2709,PgClassExpression2710,PgClassExpression2711,PgClassExpression2712,PgClassExpression2713,PgClassExpression2714,PgClassExpression2715,PgClassExpression2716,PgClassExpression2717,PgClassExpression2719,PgClassExpression2721,PgClassExpression2722,PgSelect2724,First2726,PgSelectSingle2727,PgSelect2730,First2732,PgSelectSingle2733,PgClassExpression2736,PgClassExpression2737,RemapKeys6132,RemapKeys6166,RemapKeys6183,RemapKeys6200,RemapKeys6251 bucket336
     Bucket337("Bucket 337 (listItem)<br /><br />ROOT __Item{337}ᐸ2555ᐳ[2556]"):::bucket
     classDef bucket337 stroke:#a52a2a
     class Bucket337,__Item2556 bucket337
@@ -7690,7 +7694,7 @@ graph TD
     class Bucket352,PgClassExpression2661,PgClassExpression2662,PgClassExpression2663,PgClassExpression2664,PgClassExpression2665,PgClassExpression2666,PgClassExpression2667 bucket352
     Bucket353("Bucket 353 (nullableBoundary)<br />Deps: 2672<br /><br />ROOT PgSelectSingle{336}ᐸfrmcdc_nestedCompoundTypeᐳ[2672]"):::bucket
     classDef bucket353 stroke:#3cb371
-    class Bucket353,PgSelectSingle2679,PgSelectSingle2691,PgClassExpression2699,RemapKeys6075 bucket353
+    class Bucket353,PgSelectSingle2679,PgSelectSingle2691,PgClassExpression2699,RemapKeys6234 bucket353
     Bucket354("Bucket 354 (nullableBoundary)<br />Deps: 2679<br /><br />ROOT PgSelectSingle{353}ᐸfrmcdc_compoundTypeᐳ[2679]"):::bucket
     classDef bucket354 stroke:#a52a2a
     class Bucket354,PgClassExpression2680,PgClassExpression2681,PgClassExpression2682,PgClassExpression2683,PgClassExpression2684,PgClassExpression2685,PgClassExpression2686 bucket354
@@ -7721,15 +7725,15 @@ graph TD
     Bucket363("Bucket 363 (subroutine)<br /><br />ROOT PgSelectSingle{363}ᐸperson_type_function_connectionᐳ[2742]"):::bucket
     classDef bucket363 stroke:#ff1493
     class Bucket363,__Item2741,PgSelectSingle2742 bucket363
-    Bucket364("Bucket 364 (listItem)<br />Deps: 2543, 12, 3596, 3599, 6116, 6121, 6102, 6107<br /><br />ROOT __Item{364}ᐸ2740ᐳ[2743]"):::bucket
+    Bucket364("Bucket 364 (listItem)<br />Deps: 2543, 12, 3596, 3600, 6278, 6283, 6263, 6268<br /><br />ROOT __Item{364}ᐸ2740ᐳ[2743]"):::bucket
     classDef bucket364 stroke:#808000
-    class Bucket364,__Item2743,PgSelectSingle2744,Edge6093 bucket364
-    Bucket365("Bucket 365 (nullableBoundary)<br />Deps: 6093, 2744, 12, 3596, 3599, 6116, 6121, 6102, 6107<br /><br />ROOT Edge{364}[6093]"):::bucket
+    class Bucket364,__Item2743,PgSelectSingle2744,Edge6253 bucket364
+    Bucket365("Bucket 365 (nullableBoundary)<br />Deps: 6253, 2744, 12, 3596, 3600, 6278, 6283, 6263, 6268<br /><br />ROOT Edge{364}[6253]"):::bucket
     classDef bucket365 stroke:#dda0dd
     class Bucket365 bucket365
-    Bucket366("Bucket 366 (nullableBoundary)<br />Deps: 2744, 12, 3596, 3599, 6116, 6121, 6102, 6107<br /><br />ROOT PgSelectSingle{364}ᐸperson_type_function_connectionᐳ[2744]<br />1: <br />ᐳ: 2749, 2750, 2751, 2752, 2753, 2754, 2755, 2756, 2757, 2759, 2760, 2761, 2763, 2764, 2765, 2772, 2779, 2786, 2793, 2794, 2795, 2796, 2797, 2798, 2805, 2813, 2902, 2905, 2908, 2909, 2910, 2911, 2912, 2913, 2914, 2915, 2916, 2917, 2918, 2919, 2921, 2923, 2924, 2938, 2939, 6136, 6184, 6200, 6248, 2773, 2776, 2780, 2783, 2787, 2790, 2820, 2821, 2822, 2823, 2824, 2825, 2826, 2827, 2832, 2837, 2857, 2862, 2874, 6168, 2849<br />2: PgSelect[2926], PgSelect[2932]<br />ᐳ: 2928, 2929, 2934, 2935"):::bucket
+    Bucket366("Bucket 366 (nullableBoundary)<br />Deps: 2744, 12, 3596, 3600, 6278, 6283, 6263, 6268<br /><br />ROOT PgSelectSingle{364}ᐸperson_type_function_connectionᐳ[2744]<br />1: <br />ᐳ: 2749, 2750, 2751, 2752, 2753, 2754, 2755, 2756, 2757, 2759, 2760, 2761, 2763, 2764, 2765, 2772, 2779, 2786, 2793, 2794, 2795, 2796, 2797, 2798, 2805, 2813, 2902, 2905, 2908, 2909, 2910, 2911, 2912, 2913, 2914, 2915, 2916, 2917, 2918, 2919, 2921, 2923, 2924, 2938, 2939, 6299, 6350, 6367, 6418, 2773, 2776, 2780, 2783, 2787, 2790, 2820, 2821, 2822, 2823, 2824, 2825, 2826, 2827, 2832, 2837, 2857, 2862, 2874, 6333, 2849<br />2: PgSelect[2926], PgSelect[2932]<br />ᐳ: 2928, 2929, 2934, 2935"):::bucket
     classDef bucket366 stroke:#ff0000
-    class Bucket366,PgClassExpression2749,PgClassExpression2750,PgClassExpression2751,PgClassExpression2752,PgClassExpression2753,PgClassExpression2754,PgClassExpression2755,PgClassExpression2756,PgClassExpression2757,PgClassExpression2759,PgClassExpression2760,PgClassExpression2761,PgClassExpression2763,PgClassExpression2764,PgClassExpression2765,PgClassExpression2772,Access2773,Access2776,PgClassExpression2779,Access2780,Access2783,PgClassExpression2786,Access2787,Access2790,PgClassExpression2793,PgClassExpression2794,PgClassExpression2795,PgClassExpression2796,PgClassExpression2797,PgClassExpression2798,PgClassExpression2805,PgClassExpression2813,PgSelectSingle2820,PgClassExpression2821,PgClassExpression2822,PgClassExpression2823,PgClassExpression2824,PgClassExpression2825,PgClassExpression2826,PgClassExpression2827,PgSelectSingle2832,PgSelectSingle2837,PgSelectSingle2849,PgClassExpression2857,PgSelectSingle2862,PgSelectSingle2874,PgClassExpression2902,PgClassExpression2905,PgClassExpression2908,PgClassExpression2909,PgClassExpression2910,PgClassExpression2911,PgClassExpression2912,PgClassExpression2913,PgClassExpression2914,PgClassExpression2915,PgClassExpression2916,PgClassExpression2917,PgClassExpression2918,PgClassExpression2919,PgClassExpression2921,PgClassExpression2923,PgClassExpression2924,PgSelect2926,First2928,PgSelectSingle2929,PgSelect2932,First2934,PgSelectSingle2935,PgClassExpression2938,PgClassExpression2939,RemapKeys6136,RemapKeys6168,RemapKeys6184,RemapKeys6200,RemapKeys6248 bucket366
+    class Bucket366,PgClassExpression2749,PgClassExpression2750,PgClassExpression2751,PgClassExpression2752,PgClassExpression2753,PgClassExpression2754,PgClassExpression2755,PgClassExpression2756,PgClassExpression2757,PgClassExpression2759,PgClassExpression2760,PgClassExpression2761,PgClassExpression2763,PgClassExpression2764,PgClassExpression2765,PgClassExpression2772,Access2773,Access2776,PgClassExpression2779,Access2780,Access2783,PgClassExpression2786,Access2787,Access2790,PgClassExpression2793,PgClassExpression2794,PgClassExpression2795,PgClassExpression2796,PgClassExpression2797,PgClassExpression2798,PgClassExpression2805,PgClassExpression2813,PgSelectSingle2820,PgClassExpression2821,PgClassExpression2822,PgClassExpression2823,PgClassExpression2824,PgClassExpression2825,PgClassExpression2826,PgClassExpression2827,PgSelectSingle2832,PgSelectSingle2837,PgSelectSingle2849,PgClassExpression2857,PgSelectSingle2862,PgSelectSingle2874,PgClassExpression2902,PgClassExpression2905,PgClassExpression2908,PgClassExpression2909,PgClassExpression2910,PgClassExpression2911,PgClassExpression2912,PgClassExpression2913,PgClassExpression2914,PgClassExpression2915,PgClassExpression2916,PgClassExpression2917,PgClassExpression2918,PgClassExpression2919,PgClassExpression2921,PgClassExpression2923,PgClassExpression2924,PgSelect2926,First2928,PgSelectSingle2929,PgSelect2932,First2934,PgSelectSingle2935,PgClassExpression2938,PgClassExpression2939,RemapKeys6299,RemapKeys6333,RemapKeys6350,RemapKeys6367,RemapKeys6418 bucket366
     Bucket367("Bucket 367 (listItem)<br /><br />ROOT __Item{367}ᐸ2757ᐳ[2758]"):::bucket
     classDef bucket367 stroke:#ffff00
     class Bucket367,__Item2758 bucket367
@@ -7780,7 +7784,7 @@ graph TD
     class Bucket382,PgClassExpression2863,PgClassExpression2864,PgClassExpression2865,PgClassExpression2866,PgClassExpression2867,PgClassExpression2868,PgClassExpression2869 bucket382
     Bucket383("Bucket 383 (nullableBoundary)<br />Deps: 2874<br /><br />ROOT PgSelectSingle{366}ᐸfrmcdc_nestedCompoundTypeᐳ[2874]"):::bucket
     classDef bucket383 stroke:#ff0000
-    class Bucket383,PgSelectSingle2881,PgSelectSingle2893,PgClassExpression2901,RemapKeys6232 bucket383
+    class Bucket383,PgSelectSingle2881,PgSelectSingle2893,PgClassExpression2901,RemapKeys6401 bucket383
     Bucket384("Bucket 384 (nullableBoundary)<br />Deps: 2881<br /><br />ROOT PgSelectSingle{383}ᐸfrmcdc_compoundTypeᐳ[2881]"):::bucket
     classDef bucket384 stroke:#ffff00
     class Bucket384,PgClassExpression2882,PgClassExpression2883,PgClassExpression2884,PgClassExpression2885,PgClassExpression2886,PgClassExpression2887,PgClassExpression2888 bucket384
@@ -7808,12 +7812,12 @@ graph TD
     Bucket392("Bucket 392 (listItem)<br /><br />ROOT __Item{392}ᐸ2939ᐳ[2940]"):::bucket
     classDef bucket392 stroke:#00bfff
     class Bucket392,__Item2940 bucket392
-    Bucket393("Bucket 393 (nullableBoundary)<br />Deps: 2972, 6, 2971, 3594, 3596, 4092, 3597<br /><br />ROOT PgSelectSingleᐸpostᐳ[2972]"):::bucket
+    Bucket393("Bucket 393 (nullableBoundary)<br />Deps: 2972, 6, 2971, 3594, 3596, 4123, 3597, 3177, 3572<br /><br />ROOT PgSelectSingleᐸpostᐳ[2972]"):::bucket
     classDef bucket393 stroke:#7f007f
-    class Bucket393,PgClassExpression2973,PgClassExpression2974,PgSelectSingle2980,Connection3177,First3568,PgSelectSingle3569,PgClassExpression3570,PgPageInfo3572,Access3575,Object3576,Lambda3577,Object3580,Lambda3581,First3583,PgSelectSingle3584,PgCursor3585,PgClassExpression3586,List3587,Last3589,PgSelectSingle3590,PgCursor3591,PgClassExpression3592,List3593,Access6810,Object6812,Lambda6813,Access6828,Object6830,Lambda6831 bucket393
+    class Bucket393,PgClassExpression2973,PgClassExpression2974,PgSelectSingle2980,First3568,PgSelectSingle3569,PgClassExpression3570,Access3575,Object3576,Lambda3577,Object3580,Lambda3581,First3583,PgSelectSingle3584,PgCursor3585,PgClassExpression3586,List3587,Last3589,PgSelectSingle3590,PgCursor3591,PgClassExpression3592,List3593,Access7015,Object7017,Lambda7018,Access7034,Object7036,Lambda7037 bucket393
     Bucket394("Bucket 394 (nullableBoundary)<br />Deps: 2980<br /><br />ROOT PgSelectSingle{393}ᐸtypesᐳ[2980]"):::bucket
     classDef bucket394 stroke:#ffa500
-    class Bucket394,PgClassExpression2981,PgClassExpression2982,PgClassExpression2983,PgClassExpression2984,PgClassExpression2985,PgClassExpression2986,PgClassExpression2987,PgClassExpression2988,PgClassExpression2989,PgClassExpression2991,PgClassExpression2992,PgClassExpression2993,PgClassExpression2995,PgClassExpression2996,PgClassExpression2997,PgClassExpression3004,Access3005,Access3008,PgClassExpression3011,Access3012,Access3015,PgClassExpression3018,Access3019,Access3022,PgClassExpression3025,PgClassExpression3026,PgClassExpression3027,PgClassExpression3028,PgClassExpression3029,PgClassExpression3030,PgClassExpression3037,PgClassExpression3045,PgSelectSingle3052,PgClassExpression3053,PgClassExpression3054,PgClassExpression3055,PgClassExpression3056,PgClassExpression3057,PgClassExpression3058,PgClassExpression3059,PgSelectSingle3064,PgSelectSingle3069,PgSelectSingle3081,PgClassExpression3089,PgSelectSingle3094,PgSelectSingle3106,PgClassExpression3134,PgClassExpression3137,PgClassExpression3140,PgClassExpression3141,PgClassExpression3142,PgClassExpression3143,PgClassExpression3144,PgClassExpression3145,PgClassExpression3146,PgClassExpression3147,PgClassExpression3148,PgClassExpression3149,PgClassExpression3150,PgClassExpression3151,PgClassExpression3153,PgClassExpression3155,PgClassExpression3156,PgSelectSingle3161,PgSelectSingle3167,PgClassExpression3170,PgClassExpression3171,RemapKeys6329,RemapKeys6345,RemapKeys6377,RemapKeys6393,RemapKeys6409,RemapKeys6457 bucket394
+    class Bucket394,PgClassExpression2981,PgClassExpression2982,PgClassExpression2983,PgClassExpression2984,PgClassExpression2985,PgClassExpression2986,PgClassExpression2987,PgClassExpression2988,PgClassExpression2989,PgClassExpression2991,PgClassExpression2992,PgClassExpression2993,PgClassExpression2995,PgClassExpression2996,PgClassExpression2997,PgClassExpression3004,Access3005,Access3008,PgClassExpression3011,Access3012,Access3015,PgClassExpression3018,Access3019,Access3022,PgClassExpression3025,PgClassExpression3026,PgClassExpression3027,PgClassExpression3028,PgClassExpression3029,PgClassExpression3030,PgClassExpression3037,PgClassExpression3045,PgSelectSingle3052,PgClassExpression3053,PgClassExpression3054,PgClassExpression3055,PgClassExpression3056,PgClassExpression3057,PgClassExpression3058,PgClassExpression3059,PgSelectSingle3064,PgSelectSingle3069,PgSelectSingle3081,PgClassExpression3089,PgSelectSingle3094,PgSelectSingle3106,PgClassExpression3134,PgClassExpression3137,PgClassExpression3140,PgClassExpression3141,PgClassExpression3142,PgClassExpression3143,PgClassExpression3144,PgClassExpression3145,PgClassExpression3146,PgClassExpression3147,PgClassExpression3148,PgClassExpression3149,PgClassExpression3150,PgClassExpression3151,PgClassExpression3153,PgClassExpression3155,PgClassExpression3156,PgSelectSingle3161,PgSelectSingle3167,PgClassExpression3170,PgClassExpression3171,RemapKeys6504,RemapKeys6521,RemapKeys6555,RemapKeys6572,RemapKeys6589,RemapKeys6640 bucket394
     Bucket395("Bucket 395 (listItem)<br /><br />ROOT __Item{395}ᐸ2989ᐳ[2990]"):::bucket
     classDef bucket395 stroke:#0000ff
     class Bucket395,__Item2990 bucket395
@@ -7864,7 +7868,7 @@ graph TD
     class Bucket410,PgClassExpression3095,PgClassExpression3096,PgClassExpression3097,PgClassExpression3098,PgClassExpression3099,PgClassExpression3100,PgClassExpression3101 bucket410
     Bucket411("Bucket 411 (nullableBoundary)<br />Deps: 3106<br /><br />ROOT PgSelectSingle{394}ᐸfrmcdc_nestedCompoundTypeᐳ[3106]"):::bucket
     classDef bucket411 stroke:#ffa500
-    class Bucket411,PgSelectSingle3113,PgSelectSingle3125,PgClassExpression3133,RemapKeys6441 bucket411
+    class Bucket411,PgSelectSingle3113,PgSelectSingle3125,PgClassExpression3133,RemapKeys6623 bucket411
     Bucket412("Bucket 412 (nullableBoundary)<br />Deps: 3113<br /><br />ROOT PgSelectSingle{411}ᐸfrmcdc_compoundTypeᐳ[3113]"):::bucket
     classDef bucket412 stroke:#0000ff
     class Bucket412,PgClassExpression3114,PgClassExpression3115,PgClassExpression3116,PgClassExpression3117,PgClassExpression3118,PgClassExpression3119,PgClassExpression3120 bucket412
@@ -7892,12 +7896,12 @@ graph TD
     Bucket420("Bucket 420 (listItem)<br /><br />ROOT __Item{420}ᐸ3171ᐳ[3172]"):::bucket
     classDef bucket420 stroke:#4169e1
     class Bucket420,__Item3172 bucket420
-    Bucket421("Bucket 421 (listItem)<br /><br />ROOT __Item{421}ᐸ6813ᐳ[3179]"):::bucket
+    Bucket421("Bucket 421 (listItem)<br /><br />ROOT __Item{421}ᐸ7018ᐳ[3179]"):::bucket
     classDef bucket421 stroke:#3cb371
     class Bucket421,__Item3179,PgSelectSingle3180 bucket421
     Bucket422("Bucket 422 (nullableBoundary)<br />Deps: 3180<br /><br />ROOT PgSelectSingle{421}ᐸtypesᐳ[3180]"):::bucket
     classDef bucket422 stroke:#a52a2a
-    class Bucket422,PgClassExpression3181,PgClassExpression3182,PgClassExpression3183,PgClassExpression3184,PgClassExpression3185,PgClassExpression3186,PgClassExpression3187,PgClassExpression3188,PgClassExpression3189,PgClassExpression3191,PgClassExpression3192,PgClassExpression3193,PgClassExpression3195,PgClassExpression3196,PgClassExpression3197,PgClassExpression3204,Access3205,Access3208,PgClassExpression3211,Access3212,Access3215,PgClassExpression3218,Access3219,Access3222,PgClassExpression3225,PgClassExpression3226,PgClassExpression3227,PgClassExpression3228,PgClassExpression3229,PgClassExpression3230,PgClassExpression3237,PgClassExpression3245,PgSelectSingle3252,PgClassExpression3253,PgClassExpression3254,PgClassExpression3255,PgClassExpression3256,PgClassExpression3257,PgClassExpression3258,PgClassExpression3259,PgSelectSingle3264,PgSelectSingle3269,PgSelectSingle3281,PgClassExpression3289,PgSelectSingle3294,PgSelectSingle3306,PgClassExpression3334,PgClassExpression3337,PgClassExpression3340,PgClassExpression3341,PgClassExpression3342,PgClassExpression3343,PgClassExpression3344,PgClassExpression3345,PgClassExpression3346,PgClassExpression3347,PgClassExpression3348,PgClassExpression3349,PgClassExpression3350,PgClassExpression3351,PgClassExpression3353,PgClassExpression3355,PgClassExpression3356,PgSelectSingle3361,PgSelectSingle3367,PgClassExpression3370,PgClassExpression3371,RemapKeys6505,RemapKeys6521,RemapKeys6553,RemapKeys6569,RemapKeys6585,RemapKeys6633 bucket422
+    class Bucket422,PgClassExpression3181,PgClassExpression3182,PgClassExpression3183,PgClassExpression3184,PgClassExpression3185,PgClassExpression3186,PgClassExpression3187,PgClassExpression3188,PgClassExpression3189,PgClassExpression3191,PgClassExpression3192,PgClassExpression3193,PgClassExpression3195,PgClassExpression3196,PgClassExpression3197,PgClassExpression3204,Access3205,Access3208,PgClassExpression3211,Access3212,Access3215,PgClassExpression3218,Access3219,Access3222,PgClassExpression3225,PgClassExpression3226,PgClassExpression3227,PgClassExpression3228,PgClassExpression3229,PgClassExpression3230,PgClassExpression3237,PgClassExpression3245,PgSelectSingle3252,PgClassExpression3253,PgClassExpression3254,PgClassExpression3255,PgClassExpression3256,PgClassExpression3257,PgClassExpression3258,PgClassExpression3259,PgSelectSingle3264,PgSelectSingle3269,PgSelectSingle3281,PgClassExpression3289,PgSelectSingle3294,PgSelectSingle3306,PgClassExpression3334,PgClassExpression3337,PgClassExpression3340,PgClassExpression3341,PgClassExpression3342,PgClassExpression3343,PgClassExpression3344,PgClassExpression3345,PgClassExpression3346,PgClassExpression3347,PgClassExpression3348,PgClassExpression3349,PgClassExpression3350,PgClassExpression3351,PgClassExpression3353,PgClassExpression3355,PgClassExpression3356,PgSelectSingle3361,PgSelectSingle3367,PgClassExpression3370,PgClassExpression3371,RemapKeys6691,RemapKeys6708,RemapKeys6742,RemapKeys6759,RemapKeys6776,RemapKeys6827 bucket422
     Bucket423("Bucket 423 (listItem)<br /><br />ROOT __Item{423}ᐸ3189ᐳ[3190]"):::bucket
     classDef bucket423 stroke:#ff00ff
     class Bucket423,__Item3190 bucket423
@@ -7948,7 +7952,7 @@ graph TD
     class Bucket438,PgClassExpression3295,PgClassExpression3296,PgClassExpression3297,PgClassExpression3298,PgClassExpression3299,PgClassExpression3300,PgClassExpression3301 bucket438
     Bucket439("Bucket 439 (nullableBoundary)<br />Deps: 3306<br /><br />ROOT PgSelectSingle{422}ᐸfrmcdc_nestedCompoundTypeᐳ[3306]"):::bucket
     classDef bucket439 stroke:#a52a2a
-    class Bucket439,PgSelectSingle3313,PgSelectSingle3325,PgClassExpression3333,RemapKeys6617 bucket439
+    class Bucket439,PgSelectSingle3313,PgSelectSingle3325,PgClassExpression3333,RemapKeys6810 bucket439
     Bucket440("Bucket 440 (nullableBoundary)<br />Deps: 3313<br /><br />ROOT PgSelectSingle{439}ᐸfrmcdc_compoundTypeᐳ[3313]"):::bucket
     classDef bucket440 stroke:#ff00ff
     class Bucket440,PgClassExpression3314,PgClassExpression3315,PgClassExpression3316,PgClassExpression3317,PgClassExpression3318,PgClassExpression3319,PgClassExpression3320 bucket440
@@ -7978,7 +7982,7 @@ graph TD
     class Bucket448,__Item3372 bucket448
     Bucket449("Bucket 449 (nullableBoundary)<br />Deps: 3180<br /><br />ROOT PgSelectSingle{421}ᐸtypesᐳ[3180]"):::bucket
     classDef bucket449 stroke:#808000
-    class Bucket449,PgClassExpression3375,PgClassExpression3376,PgClassExpression3377,PgClassExpression3378,PgClassExpression3379,PgClassExpression3380,PgClassExpression3381,PgClassExpression3382,PgClassExpression3383,PgClassExpression3385,PgClassExpression3386,PgClassExpression3387,PgClassExpression3389,PgClassExpression3390,PgClassExpression3391,PgClassExpression3398,Access3399,Access3402,PgClassExpression3405,Access3406,Access3409,PgClassExpression3412,Access3413,Access3416,PgClassExpression3419,PgClassExpression3420,PgClassExpression3421,PgClassExpression3422,PgClassExpression3423,PgClassExpression3424,PgClassExpression3431,PgClassExpression3439,PgSelectSingle3446,PgClassExpression3447,PgClassExpression3448,PgClassExpression3449,PgClassExpression3450,PgClassExpression3451,PgClassExpression3452,PgClassExpression3453,PgSelectSingle3458,PgSelectSingle3463,PgSelectSingle3475,PgClassExpression3483,PgSelectSingle3488,PgSelectSingle3500,PgClassExpression3528,PgClassExpression3531,PgClassExpression3534,PgClassExpression3535,PgClassExpression3536,PgClassExpression3537,PgClassExpression3538,PgClassExpression3539,PgClassExpression3540,PgClassExpression3541,PgClassExpression3542,PgClassExpression3543,PgClassExpression3544,PgClassExpression3545,PgClassExpression3547,PgClassExpression3549,PgClassExpression3550,PgSelectSingle3555,PgSelectSingle3561,PgClassExpression3564,PgClassExpression3565,RemapKeys6649,RemapKeys6665,RemapKeys6681,RemapKeys6713,RemapKeys6729,RemapKeys6745,RemapKeys6793 bucket449
+    class Bucket449,PgClassExpression3375,PgClassExpression3376,PgClassExpression3377,PgClassExpression3378,PgClassExpression3379,PgClassExpression3380,PgClassExpression3381,PgClassExpression3382,PgClassExpression3383,PgClassExpression3385,PgClassExpression3386,PgClassExpression3387,PgClassExpression3389,PgClassExpression3390,PgClassExpression3391,PgClassExpression3398,Access3399,Access3402,PgClassExpression3405,Access3406,Access3409,PgClassExpression3412,Access3413,Access3416,PgClassExpression3419,PgClassExpression3420,PgClassExpression3421,PgClassExpression3422,PgClassExpression3423,PgClassExpression3424,PgClassExpression3431,PgClassExpression3439,PgSelectSingle3446,PgClassExpression3447,PgClassExpression3448,PgClassExpression3449,PgClassExpression3450,PgClassExpression3451,PgClassExpression3452,PgClassExpression3453,PgSelectSingle3458,PgSelectSingle3463,PgSelectSingle3475,PgClassExpression3483,PgSelectSingle3488,PgSelectSingle3500,PgClassExpression3528,PgClassExpression3531,PgClassExpression3534,PgClassExpression3535,PgClassExpression3536,PgClassExpression3537,PgClassExpression3538,PgClassExpression3539,PgClassExpression3540,PgClassExpression3541,PgClassExpression3542,PgClassExpression3543,PgClassExpression3544,PgClassExpression3545,PgClassExpression3547,PgClassExpression3549,PgClassExpression3550,PgSelectSingle3555,PgSelectSingle3561,PgClassExpression3564,PgClassExpression3565,RemapKeys6844,RemapKeys6861,RemapKeys6878,RemapKeys6912,RemapKeys6929,RemapKeys6946,RemapKeys6997 bucket449
     Bucket450("Bucket 450 (listItem)<br /><br />ROOT __Item{450}ᐸ3383ᐳ[3384]"):::bucket
     classDef bucket450 stroke:#dda0dd
     class Bucket450,__Item3384 bucket450
@@ -8029,7 +8033,7 @@ graph TD
     class Bucket465,PgClassExpression3489,PgClassExpression3490,PgClassExpression3491,PgClassExpression3492,PgClassExpression3493,PgClassExpression3494,PgClassExpression3495 bucket465
     Bucket466("Bucket 466 (nullableBoundary)<br />Deps: 3500<br /><br />ROOT PgSelectSingle{449}ᐸfrmcdc_nestedCompoundTypeᐳ[3500]"):::bucket
     classDef bucket466 stroke:#808000
-    class Bucket466,PgSelectSingle3507,PgSelectSingle3519,PgClassExpression3527,RemapKeys6777 bucket466
+    class Bucket466,PgSelectSingle3507,PgSelectSingle3519,PgClassExpression3527,RemapKeys6980 bucket466
     Bucket467("Bucket 467 (nullableBoundary)<br />Deps: 3507<br /><br />ROOT PgSelectSingle{466}ᐸfrmcdc_compoundTypeᐳ[3507]"):::bucket
     classDef bucket467 stroke:#dda0dd
     class Bucket467,PgClassExpression3508,PgClassExpression3509,PgClassExpression3510,PgClassExpression3511,PgClassExpression3512,PgClassExpression3513,PgClassExpression3514 bucket467

--- a/postgraphile/postgraphile/__tests__/queries/v4/unique-constraints.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/unique-constraints.mermaid
@@ -11,55 +11,55 @@ graph TD
     %% plan dependencies
     PgSelect24[["PgSelect[24∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant120{{"Constant[120∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant121{{"Constant[121∈0] ➊<br />ᐸ2ᐳ"}}:::plan
+    Constant125{{"Constant[125∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant126{{"Constant[126∈0] ➊<br />ᐸ2ᐳ"}}:::plan
     Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda84{{"Lambda[84∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda89{{"Lambda[89∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant120 & Constant121 & Lambda48 & Lambda51 & Lambda84 & Lambda89 --> PgSelect24
+    Access52{{"Access[52∈0] ➊<br />ᐸ51.0ᐳ"}}:::plan
+    Lambda87{{"Lambda[87∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda92{{"Lambda[92∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant125 & Constant126 & Lambda48 & Access52 & Lambda87 & Lambda92 --> PgSelect24
     PgSelect32[["PgSelect[32∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Constant122{{"Constant[122∈0] ➊<br />ᐸ4ᐳ"}}:::plan
-    Lambda98{{"Lambda[98∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda103{{"Lambda[103∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant122 & Constant122 & Lambda48 & Lambda51 & Lambda98 & Lambda103 --> PgSelect32
+    Constant127{{"Constant[127∈0] ➊<br />ᐸ4ᐳ"}}:::plan
+    Lambda102{{"Lambda[102∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda107{{"Lambda[107∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant127 & Constant127 & Lambda48 & Access52 & Lambda102 & Lambda107 --> PgSelect32
     PgSelect40[["PgSelect[40∈0] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Constant123{{"Constant[123∈0] ➊<br />ᐸ100ᐳ"}}:::plan
-    Lambda112{{"Lambda[112∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant128{{"Constant[128∈0] ➊<br />ᐸ100ᐳ"}}:::plan
     Lambda117{{"Lambda[117∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant120 & Constant123 & Lambda48 & Lambda51 & Lambda112 & Lambda117 --> PgSelect40
+    Lambda122{{"Lambda[122∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant125 & Constant128 & Lambda48 & Access52 & Lambda117 & Lambda122 --> PgSelect40
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Constant118{{"Constant[118∈0] ➊<br />ᐸ'sara.smith@email.com'ᐳ"}}:::plan
-    Lambda56{{"Lambda[56∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda61{{"Lambda[61∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant118 & Lambda48 & Lambda51 & Lambda56 & Lambda61 --> PgSelect7
+    Constant123{{"Constant[123∈0] ➊<br />ᐸ'sara.smith@email.com'ᐳ"}}:::plan
+    Lambda57{{"Lambda[57∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda62{{"Lambda[62∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant123 & Lambda48 & Access52 & Lambda57 & Lambda62 --> PgSelect7
     PgSelect16[["PgSelect[16∈0] ➊<br />ᐸpersonᐳ"]]:::plan
-    Constant119{{"Constant[119∈0] ➊<br />ᐸ'does.not.exist@email.com'ᐳ"}}:::plan
-    Lambda70{{"Lambda[70∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda75{{"Lambda[75∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object10 & Constant119 & Lambda48 & Lambda51 & Lambda70 & Lambda75 --> PgSelect16
-    Object55{{"Object[55∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant52{{"Constant[52∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant53{{"Constant[53∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Constant54{{"Constant[54∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
-    Lambda48 & Constant52 & Constant53 & Constant54 --> Object55
-    Object69{{"Object[69∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
-    Lambda48 & Constant66 & Constant67 & Constant54 --> Object69
-    Object83{{"Object[83∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant80{{"Constant[80∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Lambda48 & Constant80 & Constant81 & Constant82 --> Object83
-    Object97{{"Object[97∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant94{{"Constant[94∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant95{{"Constant[95∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda48 & Constant94 & Constant95 & Constant82 --> Object97
-    Object111{{"Object[111∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Lambda48 & Constant108 & Constant109 & Constant82 --> Object111
+    Constant124{{"Constant[124∈0] ➊<br />ᐸ'does.not.exist@email.com'ᐳ"}}:::plan
+    Lambda72{{"Lambda[72∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Lambda77{{"Lambda[77∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object10 & Constant124 & Lambda48 & Access52 & Lambda72 & Lambda77 --> PgSelect16
+    Object56{{"Object[56∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant53{{"Constant[53∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant54{{"Constant[54∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Constant55{{"Constant[55∈0] ➊<br />ᐸRecordCodec(person)ᐳ"}}:::plan
+    Lambda48 & Constant53 & Constant54 & Constant55 --> Object56
+    Object71{{"Object[71∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸsql.identifier(”person”)ᐳ"}}:::plan
+    Lambda48 & Constant68 & Constant69 & Constant55 --> Object71
+    Object86{{"Object[86∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant83{{"Constant[83∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda48 & Constant83 & Constant84 & Constant85 --> Object86
+    Object101{{"Object[101∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant98{{"Constant[98∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant99{{"Constant[99∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda48 & Constant98 & Constant99 & Constant85 --> Object101
+    Object116{{"Object[116∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda48 & Constant113 & Constant114 & Constant85 --> Object116
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -86,25 +86,27 @@ graph TD
     PgSelect40 --> First42
     PgSelectSingle43{{"PgSelectSingle[43∈0] ➊<br />ᐸcompound_keyᐳ"}}:::plan
     First42 --> PgSelectSingle43
-    Constant124{{"Constant[124∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant124 --> Lambda48
-    Constant125{{"Constant[125∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant125 --> Lambda51
-    Object55 --> Lambda56
-    Constant126{{"Constant[126∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant126 --> Lambda61
-    Object69 --> Lambda70
-    Constant127{{"Constant[127∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
-    Constant127 --> Lambda75
-    Object83 --> Lambda84
-    Constant128{{"Constant[128∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant128 --> Lambda89
-    Object97 --> Lambda98
-    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant129 --> Lambda103
-    Object111 --> Lambda112
-    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant130 --> Lambda117
+    Constant129{{"Constant[129∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant129 --> Lambda48
+    Lambda51{{"Lambda[51∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant130 --> Lambda51
+    Lambda51 --> Access52
+    Object56 --> Lambda57
+    Constant131{{"Constant[131∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant131 --> Lambda62
+    Object71 --> Lambda72
+    Constant132{{"Constant[132∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”personᐳ"}}:::plan
+    Constant132 --> Lambda77
+    Object86 --> Lambda87
+    Constant133{{"Constant[133∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant133 --> Lambda92
+    Object101 --> Lambda102
+    Constant134{{"Constant[134∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant134 --> Lambda107
+    Object116 --> Lambda117
+    Constant135{{"Constant[135∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant135 --> Lambda122
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgClassExpression13{{"PgClassExpression[13∈1] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
@@ -130,9 +132,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/v4/unique-constraints"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 52, 53, 54, 66, 67, 80, 81, 82, 94, 95, 108, 109, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 10, 48, 51, 55, 56, 61, 69, 70, 75, 83, 84, 89, 97, 98, 103, 111, 112, 117<br />2: 7, 16, 24, 32, 40<br />ᐳ: 11, 12, 18, 19, 26, 27, 34, 35, 42, 43"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 53, 54, 55, 68, 69, 83, 84, 85, 98, 99, 113, 114, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 10, 48, 51, 52, 56, 57, 62, 71, 72, 77, 86, 87, 92, 101, 102, 107, 116, 117, 122<br />2: 7, 16, 24, 32, 40<br />ᐳ: 11, 12, 18, 19, 26, 27, 34, 35, 42, 43"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgSelect16,First18,PgSelectSingle19,PgSelect24,First26,PgSelectSingle27,PgSelect32,First34,PgSelectSingle35,PgSelect40,First42,PgSelectSingle43,Lambda48,Lambda51,Constant52,Constant53,Constant54,Object55,Lambda56,Lambda61,Constant66,Constant67,Object69,Lambda70,Lambda75,Constant80,Constant81,Constant82,Object83,Lambda84,Lambda89,Constant94,Constant95,Object97,Lambda98,Lambda103,Constant108,Constant109,Object111,Lambda112,Lambda117,Constant118,Constant119,Constant120,Constant121,Constant122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgSelect16,First18,PgSelectSingle19,PgSelect24,First26,PgSelectSingle27,PgSelect32,First34,PgSelectSingle35,PgSelect40,First42,PgSelectSingle43,Lambda48,Lambda51,Access52,Constant53,Constant54,Constant55,Object56,Lambda57,Lambda62,Constant68,Constant69,Object71,Lambda72,Lambda77,Constant83,Constant84,Constant85,Object86,Lambda87,Lambda92,Constant98,Constant99,Object101,Lambda102,Lambda107,Constant113,Constant114,Object116,Lambda117,Lambda122,Constant123,Constant124,Constant125,Constant126,Constant127,Constant128,Constant129,Constant130,Constant131,Constant132,Constant133,Constant134,Constant135 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12<br /><br />ROOT PgSelectSingleᐸpersonᐳ[12]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression13,PgClassExpression14 bucket1

--- a/postgraphile/postgraphile/__tests__/queries/v4/unique-foreign-keys.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/unique-foreign-keys.mermaid
@@ -9,61 +9,63 @@ graph TD
 
 
     %% plan dependencies
-    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
-    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
-    Constant49{{"Constant[49∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant50{{"Constant[50∈0] ➊<br />ᐸsql.identifier(”unique_foreign_key”)ᐳ"}}:::plan
-    Constant51{{"Constant[51∈0] ➊<br />ᐸRecordCodec(uniqueForeignKey)ᐳ"}}:::plan
-    Constant65{{"Constant[65∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant66{{"Constant[66∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
-    Constant81{{"Constant[81∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant82{{"Constant[82∈0] ➊<br />ᐸsql.identifier(”unique_foreign_key”)ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
-    Constant98{{"Constant[98∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
-    Constant107{{"Constant[107∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant108{{"Constant[108∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant109{{"Constant[109∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant110{{"Constant[110∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
-    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
-    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸcompound_keyᐳ"]]:::plan
-    Object12{{"Object[12∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Lambda48{{"Lambda[48∈1] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Lambda53{{"Lambda[53∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda58{{"Lambda[58∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda69{{"Lambda[69∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda74{{"Lambda[74∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda85{{"Lambda[85∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda90{{"Lambda[90∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda45{{"Lambda[45∈1] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Lambda101{{"Lambda[101∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda106{{"Lambda[106∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda48 & Lambda53 & Lambda58 & Lambda69 & Lambda74 & Lambda48 & Lambda85 & Lambda90 & Lambda45 & Lambda48 & Lambda101 & Lambda106 --> PgSelect14
-    Object52{{"Object[52∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant49 & Constant50 & Constant51 --> Object52
-    Object68{{"Object[68∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant65 & Constant66 & Constant67 --> Object68
-    Object84{{"Object[84∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant81 & Constant82 & Constant51 --> Object84
-    Object100{{"Object[100∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda45 & Constant97 & Constant98 & Constant67 --> Object100
-    Access10{{"Access[10∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
-    Access11{{"Access[11∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Object53{{"Object[53∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda45{{"Lambda[45∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant50{{"Constant[50∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant51{{"Constant[51∈0] ➊<br />ᐸsql.identifier(”unique_foreign_key”)ᐳ"}}:::plan
+    Constant52{{"Constant[52∈0] ➊<br />ᐸRecordCodec(uniqueForeignKey)ᐳ"}}:::plan
+    Lambda45 & Constant50 & Constant51 & Constant52 --> Object53
+    Object70{{"Object[70∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant67{{"Constant[67∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant68{{"Constant[68∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Constant69{{"Constant[69∈0] ➊<br />ᐸRecordCodec(compoundKey)ᐳ"}}:::plan
+    Lambda45 & Constant67 & Constant68 & Constant69 --> Object70
+    Object87{{"Object[87∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant84{{"Constant[84∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant85{{"Constant[85∈0] ➊<br />ᐸsql.identifier(”unique_foreign_key”)ᐳ"}}:::plan
+    Lambda45 & Constant84 & Constant85 & Constant52 --> Object87
+    Object104{{"Object[104∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant101{{"Constant[101∈0] ➊<br />ᐸ[ { codec: Codec(int4), fragment: { n: [Array], f: 0, c: 116ᐳ"}}:::plan
+    Constant102{{"Constant[102∈0] ➊<br />ᐸsql.identifier(”compound_key”)ᐳ"}}:::plan
+    Lambda45 & Constant101 & Constant102 & Constant69 --> Object104
+    Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Constant107 --> Lambda45
-    Constant108 --> Lambda48
-    Object52 --> Lambda53
-    Constant109 --> Lambda58
-    Object68 --> Lambda69
-    Constant110 --> Lambda74
-    Object84 --> Lambda85
-    Constant111 --> Lambda90
-    Object100 --> Lambda101
-    Constant112 --> Lambda106
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant111 --> Lambda45
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
+    Constant112{{"Constant[112∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant112 --> Lambda48
+    Access49{{"Access[49∈0] ➊<br />ᐸ48.0ᐳ"}}:::plan
+    Lambda48 --> Access49
+    Lambda54{{"Lambda[54∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object53 --> Lambda54
+    Lambda59{{"Lambda[59∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant113{{"Constant[113∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant113 --> Lambda59
+    Lambda71{{"Lambda[71∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object70 --> Lambda71
+    Lambda76{{"Lambda[76∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant114{{"Constant[114∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”compouᐳ"}}:::plan
+    Constant114 --> Lambda76
+    Lambda88{{"Lambda[88∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object87 --> Lambda88
+    Lambda93{{"Lambda[93∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant115{{"Constant[115∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”uniqueᐳ"}}:::plan
+    Constant115 --> Lambda93
+    Lambda105{{"Lambda[105∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object104 --> Lambda105
+    Lambda110{{"Lambda[110∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant116{{"Constant[116∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { codec: Codec(int4), fragment:ᐳ"}}:::plan
+    Constant116 --> Lambda110
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸcompound_keyᐳ"]]:::plan
+    Object12 & Connection13 & Access49 & Lambda54 & Lambda59 & Lambda71 & Lambda76 & Access49 & Lambda88 & Lambda93 & Lambda45 & Access49 & Lambda105 & Lambda110 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸcompound_keyᐳ"}}:::plan
@@ -96,10 +98,10 @@ graph TD
     subgraph "Buckets for queries/v4/unique-foreign-keys"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Connection13,Constant49,Constant50,Constant51,Constant65,Constant66,Constant67,Constant81,Constant82,Constant97,Constant98,Constant107,Constant108,Constant109,Constant110,Constant111,Constant112 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 2, 13, 107, 108, 49, 50, 51, 109, 65, 66, 67, 110, 81, 82, 111, 97, 98, 112<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: 10, 11, 45, 48, 58, 74, 90, 106, 12, 52, 53, 68, 69, 84, 85, 100, 101<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Lambda45,Lambda48,Access49,Constant50,Constant51,Constant52,Object53,Lambda54,Lambda59,Constant67,Constant68,Constant69,Object70,Lambda71,Lambda76,Constant84,Constant85,Object87,Lambda88,Lambda93,Constant101,Constant102,Object104,Lambda105,Lambda110,Constant111,Constant112,Constant113,Constant114,Constant115,Constant116 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 49, 54, 59, 71, 76, 88, 93, 45, 105, 110<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,Access10,Access11,Object12,PgSelect14,Lambda45,Lambda48,Object52,Lambda53,Lambda58,Object68,Lambda69,Lambda74,Object84,Lambda85,Lambda90,Object100,Lambda101,Lambda106 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2

--- a/postgraphile/postgraphile/__tests__/queries/v4/view.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/view.mermaid
@@ -9,6 +9,16 @@ graph TD
 
 
     %% plan dependencies
+    Object47{{"Object[47∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
+    Constant44{{"Constant[44∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸsql.identifier(”testview”)ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0] ➊<br />ᐸRecordCodec(testview)ᐳ"}}:::plan
+    Lambda39 & Constant44 & Constant45 & Constant46 --> Object47
+    Object62{{"Object[62∈0] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0] ➊<br />ᐸ[ { attribute: 'col1', direction: 'DESC' } ]ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0] ➊<br />ᐸsql.identifier(”testview”)ᐳ"}}:::plan
+    Lambda39 & Constant59 & Constant60 & Constant46 --> Object62
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -16,30 +26,28 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
     __Value2 --> Access11
-    Lambda39{{"Lambda[39∈0] ➊<br />ᐸcalculateShouldReverseOrderᐳ"}}:::plan
-    Constant67{{"Constant[67∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant67 --> Lambda39
+    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant69 --> Lambda39
     Lambda42{{"Lambda[42∈0] ➊<br />ᐸcalculateLimitAndOffsetSQLᐳ"}}:::plan
-    Constant68{{"Constant[68∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
-    Constant68 --> Lambda42
+    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ first: null, last: null, cursorLower: null, cursorUpper: ᐳ"}}:::plan
+    Constant70 --> Lambda42
+    Access43{{"Access[43∈0] ➊<br />ᐸ42.0ᐳ"}}:::plan
+    Lambda42 --> Access43
+    Lambda48{{"Lambda[48∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object47 --> Lambda48
+    Lambda53{{"Lambda[53∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant71{{"Constant[71∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”testviᐳ"}}:::plan
+    Constant71 --> Lambda53
+    Lambda63{{"Lambda[63∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Object62 --> Lambda63
+    Lambda68{{"Lambda[68∈0] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
+    Constant72{{"Constant[72∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col1', direction:ᐳ"}}:::plan
+    Constant72 --> Lambda68
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection13{{"Connection[13∈0] ➊<br />ᐸ9ᐳ"}}:::plan
     Connection27{{"Connection[27∈0] ➊<br />ᐸ25ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
-    Constant44{{"Constant[44∈0] ➊<br />ᐸsql.identifier(”testview”)ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸRecordCodec(testview)ᐳ"}}:::plan
-    Constant57{{"Constant[57∈0] ➊<br />ᐸ[ { attribute: 'col1', direction: 'DESC' } ]ᐳ"}}:::plan
-    Constant58{{"Constant[58∈0] ➊<br />ᐸsql.identifier(”testview”)ᐳ"}}:::plan
-    Constant69{{"Constant[69∈0] ➊<br />ᐸ§{ reverse: false, orders: [], alias: sql.identifier(”testviᐳ"}}:::plan
-    Constant70{{"Constant[70∈0] ➊<br />ᐸ§{ reverse: false, orders: [ { attribute: 'col1', direction:ᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸtestviewᐳ"]]:::plan
-    Lambda47{{"Lambda[47∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda52{{"Lambda[52∈1] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection13 & Lambda39 & Lambda42 & Lambda47 & Lambda52 --> PgSelect14
-    Object46{{"Object[46∈1] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda39 & Constant43 & Constant44 & Constant45 --> Object46
-    Object46 --> Lambda47
-    Constant69 --> Lambda52
+    Object12 & Connection13 & Lambda39 & Access43 & Lambda48 & Lambda53 --> PgSelect14
     __Item15[/"__Item[15∈2]<br />ᐸ14ᐳ"\]:::itemplan
     PgSelect14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈2]<br />ᐸtestviewᐳ"}}:::plan
@@ -57,13 +65,7 @@ graph TD
     PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__testview__.”col2”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression22
     PgSelect28[["PgSelect[28∈4] ➊<br />ᐸtestviewᐳ"]]:::plan
-    Lambda61{{"Lambda[61∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Lambda66{{"Lambda[66∈4] ➊<br />ᐸcalculateOrderBySQLᐳ"}}:::plan
-    Object12 & Connection27 & Lambda39 & Lambda42 & Lambda61 & Lambda66 --> PgSelect28
-    Object60{{"Object[60∈4] ➊<br />ᐸ{reverse,orders,alias,codec}ᐳ"}}:::plan
-    Lambda39 & Constant57 & Constant58 & Constant45 --> Object60
-    Object60 --> Lambda61
-    Constant70 --> Lambda66
+    Object12 & Connection27 & Lambda39 & Access43 & Lambda63 & Lambda68 --> PgSelect28
     __Item29[/"__Item[29∈5]<br />ᐸ28ᐳ"\]:::itemplan
     PgSelect28 ==> __Item29
     PgSelectSingle30{{"PgSelectSingle[30∈5]<br />ᐸtestviewᐳ"}}:::plan
@@ -84,19 +86,19 @@ graph TD
     subgraph "Buckets for queries/v4/view"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection27,Lambda39,Lambda42,Constant43,Constant44,Constant45,Constant57,Constant58,Constant67,Constant68,Constant69,Constant70 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 39, 42, 43, 44, 45, 69<br /><br />ROOT Connectionᐸ9ᐳ[13]<br />1: <br />ᐳ: Object[46], Lambda[52], Lambda[47]<br />2: PgSelect[14]"):::bucket
+    class Bucket0,__Value2,__Value4,Access10,Access11,Object12,Connection13,Connection27,Lambda39,Lambda42,Access43,Constant44,Constant45,Constant46,Object47,Lambda48,Lambda53,Constant59,Constant60,Object62,Lambda63,Lambda68,Constant69,Constant70,Constant71,Constant72 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 13, 39, 43, 48, 53<br /><br />ROOT Connectionᐸ9ᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect14,Object46,Lambda47,Lambda52 bucket1
+    class Bucket1,PgSelect14 bucket1
     Bucket2("Bucket 2 (listItem)<br /><br />ROOT __Item{2}ᐸ14ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item15,PgSelectSingle16 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16<br /><br />ROOT PgSelectSingle{2}ᐸtestviewᐳ[16]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgCursor17,PgClassExpression18,List19,PgClassExpression20,PgClassExpression21,PgClassExpression22 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 27, 39, 42, 57, 58, 45, 70<br /><br />ROOT Connectionᐸ25ᐳ[27]<br />1: <br />ᐳ: Object[60], Lambda[66], Lambda[61]<br />2: PgSelect[28]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 12, 27, 39, 43, 63, 68<br /><br />ROOT Connectionᐸ25ᐳ[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect28,Object60,Lambda61,Lambda66 bucket4
+    class Bucket4,PgSelect28 bucket4
     Bucket5("Bucket 5 (listItem)<br /><br />ROOT __Item{5}ᐸ28ᐳ[29]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item29,PgSelectSingle30 bucket5


### PR DESCRIPTION
## Description

Like

- #2326 

but for pgUnionAll rather than pgSelect.

## Performance impact

Worst case scenario improved.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
