### PR TITLE
Handle errors before performing processRoot

### DIFF
--- a/.changeset/purple-suns-explode.md
+++ b/.changeset/purple-suns-explode.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Fix bug in handling errors inside lists

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -645,7 +645,7 @@ export function coerceError(
     }
   } else {
     return new GraphQLError(
-      error.message,
+      error?.message ?? String(error),
       locationDetails.node,
       null,
       null,
@@ -888,6 +888,13 @@ function makeExecutor<
         }
       }
     }
+    if (bucketRootFlags & FLAG_ERROR) {
+      throw coerceError(
+        rawBucketRootValue,
+        this.locationDetails,
+        mutablePath.slice(1),
+      );
+    }
     const bucketRootValue =
       this.processRoot !== null
         ? this.processRoot(rawBucketRootValue, bucketRootFlags)
@@ -898,13 +905,6 @@ function makeExecutor<
     );
     if (earlyReturn !== undefined) {
       return earlyReturn as any;
-    }
-    if (bucketRootFlags & FLAG_ERROR) {
-      throw coerceError(
-        bucketRootValue,
-        this.locationDetails,
-        mutablePath.slice(1),
-      );
     }
     if (!skipNullHandling) {
       if (bucketRootValue == null)


### PR DESCRIPTION
## Description

When working on #2339 I got into a situation where the cursors were invalid and thrown an error; but that error was then passed to `processRoot` which resulted in `undefined` error; which we then threw. Made little sense.

This PR moves the error check earlier... I don't think we want errors going through processRoot?

## Performance impact

Marginal.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
