### PR TITLE
Cleaner cloner

### DIFF
--- a/.changeset/lemon-geckos-sit.md
+++ b/.changeset/lemon-geckos-sit.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+---
+
+PgUnionAllStep now has static clone method and its constructor has been
+simplified.

--- a/.changeset/slimy-elephants-explain.md
+++ b/.changeset/slimy-elephants-explain.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+PgSelectStep now has clone method and its constructor has been simplified.

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -217,6 +217,8 @@ export interface PgSelectOptions<
   context?: ExecutableStep<PgExecutorContextPlans<any>>;
   /** @internal */
   _internalCloneSymbol?: symbol | string;
+  /** @internal */
+  _internalCloneAlias?: SQL;
 }
 
 /**
@@ -465,6 +467,7 @@ export class PgSelectStep<
       forceIdentity: cloneFrom.forceIdentity,
 
       _internalCloneSymbol: cloneFrom.symbol,
+      _internalCloneAlias: cloneFrom.alias,
     });
 
     if ($clone.dependencies.length !== 1) {
@@ -561,6 +564,7 @@ export class PgSelectStep<
 
       // Clone only details
       _internalCloneSymbol,
+      _internalCloneAlias,
     } = options;
 
     this.mode = mode ?? "normal";
@@ -588,7 +592,7 @@ export class PgSelectStep<
     this.name = name ?? resource.name;
     this.symbol = _internalCloneSymbol ?? Symbol(this.name);
     this._symbolSubstitutes = new Map();
-    this.alias = sql.identifier(this.symbol);
+    this.alias = _internalCloneAlias ?? sql.identifier(this.symbol);
     this.from = inFrom ?? resource.from;
     this.hasImplicitOrder = inHasImplicitOrder ?? resource.hasImplicitOrder;
     this.placeholders = [];

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -162,8 +162,6 @@ export interface PgUnionAllStepConfig<
    */
   forceIdentity?: boolean;
 
-  /** @internal @experimental */
-  context?: ExecutableStep<PgExecutorContextPlans<any>>;
   /** @internal */
   _internalCloneSymbol?: symbol | string;
   /** @internal */
