### PR TITLE
Remove TODO from make-add-pg-table-condition-plugin.md

### DIFF
--- a/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
+++ b/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
@@ -44,7 +44,6 @@ To return a list of forums which match a list of primary keys:
 import { makeAddPgTableConditionPlugin } from "postgraphile/utils";
 import { TYPES, listOfCodec } from "postgraphile/@dataplan/pg";
 
-/* TODO: test this plugin works! */
 export default makeAddPgTableConditionPlugin(
   { schemaName: "app_public", tableName: "forums" },
   "idIn",


### PR DESCRIPTION
I tested it by creating a nearly identical plugin in my Postgraphile project. It works. TODO no longer necessary unless you wanted some more rigorous or automated testing or something
