### PR TITLE
Mark a few of the pg-sql2 inputs as readonly

### DIFF
--- a/.changeset/honest-goats-learn.md
+++ b/.changeset/honest-goats-learn.md
@@ -1,0 +1,6 @@
+---
+"pg-sql2": patch
+---
+
+Some of the pg-sql2 inputs are now marked Readonly to indicate we won't mutate
+them.

--- a/utils/pg-sql2/src/index.ts
+++ b/utils/pg-sql2/src/index.ts
@@ -401,7 +401,7 @@ function enforceValidNode(node: unknown, where?: string): SQL {
  */
 export function compile(
   sql: SQL,
-  options?: { placeholderValues?: Map<symbol, SQL> },
+  options?: { placeholderValues?: ReadonlyMap<symbol, SQL> },
 ): {
   text: string;
   values: SQLRawValue[];
@@ -806,7 +806,7 @@ export function literal(val: string | number | boolean | null): SQL {
  * dealing with lists of SQL items, for example a dynamic list of columns or
  * variadic SQL function arguments.
  */
-export function join(items: Array<SQL>, separator = ""): SQL {
+export function join(items: ReadonlyArray<SQL>, separator = ""): SQL {
   if (!Array.isArray(items)) {
     throw new Error(
       `[pg-sql2] Invalid sql.join call - the first argument should be an array, but it was '${inspect(
@@ -1235,7 +1235,7 @@ export function replaceSymbol(
  */
 function getSubstitute(
   initialSymbol: symbol,
-  symbolSubstitutes?: Map<symbol, symbol>,
+  symbolSubstitutes?: ReadonlyMap<symbol, symbol>,
 ): symbol {
   const path: symbol[] = [];
   let symbol = initialSymbol;


### PR DESCRIPTION
## Description

As above

## Performance impact

Types only.

## Security impact

Types only.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