@@ -535,32 +533,23 @@ export class PgUnionAllStep<
     TTypeNames extends string = string,
   >(cloneFrom: PgUnionAllStep<TAttributes, TTypeNames>, mode = cloneFrom.mode) {
     const cloneFromMatchingMode = cloneFrom?.mode === mode ? cloneFrom : null;
-    const context =
-      cloneFrom.contextId != null
-        ? cloneFrom.getDep(cloneFrom.contextId)
-        : undefined;
-    if (context && cloneFrom.contextId !== 0) {
-      throw new Error(`The first dependency must be the context`);
-    }
     const $clone = new PgUnionAllStep({
       ...cloneFrom.spec,
       mode,
       members: [], // This will be overwritten later
       forceIdentity: cloneFrom.forceIdentity,
-      context,
 
       _internalCloneSymbol: cloneFrom.symbol,
       _internalCloneAlias: cloneFrom.alias,
     });
 
-    if ($clone.dependencies.length !== (context ? 1 : 0)) {
+    if ($clone.dependencies.length !== 0) {
       throw new Error(
-        "Should not have any dependencies other than context yet",
+        `Should not have any dependencies yet: ${$clone.dependencies}`,
       );
     }
 
     cloneFrom.dependencies.forEach((planId, idx) => {
-      if (context && idx === 0) return;
       const myIdx = $clone.addDependency({
         ...cloneFrom.getDepOptions(idx),
         skipDeduplication: true,

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -33,11 +33,7 @@ import { $$symbolToIdentifier, $$toSQL, sql } from "pg-sql2";
 import type { PgCodecAttributes } from "../codecs.js";
 import { TYPES } from "../codecs.js";
 import type { PgResource, PgResourceUnique } from "../datasource.js";
-import type {
-  PgExecutor,
-  PgExecutorContextPlans,
-  PgExecutorInput,
-} from "../executor.js";
+import type { PgExecutor, PgExecutorInput } from "../executor.js";
 import type { PgCodecRefPath, PgCodecRelation, PgGroupSpec } from "../index.js";
 import type {
   PgCodec,

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -445,7 +445,7 @@ export class PgUnionAllStep<
   public symbol: symbol;
   public alias: SQL;
 
-  private selects: PgUnionAllStepSelect<TAttributes>[];
+  private selects: PgUnionAllStepSelect<TAttributes>[] = [];
 
   private executor!: PgExecutor;
   private contextId!: number;
@@ -454,9 +454,9 @@ export class PgUnionAllStep<
   public readonly spec: PgUnionAllStepConfig<TAttributes, TTypeNames>;
 
   /** @internal */
-  public orders: Array<PgOrderFragmentSpec>;
+  public orders: Array<PgOrderFragmentSpec> = [];
   /** The select index used to store the order value for the given order */
-  private orderSelectIndex: Array<number>;
+  private orderSelectIndex: Array<number> = [];
   /**
    * `ordersForCursor` is the same as `orders`, but then with the type and
    * primary key added. This ensures unique ordering, as required by cursor
@@ -469,56 +469,56 @@ export class PgUnionAllStep<
    * entries with `pk` higher than the given `pk`, and for all other `type`s we
    * can include all records.
    */
-  private ordersForCursor: Array<PgOrderFragmentSpec>;
+  private ordersForCursor: Array<PgOrderFragmentSpec> = [];
 
   /**
    * Values used in this plan.
    */
-  protected placeholders: Array<PgStmtDeferredPlaceholder>;
-  protected deferreds: Array<PgStmtDeferredSQL>;
+  protected placeholders: Array<PgStmtDeferredPlaceholder> = [];
+  protected deferreds: Array<PgStmtDeferredSQL> = [];
 
   // GROUP BY
 
-  private groups: Array<PgGroupSpec>;
+  private groups: Array<PgGroupSpec> = [];
 
   // HAVING
 
-  private havingConditions: SQL[];
+  private havingConditions: SQL[] = [];
 
   // LIMIT
 
-  protected firstStepId: number | null;
-  protected lastStepId: number | null;
+  protected firstStepId: number | null = null;
+  protected lastStepId: number | null = null;
   protected fetchOneExtra = false;
   /** When using natural pagination, this index is the lower bound (and should be excluded) */
-  protected lowerIndexStepId: number | null;
+  protected lowerIndexStepId: number | null = null;
   /** When using natural pagination, this index is the upper bound (and should be excluded) */
-  protected upperIndexStepId: number | null;
+  protected upperIndexStepId: number | null = null;
   /** When we calculate the limit/offset, we may be able to determine there cannot be a next page */
-  private limitAndOffsetId: number | null;
+  private limitAndOffsetId: number | null = null;
 
   // OFFSET
 
-  protected offsetStepId: number | null;
+  protected offsetStepId: number | null = null;
 
   // CURSORS
 
-  protected beforeStepId: number | null;
-  protected afterStepId: number | null;
+  protected beforeStepId: number | null = null;
+  protected afterStepId: number | null = null;
 
-  protected shouldReverseOrderId: number | null;
+  protected shouldReverseOrderId: number | null = null;
 
   // Connection
   private connectionDepId: number | null = null;
 
-  protected limitAndOffsetSQL: SQL | null;
-  private innerLimitSQL: SQL | null;
+  protected limitAndOffsetSQL: SQL | null = null;
+  private innerLimitSQL: SQL | null = null;
 
   public readonly mode: PgUnionAllMode;
 
   protected locker: PgLocker<this> = new PgLocker(this);
 
-  private memberDigests: MemberDigest<TTypeNames>[];
+  private memberDigests: MemberDigest<TTypeNames>[] = [];
   private _limitToTypes: string[] | undefined;
 
   /**
@@ -526,7 +526,7 @@ export class PgUnionAllStep<
    * seemingly innocuous things such as `random()`) otherwise we might only
    * call the relevant function once and re-use the result.
    */
-  public forceIdentity: boolean;
+  public forceIdentity = false;
 
   static clone<
     TAttributes extends string = string,
@@ -600,18 +600,6 @@ export class PgUnionAllStep<
   constructor(spec: PgUnionAllStepConfig<TAttributes, TTypeNames>) {
     super();
     {
-      this.firstStepId = null;
-      this.lastStepId = null;
-      this.offsetStepId = null;
-      this.lowerIndexStepId = null;
-      this.upperIndexStepId = null;
-      this.limitAndOffsetId = null;
-      this.beforeStepId = null;
-      this.afterStepId = null;
-      this.shouldReverseOrderId = null;
-      this.limitAndOffsetSQL = null;
-      this.innerLimitSQL = null;
-
       this.mode = spec.mode ?? "normal";
 
       if (this.mode === "aggregate") {
@@ -620,7 +608,6 @@ export class PgUnionAllStep<
         );
       }
       this.spec = spec;
-      this.forceIdentity = false;
       // If the user doesn't specify members, we'll just build membership based
       // on the provided resources.
       const members =
@@ -641,16 +628,6 @@ export class PgUnionAllStep<
       this.symbol = Symbol(spec.name ?? "union");
       this.alias = sql.identifier(this.symbol);
 
-      this.selects = [];
-      this.placeholders = [];
-      this.deferreds = [];
-      this.groups = [];
-      this.havingConditions = [];
-      this.orders = [];
-      this.orderSelectIndex = [];
-      this.ordersForCursor = [];
-
-      this.memberDigests = [];
       for (const member of members) {
         if (!this.executor) {
           this.executor = member.resource.executor;


### PR DESCRIPTION
## Description

PgSelectStep and PgUnionAllStep had ugly constructors that were overloaded to allow for cloning versus creating new steps. Horrible.

This PR creates new static clone methods instead, and refactors the constructor to be simpler.

This technically isn't a breaking change because people should not be constructing classes directly, they should be using the helper functions as detailed in the docs. And even if they are constructing the classes directly they shouldn't be using that for cloning.

## Performance impact

Marginal?

## Security impact

If there's bugs in this, the bugs could be unpleasant.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
