### PR TITLE
Fix bug in operationPlan.cacheStep that didn't respect polymorphic paths

### DIFF
--- a/.changeset/brown-experts-complain.md
+++ b/.changeset/brown-experts-complain.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Fix bug in operationPlan.cacheStep that didn't respect polymorphic paths.

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.deopt.mermaid
@@ -77,20 +77,25 @@ graph TD
     PgSelect39 --> PgSelectRows44
     First43 --> PgSelectSingle45
     PgSelectSingle45 --> PgClassExpression46
+    PgClassExpression48{{"PgClassExpression[48∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle45 --> PgClassExpression48
     First82{{"First[82∈4] ➊"}}:::plan
     PgSelectRows83[["PgSelectRows[83∈4] ➊"]]:::plan
     PgSelectRows83 --> First82
     PgSelect80 --> PgSelectRows83
     First82 --> PgSelectSingle84
     PgSelectSingle84 --> PgClassExpression85
+    PgClassExpression87{{"PgClassExpression[87∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression87
     First121{{"First[121∈4] ➊"}}:::plan
     PgSelectRows122[["PgSelectRows[122∈4] ➊"]]:::plan
     PgSelectRows122 --> First121
     PgSelect119 --> PgSelectRows122
     First121 --> PgSelectSingle123
     PgSelectSingle123 --> PgClassExpression124
+    PgClassExpression126{{"PgClassExpression[126∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle123 --> PgClassExpression126
     PgSelect49[["PgSelect[49∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression48{{"PgClassExpression[48∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object31 & PgClassExpression48 --> PgSelect49
     PgSelect56[["PgSelect[56∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object31 & PgClassExpression48 --> PgSelect56
@@ -100,7 +105,6 @@ graph TD
     Object31 & PgClassExpression48 --> PgSelect69
     PgSelect74[["PgSelect[74∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object31 & PgClassExpression48 --> PgSelect74
-    PgSelectSingle45 --> PgClassExpression48
     First53{{"First[53∈6] ➊"}}:::plan
     PgSelectRows54[["PgSelectRows[54∈6] ➊"]]:::plan
     PgSelectRows54 --> First53
@@ -138,7 +142,6 @@ graph TD
     PgSelectSingle78{{"PgSelectSingle[78∈6] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First76 --> PgSelectSingle78
     PgSelect88[["PgSelect[88∈7] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression87{{"PgClassExpression[87∈7] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object31 & PgClassExpression87 --> PgSelect88
     PgSelect95[["PgSelect[95∈7] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object31 & PgClassExpression87 --> PgSelect95
@@ -148,7 +151,6 @@ graph TD
     Object31 & PgClassExpression87 --> PgSelect108
     PgSelect113[["PgSelect[113∈7] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object31 & PgClassExpression87 --> PgSelect113
-    PgSelectSingle84 --> PgClassExpression87
     First92{{"First[92∈7] ➊"}}:::plan
     PgSelectRows93[["PgSelectRows[93∈7] ➊"]]:::plan
     PgSelectRows93 --> First92
@@ -186,7 +188,6 @@ graph TD
     PgSelectSingle117{{"PgSelectSingle[117∈7] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First115 --> PgSelectSingle117
     PgSelect127[["PgSelect[127∈8] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression126{{"PgClassExpression[126∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object31 & PgClassExpression126 --> PgSelect127
     PgSelect134[["PgSelect[134∈8] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object31 & PgClassExpression126 --> PgSelect134
@@ -196,7 +197,6 @@ graph TD
     Object31 & PgClassExpression126 --> PgSelect147
     PgSelect152[["PgSelect[152∈8] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object31 & PgClassExpression126 --> PgSelect152
-    PgSelectSingle123 --> PgClassExpression126
     First131{{"First[131∈8] ➊"}}:::plan
     PgSelectRows132[["PgSelectRows[132∈8] ➊"]]:::plan
     PgSelectRows132 --> First131
@@ -271,20 +271,25 @@ graph TD
     PgSelect174 --> PgSelectRows179
     First178 --> PgSelectSingle180
     PgSelectSingle180 --> PgClassExpression181
+    PgClassExpression183{{"PgClassExpression[183∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle180 --> PgClassExpression183
     First217{{"First[217∈10] ➊"}}:::plan
     PgSelectRows218[["PgSelectRows[218∈10] ➊"]]:::plan
     PgSelectRows218 --> First217
     PgSelect215 --> PgSelectRows218
     First217 --> PgSelectSingle219
     PgSelectSingle219 --> PgClassExpression220
+    PgClassExpression222{{"PgClassExpression[222∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle219 --> PgClassExpression222
     First256{{"First[256∈10] ➊"}}:::plan
     PgSelectRows257[["PgSelectRows[257∈10] ➊"]]:::plan
     PgSelectRows257 --> First256
     PgSelect254 --> PgSelectRows257
     First256 --> PgSelectSingle258
     PgSelectSingle258 --> PgClassExpression259
+    PgClassExpression261{{"PgClassExpression[261∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle258 --> PgClassExpression261
     PgSelect184[["PgSelect[184∈12] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression183{{"PgClassExpression[183∈12] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object166 & PgClassExpression183 --> PgSelect184
     PgSelect191[["PgSelect[191∈12] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object166 & PgClassExpression183 --> PgSelect191
@@ -294,7 +299,6 @@ graph TD
     Object166 & PgClassExpression183 --> PgSelect204
     PgSelect209[["PgSelect[209∈12] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object166 & PgClassExpression183 --> PgSelect209
-    PgSelectSingle180 --> PgClassExpression183
     First188{{"First[188∈12] ➊"}}:::plan
     PgSelectRows189[["PgSelectRows[189∈12] ➊"]]:::plan
     PgSelectRows189 --> First188
@@ -332,7 +336,6 @@ graph TD
     PgSelectSingle213{{"PgSelectSingle[213∈12] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First211 --> PgSelectSingle213
     PgSelect223[["PgSelect[223∈13] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression222{{"PgClassExpression[222∈13] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object166 & PgClassExpression222 --> PgSelect223
     PgSelect230[["PgSelect[230∈13] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object166 & PgClassExpression222 --> PgSelect230
@@ -342,7 +345,6 @@ graph TD
     Object166 & PgClassExpression222 --> PgSelect243
     PgSelect248[["PgSelect[248∈13] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object166 & PgClassExpression222 --> PgSelect248
-    PgSelectSingle219 --> PgClassExpression222
     First227{{"First[227∈13] ➊"}}:::plan
     PgSelectRows228[["PgSelectRows[228∈13] ➊"]]:::plan
     PgSelectRows228 --> First227
@@ -380,7 +382,6 @@ graph TD
     PgSelectSingle252{{"PgSelectSingle[252∈13] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First250 --> PgSelectSingle252
     PgSelect262[["PgSelect[262∈14] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression261{{"PgClassExpression[261∈14] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object166 & PgClassExpression261 --> PgSelect262
     PgSelect269[["PgSelect[269∈14] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object166 & PgClassExpression261 --> PgSelect269
@@ -390,7 +391,6 @@ graph TD
     Object166 & PgClassExpression261 --> PgSelect282
     PgSelect287[["PgSelect[287∈14] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object166 & PgClassExpression261 --> PgSelect287
-    PgSelectSingle258 --> PgClassExpression261
     First266{{"First[266∈14] ➊"}}:::plan
     PgSelectRows267[["PgSelectRows[267∈14] ➊"]]:::plan
     PgSelectRows267 --> First266
@@ -443,39 +443,39 @@ graph TD
     Bucket3("Bucket 3 (mutationField)<br />Deps: 10, 11, 2, 295, 296, 297, 298, 299, 300, 4<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgInsertSingle[28]<br />5: PgClassExpression[32]<br />6: PgInsertSingle[33]<br />7: <br />ᐳ: PgClassExpression[37]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgInsertSingle28,Access29,Access30,Object31,PgClassExpression32,PgInsertSingle33,PgClassExpression37 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 298, 299, 300, 37, 4<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]<br />1: 39, 80, 119<br />2: 44, 83, 122<br />ᐳ: 43, 45, 46, 47, 82, 84, 85, 86, 121, 123, 124, 125"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 298, 299, 300, 37, 4<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]<br />1: 39, 80, 119<br />2: 44, 83, 122<br />ᐳ: 43, 45, 46, 47, 48, 82, 84, 85, 86, 87, 121, 123, 124, 125, 126"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgClassExpression46,PgPolymorphic47,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgClassExpression124,PgPolymorphic125 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 4, 45, 31, 47, 84, 86, 123, 125<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket4,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgClassExpression46,PgPolymorphic47,PgClassExpression48,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgClassExpression87,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgClassExpression124,PgPolymorphic125,PgClassExpression126 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 4, 31, 48, 47, 87, 86, 126, 125<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 45, 31, 47<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[48]<br />2: 49, 56, 64, 69, 74<br />3: 54, 59, 67, 72, 77<br />ᐳ: 53, 55, 58, 60, 61, 62, 63, 66, 68, 71, 73, 76, 78"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 31, 48, 47<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 49, 56, 64, 69, 74<br />2: 54, 59, 67, 72, 77<br />ᐳ: 53, 55, 58, 60, 61, 62, 63, 66, 68, 71, 73, 76, 78"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression48,PgSelect49,First53,PgSelectRows54,PgSelectSingle55,PgSelect56,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 84, 31, 86<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[87]<br />2: 88, 95, 103, 108, 113<br />3: 93, 98, 106, 111, 116<br />ᐳ: 92, 94, 97, 99, 100, 101, 102, 105, 107, 110, 112, 115, 117"):::bucket
+    class Bucket6,PgSelect49,First53,PgSelectRows54,PgSelectSingle55,PgSelect56,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 31, 87, 86<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 88, 95, 103, 108, 113<br />2: 93, 98, 106, 111, 116<br />ᐳ: 92, 94, 97, 99, 100, 101, 102, 105, 107, 110, 112, 115, 117"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression87,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgSelect95,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,PgClassExpression101,PgClassExpression102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgSelect113,First115,PgSelectRows116,PgSelectSingle117 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 123, 31, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[126]<br />2: 127, 134, 142, 147, 152<br />3: 132, 137, 145, 150, 155<br />ᐳ: 131, 133, 136, 138, 139, 140, 141, 144, 146, 149, 151, 154, 156"):::bucket
+    class Bucket7,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgSelect95,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,PgClassExpression101,PgClassExpression102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgSelect113,First115,PgSelectRows116,PgSelectSingle117 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 31, 126, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 127, 134, 142, 147, 152<br />2: 132, 137, 145, 150, 155<br />ᐳ: 131, 133, 136, 138, 139, 140, 141, 144, 146, 149, 151, 154, 156"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression126,PgSelect127,First131,PgSelectRows132,PgSelectSingle133,PgSelect134,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression139,PgClassExpression140,PgClassExpression141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146,PgSelect147,First149,PgSelectRows150,PgSelectSingle151,PgSelect152,First154,PgSelectRows155,PgSelectSingle156 bucket8
+    class Bucket8,PgSelect127,First131,PgSelectRows132,PgSelectSingle133,PgSelect134,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression139,PgClassExpression140,PgClassExpression141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146,PgSelect147,First149,PgSelectRows150,PgSelectSingle151,PgSelect152,First154,PgSelectRows155,PgSelectSingle156 bucket8
     Bucket9("Bucket 9 (mutationField)<br />Deps: 10, 11, 2, 301, 302, 303, 298, 299, 300, 4<br /><br />1: Access[164]<br />2: Access[165]<br />3: Object[166]<br />4: PgInsertSingle[163]<br />5: PgClassExpression[167]<br />6: PgInsertSingle[168]<br />7: <br />ᐳ: PgClassExpression[172]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgInsertSingle163,Access164,Access165,Object166,PgClassExpression167,PgInsertSingle168,PgClassExpression172 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 166, 298, 299, 300, 172, 4<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[172]<br />1: 174, 215, 254<br />2: 179, 218, 257<br />ᐳ: 178, 180, 181, 182, 217, 219, 220, 221, 256, 258, 259, 260"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 166, 298, 299, 300, 172, 4<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[172]<br />1: 174, 215, 254<br />2: 179, 218, 257<br />ᐳ: 178, 180, 181, 182, 183, 217, 219, 220, 221, 222, 256, 258, 259, 260, 261"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect174,First178,PgSelectRows179,PgSelectSingle180,PgClassExpression181,PgPolymorphic182,PgSelect215,First217,PgSelectRows218,PgSelectSingle219,PgClassExpression220,PgPolymorphic221,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgClassExpression259,PgPolymorphic260 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 4, 180, 166, 182, 219, 221, 258, 260<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket10,PgSelect174,First178,PgSelectRows179,PgSelectSingle180,PgClassExpression181,PgPolymorphic182,PgClassExpression183,PgSelect215,First217,PgSelectRows218,PgSelectSingle219,PgClassExpression220,PgPolymorphic221,PgClassExpression222,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgClassExpression259,PgPolymorphic260,PgClassExpression261 bucket10
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 4, 166, 183, 182, 222, 221, 261, 260<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 180, 166, 182<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[183]<br />2: 184, 191, 199, 204, 209<br />3: 189, 194, 202, 207, 212<br />ᐳ: 188, 190, 193, 195, 196, 197, 198, 201, 203, 206, 208, 211, 213"):::bucket
+    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 166, 183, 182<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 184, 191, 199, 204, 209<br />2: 189, 194, 202, 207, 212<br />ᐳ: 188, 190, 193, 195, 196, 197, 198, 201, 203, 206, 208, 211, 213"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression183,PgSelect184,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgClassExpression196,PgClassExpression197,PgClassExpression198,PgSelect199,First201,PgSelectRows202,PgSelectSingle203,PgSelect204,First206,PgSelectRows207,PgSelectSingle208,PgSelect209,First211,PgSelectRows212,PgSelectSingle213 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 219, 166, 221<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[222]<br />2: 223, 230, 238, 243, 248<br />3: 228, 233, 241, 246, 251<br />ᐳ: 227, 229, 232, 234, 235, 236, 237, 240, 242, 245, 247, 250, 252"):::bucket
+    class Bucket12,PgSelect184,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgClassExpression196,PgClassExpression197,PgClassExpression198,PgSelect199,First201,PgSelectRows202,PgSelectSingle203,PgSelect204,First206,PgSelectRows207,PgSelectSingle208,PgSelect209,First211,PgSelectRows212,PgSelectSingle213 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 166, 222, 221<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 223, 230, 238, 243, 248<br />2: 228, 233, 241, 246, 251<br />ᐳ: 227, 229, 232, 234, 235, 236, 237, 240, 242, 245, 247, 250, 252"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression222,PgSelect223,First227,PgSelectRows228,PgSelectSingle229,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgClassExpression235,PgClassExpression236,PgClassExpression237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242,PgSelect243,First245,PgSelectRows246,PgSelectSingle247,PgSelect248,First250,PgSelectRows251,PgSelectSingle252 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 258, 166, 260<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[261]<br />2: 262, 269, 277, 282, 287<br />3: 267, 272, 280, 285, 290<br />ᐳ: 266, 268, 271, 273, 274, 275, 276, 279, 281, 284, 286, 289, 291"):::bucket
+    class Bucket13,PgSelect223,First227,PgSelectRows228,PgSelectSingle229,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgClassExpression235,PgClassExpression236,PgClassExpression237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242,PgSelect243,First245,PgSelectRows246,PgSelectSingle247,PgSelect248,First250,PgSelectRows251,PgSelectSingle252 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 166, 261, 260<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 262, 269, 277, 282, 287<br />2: 267, 272, 280, 285, 290<br />ᐳ: 266, 268, 271, 273, 274, 275, 276, 279, 281, 284, 286, 289, 291"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression261,PgSelect262,First266,PgSelectRows267,PgSelectSingle268,PgSelect269,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression274,PgClassExpression275,PgClassExpression276,PgSelect277,First279,PgSelectRows280,PgSelectSingle281,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,PgSelect287,First289,PgSelectRows290,PgSelectSingle291 bucket14
+    class Bucket14,PgSelect262,First266,PgSelectRows267,PgSelectSingle268,PgSelect269,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression274,PgClassExpression275,PgClassExpression276,PgSelect277,First279,PgSelectRows280,PgSelectSingle281,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,PgSelect287,First289,PgSelectRows290,PgSelectSingle291 bucket14
     Bucket0 --> Bucket1 & Bucket3 & Bucket9
     Bucket1 --> Bucket2
     Bucket3 --> Bucket4

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-relational-post-no-query.mermaid
@@ -77,20 +77,25 @@ graph TD
     PgSelect39 --> PgSelectRows44
     First43 --> PgSelectSingle45
     PgSelectSingle45 --> PgClassExpression46
+    PgClassExpression48{{"PgClassExpression[48∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle45 --> PgClassExpression48
     First82{{"First[82∈4] ➊"}}:::plan
     PgSelectRows83[["PgSelectRows[83∈4] ➊"]]:::plan
     PgSelectRows83 --> First82
     PgSelect80 --> PgSelectRows83
     First82 --> PgSelectSingle84
     PgSelectSingle84 --> PgClassExpression85
+    PgClassExpression87{{"PgClassExpression[87∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression87
     First121{{"First[121∈4] ➊"}}:::plan
     PgSelectRows122[["PgSelectRows[122∈4] ➊"]]:::plan
     PgSelectRows122 --> First121
     PgSelect119 --> PgSelectRows122
     First121 --> PgSelectSingle123
     PgSelectSingle123 --> PgClassExpression124
+    PgClassExpression126{{"PgClassExpression[126∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle123 --> PgClassExpression126
     PgSelect49[["PgSelect[49∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression48{{"PgClassExpression[48∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object31 & PgClassExpression48 --> PgSelect49
     PgSelect56[["PgSelect[56∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object31 & PgClassExpression48 --> PgSelect56
@@ -100,7 +105,6 @@ graph TD
     Object31 & PgClassExpression48 --> PgSelect69
     PgSelect74[["PgSelect[74∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object31 & PgClassExpression48 --> PgSelect74
-    PgSelectSingle45 --> PgClassExpression48
     First53{{"First[53∈6] ➊"}}:::plan
     PgSelectRows54[["PgSelectRows[54∈6] ➊"]]:::plan
     PgSelectRows54 --> First53
@@ -138,7 +142,6 @@ graph TD
     PgSelectSingle78{{"PgSelectSingle[78∈6] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First76 --> PgSelectSingle78
     PgSelect88[["PgSelect[88∈7] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression87{{"PgClassExpression[87∈7] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object31 & PgClassExpression87 --> PgSelect88
     PgSelect95[["PgSelect[95∈7] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object31 & PgClassExpression87 --> PgSelect95
@@ -148,7 +151,6 @@ graph TD
     Object31 & PgClassExpression87 --> PgSelect108
     PgSelect113[["PgSelect[113∈7] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object31 & PgClassExpression87 --> PgSelect113
-    PgSelectSingle84 --> PgClassExpression87
     First92{{"First[92∈7] ➊"}}:::plan
     PgSelectRows93[["PgSelectRows[93∈7] ➊"]]:::plan
     PgSelectRows93 --> First92
@@ -186,7 +188,6 @@ graph TD
     PgSelectSingle117{{"PgSelectSingle[117∈7] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First115 --> PgSelectSingle117
     PgSelect127[["PgSelect[127∈8] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression126{{"PgClassExpression[126∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object31 & PgClassExpression126 --> PgSelect127
     PgSelect134[["PgSelect[134∈8] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object31 & PgClassExpression126 --> PgSelect134
@@ -196,7 +197,6 @@ graph TD
     Object31 & PgClassExpression126 --> PgSelect147
     PgSelect152[["PgSelect[152∈8] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object31 & PgClassExpression126 --> PgSelect152
-    PgSelectSingle123 --> PgClassExpression126
     First131{{"First[131∈8] ➊"}}:::plan
     PgSelectRows132[["PgSelectRows[132∈8] ➊"]]:::plan
     PgSelectRows132 --> First131
@@ -271,20 +271,25 @@ graph TD
     PgSelect174 --> PgSelectRows179
     First178 --> PgSelectSingle180
     PgSelectSingle180 --> PgClassExpression181
+    PgClassExpression183{{"PgClassExpression[183∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle180 --> PgClassExpression183
     First217{{"First[217∈10] ➊"}}:::plan
     PgSelectRows218[["PgSelectRows[218∈10] ➊"]]:::plan
     PgSelectRows218 --> First217
     PgSelect215 --> PgSelectRows218
     First217 --> PgSelectSingle219
     PgSelectSingle219 --> PgClassExpression220
+    PgClassExpression222{{"PgClassExpression[222∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle219 --> PgClassExpression222
     First256{{"First[256∈10] ➊"}}:::plan
     PgSelectRows257[["PgSelectRows[257∈10] ➊"]]:::plan
     PgSelectRows257 --> First256
     PgSelect254 --> PgSelectRows257
     First256 --> PgSelectSingle258
     PgSelectSingle258 --> PgClassExpression259
+    PgClassExpression261{{"PgClassExpression[261∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle258 --> PgClassExpression261
     PgSelect184[["PgSelect[184∈12] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression183{{"PgClassExpression[183∈12] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object166 & PgClassExpression183 --> PgSelect184
     PgSelect191[["PgSelect[191∈12] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object166 & PgClassExpression183 --> PgSelect191
@@ -294,7 +299,6 @@ graph TD
     Object166 & PgClassExpression183 --> PgSelect204
     PgSelect209[["PgSelect[209∈12] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object166 & PgClassExpression183 --> PgSelect209
-    PgSelectSingle180 --> PgClassExpression183
     First188{{"First[188∈12] ➊"}}:::plan
     PgSelectRows189[["PgSelectRows[189∈12] ➊"]]:::plan
     PgSelectRows189 --> First188
@@ -332,7 +336,6 @@ graph TD
     PgSelectSingle213{{"PgSelectSingle[213∈12] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First211 --> PgSelectSingle213
     PgSelect223[["PgSelect[223∈13] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression222{{"PgClassExpression[222∈13] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object166 & PgClassExpression222 --> PgSelect223
     PgSelect230[["PgSelect[230∈13] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object166 & PgClassExpression222 --> PgSelect230
@@ -342,7 +345,6 @@ graph TD
     Object166 & PgClassExpression222 --> PgSelect243
     PgSelect248[["PgSelect[248∈13] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object166 & PgClassExpression222 --> PgSelect248
-    PgSelectSingle219 --> PgClassExpression222
     First227{{"First[227∈13] ➊"}}:::plan
     PgSelectRows228[["PgSelectRows[228∈13] ➊"]]:::plan
     PgSelectRows228 --> First227
@@ -380,7 +382,6 @@ graph TD
     PgSelectSingle252{{"PgSelectSingle[252∈13] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First250 --> PgSelectSingle252
     PgSelect262[["PgSelect[262∈14] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression261{{"PgClassExpression[261∈14] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object166 & PgClassExpression261 --> PgSelect262
     PgSelect269[["PgSelect[269∈14] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object166 & PgClassExpression261 --> PgSelect269
@@ -390,7 +391,6 @@ graph TD
     Object166 & PgClassExpression261 --> PgSelect282
     PgSelect287[["PgSelect[287∈14] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object166 & PgClassExpression261 --> PgSelect287
-    PgSelectSingle258 --> PgClassExpression261
     First266{{"First[266∈14] ➊"}}:::plan
     PgSelectRows267[["PgSelectRows[267∈14] ➊"]]:::plan
     PgSelectRows267 --> First266
@@ -443,39 +443,39 @@ graph TD
     Bucket3("Bucket 3 (mutationField)<br />Deps: 10, 11, 2, 295, 296, 297, 298, 299, 300, 4<br /><br />1: Access[29]<br />2: Access[30]<br />3: Object[31]<br />4: PgInsertSingle[28]<br />5: PgClassExpression[32]<br />6: PgInsertSingle[33]<br />7: <br />ᐳ: PgClassExpression[37]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgInsertSingle28,Access29,Access30,Object31,PgClassExpression32,PgInsertSingle33,PgClassExpression37 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 298, 299, 300, 37, 4<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]<br />1: 39, 80, 119<br />2: 44, 83, 122<br />ᐳ: 43, 45, 46, 47, 82, 84, 85, 86, 121, 123, 124, 125"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 31, 298, 299, 300, 37, 4<br /><br />ROOT PgClassExpression{3}ᐸ__relational_posts__ᐳ[37]<br />1: 39, 80, 119<br />2: 44, 83, 122<br />ᐳ: 43, 45, 46, 47, 48, 82, 84, 85, 86, 87, 121, 123, 124, 125, 126"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgClassExpression46,PgPolymorphic47,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgClassExpression124,PgPolymorphic125 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 4, 45, 31, 47, 84, 86, 123, 125<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket4,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgClassExpression46,PgPolymorphic47,PgClassExpression48,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgClassExpression87,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgClassExpression124,PgPolymorphic125,PgClassExpression126 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 4, 31, 48, 47, 87, 86, 126, 125<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 45, 31, 47<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[48]<br />2: 49, 56, 64, 69, 74<br />3: 54, 59, 67, 72, 77<br />ᐳ: 53, 55, 58, 60, 61, 62, 63, 66, 68, 71, 73, 76, 78"):::bucket
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 31, 48, 47<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 49, 56, 64, 69, 74<br />2: 54, 59, 67, 72, 77<br />ᐳ: 53, 55, 58, 60, 61, 62, 63, 66, 68, 71, 73, 76, 78"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression48,PgSelect49,First53,PgSelectRows54,PgSelectSingle55,PgSelect56,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 84, 31, 86<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[87]<br />2: 88, 95, 103, 108, 113<br />3: 93, 98, 106, 111, 116<br />ᐳ: 92, 94, 97, 99, 100, 101, 102, 105, 107, 110, 112, 115, 117"):::bucket
+    class Bucket6,PgSelect49,First53,PgSelectRows54,PgSelectSingle55,PgSelect56,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 31, 87, 86<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 88, 95, 103, 108, 113<br />2: 93, 98, 106, 111, 116<br />ᐳ: 92, 94, 97, 99, 100, 101, 102, 105, 107, 110, 112, 115, 117"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression87,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgSelect95,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,PgClassExpression101,PgClassExpression102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgSelect113,First115,PgSelectRows116,PgSelectSingle117 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 123, 31, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[126]<br />2: 127, 134, 142, 147, 152<br />3: 132, 137, 145, 150, 155<br />ᐳ: 131, 133, 136, 138, 139, 140, 141, 144, 146, 149, 151, 154, 156"):::bucket
+    class Bucket7,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgSelect95,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,PgClassExpression101,PgClassExpression102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgSelect113,First115,PgSelectRows116,PgSelectSingle117 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 31, 126, 125<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 127, 134, 142, 147, 152<br />2: 132, 137, 145, 150, 155<br />ᐳ: 131, 133, 136, 138, 139, 140, 141, 144, 146, 149, 151, 154, 156"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression126,PgSelect127,First131,PgSelectRows132,PgSelectSingle133,PgSelect134,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression139,PgClassExpression140,PgClassExpression141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146,PgSelect147,First149,PgSelectRows150,PgSelectSingle151,PgSelect152,First154,PgSelectRows155,PgSelectSingle156 bucket8
+    class Bucket8,PgSelect127,First131,PgSelectRows132,PgSelectSingle133,PgSelect134,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression139,PgClassExpression140,PgClassExpression141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146,PgSelect147,First149,PgSelectRows150,PgSelectSingle151,PgSelect152,First154,PgSelectRows155,PgSelectSingle156 bucket8
     Bucket9("Bucket 9 (mutationField)<br />Deps: 10, 11, 2, 301, 302, 303, 298, 299, 300, 4<br /><br />1: Access[164]<br />2: Access[165]<br />3: Object[166]<br />4: PgInsertSingle[163]<br />5: PgClassExpression[167]<br />6: PgInsertSingle[168]<br />7: <br />ᐳ: PgClassExpression[172]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgInsertSingle163,Access164,Access165,Object166,PgClassExpression167,PgInsertSingle168,PgClassExpression172 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 166, 298, 299, 300, 172, 4<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[172]<br />1: 174, 215, 254<br />2: 179, 218, 257<br />ᐳ: 178, 180, 181, 182, 217, 219, 220, 221, 256, 258, 259, 260"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 166, 298, 299, 300, 172, 4<br /><br />ROOT PgClassExpression{9}ᐸ__relational_posts__ᐳ[172]<br />1: 174, 215, 254<br />2: 179, 218, 257<br />ᐳ: 178, 180, 181, 182, 183, 217, 219, 220, 221, 222, 256, 258, 259, 260, 261"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect174,First178,PgSelectRows179,PgSelectSingle180,PgClassExpression181,PgPolymorphic182,PgSelect215,First217,PgSelectRows218,PgSelectSingle219,PgClassExpression220,PgPolymorphic221,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgClassExpression259,PgPolymorphic260 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 4, 180, 166, 182, 219, 221, 258, 260<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket10,PgSelect174,First178,PgSelectRows179,PgSelectSingle180,PgClassExpression181,PgPolymorphic182,PgClassExpression183,PgSelect215,First217,PgSelectRows218,PgSelectSingle219,PgClassExpression220,PgPolymorphic221,PgClassExpression222,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgClassExpression259,PgPolymorphic260,PgClassExpression261 bucket10
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 4, 166, 183, 182, 222, 221, 261, 260<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 180, 166, 182<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[183]<br />2: 184, 191, 199, 204, 209<br />3: 189, 194, 202, 207, 212<br />ᐳ: 188, 190, 193, 195, 196, 197, 198, 201, 203, 206, 208, 211, 213"):::bucket
+    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 166, 183, 182<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 184, 191, 199, 204, 209<br />2: 189, 194, 202, 207, 212<br />ᐳ: 188, 190, 193, 195, 196, 197, 198, 201, 203, 206, 208, 211, 213"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression183,PgSelect184,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgClassExpression196,PgClassExpression197,PgClassExpression198,PgSelect199,First201,PgSelectRows202,PgSelectSingle203,PgSelect204,First206,PgSelectRows207,PgSelectSingle208,PgSelect209,First211,PgSelectRows212,PgSelectSingle213 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 219, 166, 221<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[222]<br />2: 223, 230, 238, 243, 248<br />3: 228, 233, 241, 246, 251<br />ᐳ: 227, 229, 232, 234, 235, 236, 237, 240, 242, 245, 247, 250, 252"):::bucket
+    class Bucket12,PgSelect184,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgClassExpression196,PgClassExpression197,PgClassExpression198,PgSelect199,First201,PgSelectRows202,PgSelectSingle203,PgSelect204,First206,PgSelectRows207,PgSelectSingle208,PgSelect209,First211,PgSelectRows212,PgSelectSingle213 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 166, 222, 221<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 223, 230, 238, 243, 248<br />2: 228, 233, 241, 246, 251<br />ᐳ: 227, 229, 232, 234, 235, 236, 237, 240, 242, 245, 247, 250, 252"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression222,PgSelect223,First227,PgSelectRows228,PgSelectSingle229,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgClassExpression235,PgClassExpression236,PgClassExpression237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242,PgSelect243,First245,PgSelectRows246,PgSelectSingle247,PgSelect248,First250,PgSelectRows251,PgSelectSingle252 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 258, 166, 260<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[261]<br />2: 262, 269, 277, 282, 287<br />3: 267, 272, 280, 285, 290<br />ᐳ: 266, 268, 271, 273, 274, 275, 276, 279, 281, 284, 286, 289, 291"):::bucket
+    class Bucket13,PgSelect223,First227,PgSelectRows228,PgSelectSingle229,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgClassExpression235,PgClassExpression236,PgClassExpression237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242,PgSelect243,First245,PgSelectRows246,PgSelectSingle247,PgSelect248,First250,PgSelectRows251,PgSelectSingle252 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 166, 261, 260<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 262, 269, 277, 282, 287<br />2: 267, 272, 280, 285, 290<br />ᐳ: 266, 268, 271, 273, 274, 275, 276, 279, 281, 284, 286, 289, 291"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression261,PgSelect262,First266,PgSelectRows267,PgSelectSingle268,PgSelect269,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression274,PgClassExpression275,PgClassExpression276,PgSelect277,First279,PgSelectRows280,PgSelectSingle281,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,PgSelect287,First289,PgSelectRows290,PgSelectSingle291 bucket14
+    class Bucket14,PgSelect262,First266,PgSelectRows267,PgSelectSingle268,PgSelect269,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression274,PgClassExpression275,PgClassExpression276,PgSelect277,First279,PgSelectRows280,PgSelectSingle281,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,PgSelect287,First289,PgSelectRows290,PgSelectSingle291 bucket14
     Bucket0 --> Bucket1 & Bucket3 & Bucket9
     Bucket1 --> Bucket2
     Bucket3 --> Bucket4

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.deopt.mermaid
@@ -62,20 +62,25 @@ graph TD
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
     PgSelectSingle35 --> PgClassExpression36
+    PgClassExpression38{{"PgClassExpression[38∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression38
     First72{{"First[72∈2] ➊"}}:::plan
     PgSelectRows73[["PgSelectRows[73∈2] ➊"]]:::plan
     PgSelectRows73 --> First72
     PgSelect70 --> PgSelectRows73
     First72 --> PgSelectSingle74
     PgSelectSingle74 --> PgClassExpression75
+    PgClassExpression77{{"PgClassExpression[77∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression77
     First111{{"First[111∈2] ➊"}}:::plan
     PgSelectRows112[["PgSelectRows[112∈2] ➊"]]:::plan
     PgSelectRows112 --> First111
     PgSelect109 --> PgSelectRows112
     First111 --> PgSelectSingle113
     PgSelectSingle113 --> PgClassExpression114
+    PgClassExpression116{{"PgClassExpression[116∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle113 --> PgClassExpression116
     PgSelect39[["PgSelect[39∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression38{{"PgClassExpression[38∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression38 --> PgSelect39
     PgSelect46[["PgSelect[46∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression38 --> PgSelect46
@@ -85,7 +90,6 @@ graph TD
     Object11 & PgClassExpression38 --> PgSelect59
     PgSelect64[["PgSelect[64∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression38 --> PgSelect64
-    PgSelectSingle35 --> PgClassExpression38
     First43{{"First[43∈4] ➊"}}:::plan
     PgSelectRows44[["PgSelectRows[44∈4] ➊"]]:::plan
     PgSelectRows44 --> First43
@@ -123,7 +127,6 @@ graph TD
     PgSelectSingle68{{"PgSelectSingle[68∈4] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First66 --> PgSelectSingle68
     PgSelect78[["PgSelect[78∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression77{{"PgClassExpression[77∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression77 --> PgSelect78
     PgSelect85[["PgSelect[85∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression77 --> PgSelect85
@@ -133,7 +136,6 @@ graph TD
     Object11 & PgClassExpression77 --> PgSelect98
     PgSelect103[["PgSelect[103∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression77 --> PgSelect103
-    PgSelectSingle74 --> PgClassExpression77
     First82{{"First[82∈5] ➊"}}:::plan
     PgSelectRows83[["PgSelectRows[83∈5] ➊"]]:::plan
     PgSelectRows83 --> First82
@@ -171,7 +173,6 @@ graph TD
     PgSelectSingle107{{"PgSelectSingle[107∈5] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First105 --> PgSelectSingle107
     PgSelect117[["PgSelect[117∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression116{{"PgClassExpression[116∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression116 --> PgSelect117
     PgSelect124[["PgSelect[124∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression116 --> PgSelect124
@@ -181,7 +182,6 @@ graph TD
     Object11 & PgClassExpression116 --> PgSelect137
     PgSelect142[["PgSelect[142∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression116 --> PgSelect142
-    PgSelectSingle113 --> PgClassExpression116
     First121{{"First[121∈6] ➊"}}:::plan
     PgSelectRows122[["PgSelectRows[122∈6] ➊"]]:::plan
     PgSelectRows122 --> First121
@@ -232,21 +232,21 @@ graph TD
     Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 19, 147, 148, 149, 4<br /><br />1: PgSelect[8]<br />2: PgSelect[14]<br />3: PgSelect[20]<br />4: PgSelectRows[25]<br />ᐳ: 24, 26, 27"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect8,PgSelect14,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 147, 148, 149, 27, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[27]<br />1: 29, 70, 109<br />2: 34, 73, 112<br />ᐳ: 33, 35, 36, 37, 72, 74, 75, 76, 111, 113, 114, 115"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 147, 148, 149, 27, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[27]<br />1: 29, 70, 109<br />2: 34, 73, 112<br />ᐳ: 33, 35, 36, 37, 38, 72, 74, 75, 76, 77, 111, 113, 114, 115, 116"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,PgPolymorphic37,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgPolymorphic76,PgSelect109,First111,PgSelectRows112,PgSelectSingle113,PgClassExpression114,PgPolymorphic115 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 35, 11, 37, 74, 76, 113, 115<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,PgPolymorphic37,PgClassExpression38,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgPolymorphic76,PgClassExpression77,PgSelect109,First111,PgSelectRows112,PgSelectSingle113,PgClassExpression114,PgPolymorphic115,PgClassExpression116 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 11, 38, 37, 77, 76, 116, 115<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 35, 11, 37<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[38]<br />2: 39, 46, 54, 59, 64<br />3: 44, 49, 57, 62, 67<br />ᐳ: 43, 45, 48, 50, 51, 52, 53, 56, 58, 61, 63, 66, 68"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 38, 37<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 39, 46, 54, 59, 64<br />2: 44, 49, 57, 62, 67<br />ᐳ: 43, 45, 48, 50, 51, 52, 53, 56, 58, 61, 63, 66, 68"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression38,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgSelect59,First61,PgSelectRows62,PgSelectSingle63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 74, 11, 76<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[77]<br />2: 78, 85, 93, 98, 103<br />3: 83, 88, 96, 101, 106<br />ᐳ: 82, 84, 87, 89, 90, 91, 92, 95, 97, 100, 102, 105, 107"):::bucket
+    class Bucket4,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgSelect59,First61,PgSelectRows62,PgSelectSingle63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 77, 76<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 78, 85, 93, 98, 103<br />2: 83, 88, 96, 101, 106<br />ᐳ: 82, 84, 87, 89, 90, 91, 92, 95, 97, 100, 102, 105, 107"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression77,PgSelect78,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 113, 11, 115<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[116]<br />2: 117, 124, 132, 137, 142<br />3: 122, 127, 135, 140, 145<br />ᐳ: 121, 123, 126, 128, 129, 130, 131, 134, 136, 139, 141, 144, 146"):::bucket
+    class Bucket5,PgSelect78,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 116, 115<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 117, 124, 132, 137, 142<br />2: 122, 127, 135, 140, 145<br />ᐳ: 121, 123, 126, 128, 129, 130, 131, 134, 136, 139, 141, 144, 146"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression116,PgSelect117,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128,PgClassExpression129,PgClassExpression130,PgClassExpression131,PgSelect132,First134,PgSelectRows135,PgSelectSingle136,PgSelect137,First139,PgSelectRows140,PgSelectSingle141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146 bucket6
+    class Bucket6,PgSelect117,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128,PgClassExpression129,PgClassExpression130,PgClassExpression131,PgSelect132,First134,PgSelectRows135,PgSelectSingle136,PgSelect137,First139,PgSelectRows140,PgSelectSingle141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts-computed.mermaid
@@ -62,20 +62,25 @@ graph TD
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
     PgSelectSingle35 --> PgClassExpression36
+    PgClassExpression38{{"PgClassExpression[38∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression38
     First72{{"First[72∈2] ➊"}}:::plan
     PgSelectRows73[["PgSelectRows[73∈2] ➊"]]:::plan
     PgSelectRows73 --> First72
     PgSelect70 --> PgSelectRows73
     First72 --> PgSelectSingle74
     PgSelectSingle74 --> PgClassExpression75
+    PgClassExpression77{{"PgClassExpression[77∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression77
     First111{{"First[111∈2] ➊"}}:::plan
     PgSelectRows112[["PgSelectRows[112∈2] ➊"]]:::plan
     PgSelectRows112 --> First111
     PgSelect109 --> PgSelectRows112
     First111 --> PgSelectSingle113
     PgSelectSingle113 --> PgClassExpression114
+    PgClassExpression116{{"PgClassExpression[116∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle113 --> PgClassExpression116
     PgSelect39[["PgSelect[39∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression38{{"PgClassExpression[38∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression38 --> PgSelect39
     PgSelect46[["PgSelect[46∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression38 --> PgSelect46
@@ -85,7 +90,6 @@ graph TD
     Object11 & PgClassExpression38 --> PgSelect59
     PgSelect64[["PgSelect[64∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression38 --> PgSelect64
-    PgSelectSingle35 --> PgClassExpression38
     First43{{"First[43∈4] ➊"}}:::plan
     PgSelectRows44[["PgSelectRows[44∈4] ➊"]]:::plan
     PgSelectRows44 --> First43
@@ -123,7 +127,6 @@ graph TD
     PgSelectSingle68{{"PgSelectSingle[68∈4] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First66 --> PgSelectSingle68
     PgSelect78[["PgSelect[78∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression77{{"PgClassExpression[77∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression77 --> PgSelect78
     PgSelect85[["PgSelect[85∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression77 --> PgSelect85
@@ -133,7 +136,6 @@ graph TD
     Object11 & PgClassExpression77 --> PgSelect98
     PgSelect103[["PgSelect[103∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression77 --> PgSelect103
-    PgSelectSingle74 --> PgClassExpression77
     First82{{"First[82∈5] ➊"}}:::plan
     PgSelectRows83[["PgSelectRows[83∈5] ➊"]]:::plan
     PgSelectRows83 --> First82
@@ -171,7 +173,6 @@ graph TD
     PgSelectSingle107{{"PgSelectSingle[107∈5] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First105 --> PgSelectSingle107
     PgSelect117[["PgSelect[117∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression116{{"PgClassExpression[116∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression116 --> PgSelect117
     PgSelect124[["PgSelect[124∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression116 --> PgSelect124
@@ -181,7 +182,6 @@ graph TD
     Object11 & PgClassExpression116 --> PgSelect137
     PgSelect142[["PgSelect[142∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression116 --> PgSelect142
-    PgSelectSingle113 --> PgClassExpression116
     First121{{"First[121∈6] ➊"}}:::plan
     PgSelectRows122[["PgSelectRows[122∈6] ➊"]]:::plan
     PgSelectRows122 --> First121
@@ -232,21 +232,21 @@ graph TD
     Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 19, 147, 148, 149, 4<br /><br />1: PgSelect[8]<br />2: PgSelect[14]<br />3: PgSelect[20]<br />4: PgSelectRows[25]<br />ᐳ: 24, 26, 27"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect8,PgSelect14,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 147, 148, 149, 27, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[27]<br />1: 29, 70, 109<br />2: 34, 73, 112<br />ᐳ: 33, 35, 36, 37, 72, 74, 75, 76, 111, 113, 114, 115"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 147, 148, 149, 27, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[27]<br />1: 29, 70, 109<br />2: 34, 73, 112<br />ᐳ: 33, 35, 36, 37, 38, 72, 74, 75, 76, 77, 111, 113, 114, 115, 116"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,PgPolymorphic37,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgPolymorphic76,PgSelect109,First111,PgSelectRows112,PgSelectSingle113,PgClassExpression114,PgPolymorphic115 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 35, 11, 37, 74, 76, 113, 115<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,PgPolymorphic37,PgClassExpression38,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgPolymorphic76,PgClassExpression77,PgSelect109,First111,PgSelectRows112,PgSelectSingle113,PgClassExpression114,PgPolymorphic115,PgClassExpression116 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 11, 38, 37, 77, 76, 116, 115<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 35, 11, 37<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[38]<br />2: 39, 46, 54, 59, 64<br />3: 44, 49, 57, 62, 67<br />ᐳ: 43, 45, 48, 50, 51, 52, 53, 56, 58, 61, 63, 66, 68"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 38, 37<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 39, 46, 54, 59, 64<br />2: 44, 49, 57, 62, 67<br />ᐳ: 43, 45, 48, 50, 51, 52, 53, 56, 58, 61, 63, 66, 68"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression38,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgSelect59,First61,PgSelectRows62,PgSelectSingle63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 74, 11, 76<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[77]<br />2: 78, 85, 93, 98, 103<br />3: 83, 88, 96, 101, 106<br />ᐳ: 82, 84, 87, 89, 90, 91, 92, 95, 97, 100, 102, 105, 107"):::bucket
+    class Bucket4,PgSelect39,First43,PgSelectRows44,PgSelectSingle45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgSelect59,First61,PgSelectRows62,PgSelectSingle63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 77, 76<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 78, 85, 93, 98, 103<br />2: 83, 88, 96, 101, 106<br />ᐳ: 82, 84, 87, 89, 90, 91, 92, 95, 97, 100, 102, 105, 107"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression77,PgSelect78,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 113, 11, 115<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[116]<br />2: 117, 124, 132, 137, 142<br />3: 122, 127, 135, 140, 145<br />ᐳ: 121, 123, 126, 128, 129, 130, 131, 134, 136, 139, 141, 144, 146"):::bucket
+    class Bucket5,PgSelect78,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,PgSelect103,First105,PgSelectRows106,PgSelectSingle107 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 116, 115<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 117, 124, 132, 137, 142<br />2: 122, 127, 135, 140, 145<br />ᐳ: 121, 123, 126, 128, 129, 130, 131, 134, 136, 139, 141, 144, 146"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression116,PgSelect117,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128,PgClassExpression129,PgClassExpression130,PgClassExpression131,PgSelect132,First134,PgSelectRows135,PgSelectSingle136,PgSelect137,First139,PgSelectRows140,PgSelectSingle141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146 bucket6
+    class Bucket6,PgSelect117,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128,PgClassExpression129,PgClassExpression130,PgClassExpression131,PgSelect132,First134,PgSelectRows135,PgSelectSingle136,PgSelect137,First139,PgSelectRows140,PgSelectSingle141,PgSelect142,First144,PgSelectRows145,PgSelectSingle146 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.deopt.mermaid
@@ -73,20 +73,25 @@ graph TD
     PgSelect50 --> PgSelectRows55
     First54 --> PgSelectSingle56
     PgSelectSingle56 --> PgClassExpression57
+    PgClassExpression59{{"PgClassExpression[59∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression59
     First93{{"First[93∈2] ➊"}}:::plan
     PgSelectRows94[["PgSelectRows[94∈2] ➊"]]:::plan
     PgSelectRows94 --> First93
     PgSelect91 --> PgSelectRows94
     First93 --> PgSelectSingle95
     PgSelectSingle95 --> PgClassExpression96
+    PgClassExpression98{{"PgClassExpression[98∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle95 --> PgClassExpression98
     First132{{"First[132∈2] ➊"}}:::plan
     PgSelectRows133[["PgSelectRows[133∈2] ➊"]]:::plan
     PgSelectRows133 --> First132
     PgSelect130 --> PgSelectRows133
     First132 --> PgSelectSingle134
     PgSelectSingle134 --> PgClassExpression135
+    PgClassExpression137{{"PgClassExpression[137∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle134 --> PgClassExpression137
     PgSelect60[["PgSelect[60∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression59{{"PgClassExpression[59∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression59 --> PgSelect60
     PgSelect67[["PgSelect[67∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression59 --> PgSelect67
@@ -96,7 +101,6 @@ graph TD
     Object11 & PgClassExpression59 --> PgSelect80
     PgSelect85[["PgSelect[85∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression59 --> PgSelect85
-    PgSelectSingle56 --> PgClassExpression59
     First64{{"First[64∈4] ➊"}}:::plan
     PgSelectRows65[["PgSelectRows[65∈4] ➊"]]:::plan
     PgSelectRows65 --> First64
@@ -134,7 +138,6 @@ graph TD
     PgSelectSingle89{{"PgSelectSingle[89∈4] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First87 --> PgSelectSingle89
     PgSelect99[["PgSelect[99∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression98{{"PgClassExpression[98∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression98 --> PgSelect99
     PgSelect106[["PgSelect[106∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression98 --> PgSelect106
@@ -144,7 +147,6 @@ graph TD
     Object11 & PgClassExpression98 --> PgSelect119
     PgSelect124[["PgSelect[124∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression98 --> PgSelect124
-    PgSelectSingle95 --> PgClassExpression98
     First103{{"First[103∈5] ➊"}}:::plan
     PgSelectRows104[["PgSelectRows[104∈5] ➊"]]:::plan
     PgSelectRows104 --> First103
@@ -182,7 +184,6 @@ graph TD
     PgSelectSingle128{{"PgSelectSingle[128∈5] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First126 --> PgSelectSingle128
     PgSelect138[["PgSelect[138∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression137{{"PgClassExpression[137∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression137 --> PgSelect138
     PgSelect145[["PgSelect[145∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression137 --> PgSelect145
@@ -192,7 +193,6 @@ graph TD
     Object11 & PgClassExpression137 --> PgSelect158
     PgSelect163[["PgSelect[163∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression137 --> PgSelect163
-    PgSelectSingle134 --> PgClassExpression137
     First142{{"First[142∈6] ➊"}}:::plan
     PgSelectRows143[["PgSelectRows[143∈6] ➊"]]:::plan
     PgSelectRows143 --> First142
@@ -243,21 +243,21 @@ graph TD
     Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 14, 15, 27, 28, 41, 42, 168, 169, 170, 4<br /><br />1: PgInsertSingle[8]<br />2: PgClassExpression[12]<br />3: PgInsertSingle[16]<br />4: PgInsertSingle[22]<br />5: PgClassExpression[26]<br />6: PgInsertSingle[30]<br />7: PgInsertSingle[36]<br />8: PgClassExpression[40]<br />9: PgInsertSingle[44]<br />10: <br />ᐳ: PgClassExpression[48]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle8,PgClassExpression12,PgInsertSingle16,PgInsertSingle22,PgClassExpression26,PgInsertSingle30,PgInsertSingle36,PgClassExpression40,PgInsertSingle44,PgClassExpression48 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 168, 169, 170, 48, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]<br />1: 50, 91, 130<br />2: 55, 94, 133<br />ᐳ: 54, 56, 57, 58, 93, 95, 96, 97, 132, 134, 135, 136"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 168, 169, 170, 48, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]<br />1: 50, 91, 130<br />2: 55, 94, 133<br />ᐳ: 54, 56, 57, 58, 59, 93, 95, 96, 97, 98, 132, 134, 135, 136, 137"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect50,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,PgPolymorphic58,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,PgClassExpression96,PgPolymorphic97,PgSelect130,First132,PgSelectRows133,PgSelectSingle134,PgClassExpression135,PgPolymorphic136 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 56, 11, 58, 95, 97, 134, 136<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect50,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,PgPolymorphic58,PgClassExpression59,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,PgClassExpression96,PgPolymorphic97,PgClassExpression98,PgSelect130,First132,PgSelectRows133,PgSelectSingle134,PgClassExpression135,PgPolymorphic136,PgClassExpression137 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 11, 59, 58, 98, 97, 137, 136<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 56, 11, 58<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[59]<br />2: 60, 67, 75, 80, 85<br />3: 65, 70, 78, 83, 88<br />ᐳ: 64, 66, 69, 71, 72, 73, 74, 77, 79, 82, 84, 87, 89"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 59, 58<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 60, 67, 75, 80, 85<br />2: 65, 70, 78, 83, 88<br />ᐳ: 64, 66, 69, 71, 72, 73, 74, 77, 79, 82, 84, 87, 89"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression59,PgSelect60,First64,PgSelectRows65,PgSelectSingle66,PgSelect67,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgClassExpression74,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 95, 11, 97<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[98]<br />2: 99, 106, 114, 119, 124<br />3: 104, 109, 117, 122, 127<br />ᐳ: 103, 105, 108, 110, 111, 112, 113, 116, 118, 121, 123, 126, 128"):::bucket
+    class Bucket4,PgSelect60,First64,PgSelectRows65,PgSelectSingle66,PgSelect67,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgClassExpression74,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 98, 97<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 99, 106, 114, 119, 124<br />2: 104, 109, 117, 122, 127<br />ᐳ: 103, 105, 108, 110, 111, 112, 113, 116, 118, 121, 123, 126, 128"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression98,PgSelect99,First103,PgSelectRows104,PgSelectSingle105,PgSelect106,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111,PgClassExpression112,PgClassExpression113,PgSelect114,First116,PgSelectRows117,PgSelectSingle118,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 134, 11, 136<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[137]<br />2: 138, 145, 153, 158, 163<br />3: 143, 148, 156, 161, 166<br />ᐳ: 142, 144, 147, 149, 150, 151, 152, 155, 157, 160, 162, 165, 167"):::bucket
+    class Bucket5,PgSelect99,First103,PgSelectRows104,PgSelectSingle105,PgSelect106,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111,PgClassExpression112,PgClassExpression113,PgSelect114,First116,PgSelectRows117,PgSelectSingle118,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 137, 136<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 138, 145, 153, 158, 163<br />2: 143, 148, 156, 161, 166<br />ᐳ: 142, 144, 147, 149, 150, 151, 152, 155, 157, 160, 162, 165, 167"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression137,PgSelect138,First142,PgSelectRows143,PgSelectSingle144,PgSelect145,First147,PgSelectRows148,PgSelectSingle149,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgSelect153,First155,PgSelectRows156,PgSelectSingle157,PgSelect158,First160,PgSelectRows161,PgSelectSingle162,PgSelect163,First165,PgSelectRows166,PgSelectSingle167 bucket6
+    class Bucket6,PgSelect138,First142,PgSelectRows143,PgSelectSingle144,PgSelect145,First147,PgSelectRows148,PgSelectSingle149,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgSelect153,First155,PgSelectRows156,PgSelectSingle157,PgSelect158,First160,PgSelectRows161,PgSelectSingle162,PgSelect163,First165,PgSelectRows166,PgSelectSingle167 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/basics/create-three-relational-posts.mermaid
@@ -73,20 +73,25 @@ graph TD
     PgSelect50 --> PgSelectRows55
     First54 --> PgSelectSingle56
     PgSelectSingle56 --> PgClassExpression57
+    PgClassExpression59{{"PgClassExpression[59∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression59
     First93{{"First[93∈2] ➊"}}:::plan
     PgSelectRows94[["PgSelectRows[94∈2] ➊"]]:::plan
     PgSelectRows94 --> First93
     PgSelect91 --> PgSelectRows94
     First93 --> PgSelectSingle95
     PgSelectSingle95 --> PgClassExpression96
+    PgClassExpression98{{"PgClassExpression[98∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle95 --> PgClassExpression98
     First132{{"First[132∈2] ➊"}}:::plan
     PgSelectRows133[["PgSelectRows[133∈2] ➊"]]:::plan
     PgSelectRows133 --> First132
     PgSelect130 --> PgSelectRows133
     First132 --> PgSelectSingle134
     PgSelectSingle134 --> PgClassExpression135
+    PgClassExpression137{{"PgClassExpression[137∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle134 --> PgClassExpression137
     PgSelect60[["PgSelect[60∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression59{{"PgClassExpression[59∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression59 --> PgSelect60
     PgSelect67[["PgSelect[67∈4] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression59 --> PgSelect67
@@ -96,7 +101,6 @@ graph TD
     Object11 & PgClassExpression59 --> PgSelect80
     PgSelect85[["PgSelect[85∈4] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression59 --> PgSelect85
-    PgSelectSingle56 --> PgClassExpression59
     First64{{"First[64∈4] ➊"}}:::plan
     PgSelectRows65[["PgSelectRows[65∈4] ➊"]]:::plan
     PgSelectRows65 --> First64
@@ -134,7 +138,6 @@ graph TD
     PgSelectSingle89{{"PgSelectSingle[89∈4] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First87 --> PgSelectSingle89
     PgSelect99[["PgSelect[99∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression98{{"PgClassExpression[98∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression98 --> PgSelect99
     PgSelect106[["PgSelect[106∈5] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression98 --> PgSelect106
@@ -144,7 +147,6 @@ graph TD
     Object11 & PgClassExpression98 --> PgSelect119
     PgSelect124[["PgSelect[124∈5] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression98 --> PgSelect124
-    PgSelectSingle95 --> PgClassExpression98
     First103{{"First[103∈5] ➊"}}:::plan
     PgSelectRows104[["PgSelectRows[104∈5] ➊"]]:::plan
     PgSelectRows104 --> First103
@@ -182,7 +184,6 @@ graph TD
     PgSelectSingle128{{"PgSelectSingle[128∈5] ➊<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First126 --> PgSelectSingle128
     PgSelect138[["PgSelect[138∈6] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression137{{"PgClassExpression[137∈6] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object11 & PgClassExpression137 --> PgSelect138
     PgSelect145[["PgSelect[145∈6] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object11 & PgClassExpression137 --> PgSelect145
@@ -192,7 +193,6 @@ graph TD
     Object11 & PgClassExpression137 --> PgSelect158
     PgSelect163[["PgSelect[163∈6] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object11 & PgClassExpression137 --> PgSelect163
-    PgSelectSingle134 --> PgClassExpression137
     First142{{"First[142∈6] ➊"}}:::plan
     PgSelectRows143[["PgSelectRows[143∈6] ➊"]]:::plan
     PgSelectRows143 --> First142
@@ -243,21 +243,21 @@ graph TD
     Bucket1("Bucket 1 (mutationField)<br />Deps: 11, 6, 7, 13, 14, 15, 27, 28, 41, 42, 168, 169, 170, 4<br /><br />1: PgInsertSingle[8]<br />2: PgClassExpression[12]<br />3: PgInsertSingle[16]<br />4: PgInsertSingle[22]<br />5: PgClassExpression[26]<br />6: PgInsertSingle[30]<br />7: PgInsertSingle[36]<br />8: PgClassExpression[40]<br />9: PgInsertSingle[44]<br />10: <br />ᐳ: PgClassExpression[48]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle8,PgClassExpression12,PgInsertSingle16,PgInsertSingle22,PgClassExpression26,PgInsertSingle30,PgInsertSingle36,PgClassExpression40,PgInsertSingle44,PgClassExpression48 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 168, 169, 170, 48, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]<br />1: 50, 91, 130<br />2: 55, 94, 133<br />ᐳ: 54, 56, 57, 58, 93, 95, 96, 97, 132, 134, 135, 136"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 168, 169, 170, 48, 4<br /><br />ROOT PgClassExpression{1}ᐸ__relational_posts__ᐳ[48]<br />1: 50, 91, 130<br />2: 55, 94, 133<br />ᐳ: 54, 56, 57, 58, 59, 93, 95, 96, 97, 98, 132, 134, 135, 136, 137"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgSelect50,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,PgPolymorphic58,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,PgClassExpression96,PgPolymorphic97,PgSelect130,First132,PgSelectRows133,PgSelectSingle134,PgClassExpression135,PgPolymorphic136 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 56, 11, 58, 95, 97, 134, 136<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
+    class Bucket2,PgSelect50,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,PgPolymorphic58,PgClassExpression59,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,PgClassExpression96,PgPolymorphic97,PgClassExpression98,PgSelect130,First132,PgSelectRows133,PgSelectSingle134,PgClassExpression135,PgPolymorphic136,PgClassExpression137 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 4, 11, 59, 58, 98, 97, 137, 136<br /><br />ROOT __ValueᐸrootValueᐳ[4]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 56, 11, 58<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[59]<br />2: 60, 67, 75, 80, 85<br />3: 65, 70, 78, 83, 88<br />ᐳ: 64, 66, 69, 71, 72, 73, 74, 77, 79, 82, 84, 87, 89"):::bucket
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 59, 58<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 60, 67, 75, 80, 85<br />2: 65, 70, 78, 83, 88<br />ᐳ: 64, 66, 69, 71, 72, 73, 74, 77, 79, 82, 84, 87, 89"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression59,PgSelect60,First64,PgSelectRows65,PgSelectSingle66,PgSelect67,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgClassExpression74,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 95, 11, 97<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[98]<br />2: 99, 106, 114, 119, 124<br />3: 104, 109, 117, 122, 127<br />ᐳ: 103, 105, 108, 110, 111, 112, 113, 116, 118, 121, 123, 126, 128"):::bucket
+    class Bucket4,PgSelect60,First64,PgSelectRows65,PgSelectSingle66,PgSelect67,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgClassExpression74,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgSelect85,First87,PgSelectRows88,PgSelectSingle89 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 98, 97<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 99, 106, 114, 119, 124<br />2: 104, 109, 117, 122, 127<br />ᐳ: 103, 105, 108, 110, 111, 112, 113, 116, 118, 121, 123, 126, 128"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression98,PgSelect99,First103,PgSelectRows104,PgSelectSingle105,PgSelect106,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111,PgClassExpression112,PgClassExpression113,PgSelect114,First116,PgSelectRows117,PgSelectSingle118,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 134, 11, 136<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[137]<br />2: 138, 145, 153, 158, 163<br />3: 143, 148, 156, 161, 166<br />ᐳ: 142, 144, 147, 149, 150, 151, 152, 155, 157, 160, 162, 165, 167"):::bucket
+    class Bucket5,PgSelect99,First103,PgSelectRows104,PgSelectSingle105,PgSelect106,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111,PgClassExpression112,PgClassExpression113,PgSelect114,First116,PgSelectRows117,PgSelectSingle118,PgSelect119,First121,PgSelectRows122,PgSelectSingle123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 11, 137, 136<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 138, 145, 153, 158, 163<br />2: 143, 148, 156, 161, 166<br />ᐳ: 142, 144, 147, 149, 150, 151, 152, 155, 157, 160, 162, 165, 167"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression137,PgSelect138,First142,PgSelectRows143,PgSelectSingle144,PgSelect145,First147,PgSelectRows148,PgSelectSingle149,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgSelect153,First155,PgSelectRows156,PgSelectSingle157,PgSelect158,First160,PgSelectRows161,PgSelectSingle162,PgSelect163,First165,PgSelectRows166,PgSelectSingle167 bucket6
+    class Bucket6,PgSelect138,First142,PgSelectRows143,PgSelectSingle144,PgSelect145,First147,PgSelectRows148,PgSelectSingle149,PgClassExpression150,PgClassExpression151,PgClassExpression152,PgSelect153,First155,PgSelectRows156,PgSelectSingle157,PgSelect158,First160,PgSelectRows161,PgSelectSingle162,PgSelect163,First165,PgSelectRows166,PgSelectSingle167 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.mermaid
@@ -47,8 +47,21 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression36{{"PgClassExpression[36∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression36
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression37
+    PgClassExpression38{{"PgClassExpression[38∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression38
+    PgClassExpression39{{"PgClassExpression[39∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression39
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression40
+    PgClassExpression41{{"PgClassExpression[41∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression41
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect43[["PgSelect[43∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect43
@@ -58,25 +71,12 @@ graph TD
     Object9 & PgClassExpression27 --> PgSelect58
     PgSelect64[["PgSelect[64∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect64
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression38
-    PgClassExpression39{{"PgClassExpression[39∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression39
-    PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression40
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression42
     First45{{"First[45∈5]"}}:::plan
@@ -137,10 +137,10 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 36, 37, 38, 39, 40, 41<br />2: 28, 43, 51, 58, 64<br />3: 33, 46, 54, 61, 67<br />ᐳ: 32, 34, 42, 45, 47, 48, 49, 50, 53, 55, 56, 57, 60, 62, 63, 66, 68, 69, 70"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 26, 25, 36, 37, 38, 39, 40, 41<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 43, 51, 58, 64<br />2: 33, 46, 54, 61, 67<br />ᐳ: 32, 34, 42, 45, 47, 48, 49, 50, 53, 55, 56, 57, 60, 62, 63, 66, 68, 69, 70"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,PgClassExpression57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgClassExpression70 bucket5
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,PgClassExpression57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgClassExpression70 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.mermaid
@@ -47,8 +47,21 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression36{{"PgClassExpression[36∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression36
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression37
+    PgClassExpression38{{"PgClassExpression[38∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression38
+    PgClassExpression39{{"PgClassExpression[39∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression39
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression40
+    PgClassExpression41{{"PgClassExpression[41∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression41
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect43[["PgSelect[43∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect43
@@ -58,25 +71,12 @@ graph TD
     Object9 & PgClassExpression27 --> PgSelect58
     PgSelect64[["PgSelect[64∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect64
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression38
-    PgClassExpression39{{"PgClassExpression[39∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression39
-    PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression40
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression41
     PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression42
     First45{{"First[45∈5]"}}:::plan
@@ -137,10 +137,10 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 36, 37, 38, 39, 40, 41<br />2: 28, 43, 51, 58, 64<br />3: 33, 46, 54, 61, 67<br />ᐳ: 32, 34, 42, 45, 47, 48, 49, 50, 53, 55, 56, 57, 60, 62, 63, 66, 68, 69, 70"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 26, 25, 36, 37, 38, 39, 40, 41<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 43, 51, 58, 64<br />2: 33, 46, 54, 61, 67<br />ᐳ: 32, 34, 42, 45, 47, 48, 49, 50, 53, 55, 56, 57, 60, 62, 63, 66, 68, 69, 70"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,PgClassExpression57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgClassExpression70 bucket5
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgClassExpression50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,PgClassExpression57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,PgSelect64,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgClassExpression70 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.mermaid
@@ -47,8 +47,21 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression36{{"PgClassExpression[36∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression36
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression37
+    PgClassExpression38{{"PgClassExpression[38∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression38
+    PgClassExpression39{{"PgClassExpression[39∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression39
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression40
+    PgClassExpression41{{"PgClassExpression[41∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression41
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect42[["PgSelect[42∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect42
@@ -58,25 +71,12 @@ graph TD
     Object9 & PgClassExpression27 --> PgSelect52
     PgSelect57[["PgSelect[57∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect57
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression38
-    PgClassExpression39{{"PgClassExpression[39∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression39
-    PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression40
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression41
     First44{{"First[44∈5]"}}:::plan
     PgSelectRows45[["PgSelectRows[45∈5]"]]:::plan
     PgSelectRows45 --> First44
@@ -119,10 +119,10 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 36, 37, 38, 39, 40, 41<br />2: 28, 42, 47, 52, 57<br />3: 33, 45, 50, 55, 60<br />ᐳ: 32, 34, 44, 46, 49, 51, 54, 56, 59, 61"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 26, 25, 36, 37, 38, 39, 40, 41<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 42, 47, 52, 57<br />2: 33, 45, 50, 55, 60<br />ᐳ: 32, 34, 44, 46, 49, 51, 54, 56, 59, 61"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgSelect42,First44,PgSelectRows45,PgSelectSingle46,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgSelect57,First59,PgSelectRows60,PgSelectSingle61 bucket5
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect42,First44,PgSelectRows45,PgSelectSingle46,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgSelect57,First59,PgSelectRows60,PgSelectSingle61 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.mermaid
@@ -47,8 +47,21 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression36{{"PgClassExpression[36∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression36
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression37
+    PgClassExpression38{{"PgClassExpression[38∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression38
+    PgClassExpression39{{"PgClassExpression[39∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression39
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression40
+    PgClassExpression41{{"PgClassExpression[41∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression41
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect42[["PgSelect[42∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect42
@@ -58,25 +71,12 @@ graph TD
     Object9 & PgClassExpression27 --> PgSelect52
     PgSelect57[["PgSelect[57∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect57
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression38
-    PgClassExpression39{{"PgClassExpression[39∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression39
-    PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression40
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression41
     First44{{"First[44∈5]"}}:::plan
     PgSelectRows45[["PgSelectRows[45∈5]"]]:::plan
     PgSelectRows45 --> First44
@@ -119,10 +119,10 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 36, 37, 38, 39, 40, 41<br />2: 28, 42, 47, 52, 57<br />3: 33, 45, 50, 55, 60<br />ᐳ: 32, 34, 44, 46, 49, 51, 54, 56, 59, 61"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 26, 25, 36, 37, 38, 39, 40, 41<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 42, 47, 52, 57<br />2: 33, 45, 50, 55, 60<br />ᐳ: 32, 34, 44, 46, 49, 51, 54, 56, 59, 61"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40,PgClassExpression41,PgSelect42,First44,PgSelectRows45,PgSelectSingle46,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgSelect57,First59,PgSelectRows60,PgSelectSingle61 bucket5
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect42,First44,PgSelectRows45,PgSelectSingle46,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgSelect57,First59,PgSelectRows60,PgSelectSingle61 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.deopt.mermaid
@@ -36,8 +36,9 @@ graph TD
     __ListTransform11 ==> __Item15
     __Item15 --> PgSelectSingle16
     PgSelectSingle16 --> PgClassExpression17
+    PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__relation...les__.”id”ᐳ"}}:::plan
+    PgSelectSingle16 --> PgClassExpression19
     PgSelect20[["PgSelect[20∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
     Object10 & PgClassExpression19 --> PgSelect20
     PgSelect28[["PgSelect[28∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
@@ -52,7 +53,6 @@ graph TD
     PgSelect76[["PgSelect[76∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression75{{"PgClassExpression[75∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
     Object10 & PgClassExpression75 --> PgSelect76
-    PgSelectSingle16 --> PgClassExpression19
     First24{{"First[24∈3]"}}:::plan
     PgSelectRows25[["PgSelectRows[25∈3]"]]:::plan
     PgSelectRows25 --> First24
@@ -158,10 +158,10 @@ graph TD
     class Bucket1,__Item13,PgSelectSingle14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 10<br /><br />ROOT __Item{2}ᐸ11ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 10, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[19]<br />2: 20, 46, 70<br />3: 25, 49, 73<br />ᐳ: 24, 26, 27, 48, 50, 51, 72, 74, 75<br />4: 28, 52, 76<br />5: 31, 37, 43, 55, 61, 67, 79, 85, 91<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 54, 56, 57, 60, 62, 63, 66, 68, 69, 78, 80, 81, 84, 86, 87, 90, 92, 93"):::bucket
+    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18,PgClassExpression19 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 19, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 20, 46, 70<br />2: 25, 49, 73<br />ᐳ: 24, 26, 27, 48, 50, 51, 72, 74, 75<br />3: 28, 52, 76<br />4: 31, 37, 43, 55, 61, 67, 79, 85, 91<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 54, 56, 57, 60, 62, 63, 66, 68, 69, 78, 80, 81, 84, 86, 87, 90, 92, 93"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,PgClassExpression81,First84,PgSelectRows85,PgSelectSingle86,PgClassExpression87,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression93 bucket3
+    class Bucket3,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,PgClassExpression81,First84,PgSelectRows85,PgSelectSingle86,PgClassExpression87,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression93 bucket3
     Bucket0 --> Bucket1 & Bucket2
     Bucket2 --> Bucket3
     end

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.mermaid
@@ -36,8 +36,9 @@ graph TD
     __ListTransform11 ==> __Item15
     __Item15 --> PgSelectSingle16
     PgSelectSingle16 --> PgClassExpression17
+    PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__relation...les__.”id”ᐳ"}}:::plan
+    PgSelectSingle16 --> PgClassExpression19
     PgSelect20[["PgSelect[20∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
     Object10 & PgClassExpression19 --> PgSelect20
     PgSelect28[["PgSelect[28∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
@@ -52,7 +53,6 @@ graph TD
     PgSelect76[["PgSelect[76∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression75{{"PgClassExpression[75∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
     Object10 & PgClassExpression75 --> PgSelect76
-    PgSelectSingle16 --> PgClassExpression19
     First24{{"First[24∈3]"}}:::plan
     PgSelectRows25[["PgSelectRows[25∈3]"]]:::plan
     PgSelectRows25 --> First24
@@ -158,10 +158,10 @@ graph TD
     class Bucket1,__Item13,PgSelectSingle14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 10<br /><br />ROOT __Item{2}ᐸ11ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 10, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[19]<br />2: 20, 46, 70<br />3: 25, 49, 73<br />ᐳ: 24, 26, 27, 48, 50, 51, 72, 74, 75<br />4: 28, 52, 76<br />5: 31, 37, 43, 55, 61, 67, 79, 85, 91<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 54, 56, 57, 60, 62, 63, 66, 68, 69, 78, 80, 81, 84, 86, 87, 90, 92, 93"):::bucket
+    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18,PgClassExpression19 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 19, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 20, 46, 70<br />2: 25, 49, 73<br />ᐳ: 24, 26, 27, 48, 50, 51, 72, 74, 75<br />3: 28, 52, 76<br />4: 31, 37, 43, 55, 61, 67, 79, 85, 91<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 54, 56, 57, 60, 62, 63, 66, 68, 69, 78, 80, 81, 84, 86, 87, 90, 92, 93"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,PgClassExpression81,First84,PgSelectRows85,PgSelectSingle86,PgClassExpression87,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression93 bucket3
+    class Bucket3,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgSelect46,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression51,PgSelect52,First54,PgSelectRows55,PgSelectSingle56,PgClassExpression57,First60,PgSelectRows61,PgSelectSingle62,PgClassExpression63,First66,PgSelectRows67,PgSelectSingle68,PgClassExpression69,PgSelect70,First72,PgSelectRows73,PgSelectSingle74,PgClassExpression75,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,PgClassExpression81,First84,PgSelectRows85,PgSelectSingle86,PgClassExpression87,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression93 bucket3
     Bucket0 --> Bucket1 & Bucket2
     Bucket2 --> Bucket3
     end

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.mermaid
@@ -35,8 +35,9 @@ graph TD
     __ListTransform11 ==> __Item15
     __Item15 --> PgSelectSingle16
     PgSelectSingle16 --> PgClassExpression17
+    PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__relation...les__.”id”ᐳ"}}:::plan
+    PgSelectSingle16 --> PgClassExpression19
     PgSelect20[["PgSelect[20∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
     Object10 & PgClassExpression19 --> PgSelect20
     PgSelect28[["PgSelect[28∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
@@ -51,7 +52,6 @@ graph TD
     PgSelect80[["PgSelect[80∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression79{{"PgClassExpression[79∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
     Object10 & PgClassExpression79 --> PgSelect80
-    PgSelectSingle16 --> PgClassExpression19
     First24{{"First[24∈3]"}}:::plan
     PgSelectRows25[["PgSelectRows[25∈3]"]]:::plan
     PgSelectRows25 --> First24
@@ -169,10 +169,10 @@ graph TD
     class Bucket1,__Item13,PgSelectSingle14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 10<br /><br />ROOT __Item{2}ᐸ11ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 10, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[19]<br />2: 20, 49, 74<br />3: 25, 52, 77<br />ᐳ: 24, 26, 27, 46, 47, 48, 51, 53, 54, 73, 76, 78, 79, 98, 99<br />4: 28, 55, 80<br />5: 31, 37, 43, 58, 64, 70, 83, 89, 95<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 57, 59, 60, 63, 65, 66, 69, 71, 72, 82, 84, 85, 88, 90, 91, 94, 96, 97"):::bucket
+    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18,PgClassExpression19 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 19, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 20, 49, 74<br />2: 25, 52, 77<br />ᐳ: 24, 26, 27, 46, 47, 48, 51, 53, 54, 73, 76, 78, 79, 98, 99<br />3: 28, 55, 80<br />4: 31, 37, 43, 58, 64, 70, 83, 89, 95<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 57, 59, 60, 63, 65, 66, 69, 71, 72, 82, 84, 85, 88, 90, 91, 94, 96, 97"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectRows52,PgSelectSingle53,PgClassExpression54,PgSelect55,First57,PgSelectRows58,PgSelectSingle59,PgClassExpression60,First63,PgSelectRows64,PgSelectSingle65,PgClassExpression66,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,First88,PgSelectRows89,PgSelectSingle90,PgClassExpression91,First94,PgSelectRows95,PgSelectSingle96,PgClassExpression97,PgClassExpression98,PgClassExpression99 bucket3
+    class Bucket3,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectRows52,PgSelectSingle53,PgClassExpression54,PgSelect55,First57,PgSelectRows58,PgSelectSingle59,PgClassExpression60,First63,PgSelectRows64,PgSelectSingle65,PgClassExpression66,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,First88,PgSelectRows89,PgSelectSingle90,PgClassExpression91,First94,PgSelectRows95,PgSelectSingle96,PgClassExpression97,PgClassExpression98,PgClassExpression99 bucket3
     Bucket0 --> Bucket1 & Bucket2
     Bucket2 --> Bucket3
     end

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.mermaid
@@ -35,8 +35,9 @@ graph TD
     __ListTransform11 ==> __Item15
     __Item15 --> PgSelectSingle16
     PgSelectSingle16 --> PgClassExpression17
+    PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__relation...les__.”id”ᐳ"}}:::plan
+    PgSelectSingle16 --> PgClassExpression19
     PgSelect20[["PgSelect[20∈3]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__relation...les__.”id”ᐳ<br />ᐳRelationalPost"}}:::plan
     Object10 & PgClassExpression19 --> PgSelect20
     PgSelect28[["PgSelect[28∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalPost"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈3]<br />ᐸ__relation...sts__.”id”ᐳ"}}:::plan
@@ -51,7 +52,6 @@ graph TD
     PgSelect80[["PgSelect[80∈3]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     PgClassExpression79{{"PgClassExpression[79∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
     Object10 & PgClassExpression79 --> PgSelect80
-    PgSelectSingle16 --> PgClassExpression19
     First24{{"First[24∈3]"}}:::plan
     PgSelectRows25[["PgSelectRows[25∈3]"]]:::plan
     PgSelectRows25 --> First24
@@ -169,10 +169,10 @@ graph TD
     class Bucket1,__Item13,PgSelectSingle14 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 10<br /><br />ROOT __Item{2}ᐸ11ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 10, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[19]<br />2: 20, 49, 74<br />3: 25, 52, 77<br />ᐳ: 24, 26, 27, 46, 47, 48, 51, 53, 54, 73, 76, 78, 79, 98, 99<br />4: 28, 55, 80<br />5: 31, 37, 43, 58, 64, 70, 83, 89, 95<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 57, 59, 60, 63, 65, 66, 69, 71, 72, 82, 84, 85, 88, 90, 91, 94, 96, 97"):::bucket
+    class Bucket2,__Item15,PgSelectSingle16,PgClassExpression17,PgPolymorphic18,PgClassExpression19 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />RelationalPost,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 19, 18<br />ᐳRelationalPost<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 20, 49, 74<br />2: 25, 52, 77<br />ᐳ: 24, 26, 27, 46, 47, 48, 51, 53, 54, 73, 76, 78, 79, 98, 99<br />3: 28, 55, 80<br />4: 31, 37, 43, 58, 64, 70, 83, 89, 95<br />ᐳ: 30, 32, 33, 36, 38, 39, 42, 44, 45, 57, 59, 60, 63, 65, 66, 69, 71, 72, 82, 84, 85, 88, 90, 91, 94, 96, 97"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectRows52,PgSelectSingle53,PgClassExpression54,PgSelect55,First57,PgSelectRows58,PgSelectSingle59,PgClassExpression60,First63,PgSelectRows64,PgSelectSingle65,PgClassExpression66,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,First88,PgSelectRows89,PgSelectSingle90,PgClassExpression91,First94,PgSelectRows95,PgSelectSingle96,PgClassExpression97,PgClassExpression98,PgClassExpression99 bucket3
+    class Bucket3,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression27,PgSelect28,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,PgClassExpression48,PgSelect49,First51,PgSelectRows52,PgSelectSingle53,PgClassExpression54,PgSelect55,First57,PgSelectRows58,PgSelectSingle59,PgClassExpression60,First63,PgSelectRows64,PgSelectSingle65,PgClassExpression66,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgSelect74,First76,PgSelectRows77,PgSelectSingle78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,First88,PgSelectRows89,PgSelectSingle90,PgClassExpression91,First94,PgSelectRows95,PgSelectSingle96,PgClassExpression97,PgClassExpression98,PgClassExpression99 bucket3
     Bucket0 --> Bucket1 & Bucket2
     Bucket2 --> Bucket3
     end

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.mermaid
@@ -47,76 +47,92 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression35
+    PgClassExpression119{{"PgClassExpression[119∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression119
+    PgClassExpression120{{"PgClassExpression[120∈4]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression120
+    PgClassExpression127{{"PgClassExpression[127∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression129
+    PgClassExpression130{{"PgClassExpression[130∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression130
+    PgClassExpression131{{"PgClassExpression[131∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression131
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect36[["PgSelect[36∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression35 --> PgSelect36
     PgPolymorphic42{{"PgPolymorphic[42∈5]<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle40{{"PgSelectSingle[40∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle40 & PgClassExpression41 --> PgPolymorphic42
     PgSelect121[["PgSelect[121∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression120 --> PgSelect121
     PgSelect133[["PgSelect[133∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect133
     PgPolymorphic144{{"PgPolymorphic[144∈5]<br />ᐳRelationalPost"}}:::plan
     PgSelectSingle142{{"PgSelectSingle[142∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression143{{"PgClassExpression[143∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression143{{"PgClassExpression[143∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle142 & PgClassExpression143 --> PgPolymorphic144
     PgSelect229[["PgSelect[229∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect229
     PgPolymorphic240{{"PgPolymorphic[240∈5]<br />ᐳRelationalDivider"}}:::plan
     PgSelectSingle238{{"PgSelectSingle[238∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression239{{"PgClassExpression[239∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression239{{"PgClassExpression[239∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle238 & PgClassExpression239 --> PgPolymorphic240
     PgSelect324[["PgSelect[324∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect324
     PgPolymorphic335{{"PgPolymorphic[335∈5]<br />ᐳRelationalChecklist"}}:::plan
     PgSelectSingle333{{"PgSelectSingle[333∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression334{{"PgClassExpression[334∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression334{{"PgClassExpression[334∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle333 & PgClassExpression334 --> PgPolymorphic335
     PgSelect418[["PgSelect[418∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect418
     PgPolymorphic429{{"PgPolymorphic[429∈5]<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle427{{"PgSelectSingle[427∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression428{{"PgClassExpression[428∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression428{{"PgClassExpression[428∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle427 & PgClassExpression428 --> PgPolymorphic429
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgSelectSingle24 --> PgClassExpression35
     First38{{"First[38∈5]"}}:::plan
     PgSelectRows39[["PgSelectRows[39∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows39 --> First38
     PgSelect36 --> PgSelectRows39
     First38 --> PgSelectSingle40
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression119
-    PgSelectSingle24 --> PgClassExpression120
+    PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression43
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression53
+    PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression60
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression62
+    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression63
+    PgClassExpression64{{"PgClassExpression[64∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression64
     First123{{"First[123∈5]"}}:::plan
     PgSelectRows124[["PgSelectRows[124∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows124 --> First123
     PgSelect121 --> PgSelectRows124
     PgSelectSingle125{{"PgSelectSingle[125∈5]<br />ᐸpeopleᐳ"}}:::plan
     First123 --> PgSelectSingle125
-    PgClassExpression127{{"PgClassExpression[127∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression127
-    PgClassExpression128{{"PgClassExpression[128∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression128
-    PgClassExpression129{{"PgClassExpression[129∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression129
-    PgClassExpression130{{"PgClassExpression[130∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression130
-    PgClassExpression131{{"PgClassExpression[131∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression131
     PgClassExpression132{{"PgClassExpression[132∈5]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression132
     First135{{"First[135∈5]"}}:::plan
@@ -131,6 +147,22 @@ graph TD
     PgSelect36 --> PgSelectRows141
     First140 --> PgSelectSingle142
     PgSelectSingle142 --> PgClassExpression143
+    PgClassExpression145{{"PgClassExpression[145∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression145
+    PgClassExpression154{{"PgClassExpression[154∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression154
+    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression155
+    PgClassExpression162{{"PgClassExpression[162∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression162
+    PgClassExpression163{{"PgClassExpression[163∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression163
+    PgClassExpression164{{"PgClassExpression[164∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression164
+    PgClassExpression165{{"PgClassExpression[165∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression165
+    PgClassExpression166{{"PgClassExpression[166∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression166
     First222{{"First[222∈5]"}}:::plan
     PgSelectRows223[["PgSelectRows[223∈5]<br />ᐳRelationalPost"]]:::plan
     PgSelectRows223 --> First222
@@ -155,6 +187,22 @@ graph TD
     PgSelect36 --> PgSelectRows237
     First236 --> PgSelectSingle238
     PgSelectSingle238 --> PgClassExpression239
+    PgClassExpression241{{"PgClassExpression[241∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression241
+    PgClassExpression250{{"PgClassExpression[250∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression250
+    PgClassExpression251{{"PgClassExpression[251∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression251
+    PgClassExpression258{{"PgClassExpression[258∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression258
+    PgClassExpression259{{"PgClassExpression[259∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression259
+    PgClassExpression260{{"PgClassExpression[260∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression260
+    PgClassExpression261{{"PgClassExpression[261∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression261
+    PgClassExpression262{{"PgClassExpression[262∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression262
     First318{{"First[318∈5]"}}:::plan
     PgSelectRows319[["PgSelectRows[319∈5]<br />ᐳRelationalDivider"]]:::plan
     PgSelectRows319 --> First318
@@ -177,6 +225,22 @@ graph TD
     PgSelect36 --> PgSelectRows332
     First331 --> PgSelectSingle333
     PgSelectSingle333 --> PgClassExpression334
+    PgClassExpression336{{"PgClassExpression[336∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression336
+    PgClassExpression345{{"PgClassExpression[345∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression345
+    PgClassExpression346{{"PgClassExpression[346∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression346
+    PgClassExpression353{{"PgClassExpression[353∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression353
+    PgClassExpression354{{"PgClassExpression[354∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression354
+    PgClassExpression355{{"PgClassExpression[355∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression355
+    PgClassExpression356{{"PgClassExpression[356∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression356
+    PgClassExpression357{{"PgClassExpression[357∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression357
     First413{{"First[413∈5]"}}:::plan
     PgSelectRows414[["PgSelectRows[414∈5]<br />ᐳRelationalChecklist"]]:::plan
     PgSelectRows414 --> First413
@@ -197,6 +261,22 @@ graph TD
     PgSelect36 --> PgSelectRows426
     First425 --> PgSelectSingle427
     PgSelectSingle427 --> PgClassExpression428
+    PgClassExpression430{{"PgClassExpression[430∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression430
+    PgClassExpression439{{"PgClassExpression[439∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression439
+    PgClassExpression440{{"PgClassExpression[440∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression440
+    PgClassExpression447{{"PgClassExpression[447∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression447
+    PgClassExpression448{{"PgClassExpression[448∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression448
+    PgClassExpression449{{"PgClassExpression[449∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression449
+    PgClassExpression450{{"PgClassExpression[450∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression450
+    PgClassExpression451{{"PgClassExpression[451∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression451
     First507{{"First[507∈5]"}}:::plan
     PgSelectRows508[["PgSelectRows[508∈5]<br />ᐳRelationalChecklistItem"]]:::plan
     PgSelectRows508 --> First507
@@ -208,10 +288,8 @@ graph TD
     PgClassExpression512{{"PgClassExpression[512∈5]<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle422 --> PgClassExpression512
     PgSelect44[["PgSelect[44∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression43{{"PgClassExpression[43∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression43 --> PgSelect44
     PgSelect54[["PgSelect[54∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression53 --> PgSelect54
     PgSelect66[["PgSelect[66∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect66
@@ -221,32 +299,18 @@ graph TD
     Object9 & PgClassExpression43 --> PgSelect93
     PgSelect105[["PgSelect[105∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect105
-    PgSelectSingle40 --> PgClassExpression43
     First48{{"First[48∈6]"}}:::plan
     PgSelectRows49[["PgSelectRows[49∈6]"]]:::plan
     PgSelectRows49 --> First48
     PgSelect44 --> PgSelectRows49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸrelational_topicsᐳ"}}:::plan
     First48 --> PgSelectSingle50
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression52
-    PgSelectSingle40 --> PgClassExpression53
     First56{{"First[56∈6]"}}:::plan
     PgSelectRows57[["PgSelectRows[57∈6]<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgSelectRows57 --> First56
     PgSelect54 --> PgSelectRows57
     PgSelectSingle58{{"PgSelectSingle[58∈6]<br />ᐸpeopleᐳ"}}:::plan
     First56 --> PgSelectSingle58
-    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression60
-    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression61
-    PgClassExpression62{{"PgClassExpression[62∈6]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression62
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression64
     PgClassExpression65{{"PgClassExpression[65∈6]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle50 --> PgClassExpression65
     First68{{"First[68∈6]"}}:::plan
@@ -326,10 +390,8 @@ graph TD
     PgClassExpression126{{"PgClassExpression[126∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle125 --> PgClassExpression126
     PgSelect146[["PgSelect[146∈13]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression145{{"PgClassExpression[145∈13]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression145 --> PgSelect146
     PgSelect156[["PgSelect[156∈13]<br />ᐸpeopleᐳ<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression155{{"PgClassExpression[155∈13]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression155 --> PgSelect156
     PgSelect168[["PgSelect[168∈13]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression145 --> PgSelect168
@@ -339,32 +401,18 @@ graph TD
     Object9 & PgClassExpression145 --> PgSelect195
     PgSelect207[["PgSelect[207∈13]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression145 --> PgSelect207
-    PgSelectSingle142 --> PgClassExpression145
     First150{{"First[150∈13]"}}:::plan
     PgSelectRows151[["PgSelectRows[151∈13]"]]:::plan
     PgSelectRows151 --> First150
     PgSelect146 --> PgSelectRows151
     PgSelectSingle152{{"PgSelectSingle[152∈13]<br />ᐸrelational_topicsᐳ"}}:::plan
     First150 --> PgSelectSingle152
-    PgClassExpression154{{"PgClassExpression[154∈13]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression154
-    PgSelectSingle142 --> PgClassExpression155
     First158{{"First[158∈13]"}}:::plan
     PgSelectRows159[["PgSelectRows[159∈13]<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgSelectRows159 --> First158
     PgSelect156 --> PgSelectRows159
     PgSelectSingle160{{"PgSelectSingle[160∈13]<br />ᐸpeopleᐳ"}}:::plan
     First158 --> PgSelectSingle160
-    PgClassExpression162{{"PgClassExpression[162∈13]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression162
-    PgClassExpression163{{"PgClassExpression[163∈13]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression163
-    PgClassExpression164{{"PgClassExpression[164∈13]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression164
-    PgClassExpression165{{"PgClassExpression[165∈13]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression165
-    PgClassExpression166{{"PgClassExpression[166∈13]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression166
     PgClassExpression167{{"PgClassExpression[167∈13]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle152 --> PgClassExpression167
     First170{{"First[170∈13]"}}:::plan
@@ -444,10 +492,8 @@ graph TD
     PgClassExpression225{{"PgClassExpression[225∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle224 --> PgClassExpression225
     PgSelect242[["PgSelect[242∈20]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression241{{"PgClassExpression[241∈20]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression241 --> PgSelect242
     PgSelect252[["PgSelect[252∈20]<br />ᐸpeopleᐳ<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression251{{"PgClassExpression[251∈20]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression251 --> PgSelect252
     PgSelect264[["PgSelect[264∈20]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression241 --> PgSelect264
@@ -457,32 +503,18 @@ graph TD
     Object9 & PgClassExpression241 --> PgSelect291
     PgSelect303[["PgSelect[303∈20]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression241 --> PgSelect303
-    PgSelectSingle238 --> PgClassExpression241
     First246{{"First[246∈20]"}}:::plan
     PgSelectRows247[["PgSelectRows[247∈20]"]]:::plan
     PgSelectRows247 --> First246
     PgSelect242 --> PgSelectRows247
     PgSelectSingle248{{"PgSelectSingle[248∈20]<br />ᐸrelational_topicsᐳ"}}:::plan
     First246 --> PgSelectSingle248
-    PgClassExpression250{{"PgClassExpression[250∈20]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression250
-    PgSelectSingle238 --> PgClassExpression251
     First254{{"First[254∈20]"}}:::plan
     PgSelectRows255[["PgSelectRows[255∈20]<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgSelectRows255 --> First254
     PgSelect252 --> PgSelectRows255
     PgSelectSingle256{{"PgSelectSingle[256∈20]<br />ᐸpeopleᐳ"}}:::plan
     First254 --> PgSelectSingle256
-    PgClassExpression258{{"PgClassExpression[258∈20]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression258
-    PgClassExpression259{{"PgClassExpression[259∈20]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression259
-    PgClassExpression260{{"PgClassExpression[260∈20]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression260
-    PgClassExpression261{{"PgClassExpression[261∈20]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression261
-    PgClassExpression262{{"PgClassExpression[262∈20]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression262
     PgClassExpression263{{"PgClassExpression[263∈20]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle248 --> PgClassExpression263
     First266{{"First[266∈20]"}}:::plan
@@ -562,10 +594,8 @@ graph TD
     PgClassExpression321{{"PgClassExpression[321∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle320 --> PgClassExpression321
     PgSelect337[["PgSelect[337∈27]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression336{{"PgClassExpression[336∈27]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression336 --> PgSelect337
     PgSelect347[["PgSelect[347∈27]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression346{{"PgClassExpression[346∈27]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression346 --> PgSelect347
     PgSelect359[["PgSelect[359∈27]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression336 --> PgSelect359
@@ -575,32 +605,18 @@ graph TD
     Object9 & PgClassExpression336 --> PgSelect386
     PgSelect398[["PgSelect[398∈27]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression336 --> PgSelect398
-    PgSelectSingle333 --> PgClassExpression336
     First341{{"First[341∈27]"}}:::plan
     PgSelectRows342[["PgSelectRows[342∈27]"]]:::plan
     PgSelectRows342 --> First341
     PgSelect337 --> PgSelectRows342
     PgSelectSingle343{{"PgSelectSingle[343∈27]<br />ᐸrelational_topicsᐳ"}}:::plan
     First341 --> PgSelectSingle343
-    PgClassExpression345{{"PgClassExpression[345∈27]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression345
-    PgSelectSingle333 --> PgClassExpression346
     First349{{"First[349∈27]"}}:::plan
     PgSelectRows350[["PgSelectRows[350∈27]<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgSelectRows350 --> First349
     PgSelect347 --> PgSelectRows350
     PgSelectSingle351{{"PgSelectSingle[351∈27]<br />ᐸpeopleᐳ"}}:::plan
     First349 --> PgSelectSingle351
-    PgClassExpression353{{"PgClassExpression[353∈27]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression353
-    PgClassExpression354{{"PgClassExpression[354∈27]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression354
-    PgClassExpression355{{"PgClassExpression[355∈27]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression355
-    PgClassExpression356{{"PgClassExpression[356∈27]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression356
-    PgClassExpression357{{"PgClassExpression[357∈27]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression357
     PgClassExpression358{{"PgClassExpression[358∈27]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle343 --> PgClassExpression358
     First361{{"First[361∈27]"}}:::plan
@@ -680,10 +696,8 @@ graph TD
     PgClassExpression416{{"PgClassExpression[416∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle415 --> PgClassExpression416
     PgSelect431[["PgSelect[431∈34]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression430{{"PgClassExpression[430∈34]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression430 --> PgSelect431
     PgSelect441[["PgSelect[441∈34]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression440{{"PgClassExpression[440∈34]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression440 --> PgSelect441
     PgSelect453[["PgSelect[453∈34]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression430 --> PgSelect453
@@ -693,32 +707,18 @@ graph TD
     Object9 & PgClassExpression430 --> PgSelect480
     PgSelect492[["PgSelect[492∈34]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression430 --> PgSelect492
-    PgSelectSingle427 --> PgClassExpression430
     First435{{"First[435∈34]"}}:::plan
     PgSelectRows436[["PgSelectRows[436∈34]"]]:::plan
     PgSelectRows436 --> First435
     PgSelect431 --> PgSelectRows436
     PgSelectSingle437{{"PgSelectSingle[437∈34]<br />ᐸrelational_topicsᐳ"}}:::plan
     First435 --> PgSelectSingle437
-    PgClassExpression439{{"PgClassExpression[439∈34]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression439
-    PgSelectSingle427 --> PgClassExpression440
     First443{{"First[443∈34]"}}:::plan
     PgSelectRows444[["PgSelectRows[444∈34]<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgSelectRows444 --> First443
     PgSelect441 --> PgSelectRows444
     PgSelectSingle445{{"PgSelectSingle[445∈34]<br />ᐸpeopleᐳ"}}:::plan
     First443 --> PgSelectSingle445
-    PgClassExpression447{{"PgClassExpression[447∈34]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression447
-    PgClassExpression448{{"PgClassExpression[448∈34]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression448
-    PgClassExpression449{{"PgClassExpression[449∈34]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression449
-    PgClassExpression450{{"PgClassExpression[450∈34]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression450
-    PgClassExpression451{{"PgClassExpression[451∈34]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression451
     PgClassExpression452{{"PgClassExpression[452∈34]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle437 --> PgClassExpression452
     First455{{"First[455∈34]"}}:::plan
@@ -815,13 +815,13 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 35, 119, 120, 127, 128, 129, 130, 131<br />2: 28, 36, 121, 133, 229, 324, 418<br />3: 33, 39, 124, 136, 141, 223, 232, 237, 319, 327, 332, 414, 421, 426, 508<br />ᐳ: 32, 34, 38, 40, 41, 42, 123, 125, 132, 135, 137, 140, 142, 143, 144, 222, 224, 226, 227, 228, 231, 233, 236, 238, 239, 240, 318, 320, 322, 323, 326, 328, 331, 333, 334, 335, 413, 415, 417, 420, 422, 425, 427, 428, 429, 507, 509, 511, 512"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression35,PgClassExpression119,PgClassExpression120,PgClassExpression127,PgClassExpression128,PgClassExpression129,PgClassExpression130,PgClassExpression131 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 35, 120, 26, 25, 119, 127, 128, 129, 130, 131<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 36, 121, 133, 229, 324, 418<br />2: 33, 39, 124, 136, 141, 223, 232, 237, 319, 327, 332, 414, 421, 426, 508<br />ᐳ: 32, 34, 38, 40, 41, 42, 43, 52, 53, 60, 61, 62, 63, 64, 123, 125, 132, 135, 137, 140, 142, 143, 144, 145, 154, 155, 162, 163, 164, 165, 166, 222, 224, 226, 227, 228, 231, 233, 236, 238, 239, 240, 241, 250, 251, 258, 259, 260, 261, 262, 318, 320, 322, 323, 326, 328, 331, 333, 334, 335, 336, 345, 346, 353, 354, 355, 356, 357, 413, 415, 417, 420, 422, 425, 427, 428, 429, 430, 439, 440, 447, 448, 449, 450, 451, 507, 509, 511, 512"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression119,PgClassExpression120,PgSelect121,First123,PgSelectRows124,PgSelectSingle125,PgClassExpression127,PgClassExpression128,PgClassExpression129,PgClassExpression130,PgClassExpression131,PgClassExpression132,PgSelect133,First135,PgSelectRows136,PgSelectSingle137,First140,PgSelectRows141,PgSelectSingle142,PgClassExpression143,PgPolymorphic144,First222,PgSelectRows223,PgSelectSingle224,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgSelect229,First231,PgSelectRows232,PgSelectSingle233,First236,PgSelectRows237,PgSelectSingle238,PgClassExpression239,PgPolymorphic240,First318,PgSelectRows319,PgSelectSingle320,PgClassExpression322,PgClassExpression323,PgSelect324,First326,PgSelectRows327,PgSelectSingle328,First331,PgSelectRows332,PgSelectSingle333,PgClassExpression334,PgPolymorphic335,First413,PgSelectRows414,PgSelectSingle415,PgClassExpression417,PgSelect418,First420,PgSelectRows421,PgSelectSingle422,First425,PgSelectRows426,PgSelectSingle427,PgClassExpression428,PgPolymorphic429,First507,PgSelectRows508,PgSelectSingle509,PgClassExpression511,PgClassExpression512 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 40, 9, 42, 41<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 43, 52, 53, 60, 61, 62, 63, 64<br />2: 44, 54, 66, 80, 93, 105<br />3: 49, 57, 69, 74, 83, 88, 96, 101, 108, 113<br />ᐳ: 48, 50, 56, 58, 65, 68, 70, 73, 75, 77, 78, 79, 82, 84, 87, 89, 91, 92, 95, 97, 100, 102, 104, 107, 109, 112, 114, 116, 117"):::bucket
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression43,PgClassExpression52,PgClassExpression53,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgSelect121,First123,PgSelectRows124,PgSelectSingle125,PgClassExpression132,PgSelect133,First135,PgSelectRows136,PgSelectSingle137,First140,PgSelectRows141,PgSelectSingle142,PgClassExpression143,PgPolymorphic144,PgClassExpression145,PgClassExpression154,PgClassExpression155,PgClassExpression162,PgClassExpression163,PgClassExpression164,PgClassExpression165,PgClassExpression166,First222,PgSelectRows223,PgSelectSingle224,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgSelect229,First231,PgSelectRows232,PgSelectSingle233,First236,PgSelectRows237,PgSelectSingle238,PgClassExpression239,PgPolymorphic240,PgClassExpression241,PgClassExpression250,PgClassExpression251,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression261,PgClassExpression262,First318,PgSelectRows319,PgSelectSingle320,PgClassExpression322,PgClassExpression323,PgSelect324,First326,PgSelectRows327,PgSelectSingle328,First331,PgSelectRows332,PgSelectSingle333,PgClassExpression334,PgPolymorphic335,PgClassExpression336,PgClassExpression345,PgClassExpression346,PgClassExpression353,PgClassExpression354,PgClassExpression355,PgClassExpression356,PgClassExpression357,First413,PgSelectRows414,PgSelectSingle415,PgClassExpression417,PgSelect418,First420,PgSelectRows421,PgSelectSingle422,First425,PgSelectRows426,PgSelectSingle427,PgClassExpression428,PgPolymorphic429,PgClassExpression430,PgClassExpression439,PgClassExpression440,PgClassExpression447,PgClassExpression448,PgClassExpression449,PgClassExpression450,PgClassExpression451,First507,PgSelectRows508,PgSelectSingle509,PgClassExpression511,PgClassExpression512 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 43, 53, 42, 41, 52, 60, 61, 62, 63, 64<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 44, 54, 66, 80, 93, 105<br />2: 49, 57, 69, 74, 83, 88, 96, 101, 108, 113<br />ᐳ: 48, 50, 56, 58, 65, 68, 70, 73, 75, 77, 78, 79, 82, 84, 87, 89, 91, 92, 95, 97, 100, 102, 104, 107, 109, 112, 114, 116, 117"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgSelect66,First68,PgSelectRows69,PgSelectSingle70,First73,PgSelectRows74,PgSelectSingle75,PgClassExpression77,PgClassExpression78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,First100,PgSelectRows101,PgSelectSingle102,PgClassExpression104,PgSelect105,First107,PgSelectRows108,PgSelectSingle109,First112,PgSelectRows113,PgSelectSingle114,PgClassExpression116,PgClassExpression117 bucket6
+    class Bucket6,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgClassExpression65,PgSelect66,First68,PgSelectRows69,PgSelectSingle70,First73,PgSelectRows74,PgSelectSingle75,PgClassExpression77,PgClassExpression78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,First100,PgSelectRows101,PgSelectSingle102,PgClassExpression104,PgSelect105,First107,PgSelectRows108,PgSelectSingle109,First112,PgSelectRows113,PgSelectSingle114,PgClassExpression116,PgClassExpression117 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 58<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[58]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression59 bucket7
@@ -840,9 +840,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 125<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[125]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression126 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 142, 9, 144, 143<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 145, 154, 155, 162, 163, 164, 165, 166<br />2: 146, 156, 168, 182, 195, 207<br />3: 151, 159, 171, 176, 185, 190, 198, 203, 210, 215<br />ᐳ: 150, 152, 158, 160, 167, 170, 172, 175, 177, 179, 180, 181, 184, 186, 189, 191, 193, 194, 197, 199, 202, 204, 206, 209, 211, 214, 216, 218, 219"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 145, 155, 144, 143, 154, 162, 163, 164, 165, 166<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 146, 156, 168, 182, 195, 207<br />2: 151, 159, 171, 176, 185, 190, 198, 203, 210, 215<br />ᐳ: 150, 152, 158, 160, 167, 170, 172, 175, 177, 179, 180, 181, 184, 186, 189, 191, 193, 194, 197, 199, 202, 204, 206, 209, 211, 214, 216, 218, 219"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression145,PgSelect146,First150,PgSelectRows151,PgSelectSingle152,PgClassExpression154,PgClassExpression155,PgSelect156,First158,PgSelectRows159,PgSelectSingle160,PgClassExpression162,PgClassExpression163,PgClassExpression164,PgClassExpression165,PgClassExpression166,PgClassExpression167,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgSelect182,First184,PgSelectRows185,PgSelectSingle186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,PgSelect195,First197,PgSelectRows198,PgSelectSingle199,First202,PgSelectRows203,PgSelectSingle204,PgClassExpression206,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression218,PgClassExpression219 bucket13
+    class Bucket13,PgSelect146,First150,PgSelectRows151,PgSelectSingle152,PgSelect156,First158,PgSelectRows159,PgSelectSingle160,PgClassExpression167,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgSelect182,First184,PgSelectRows185,PgSelectSingle186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,PgSelect195,First197,PgSelectRows198,PgSelectSingle199,First202,PgSelectRows203,PgSelectSingle204,PgClassExpression206,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression218,PgClassExpression219 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 160<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[160]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression161 bucket14
@@ -861,9 +861,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 224<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[224]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression225 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 238, 9, 240, 239<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 241, 250, 251, 258, 259, 260, 261, 262<br />2: 242, 252, 264, 278, 291, 303<br />3: 247, 255, 267, 272, 281, 286, 294, 299, 306, 311<br />ᐳ: 246, 248, 254, 256, 263, 266, 268, 271, 273, 275, 276, 277, 280, 282, 285, 287, 289, 290, 293, 295, 298, 300, 302, 305, 307, 310, 312, 314, 315"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 241, 251, 240, 239, 250, 258, 259, 260, 261, 262<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 242, 252, 264, 278, 291, 303<br />2: 247, 255, 267, 272, 281, 286, 294, 299, 306, 311<br />ᐳ: 246, 248, 254, 256, 263, 266, 268, 271, 273, 275, 276, 277, 280, 282, 285, 287, 289, 290, 293, 295, 298, 300, 302, 305, 307, 310, 312, 314, 315"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression241,PgSelect242,First246,PgSelectRows247,PgSelectSingle248,PgClassExpression250,PgClassExpression251,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression261,PgClassExpression262,PgClassExpression263,PgSelect264,First266,PgSelectRows267,PgSelectSingle268,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression275,PgClassExpression276,PgClassExpression277,PgSelect278,First280,PgSelectRows281,PgSelectSingle282,First285,PgSelectRows286,PgSelectSingle287,PgClassExpression289,PgClassExpression290,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression302,PgSelect303,First305,PgSelectRows306,PgSelectSingle307,First310,PgSelectRows311,PgSelectSingle312,PgClassExpression314,PgClassExpression315 bucket20
+    class Bucket20,PgSelect242,First246,PgSelectRows247,PgSelectSingle248,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,PgClassExpression263,PgSelect264,First266,PgSelectRows267,PgSelectSingle268,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression275,PgClassExpression276,PgClassExpression277,PgSelect278,First280,PgSelectRows281,PgSelectSingle282,First285,PgSelectRows286,PgSelectSingle287,PgClassExpression289,PgClassExpression290,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression302,PgSelect303,First305,PgSelectRows306,PgSelectSingle307,First310,PgSelectRows311,PgSelectSingle312,PgClassExpression314,PgClassExpression315 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 256<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[256]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression257 bucket21
@@ -882,9 +882,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 320<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[320]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression321 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 333, 9, 335, 334<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 336, 345, 346, 353, 354, 355, 356, 357<br />2: 337, 347, 359, 373, 386, 398<br />3: 342, 350, 362, 367, 376, 381, 389, 394, 401, 406<br />ᐳ: 341, 343, 349, 351, 358, 361, 363, 366, 368, 370, 371, 372, 375, 377, 380, 382, 384, 385, 388, 390, 393, 395, 397, 400, 402, 405, 407, 409, 410"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 336, 346, 335, 334, 345, 353, 354, 355, 356, 357<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 337, 347, 359, 373, 386, 398<br />2: 342, 350, 362, 367, 376, 381, 389, 394, 401, 406<br />ᐳ: 341, 343, 349, 351, 358, 361, 363, 366, 368, 370, 371, 372, 375, 377, 380, 382, 384, 385, 388, 390, 393, 395, 397, 400, 402, 405, 407, 409, 410"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression336,PgSelect337,First341,PgSelectRows342,PgSelectSingle343,PgClassExpression345,PgClassExpression346,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,PgClassExpression353,PgClassExpression354,PgClassExpression355,PgClassExpression356,PgClassExpression357,PgClassExpression358,PgSelect359,First361,PgSelectRows362,PgSelectSingle363,First366,PgSelectRows367,PgSelectSingle368,PgClassExpression370,PgClassExpression371,PgClassExpression372,PgSelect373,First375,PgSelectRows376,PgSelectSingle377,First380,PgSelectRows381,PgSelectSingle382,PgClassExpression384,PgClassExpression385,PgSelect386,First388,PgSelectRows389,PgSelectSingle390,First393,PgSelectRows394,PgSelectSingle395,PgClassExpression397,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,First405,PgSelectRows406,PgSelectSingle407,PgClassExpression409,PgClassExpression410 bucket27
+    class Bucket27,PgSelect337,First341,PgSelectRows342,PgSelectSingle343,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,PgClassExpression358,PgSelect359,First361,PgSelectRows362,PgSelectSingle363,First366,PgSelectRows367,PgSelectSingle368,PgClassExpression370,PgClassExpression371,PgClassExpression372,PgSelect373,First375,PgSelectRows376,PgSelectSingle377,First380,PgSelectRows381,PgSelectSingle382,PgClassExpression384,PgClassExpression385,PgSelect386,First388,PgSelectRows389,PgSelectSingle390,First393,PgSelectRows394,PgSelectSingle395,PgClassExpression397,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,First405,PgSelectRows406,PgSelectSingle407,PgClassExpression409,PgClassExpression410 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 351<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[351]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression352 bucket28
@@ -903,9 +903,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 415<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[415]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression416 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 427, 9, 429, 428<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 430, 439, 440, 447, 448, 449, 450, 451<br />2: 431, 441, 453, 467, 480, 492<br />3: 436, 444, 456, 461, 470, 475, 483, 488, 495, 500<br />ᐳ: 435, 437, 443, 445, 452, 455, 457, 460, 462, 464, 465, 466, 469, 471, 474, 476, 478, 479, 482, 484, 487, 489, 491, 494, 496, 499, 501, 503, 504"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 430, 440, 429, 428, 439, 447, 448, 449, 450, 451<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 431, 441, 453, 467, 480, 492<br />2: 436, 444, 456, 461, 470, 475, 483, 488, 495, 500<br />ᐳ: 435, 437, 443, 445, 452, 455, 457, 460, 462, 464, 465, 466, 469, 471, 474, 476, 478, 479, 482, 484, 487, 489, 491, 494, 496, 499, 501, 503, 504"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression430,PgSelect431,First435,PgSelectRows436,PgSelectSingle437,PgClassExpression439,PgClassExpression440,PgSelect441,First443,PgSelectRows444,PgSelectSingle445,PgClassExpression447,PgClassExpression448,PgClassExpression449,PgClassExpression450,PgClassExpression451,PgClassExpression452,PgSelect453,First455,PgSelectRows456,PgSelectSingle457,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,PgClassExpression465,PgClassExpression466,PgSelect467,First469,PgSelectRows470,PgSelectSingle471,First474,PgSelectRows475,PgSelectSingle476,PgClassExpression478,PgClassExpression479,PgSelect480,First482,PgSelectRows483,PgSelectSingle484,First487,PgSelectRows488,PgSelectSingle489,PgClassExpression491,PgSelect492,First494,PgSelectRows495,PgSelectSingle496,First499,PgSelectRows500,PgSelectSingle501,PgClassExpression503,PgClassExpression504 bucket34
+    class Bucket34,PgSelect431,First435,PgSelectRows436,PgSelectSingle437,PgSelect441,First443,PgSelectRows444,PgSelectSingle445,PgClassExpression452,PgSelect453,First455,PgSelectRows456,PgSelectSingle457,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,PgClassExpression465,PgClassExpression466,PgSelect467,First469,PgSelectRows470,PgSelectSingle471,First474,PgSelectRows475,PgSelectSingle476,PgClassExpression478,PgClassExpression479,PgSelect480,First482,PgSelectRows483,PgSelectSingle484,First487,PgSelectRows488,PgSelectSingle489,PgClassExpression491,PgSelect492,First494,PgSelectRows495,PgSelectSingle496,First499,PgSelectRows500,PgSelectSingle501,PgClassExpression503,PgClassExpression504 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 445<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[445]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression446 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.mermaid
@@ -47,76 +47,92 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression35
+    PgClassExpression119{{"PgClassExpression[119∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression119
+    PgClassExpression120{{"PgClassExpression[120∈4]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression120
+    PgClassExpression127{{"PgClassExpression[127∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression129
+    PgClassExpression130{{"PgClassExpression[130∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression130
+    PgClassExpression131{{"PgClassExpression[131∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression131
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect36[["PgSelect[36∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression35 --> PgSelect36
     PgPolymorphic42{{"PgPolymorphic[42∈5]<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle40{{"PgSelectSingle[40∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle40 & PgClassExpression41 --> PgPolymorphic42
     PgSelect121[["PgSelect[121∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression120 --> PgSelect121
     PgSelect133[["PgSelect[133∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect133
     PgPolymorphic144{{"PgPolymorphic[144∈5]<br />ᐳRelationalPost"}}:::plan
     PgSelectSingle142{{"PgSelectSingle[142∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression143{{"PgClassExpression[143∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression143{{"PgClassExpression[143∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle142 & PgClassExpression143 --> PgPolymorphic144
     PgSelect229[["PgSelect[229∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect229
     PgPolymorphic240{{"PgPolymorphic[240∈5]<br />ᐳRelationalDivider"}}:::plan
     PgSelectSingle238{{"PgSelectSingle[238∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression239{{"PgClassExpression[239∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression239{{"PgClassExpression[239∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle238 & PgClassExpression239 --> PgPolymorphic240
     PgSelect324[["PgSelect[324∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect324
     PgPolymorphic335{{"PgPolymorphic[335∈5]<br />ᐳRelationalChecklist"}}:::plan
     PgSelectSingle333{{"PgSelectSingle[333∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression334{{"PgClassExpression[334∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression334{{"PgClassExpression[334∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle333 & PgClassExpression334 --> PgPolymorphic335
     PgSelect418[["PgSelect[418∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect418
     PgPolymorphic429{{"PgPolymorphic[429∈5]<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle427{{"PgSelectSingle[427∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression428{{"PgClassExpression[428∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression428{{"PgClassExpression[428∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle427 & PgClassExpression428 --> PgPolymorphic429
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgSelectSingle24 --> PgClassExpression35
     First38{{"First[38∈5]"}}:::plan
     PgSelectRows39[["PgSelectRows[39∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows39 --> First38
     PgSelect36 --> PgSelectRows39
     First38 --> PgSelectSingle40
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression119
-    PgSelectSingle24 --> PgClassExpression120
+    PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression43
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression53
+    PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression60
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression62
+    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression63
+    PgClassExpression64{{"PgClassExpression[64∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression64
     First123{{"First[123∈5]"}}:::plan
     PgSelectRows124[["PgSelectRows[124∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows124 --> First123
     PgSelect121 --> PgSelectRows124
     PgSelectSingle125{{"PgSelectSingle[125∈5]<br />ᐸpeopleᐳ"}}:::plan
     First123 --> PgSelectSingle125
-    PgClassExpression127{{"PgClassExpression[127∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression127
-    PgClassExpression128{{"PgClassExpression[128∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression128
-    PgClassExpression129{{"PgClassExpression[129∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression129
-    PgClassExpression130{{"PgClassExpression[130∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression130
-    PgClassExpression131{{"PgClassExpression[131∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression131
     PgClassExpression132{{"PgClassExpression[132∈5]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle34 --> PgClassExpression132
     First135{{"First[135∈5]"}}:::plan
@@ -131,6 +147,22 @@ graph TD
     PgSelect36 --> PgSelectRows141
     First140 --> PgSelectSingle142
     PgSelectSingle142 --> PgClassExpression143
+    PgClassExpression145{{"PgClassExpression[145∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression145
+    PgClassExpression154{{"PgClassExpression[154∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression154
+    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression155
+    PgClassExpression162{{"PgClassExpression[162∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression162
+    PgClassExpression163{{"PgClassExpression[163∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression163
+    PgClassExpression164{{"PgClassExpression[164∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression164
+    PgClassExpression165{{"PgClassExpression[165∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression165
+    PgClassExpression166{{"PgClassExpression[166∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle142 --> PgClassExpression166
     First222{{"First[222∈5]"}}:::plan
     PgSelectRows223[["PgSelectRows[223∈5]<br />ᐳRelationalPost"]]:::plan
     PgSelectRows223 --> First222
@@ -155,6 +187,22 @@ graph TD
     PgSelect36 --> PgSelectRows237
     First236 --> PgSelectSingle238
     PgSelectSingle238 --> PgClassExpression239
+    PgClassExpression241{{"PgClassExpression[241∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression241
+    PgClassExpression250{{"PgClassExpression[250∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression250
+    PgClassExpression251{{"PgClassExpression[251∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression251
+    PgClassExpression258{{"PgClassExpression[258∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression258
+    PgClassExpression259{{"PgClassExpression[259∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression259
+    PgClassExpression260{{"PgClassExpression[260∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression260
+    PgClassExpression261{{"PgClassExpression[261∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression261
+    PgClassExpression262{{"PgClassExpression[262∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle238 --> PgClassExpression262
     First318{{"First[318∈5]"}}:::plan
     PgSelectRows319[["PgSelectRows[319∈5]<br />ᐳRelationalDivider"]]:::plan
     PgSelectRows319 --> First318
@@ -177,6 +225,22 @@ graph TD
     PgSelect36 --> PgSelectRows332
     First331 --> PgSelectSingle333
     PgSelectSingle333 --> PgClassExpression334
+    PgClassExpression336{{"PgClassExpression[336∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression336
+    PgClassExpression345{{"PgClassExpression[345∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression345
+    PgClassExpression346{{"PgClassExpression[346∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression346
+    PgClassExpression353{{"PgClassExpression[353∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression353
+    PgClassExpression354{{"PgClassExpression[354∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression354
+    PgClassExpression355{{"PgClassExpression[355∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression355
+    PgClassExpression356{{"PgClassExpression[356∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression356
+    PgClassExpression357{{"PgClassExpression[357∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle333 --> PgClassExpression357
     First413{{"First[413∈5]"}}:::plan
     PgSelectRows414[["PgSelectRows[414∈5]<br />ᐳRelationalChecklist"]]:::plan
     PgSelectRows414 --> First413
@@ -197,6 +261,22 @@ graph TD
     PgSelect36 --> PgSelectRows426
     First425 --> PgSelectSingle427
     PgSelectSingle427 --> PgClassExpression428
+    PgClassExpression430{{"PgClassExpression[430∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression430
+    PgClassExpression439{{"PgClassExpression[439∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression439
+    PgClassExpression440{{"PgClassExpression[440∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression440
+    PgClassExpression447{{"PgClassExpression[447∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression447
+    PgClassExpression448{{"PgClassExpression[448∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression448
+    PgClassExpression449{{"PgClassExpression[449∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression449
+    PgClassExpression450{{"PgClassExpression[450∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression450
+    PgClassExpression451{{"PgClassExpression[451∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle427 --> PgClassExpression451
     First507{{"First[507∈5]"}}:::plan
     PgSelectRows508[["PgSelectRows[508∈5]<br />ᐳRelationalChecklistItem"]]:::plan
     PgSelectRows508 --> First507
@@ -208,10 +288,8 @@ graph TD
     PgClassExpression512{{"PgClassExpression[512∈5]<br />ᐸ__relation...s__.”note”ᐳ"}}:::plan
     PgSelectSingle422 --> PgClassExpression512
     PgSelect44[["PgSelect[44∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression43{{"PgClassExpression[43∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression43 --> PgSelect44
     PgSelect54[["PgSelect[54∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression53 --> PgSelect54
     PgSelect66[["PgSelect[66∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect66
@@ -221,32 +299,18 @@ graph TD
     Object9 & PgClassExpression43 --> PgSelect93
     PgSelect105[["PgSelect[105∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect105
-    PgSelectSingle40 --> PgClassExpression43
     First48{{"First[48∈6]"}}:::plan
     PgSelectRows49[["PgSelectRows[49∈6]"]]:::plan
     PgSelectRows49 --> First48
     PgSelect44 --> PgSelectRows49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸrelational_topicsᐳ"}}:::plan
     First48 --> PgSelectSingle50
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression52
-    PgSelectSingle40 --> PgClassExpression53
     First56{{"First[56∈6]"}}:::plan
     PgSelectRows57[["PgSelectRows[57∈6]<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgSelectRows57 --> First56
     PgSelect54 --> PgSelectRows57
     PgSelectSingle58{{"PgSelectSingle[58∈6]<br />ᐸpeopleᐳ"}}:::plan
     First56 --> PgSelectSingle58
-    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression60
-    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression61
-    PgClassExpression62{{"PgClassExpression[62∈6]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression62
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression64
     PgClassExpression65{{"PgClassExpression[65∈6]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle50 --> PgClassExpression65
     First68{{"First[68∈6]"}}:::plan
@@ -326,10 +390,8 @@ graph TD
     PgClassExpression126{{"PgClassExpression[126∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle125 --> PgClassExpression126
     PgSelect146[["PgSelect[146∈13]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression145{{"PgClassExpression[145∈13]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression145 --> PgSelect146
     PgSelect156[["PgSelect[156∈13]<br />ᐸpeopleᐳ<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression155{{"PgClassExpression[155∈13]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression155 --> PgSelect156
     PgSelect168[["PgSelect[168∈13]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression145 --> PgSelect168
@@ -339,32 +401,18 @@ graph TD
     Object9 & PgClassExpression145 --> PgSelect195
     PgSelect207[["PgSelect[207∈13]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression145 --> PgSelect207
-    PgSelectSingle142 --> PgClassExpression145
     First150{{"First[150∈13]"}}:::plan
     PgSelectRows151[["PgSelectRows[151∈13]"]]:::plan
     PgSelectRows151 --> First150
     PgSelect146 --> PgSelectRows151
     PgSelectSingle152{{"PgSelectSingle[152∈13]<br />ᐸrelational_topicsᐳ"}}:::plan
     First150 --> PgSelectSingle152
-    PgClassExpression154{{"PgClassExpression[154∈13]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression154
-    PgSelectSingle142 --> PgClassExpression155
     First158{{"First[158∈13]"}}:::plan
     PgSelectRows159[["PgSelectRows[159∈13]<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgSelectRows159 --> First158
     PgSelect156 --> PgSelectRows159
     PgSelectSingle160{{"PgSelectSingle[160∈13]<br />ᐸpeopleᐳ"}}:::plan
     First158 --> PgSelectSingle160
-    PgClassExpression162{{"PgClassExpression[162∈13]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression162
-    PgClassExpression163{{"PgClassExpression[163∈13]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression163
-    PgClassExpression164{{"PgClassExpression[164∈13]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression164
-    PgClassExpression165{{"PgClassExpression[165∈13]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression165
-    PgClassExpression166{{"PgClassExpression[166∈13]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle142 --> PgClassExpression166
     PgClassExpression167{{"PgClassExpression[167∈13]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle152 --> PgClassExpression167
     First170{{"First[170∈13]"}}:::plan
@@ -444,10 +492,8 @@ graph TD
     PgClassExpression225{{"PgClassExpression[225∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle224 --> PgClassExpression225
     PgSelect242[["PgSelect[242∈20]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression241{{"PgClassExpression[241∈20]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression241 --> PgSelect242
     PgSelect252[["PgSelect[252∈20]<br />ᐸpeopleᐳ<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression251{{"PgClassExpression[251∈20]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression251 --> PgSelect252
     PgSelect264[["PgSelect[264∈20]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression241 --> PgSelect264
@@ -457,32 +503,18 @@ graph TD
     Object9 & PgClassExpression241 --> PgSelect291
     PgSelect303[["PgSelect[303∈20]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression241 --> PgSelect303
-    PgSelectSingle238 --> PgClassExpression241
     First246{{"First[246∈20]"}}:::plan
     PgSelectRows247[["PgSelectRows[247∈20]"]]:::plan
     PgSelectRows247 --> First246
     PgSelect242 --> PgSelectRows247
     PgSelectSingle248{{"PgSelectSingle[248∈20]<br />ᐸrelational_topicsᐳ"}}:::plan
     First246 --> PgSelectSingle248
-    PgClassExpression250{{"PgClassExpression[250∈20]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression250
-    PgSelectSingle238 --> PgClassExpression251
     First254{{"First[254∈20]"}}:::plan
     PgSelectRows255[["PgSelectRows[255∈20]<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgSelectRows255 --> First254
     PgSelect252 --> PgSelectRows255
     PgSelectSingle256{{"PgSelectSingle[256∈20]<br />ᐸpeopleᐳ"}}:::plan
     First254 --> PgSelectSingle256
-    PgClassExpression258{{"PgClassExpression[258∈20]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression258
-    PgClassExpression259{{"PgClassExpression[259∈20]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression259
-    PgClassExpression260{{"PgClassExpression[260∈20]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression260
-    PgClassExpression261{{"PgClassExpression[261∈20]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression261
-    PgClassExpression262{{"PgClassExpression[262∈20]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle238 --> PgClassExpression262
     PgClassExpression263{{"PgClassExpression[263∈20]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle248 --> PgClassExpression263
     First266{{"First[266∈20]"}}:::plan
@@ -562,10 +594,8 @@ graph TD
     PgClassExpression321{{"PgClassExpression[321∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle320 --> PgClassExpression321
     PgSelect337[["PgSelect[337∈27]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression336{{"PgClassExpression[336∈27]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression336 --> PgSelect337
     PgSelect347[["PgSelect[347∈27]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression346{{"PgClassExpression[346∈27]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression346 --> PgSelect347
     PgSelect359[["PgSelect[359∈27]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression336 --> PgSelect359
@@ -575,32 +605,18 @@ graph TD
     Object9 & PgClassExpression336 --> PgSelect386
     PgSelect398[["PgSelect[398∈27]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression336 --> PgSelect398
-    PgSelectSingle333 --> PgClassExpression336
     First341{{"First[341∈27]"}}:::plan
     PgSelectRows342[["PgSelectRows[342∈27]"]]:::plan
     PgSelectRows342 --> First341
     PgSelect337 --> PgSelectRows342
     PgSelectSingle343{{"PgSelectSingle[343∈27]<br />ᐸrelational_topicsᐳ"}}:::plan
     First341 --> PgSelectSingle343
-    PgClassExpression345{{"PgClassExpression[345∈27]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression345
-    PgSelectSingle333 --> PgClassExpression346
     First349{{"First[349∈27]"}}:::plan
     PgSelectRows350[["PgSelectRows[350∈27]<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgSelectRows350 --> First349
     PgSelect347 --> PgSelectRows350
     PgSelectSingle351{{"PgSelectSingle[351∈27]<br />ᐸpeopleᐳ"}}:::plan
     First349 --> PgSelectSingle351
-    PgClassExpression353{{"PgClassExpression[353∈27]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression353
-    PgClassExpression354{{"PgClassExpression[354∈27]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression354
-    PgClassExpression355{{"PgClassExpression[355∈27]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression355
-    PgClassExpression356{{"PgClassExpression[356∈27]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression356
-    PgClassExpression357{{"PgClassExpression[357∈27]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle333 --> PgClassExpression357
     PgClassExpression358{{"PgClassExpression[358∈27]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle343 --> PgClassExpression358
     First361{{"First[361∈27]"}}:::plan
@@ -680,10 +696,8 @@ graph TD
     PgClassExpression416{{"PgClassExpression[416∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle415 --> PgClassExpression416
     PgSelect431[["PgSelect[431∈34]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression430{{"PgClassExpression[430∈34]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression430 --> PgSelect431
     PgSelect441[["PgSelect[441∈34]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression440{{"PgClassExpression[440∈34]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression440 --> PgSelect441
     PgSelect453[["PgSelect[453∈34]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression430 --> PgSelect453
@@ -693,32 +707,18 @@ graph TD
     Object9 & PgClassExpression430 --> PgSelect480
     PgSelect492[["PgSelect[492∈34]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression430 --> PgSelect492
-    PgSelectSingle427 --> PgClassExpression430
     First435{{"First[435∈34]"}}:::plan
     PgSelectRows436[["PgSelectRows[436∈34]"]]:::plan
     PgSelectRows436 --> First435
     PgSelect431 --> PgSelectRows436
     PgSelectSingle437{{"PgSelectSingle[437∈34]<br />ᐸrelational_topicsᐳ"}}:::plan
     First435 --> PgSelectSingle437
-    PgClassExpression439{{"PgClassExpression[439∈34]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression439
-    PgSelectSingle427 --> PgClassExpression440
     First443{{"First[443∈34]"}}:::plan
     PgSelectRows444[["PgSelectRows[444∈34]<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgSelectRows444 --> First443
     PgSelect441 --> PgSelectRows444
     PgSelectSingle445{{"PgSelectSingle[445∈34]<br />ᐸpeopleᐳ"}}:::plan
     First443 --> PgSelectSingle445
-    PgClassExpression447{{"PgClassExpression[447∈34]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression447
-    PgClassExpression448{{"PgClassExpression[448∈34]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression448
-    PgClassExpression449{{"PgClassExpression[449∈34]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression449
-    PgClassExpression450{{"PgClassExpression[450∈34]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression450
-    PgClassExpression451{{"PgClassExpression[451∈34]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle427 --> PgClassExpression451
     PgClassExpression452{{"PgClassExpression[452∈34]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle437 --> PgClassExpression452
     First455{{"First[455∈34]"}}:::plan
@@ -815,13 +815,13 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 35, 119, 120, 127, 128, 129, 130, 131<br />2: 28, 36, 121, 133, 229, 324, 418<br />3: 33, 39, 124, 136, 141, 223, 232, 237, 319, 327, 332, 414, 421, 426, 508<br />ᐳ: 32, 34, 38, 40, 41, 42, 123, 125, 132, 135, 137, 140, 142, 143, 144, 222, 224, 226, 227, 228, 231, 233, 236, 238, 239, 240, 318, 320, 322, 323, 326, 328, 331, 333, 334, 335, 413, 415, 417, 420, 422, 425, 427, 428, 429, 507, 509, 511, 512"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression35,PgClassExpression119,PgClassExpression120,PgClassExpression127,PgClassExpression128,PgClassExpression129,PgClassExpression130,PgClassExpression131 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 35, 120, 26, 25, 119, 127, 128, 129, 130, 131<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 36, 121, 133, 229, 324, 418<br />2: 33, 39, 124, 136, 141, 223, 232, 237, 319, 327, 332, 414, 421, 426, 508<br />ᐳ: 32, 34, 38, 40, 41, 42, 43, 52, 53, 60, 61, 62, 63, 64, 123, 125, 132, 135, 137, 140, 142, 143, 144, 145, 154, 155, 162, 163, 164, 165, 166, 222, 224, 226, 227, 228, 231, 233, 236, 238, 239, 240, 241, 250, 251, 258, 259, 260, 261, 262, 318, 320, 322, 323, 326, 328, 331, 333, 334, 335, 336, 345, 346, 353, 354, 355, 356, 357, 413, 415, 417, 420, 422, 425, 427, 428, 429, 430, 439, 440, 447, 448, 449, 450, 451, 507, 509, 511, 512"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression119,PgClassExpression120,PgSelect121,First123,PgSelectRows124,PgSelectSingle125,PgClassExpression127,PgClassExpression128,PgClassExpression129,PgClassExpression130,PgClassExpression131,PgClassExpression132,PgSelect133,First135,PgSelectRows136,PgSelectSingle137,First140,PgSelectRows141,PgSelectSingle142,PgClassExpression143,PgPolymorphic144,First222,PgSelectRows223,PgSelectSingle224,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgSelect229,First231,PgSelectRows232,PgSelectSingle233,First236,PgSelectRows237,PgSelectSingle238,PgClassExpression239,PgPolymorphic240,First318,PgSelectRows319,PgSelectSingle320,PgClassExpression322,PgClassExpression323,PgSelect324,First326,PgSelectRows327,PgSelectSingle328,First331,PgSelectRows332,PgSelectSingle333,PgClassExpression334,PgPolymorphic335,First413,PgSelectRows414,PgSelectSingle415,PgClassExpression417,PgSelect418,First420,PgSelectRows421,PgSelectSingle422,First425,PgSelectRows426,PgSelectSingle427,PgClassExpression428,PgPolymorphic429,First507,PgSelectRows508,PgSelectSingle509,PgClassExpression511,PgClassExpression512 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 40, 9, 42, 41<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 43, 52, 53, 60, 61, 62, 63, 64<br />2: 44, 54, 66, 80, 93, 105<br />3: 49, 57, 69, 74, 83, 88, 96, 101, 108, 113<br />ᐳ: 48, 50, 56, 58, 65, 68, 70, 73, 75, 77, 78, 79, 82, 84, 87, 89, 91, 92, 95, 97, 100, 102, 104, 107, 109, 112, 114, 116, 117"):::bucket
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression43,PgClassExpression52,PgClassExpression53,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgSelect121,First123,PgSelectRows124,PgSelectSingle125,PgClassExpression132,PgSelect133,First135,PgSelectRows136,PgSelectSingle137,First140,PgSelectRows141,PgSelectSingle142,PgClassExpression143,PgPolymorphic144,PgClassExpression145,PgClassExpression154,PgClassExpression155,PgClassExpression162,PgClassExpression163,PgClassExpression164,PgClassExpression165,PgClassExpression166,First222,PgSelectRows223,PgSelectSingle224,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgSelect229,First231,PgSelectRows232,PgSelectSingle233,First236,PgSelectRows237,PgSelectSingle238,PgClassExpression239,PgPolymorphic240,PgClassExpression241,PgClassExpression250,PgClassExpression251,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression261,PgClassExpression262,First318,PgSelectRows319,PgSelectSingle320,PgClassExpression322,PgClassExpression323,PgSelect324,First326,PgSelectRows327,PgSelectSingle328,First331,PgSelectRows332,PgSelectSingle333,PgClassExpression334,PgPolymorphic335,PgClassExpression336,PgClassExpression345,PgClassExpression346,PgClassExpression353,PgClassExpression354,PgClassExpression355,PgClassExpression356,PgClassExpression357,First413,PgSelectRows414,PgSelectSingle415,PgClassExpression417,PgSelect418,First420,PgSelectRows421,PgSelectSingle422,First425,PgSelectRows426,PgSelectSingle427,PgClassExpression428,PgPolymorphic429,PgClassExpression430,PgClassExpression439,PgClassExpression440,PgClassExpression447,PgClassExpression448,PgClassExpression449,PgClassExpression450,PgClassExpression451,First507,PgSelectRows508,PgSelectSingle509,PgClassExpression511,PgClassExpression512 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 43, 53, 42, 41, 52, 60, 61, 62, 63, 64<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 44, 54, 66, 80, 93, 105<br />2: 49, 57, 69, 74, 83, 88, 96, 101, 108, 113<br />ᐳ: 48, 50, 56, 58, 65, 68, 70, 73, 75, 77, 78, 79, 82, 84, 87, 89, 91, 92, 95, 97, 100, 102, 104, 107, 109, 112, 114, 116, 117"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgClassExpression65,PgSelect66,First68,PgSelectRows69,PgSelectSingle70,First73,PgSelectRows74,PgSelectSingle75,PgClassExpression77,PgClassExpression78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,First100,PgSelectRows101,PgSelectSingle102,PgClassExpression104,PgSelect105,First107,PgSelectRows108,PgSelectSingle109,First112,PgSelectRows113,PgSelectSingle114,PgClassExpression116,PgClassExpression117 bucket6
+    class Bucket6,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgClassExpression65,PgSelect66,First68,PgSelectRows69,PgSelectSingle70,First73,PgSelectRows74,PgSelectSingle75,PgClassExpression77,PgClassExpression78,PgClassExpression79,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression91,PgClassExpression92,PgSelect93,First95,PgSelectRows96,PgSelectSingle97,First100,PgSelectRows101,PgSelectSingle102,PgClassExpression104,PgSelect105,First107,PgSelectRows108,PgSelectSingle109,First112,PgSelectRows113,PgSelectSingle114,PgClassExpression116,PgClassExpression117 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 58<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[58]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression59 bucket7
@@ -840,9 +840,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 125<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[125]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression126 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 142, 9, 144, 143<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 145, 154, 155, 162, 163, 164, 165, 166<br />2: 146, 156, 168, 182, 195, 207<br />3: 151, 159, 171, 176, 185, 190, 198, 203, 210, 215<br />ᐳ: 150, 152, 158, 160, 167, 170, 172, 175, 177, 179, 180, 181, 184, 186, 189, 191, 193, 194, 197, 199, 202, 204, 206, 209, 211, 214, 216, 218, 219"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 145, 155, 144, 143, 154, 162, 163, 164, 165, 166<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 146, 156, 168, 182, 195, 207<br />2: 151, 159, 171, 176, 185, 190, 198, 203, 210, 215<br />ᐳ: 150, 152, 158, 160, 167, 170, 172, 175, 177, 179, 180, 181, 184, 186, 189, 191, 193, 194, 197, 199, 202, 204, 206, 209, 211, 214, 216, 218, 219"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression145,PgSelect146,First150,PgSelectRows151,PgSelectSingle152,PgClassExpression154,PgClassExpression155,PgSelect156,First158,PgSelectRows159,PgSelectSingle160,PgClassExpression162,PgClassExpression163,PgClassExpression164,PgClassExpression165,PgClassExpression166,PgClassExpression167,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgSelect182,First184,PgSelectRows185,PgSelectSingle186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,PgSelect195,First197,PgSelectRows198,PgSelectSingle199,First202,PgSelectRows203,PgSelectSingle204,PgClassExpression206,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression218,PgClassExpression219 bucket13
+    class Bucket13,PgSelect146,First150,PgSelectRows151,PgSelectSingle152,PgSelect156,First158,PgSelectRows159,PgSelectSingle160,PgClassExpression167,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgClassExpression179,PgClassExpression180,PgClassExpression181,PgSelect182,First184,PgSelectRows185,PgSelectSingle186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,PgSelect195,First197,PgSelectRows198,PgSelectSingle199,First202,PgSelectRows203,PgSelectSingle204,PgClassExpression206,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression218,PgClassExpression219 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 160<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[160]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression161 bucket14
@@ -861,9 +861,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 224<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[224]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression225 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 238, 9, 240, 239<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 241, 250, 251, 258, 259, 260, 261, 262<br />2: 242, 252, 264, 278, 291, 303<br />3: 247, 255, 267, 272, 281, 286, 294, 299, 306, 311<br />ᐳ: 246, 248, 254, 256, 263, 266, 268, 271, 273, 275, 276, 277, 280, 282, 285, 287, 289, 290, 293, 295, 298, 300, 302, 305, 307, 310, 312, 314, 315"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 241, 251, 240, 239, 250, 258, 259, 260, 261, 262<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 242, 252, 264, 278, 291, 303<br />2: 247, 255, 267, 272, 281, 286, 294, 299, 306, 311<br />ᐳ: 246, 248, 254, 256, 263, 266, 268, 271, 273, 275, 276, 277, 280, 282, 285, 287, 289, 290, 293, 295, 298, 300, 302, 305, 307, 310, 312, 314, 315"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression241,PgSelect242,First246,PgSelectRows247,PgSelectSingle248,PgClassExpression250,PgClassExpression251,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,PgClassExpression258,PgClassExpression259,PgClassExpression260,PgClassExpression261,PgClassExpression262,PgClassExpression263,PgSelect264,First266,PgSelectRows267,PgSelectSingle268,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression275,PgClassExpression276,PgClassExpression277,PgSelect278,First280,PgSelectRows281,PgSelectSingle282,First285,PgSelectRows286,PgSelectSingle287,PgClassExpression289,PgClassExpression290,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression302,PgSelect303,First305,PgSelectRows306,PgSelectSingle307,First310,PgSelectRows311,PgSelectSingle312,PgClassExpression314,PgClassExpression315 bucket20
+    class Bucket20,PgSelect242,First246,PgSelectRows247,PgSelectSingle248,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,PgClassExpression263,PgSelect264,First266,PgSelectRows267,PgSelectSingle268,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression275,PgClassExpression276,PgClassExpression277,PgSelect278,First280,PgSelectRows281,PgSelectSingle282,First285,PgSelectRows286,PgSelectSingle287,PgClassExpression289,PgClassExpression290,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression302,PgSelect303,First305,PgSelectRows306,PgSelectSingle307,First310,PgSelectRows311,PgSelectSingle312,PgClassExpression314,PgClassExpression315 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 256<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[256]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression257 bucket21
@@ -882,9 +882,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 320<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[320]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression321 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 333, 9, 335, 334<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 336, 345, 346, 353, 354, 355, 356, 357<br />2: 337, 347, 359, 373, 386, 398<br />3: 342, 350, 362, 367, 376, 381, 389, 394, 401, 406<br />ᐳ: 341, 343, 349, 351, 358, 361, 363, 366, 368, 370, 371, 372, 375, 377, 380, 382, 384, 385, 388, 390, 393, 395, 397, 400, 402, 405, 407, 409, 410"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 336, 346, 335, 334, 345, 353, 354, 355, 356, 357<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 337, 347, 359, 373, 386, 398<br />2: 342, 350, 362, 367, 376, 381, 389, 394, 401, 406<br />ᐳ: 341, 343, 349, 351, 358, 361, 363, 366, 368, 370, 371, 372, 375, 377, 380, 382, 384, 385, 388, 390, 393, 395, 397, 400, 402, 405, 407, 409, 410"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression336,PgSelect337,First341,PgSelectRows342,PgSelectSingle343,PgClassExpression345,PgClassExpression346,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,PgClassExpression353,PgClassExpression354,PgClassExpression355,PgClassExpression356,PgClassExpression357,PgClassExpression358,PgSelect359,First361,PgSelectRows362,PgSelectSingle363,First366,PgSelectRows367,PgSelectSingle368,PgClassExpression370,PgClassExpression371,PgClassExpression372,PgSelect373,First375,PgSelectRows376,PgSelectSingle377,First380,PgSelectRows381,PgSelectSingle382,PgClassExpression384,PgClassExpression385,PgSelect386,First388,PgSelectRows389,PgSelectSingle390,First393,PgSelectRows394,PgSelectSingle395,PgClassExpression397,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,First405,PgSelectRows406,PgSelectSingle407,PgClassExpression409,PgClassExpression410 bucket27
+    class Bucket27,PgSelect337,First341,PgSelectRows342,PgSelectSingle343,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,PgClassExpression358,PgSelect359,First361,PgSelectRows362,PgSelectSingle363,First366,PgSelectRows367,PgSelectSingle368,PgClassExpression370,PgClassExpression371,PgClassExpression372,PgSelect373,First375,PgSelectRows376,PgSelectSingle377,First380,PgSelectRows381,PgSelectSingle382,PgClassExpression384,PgClassExpression385,PgSelect386,First388,PgSelectRows389,PgSelectSingle390,First393,PgSelectRows394,PgSelectSingle395,PgClassExpression397,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,First405,PgSelectRows406,PgSelectSingle407,PgClassExpression409,PgClassExpression410 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 351<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[351]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression352 bucket28
@@ -903,9 +903,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 415<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[415]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression416 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 427, 9, 429, 428<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 430, 439, 440, 447, 448, 449, 450, 451<br />2: 431, 441, 453, 467, 480, 492<br />3: 436, 444, 456, 461, 470, 475, 483, 488, 495, 500<br />ᐳ: 435, 437, 443, 445, 452, 455, 457, 460, 462, 464, 465, 466, 469, 471, 474, 476, 478, 479, 482, 484, 487, 489, 491, 494, 496, 499, 501, 503, 504"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 430, 440, 429, 428, 439, 447, 448, 449, 450, 451<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 431, 441, 453, 467, 480, 492<br />2: 436, 444, 456, 461, 470, 475, 483, 488, 495, 500<br />ᐳ: 435, 437, 443, 445, 452, 455, 457, 460, 462, 464, 465, 466, 469, 471, 474, 476, 478, 479, 482, 484, 487, 489, 491, 494, 496, 499, 501, 503, 504"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression430,PgSelect431,First435,PgSelectRows436,PgSelectSingle437,PgClassExpression439,PgClassExpression440,PgSelect441,First443,PgSelectRows444,PgSelectSingle445,PgClassExpression447,PgClassExpression448,PgClassExpression449,PgClassExpression450,PgClassExpression451,PgClassExpression452,PgSelect453,First455,PgSelectRows456,PgSelectSingle457,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,PgClassExpression465,PgClassExpression466,PgSelect467,First469,PgSelectRows470,PgSelectSingle471,First474,PgSelectRows475,PgSelectSingle476,PgClassExpression478,PgClassExpression479,PgSelect480,First482,PgSelectRows483,PgSelectSingle484,First487,PgSelectRows488,PgSelectSingle489,PgClassExpression491,PgSelect492,First494,PgSelectRows495,PgSelectSingle496,First499,PgSelectRows500,PgSelectSingle501,PgClassExpression503,PgClassExpression504 bucket34
+    class Bucket34,PgSelect431,First435,PgSelectRows436,PgSelectSingle437,PgSelect441,First443,PgSelectRows444,PgSelectSingle445,PgClassExpression452,PgSelect453,First455,PgSelectRows456,PgSelectSingle457,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,PgClassExpression465,PgClassExpression466,PgSelect467,First469,PgSelectRows470,PgSelectSingle471,First474,PgSelectRows475,PgSelectSingle476,PgClassExpression478,PgClassExpression479,PgSelect480,First482,PgSelectRows483,PgSelectSingle484,First487,PgSelectRows488,PgSelectSingle489,PgClassExpression491,PgSelect492,First494,PgSelectRows495,PgSelectSingle496,First499,PgSelectRows500,PgSelectSingle501,PgClassExpression503,PgClassExpression504 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 445<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[445]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression446 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.mermaid
@@ -47,76 +47,92 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression35
+    PgClassExpression110{{"PgClassExpression[110∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression110
+    PgClassExpression111{{"PgClassExpression[111∈4]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression111
+    PgClassExpression118{{"PgClassExpression[118∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression118
+    PgClassExpression119{{"PgClassExpression[119∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression119
+    PgClassExpression120{{"PgClassExpression[120∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression120
+    PgClassExpression121{{"PgClassExpression[121∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression121
+    PgClassExpression122{{"PgClassExpression[122∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression122
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect36[["PgSelect[36∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression35 --> PgSelect36
     PgPolymorphic42{{"PgPolymorphic[42∈5]<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle40{{"PgSelectSingle[40∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle40 & PgClassExpression41 --> PgPolymorphic42
     PgSelect112[["PgSelect[112∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression111 --> PgSelect112
     PgSelect123[["PgSelect[123∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect123
     PgPolymorphic134{{"PgPolymorphic[134∈5]<br />ᐳRelationalPost"}}:::plan
     PgSelectSingle132{{"PgSelectSingle[132∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression133{{"PgClassExpression[133∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression133{{"PgClassExpression[133∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle132 & PgClassExpression133 --> PgPolymorphic134
     PgSelect207[["PgSelect[207∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect207
     PgPolymorphic218{{"PgPolymorphic[218∈5]<br />ᐳRelationalDivider"}}:::plan
     PgSelectSingle216{{"PgSelectSingle[216∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression217{{"PgClassExpression[217∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression217{{"PgClassExpression[217∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle216 & PgClassExpression217 --> PgPolymorphic218
     PgSelect291[["PgSelect[291∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect291
     PgPolymorphic302{{"PgPolymorphic[302∈5]<br />ᐳRelationalChecklist"}}:::plan
     PgSelectSingle300{{"PgSelectSingle[300∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression301{{"PgClassExpression[301∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression301{{"PgClassExpression[301∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle300 & PgClassExpression301 --> PgPolymorphic302
     PgSelect375[["PgSelect[375∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect375
     PgPolymorphic386{{"PgPolymorphic[386∈5]<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle384{{"PgSelectSingle[384∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression385{{"PgClassExpression[385∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression385{{"PgClassExpression[385∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle384 & PgClassExpression385 --> PgPolymorphic386
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgSelectSingle24 --> PgClassExpression35
     First38{{"First[38∈5]"}}:::plan
     PgSelectRows39[["PgSelectRows[39∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows39 --> First38
     PgSelect36 --> PgSelectRows39
     First38 --> PgSelectSingle40
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression110{{"PgClassExpression[110∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression110
-    PgSelectSingle24 --> PgClassExpression111
+    PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression43
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression53
+    PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression60
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression62
+    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression63
+    PgClassExpression64{{"PgClassExpression[64∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression64
     First114{{"First[114∈5]"}}:::plan
     PgSelectRows115[["PgSelectRows[115∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows115 --> First114
     PgSelect112 --> PgSelectRows115
     PgSelectSingle116{{"PgSelectSingle[116∈5]<br />ᐸpeopleᐳ"}}:::plan
     First114 --> PgSelectSingle116
-    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression118
-    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression119
-    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression120
-    PgClassExpression121{{"PgClassExpression[121∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression121
-    PgClassExpression122{{"PgClassExpression[122∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression122
     First125{{"First[125∈5]"}}:::plan
     PgSelectRows126[["PgSelectRows[126∈5]"]]:::plan
     PgSelectRows126 --> First125
@@ -129,6 +145,22 @@ graph TD
     PgSelect36 --> PgSelectRows131
     First130 --> PgSelectSingle132
     PgSelectSingle132 --> PgClassExpression133
+    PgClassExpression135{{"PgClassExpression[135∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression135
+    PgClassExpression144{{"PgClassExpression[144∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression144
+    PgClassExpression145{{"PgClassExpression[145∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression145
+    PgClassExpression152{{"PgClassExpression[152∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression152
+    PgClassExpression153{{"PgClassExpression[153∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression153
+    PgClassExpression154{{"PgClassExpression[154∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression154
+    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression155
+    PgClassExpression156{{"PgClassExpression[156∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression156
     First203{{"First[203∈5]"}}:::plan
     PgSelectRows204[["PgSelectRows[204∈5]<br />ᐳRelationalPost"]]:::plan
     PgSelectRows204 --> First203
@@ -147,6 +179,22 @@ graph TD
     PgSelect36 --> PgSelectRows215
     First214 --> PgSelectSingle216
     PgSelectSingle216 --> PgClassExpression217
+    PgClassExpression219{{"PgClassExpression[219∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression219
+    PgClassExpression228{{"PgClassExpression[228∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression228
+    PgClassExpression229{{"PgClassExpression[229∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression229
+    PgClassExpression236{{"PgClassExpression[236∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression236
+    PgClassExpression237{{"PgClassExpression[237∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression237
+    PgClassExpression238{{"PgClassExpression[238∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression238
+    PgClassExpression239{{"PgClassExpression[239∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression239
+    PgClassExpression240{{"PgClassExpression[240∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression240
     First287{{"First[287∈5]"}}:::plan
     PgSelectRows288[["PgSelectRows[288∈5]<br />ᐳRelationalDivider"]]:::plan
     PgSelectRows288 --> First287
@@ -165,6 +213,22 @@ graph TD
     PgSelect36 --> PgSelectRows299
     First298 --> PgSelectSingle300
     PgSelectSingle300 --> PgClassExpression301
+    PgClassExpression303{{"PgClassExpression[303∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression303
+    PgClassExpression312{{"PgClassExpression[312∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression312
+    PgClassExpression313{{"PgClassExpression[313∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression313
+    PgClassExpression320{{"PgClassExpression[320∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression320
+    PgClassExpression321{{"PgClassExpression[321∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression321
+    PgClassExpression322{{"PgClassExpression[322∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression322
+    PgClassExpression323{{"PgClassExpression[323∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression323
+    PgClassExpression324{{"PgClassExpression[324∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression324
     First371{{"First[371∈5]"}}:::plan
     PgSelectRows372[["PgSelectRows[372∈5]<br />ᐳRelationalChecklist"]]:::plan
     PgSelectRows372 --> First371
@@ -183,6 +247,22 @@ graph TD
     PgSelect36 --> PgSelectRows383
     First382 --> PgSelectSingle384
     PgSelectSingle384 --> PgClassExpression385
+    PgClassExpression387{{"PgClassExpression[387∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression387
+    PgClassExpression396{{"PgClassExpression[396∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression396
+    PgClassExpression397{{"PgClassExpression[397∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression397
+    PgClassExpression404{{"PgClassExpression[404∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression404
+    PgClassExpression405{{"PgClassExpression[405∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression405
+    PgClassExpression406{{"PgClassExpression[406∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression406
+    PgClassExpression407{{"PgClassExpression[407∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression407
+    PgClassExpression408{{"PgClassExpression[408∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression408
     First455{{"First[455∈5]"}}:::plan
     PgSelectRows456[["PgSelectRows[456∈5]<br />ᐳRelationalChecklistItem"]]:::plan
     PgSelectRows456 --> First455
@@ -190,10 +270,8 @@ graph TD
     PgSelectSingle457{{"PgSelectSingle[457∈5]<br />ᐸpeopleᐳ"}}:::plan
     First455 --> PgSelectSingle457
     PgSelect44[["PgSelect[44∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression43{{"PgClassExpression[43∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression43 --> PgSelect44
     PgSelect54[["PgSelect[54∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression53 --> PgSelect54
     PgSelect65[["PgSelect[65∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect65
@@ -203,32 +281,18 @@ graph TD
     Object9 & PgClassExpression43 --> PgSelect87
     PgSelect98[["PgSelect[98∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect98
-    PgSelectSingle40 --> PgClassExpression43
     First48{{"First[48∈6]"}}:::plan
     PgSelectRows49[["PgSelectRows[49∈6]"]]:::plan
     PgSelectRows49 --> First48
     PgSelect44 --> PgSelectRows49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸrelational_topicsᐳ"}}:::plan
     First48 --> PgSelectSingle50
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression52
-    PgSelectSingle40 --> PgClassExpression53
     First56{{"First[56∈6]"}}:::plan
     PgSelectRows57[["PgSelectRows[57∈6]<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgSelectRows57 --> First56
     PgSelect54 --> PgSelectRows57
     PgSelectSingle58{{"PgSelectSingle[58∈6]<br />ᐸpeopleᐳ"}}:::plan
     First56 --> PgSelectSingle58
-    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression60
-    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression61
-    PgClassExpression62{{"PgClassExpression[62∈6]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression62
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression64
     First67{{"First[67∈6]"}}:::plan
     PgSelectRows68[["PgSelectRows[68∈6]"]]:::plan
     PgSelectRows68 --> First67
@@ -290,10 +354,8 @@ graph TD
     PgClassExpression117{{"PgClassExpression[117∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle116 --> PgClassExpression117
     PgSelect136[["PgSelect[136∈13]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression135{{"PgClassExpression[135∈13]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression135 --> PgSelect136
     PgSelect146[["PgSelect[146∈13]<br />ᐸpeopleᐳ<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression145{{"PgClassExpression[145∈13]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression145 --> PgSelect146
     PgSelect157[["PgSelect[157∈13]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression135 --> PgSelect157
@@ -303,32 +365,18 @@ graph TD
     Object9 & PgClassExpression135 --> PgSelect179
     PgSelect190[["PgSelect[190∈13]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression135 --> PgSelect190
-    PgSelectSingle132 --> PgClassExpression135
     First140{{"First[140∈13]"}}:::plan
     PgSelectRows141[["PgSelectRows[141∈13]"]]:::plan
     PgSelectRows141 --> First140
     PgSelect136 --> PgSelectRows141
     PgSelectSingle142{{"PgSelectSingle[142∈13]<br />ᐸrelational_topicsᐳ"}}:::plan
     First140 --> PgSelectSingle142
-    PgClassExpression144{{"PgClassExpression[144∈13]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression144
-    PgSelectSingle132 --> PgClassExpression145
     First148{{"First[148∈13]"}}:::plan
     PgSelectRows149[["PgSelectRows[149∈13]<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgSelectRows149 --> First148
     PgSelect146 --> PgSelectRows149
     PgSelectSingle150{{"PgSelectSingle[150∈13]<br />ᐸpeopleᐳ"}}:::plan
     First148 --> PgSelectSingle150
-    PgClassExpression152{{"PgClassExpression[152∈13]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression152
-    PgClassExpression153{{"PgClassExpression[153∈13]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression153
-    PgClassExpression154{{"PgClassExpression[154∈13]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression154
-    PgClassExpression155{{"PgClassExpression[155∈13]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression155
-    PgClassExpression156{{"PgClassExpression[156∈13]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression156
     First159{{"First[159∈13]"}}:::plan
     PgSelectRows160[["PgSelectRows[160∈13]"]]:::plan
     PgSelectRows160 --> First159
@@ -390,10 +438,8 @@ graph TD
     PgClassExpression206{{"PgClassExpression[206∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle205 --> PgClassExpression206
     PgSelect220[["PgSelect[220∈20]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression219{{"PgClassExpression[219∈20]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression219 --> PgSelect220
     PgSelect230[["PgSelect[230∈20]<br />ᐸpeopleᐳ<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression229{{"PgClassExpression[229∈20]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression229 --> PgSelect230
     PgSelect241[["PgSelect[241∈20]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression219 --> PgSelect241
@@ -403,32 +449,18 @@ graph TD
     Object9 & PgClassExpression219 --> PgSelect263
     PgSelect274[["PgSelect[274∈20]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression219 --> PgSelect274
-    PgSelectSingle216 --> PgClassExpression219
     First224{{"First[224∈20]"}}:::plan
     PgSelectRows225[["PgSelectRows[225∈20]"]]:::plan
     PgSelectRows225 --> First224
     PgSelect220 --> PgSelectRows225
     PgSelectSingle226{{"PgSelectSingle[226∈20]<br />ᐸrelational_topicsᐳ"}}:::plan
     First224 --> PgSelectSingle226
-    PgClassExpression228{{"PgClassExpression[228∈20]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression228
-    PgSelectSingle216 --> PgClassExpression229
     First232{{"First[232∈20]"}}:::plan
     PgSelectRows233[["PgSelectRows[233∈20]<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgSelectRows233 --> First232
     PgSelect230 --> PgSelectRows233
     PgSelectSingle234{{"PgSelectSingle[234∈20]<br />ᐸpeopleᐳ"}}:::plan
     First232 --> PgSelectSingle234
-    PgClassExpression236{{"PgClassExpression[236∈20]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression236
-    PgClassExpression237{{"PgClassExpression[237∈20]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression237
-    PgClassExpression238{{"PgClassExpression[238∈20]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression238
-    PgClassExpression239{{"PgClassExpression[239∈20]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression239
-    PgClassExpression240{{"PgClassExpression[240∈20]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression240
     First243{{"First[243∈20]"}}:::plan
     PgSelectRows244[["PgSelectRows[244∈20]"]]:::plan
     PgSelectRows244 --> First243
@@ -490,10 +522,8 @@ graph TD
     PgClassExpression290{{"PgClassExpression[290∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle289 --> PgClassExpression290
     PgSelect304[["PgSelect[304∈27]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression303{{"PgClassExpression[303∈27]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression303 --> PgSelect304
     PgSelect314[["PgSelect[314∈27]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression313{{"PgClassExpression[313∈27]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression313 --> PgSelect314
     PgSelect325[["PgSelect[325∈27]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression303 --> PgSelect325
@@ -503,32 +533,18 @@ graph TD
     Object9 & PgClassExpression303 --> PgSelect347
     PgSelect358[["PgSelect[358∈27]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression303 --> PgSelect358
-    PgSelectSingle300 --> PgClassExpression303
     First308{{"First[308∈27]"}}:::plan
     PgSelectRows309[["PgSelectRows[309∈27]"]]:::plan
     PgSelectRows309 --> First308
     PgSelect304 --> PgSelectRows309
     PgSelectSingle310{{"PgSelectSingle[310∈27]<br />ᐸrelational_topicsᐳ"}}:::plan
     First308 --> PgSelectSingle310
-    PgClassExpression312{{"PgClassExpression[312∈27]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression312
-    PgSelectSingle300 --> PgClassExpression313
     First316{{"First[316∈27]"}}:::plan
     PgSelectRows317[["PgSelectRows[317∈27]<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgSelectRows317 --> First316
     PgSelect314 --> PgSelectRows317
     PgSelectSingle318{{"PgSelectSingle[318∈27]<br />ᐸpeopleᐳ"}}:::plan
     First316 --> PgSelectSingle318
-    PgClassExpression320{{"PgClassExpression[320∈27]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression320
-    PgClassExpression321{{"PgClassExpression[321∈27]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression321
-    PgClassExpression322{{"PgClassExpression[322∈27]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression322
-    PgClassExpression323{{"PgClassExpression[323∈27]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression323
-    PgClassExpression324{{"PgClassExpression[324∈27]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression324
     First327{{"First[327∈27]"}}:::plan
     PgSelectRows328[["PgSelectRows[328∈27]"]]:::plan
     PgSelectRows328 --> First327
@@ -590,10 +606,8 @@ graph TD
     PgClassExpression374{{"PgClassExpression[374∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle373 --> PgClassExpression374
     PgSelect388[["PgSelect[388∈34]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression387{{"PgClassExpression[387∈34]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression387 --> PgSelect388
     PgSelect398[["PgSelect[398∈34]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression397{{"PgClassExpression[397∈34]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression397 --> PgSelect398
     PgSelect409[["PgSelect[409∈34]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression387 --> PgSelect409
@@ -603,32 +617,18 @@ graph TD
     Object9 & PgClassExpression387 --> PgSelect431
     PgSelect442[["PgSelect[442∈34]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression387 --> PgSelect442
-    PgSelectSingle384 --> PgClassExpression387
     First392{{"First[392∈34]"}}:::plan
     PgSelectRows393[["PgSelectRows[393∈34]"]]:::plan
     PgSelectRows393 --> First392
     PgSelect388 --> PgSelectRows393
     PgSelectSingle394{{"PgSelectSingle[394∈34]<br />ᐸrelational_topicsᐳ"}}:::plan
     First392 --> PgSelectSingle394
-    PgClassExpression396{{"PgClassExpression[396∈34]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression396
-    PgSelectSingle384 --> PgClassExpression397
     First400{{"First[400∈34]"}}:::plan
     PgSelectRows401[["PgSelectRows[401∈34]<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgSelectRows401 --> First400
     PgSelect398 --> PgSelectRows401
     PgSelectSingle402{{"PgSelectSingle[402∈34]<br />ᐸpeopleᐳ"}}:::plan
     First400 --> PgSelectSingle402
-    PgClassExpression404{{"PgClassExpression[404∈34]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression404
-    PgClassExpression405{{"PgClassExpression[405∈34]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression405
-    PgClassExpression406{{"PgClassExpression[406∈34]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression406
-    PgClassExpression407{{"PgClassExpression[407∈34]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression407
-    PgClassExpression408{{"PgClassExpression[408∈34]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression408
     First411{{"First[411∈34]"}}:::plan
     PgSelectRows412[["PgSelectRows[412∈34]"]]:::plan
     PgSelectRows412 --> First411
@@ -707,13 +707,13 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 35, 110, 111, 118, 119, 120, 121, 122<br />2: 28, 36, 112, 123, 207, 291, 375<br />3: 33, 39, 115, 126, 131, 204, 210, 215, 288, 294, 299, 372, 378, 383, 456<br />ᐳ: 32, 34, 38, 40, 41, 42, 114, 116, 125, 127, 130, 132, 133, 134, 203, 205, 209, 211, 214, 216, 217, 218, 287, 289, 293, 295, 298, 300, 301, 302, 371, 373, 377, 379, 382, 384, 385, 386, 455, 457"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression35,PgClassExpression110,PgClassExpression111,PgClassExpression118,PgClassExpression119,PgClassExpression120,PgClassExpression121,PgClassExpression122 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 35, 111, 26, 25, 110, 118, 119, 120, 121, 122<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 36, 112, 123, 207, 291, 375<br />2: 33, 39, 115, 126, 131, 204, 210, 215, 288, 294, 299, 372, 378, 383, 456<br />ᐳ: 32, 34, 38, 40, 41, 42, 43, 52, 53, 60, 61, 62, 63, 64, 114, 116, 125, 127, 130, 132, 133, 134, 135, 144, 145, 152, 153, 154, 155, 156, 203, 205, 209, 211, 214, 216, 217, 218, 219, 228, 229, 236, 237, 238, 239, 240, 287, 289, 293, 295, 298, 300, 301, 302, 303, 312, 313, 320, 321, 322, 323, 324, 371, 373, 377, 379, 382, 384, 385, 386, 387, 396, 397, 404, 405, 406, 407, 408, 455, 457"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression110,PgClassExpression111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgClassExpression118,PgClassExpression119,PgClassExpression120,PgClassExpression121,PgClassExpression122,PgSelect123,First125,PgSelectRows126,PgSelectSingle127,First130,PgSelectRows131,PgSelectSingle132,PgClassExpression133,PgPolymorphic134,First203,PgSelectRows204,PgSelectSingle205,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression217,PgPolymorphic218,First287,PgSelectRows288,PgSelectSingle289,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression301,PgPolymorphic302,First371,PgSelectRows372,PgSelectSingle373,PgSelect375,First377,PgSelectRows378,PgSelectSingle379,First382,PgSelectRows383,PgSelectSingle384,PgClassExpression385,PgPolymorphic386,First455,PgSelectRows456,PgSelectSingle457 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 40, 9, 42, 41<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 43, 52, 53, 60, 61, 62, 63, 64<br />2: 44, 54, 65, 76, 87, 98<br />3: 49, 57, 68, 73, 79, 84, 90, 95, 101, 106<br />ᐳ: 48, 50, 56, 58, 67, 69, 72, 74, 78, 80, 83, 85, 89, 91, 94, 96, 100, 102, 105, 107"):::bucket
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression43,PgClassExpression52,PgClassExpression53,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgSelect123,First125,PgSelectRows126,PgSelectSingle127,First130,PgSelectRows131,PgSelectSingle132,PgClassExpression133,PgPolymorphic134,PgClassExpression135,PgClassExpression144,PgClassExpression145,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156,First203,PgSelectRows204,PgSelectSingle205,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression217,PgPolymorphic218,PgClassExpression219,PgClassExpression228,PgClassExpression229,PgClassExpression236,PgClassExpression237,PgClassExpression238,PgClassExpression239,PgClassExpression240,First287,PgSelectRows288,PgSelectSingle289,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression301,PgPolymorphic302,PgClassExpression303,PgClassExpression312,PgClassExpression313,PgClassExpression320,PgClassExpression321,PgClassExpression322,PgClassExpression323,PgClassExpression324,First371,PgSelectRows372,PgSelectSingle373,PgSelect375,First377,PgSelectRows378,PgSelectSingle379,First382,PgSelectRows383,PgSelectSingle384,PgClassExpression385,PgPolymorphic386,PgClassExpression387,PgClassExpression396,PgClassExpression397,PgClassExpression404,PgClassExpression405,PgClassExpression406,PgClassExpression407,PgClassExpression408,First455,PgSelectRows456,PgSelectSingle457 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 43, 53, 42, 41, 52, 60, 61, 62, 63, 64<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 44, 54, 65, 76, 87, 98<br />2: 49, 57, 68, 73, 79, 84, 90, 95, 101, 106<br />ᐳ: 48, 50, 56, 58, 67, 69, 72, 74, 78, 80, 83, 85, 89, 91, 94, 96, 100, 102, 105, 107"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgSelect65,First67,PgSelectRows68,PgSelectSingle69,First72,PgSelectRows73,PgSelectSingle74,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,First83,PgSelectRows84,PgSelectSingle85,PgSelect87,First89,PgSelectRows90,PgSelectSingle91,First94,PgSelectRows95,PgSelectSingle96,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,First105,PgSelectRows106,PgSelectSingle107 bucket6
+    class Bucket6,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgSelect65,First67,PgSelectRows68,PgSelectSingle69,First72,PgSelectRows73,PgSelectSingle74,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,First83,PgSelectRows84,PgSelectSingle85,PgSelect87,First89,PgSelectRows90,PgSelectSingle91,First94,PgSelectRows95,PgSelectSingle96,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,First105,PgSelectRows106,PgSelectSingle107 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 58<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[58]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression59 bucket7
@@ -732,9 +732,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 116<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[116]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression117 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 132, 9, 134, 133<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 135, 144, 145, 152, 153, 154, 155, 156<br />2: 136, 146, 157, 168, 179, 190<br />3: 141, 149, 160, 165, 171, 176, 182, 187, 193, 198<br />ᐳ: 140, 142, 148, 150, 159, 161, 164, 166, 170, 172, 175, 177, 181, 183, 186, 188, 192, 194, 197, 199"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 135, 145, 134, 133, 144, 152, 153, 154, 155, 156<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 136, 146, 157, 168, 179, 190<br />2: 141, 149, 160, 165, 171, 176, 182, 187, 193, 198<br />ᐳ: 140, 142, 148, 150, 159, 161, 164, 166, 170, 172, 175, 177, 181, 183, 186, 188, 192, 194, 197, 199"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression135,PgSelect136,First140,PgSelectRows141,PgSelectSingle142,PgClassExpression144,PgClassExpression145,PgSelect146,First148,PgSelectRows149,PgSelectSingle150,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156,PgSelect157,First159,PgSelectRows160,PgSelectSingle161,First164,PgSelectRows165,PgSelectSingle166,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgSelect179,First181,PgSelectRows182,PgSelectSingle183,First186,PgSelectRows187,PgSelectSingle188,PgSelect190,First192,PgSelectRows193,PgSelectSingle194,First197,PgSelectRows198,PgSelectSingle199 bucket13
+    class Bucket13,PgSelect136,First140,PgSelectRows141,PgSelectSingle142,PgSelect146,First148,PgSelectRows149,PgSelectSingle150,PgSelect157,First159,PgSelectRows160,PgSelectSingle161,First164,PgSelectRows165,PgSelectSingle166,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgSelect179,First181,PgSelectRows182,PgSelectSingle183,First186,PgSelectRows187,PgSelectSingle188,PgSelect190,First192,PgSelectRows193,PgSelectSingle194,First197,PgSelectRows198,PgSelectSingle199 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 150<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[150]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression151 bucket14
@@ -753,9 +753,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 205<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[205]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression206 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 216, 9, 218, 217<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 219, 228, 229, 236, 237, 238, 239, 240<br />2: 220, 230, 241, 252, 263, 274<br />3: 225, 233, 244, 249, 255, 260, 266, 271, 277, 282<br />ᐳ: 224, 226, 232, 234, 243, 245, 248, 250, 254, 256, 259, 261, 265, 267, 270, 272, 276, 278, 281, 283"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 219, 229, 218, 217, 228, 236, 237, 238, 239, 240<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 220, 230, 241, 252, 263, 274<br />2: 225, 233, 244, 249, 255, 260, 266, 271, 277, 282<br />ᐳ: 224, 226, 232, 234, 243, 245, 248, 250, 254, 256, 259, 261, 265, 267, 270, 272, 276, 278, 281, 283"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression219,PgSelect220,First224,PgSelectRows225,PgSelectSingle226,PgClassExpression228,PgClassExpression229,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgClassExpression236,PgClassExpression237,PgClassExpression238,PgClassExpression239,PgClassExpression240,PgSelect241,First243,PgSelectRows244,PgSelectSingle245,First248,PgSelectRows249,PgSelectSingle250,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,First259,PgSelectRows260,PgSelectSingle261,PgSelect263,First265,PgSelectRows266,PgSelectSingle267,First270,PgSelectRows271,PgSelectSingle272,PgSelect274,First276,PgSelectRows277,PgSelectSingle278,First281,PgSelectRows282,PgSelectSingle283 bucket20
+    class Bucket20,PgSelect220,First224,PgSelectRows225,PgSelectSingle226,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgSelect241,First243,PgSelectRows244,PgSelectSingle245,First248,PgSelectRows249,PgSelectSingle250,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,First259,PgSelectRows260,PgSelectSingle261,PgSelect263,First265,PgSelectRows266,PgSelectSingle267,First270,PgSelectRows271,PgSelectSingle272,PgSelect274,First276,PgSelectRows277,PgSelectSingle278,First281,PgSelectRows282,PgSelectSingle283 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 234<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[234]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression235 bucket21
@@ -774,9 +774,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 289<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[289]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression290 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 300, 9, 302, 301<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 303, 312, 313, 320, 321, 322, 323, 324<br />2: 304, 314, 325, 336, 347, 358<br />3: 309, 317, 328, 333, 339, 344, 350, 355, 361, 366<br />ᐳ: 308, 310, 316, 318, 327, 329, 332, 334, 338, 340, 343, 345, 349, 351, 354, 356, 360, 362, 365, 367"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 303, 313, 302, 301, 312, 320, 321, 322, 323, 324<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 304, 314, 325, 336, 347, 358<br />2: 309, 317, 328, 333, 339, 344, 350, 355, 361, 366<br />ᐳ: 308, 310, 316, 318, 327, 329, 332, 334, 338, 340, 343, 345, 349, 351, 354, 356, 360, 362, 365, 367"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression303,PgSelect304,First308,PgSelectRows309,PgSelectSingle310,PgClassExpression312,PgClassExpression313,PgSelect314,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,PgClassExpression321,PgClassExpression322,PgClassExpression323,PgClassExpression324,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,First332,PgSelectRows333,PgSelectSingle334,PgSelect336,First338,PgSelectRows339,PgSelectSingle340,First343,PgSelectRows344,PgSelectSingle345,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,First354,PgSelectRows355,PgSelectSingle356,PgSelect358,First360,PgSelectRows361,PgSelectSingle362,First365,PgSelectRows366,PgSelectSingle367 bucket27
+    class Bucket27,PgSelect304,First308,PgSelectRows309,PgSelectSingle310,PgSelect314,First316,PgSelectRows317,PgSelectSingle318,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,First332,PgSelectRows333,PgSelectSingle334,PgSelect336,First338,PgSelectRows339,PgSelectSingle340,First343,PgSelectRows344,PgSelectSingle345,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,First354,PgSelectRows355,PgSelectSingle356,PgSelect358,First360,PgSelectRows361,PgSelectSingle362,First365,PgSelectRows366,PgSelectSingle367 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 318<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[318]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression319 bucket28
@@ -795,9 +795,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 373<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[373]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression374 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 384, 9, 386, 385<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 387, 396, 397, 404, 405, 406, 407, 408<br />2: 388, 398, 409, 420, 431, 442<br />3: 393, 401, 412, 417, 423, 428, 434, 439, 445, 450<br />ᐳ: 392, 394, 400, 402, 411, 413, 416, 418, 422, 424, 427, 429, 433, 435, 438, 440, 444, 446, 449, 451"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 387, 397, 386, 385, 396, 404, 405, 406, 407, 408<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 388, 398, 409, 420, 431, 442<br />2: 393, 401, 412, 417, 423, 428, 434, 439, 445, 450<br />ᐳ: 392, 394, 400, 402, 411, 413, 416, 418, 422, 424, 427, 429, 433, 435, 438, 440, 444, 446, 449, 451"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression387,PgSelect388,First392,PgSelectRows393,PgSelectSingle394,PgClassExpression396,PgClassExpression397,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,PgClassExpression404,PgClassExpression405,PgClassExpression406,PgClassExpression407,PgClassExpression408,PgSelect409,First411,PgSelectRows412,PgSelectSingle413,First416,PgSelectRows417,PgSelectSingle418,PgSelect420,First422,PgSelectRows423,PgSelectSingle424,First427,PgSelectRows428,PgSelectSingle429,PgSelect431,First433,PgSelectRows434,PgSelectSingle435,First438,PgSelectRows439,PgSelectSingle440,PgSelect442,First444,PgSelectRows445,PgSelectSingle446,First449,PgSelectRows450,PgSelectSingle451 bucket34
+    class Bucket34,PgSelect388,First392,PgSelectRows393,PgSelectSingle394,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,PgSelect409,First411,PgSelectRows412,PgSelectSingle413,First416,PgSelectRows417,PgSelectSingle418,PgSelect420,First422,PgSelectRows423,PgSelectSingle424,First427,PgSelectRows428,PgSelectSingle429,PgSelect431,First433,PgSelectRows434,PgSelectSingle435,First438,PgSelectRows439,PgSelectSingle440,PgSelect442,First444,PgSelectRows445,PgSelectSingle446,First449,PgSelectRows450,PgSelectSingle451 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 402<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[402]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression403 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.mermaid
@@ -47,76 +47,92 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression35
+    PgClassExpression110{{"PgClassExpression[110∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression110
+    PgClassExpression111{{"PgClassExpression[111∈4]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression111
+    PgClassExpression118{{"PgClassExpression[118∈4]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression118
+    PgClassExpression119{{"PgClassExpression[119∈4]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression119
+    PgClassExpression120{{"PgClassExpression[120∈4]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression120
+    PgClassExpression121{{"PgClassExpression[121∈4]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression121
+    PgClassExpression122{{"PgClassExpression[122∈4]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression122
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect36[["PgSelect[36∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression35 --> PgSelect36
     PgPolymorphic42{{"PgPolymorphic[42∈5]<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle40{{"PgSelectSingle[40∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle40 & PgClassExpression41 --> PgPolymorphic42
     PgSelect112[["PgSelect[112∈5]<br />ᐸpeopleᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈5]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression111 --> PgSelect112
     PgSelect123[["PgSelect[123∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect123
     PgPolymorphic134{{"PgPolymorphic[134∈5]<br />ᐳRelationalPost"}}:::plan
     PgSelectSingle132{{"PgSelectSingle[132∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression133{{"PgClassExpression[133∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression133{{"PgClassExpression[133∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle132 & PgClassExpression133 --> PgPolymorphic134
     PgSelect207[["PgSelect[207∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect207
     PgPolymorphic218{{"PgPolymorphic[218∈5]<br />ᐳRelationalDivider"}}:::plan
     PgSelectSingle216{{"PgSelectSingle[216∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression217{{"PgClassExpression[217∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression217{{"PgClassExpression[217∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle216 & PgClassExpression217 --> PgPolymorphic218
     PgSelect291[["PgSelect[291∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect291
     PgPolymorphic302{{"PgPolymorphic[302∈5]<br />ᐳRelationalChecklist"}}:::plan
     PgSelectSingle300{{"PgSelectSingle[300∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression301{{"PgClassExpression[301∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression301{{"PgClassExpression[301∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle300 & PgClassExpression301 --> PgPolymorphic302
     PgSelect375[["PgSelect[375∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect375
     PgPolymorphic386{{"PgPolymorphic[386∈5]<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle384{{"PgSelectSingle[384∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression385{{"PgClassExpression[385∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression385{{"PgClassExpression[385∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle384 & PgClassExpression385 --> PgPolymorphic386
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgSelectSingle24 --> PgClassExpression35
     First38{{"First[38∈5]"}}:::plan
     PgSelectRows39[["PgSelectRows[39∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows39 --> First38
     PgSelect36 --> PgSelectRows39
     First38 --> PgSelectSingle40
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression110{{"PgClassExpression[110∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression110
-    PgSelectSingle24 --> PgClassExpression111
+    PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression43
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression53
+    PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression60
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression62
+    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression63
+    PgClassExpression64{{"PgClassExpression[64∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression64
     First114{{"First[114∈5]"}}:::plan
     PgSelectRows115[["PgSelectRows[115∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows115 --> First114
     PgSelect112 --> PgSelectRows115
     PgSelectSingle116{{"PgSelectSingle[116∈5]<br />ᐸpeopleᐳ"}}:::plan
     First114 --> PgSelectSingle116
-    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression118
-    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression119
-    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression120
-    PgClassExpression121{{"PgClassExpression[121∈5]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression121
-    PgClassExpression122{{"PgClassExpression[122∈5]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression122
     First125{{"First[125∈5]"}}:::plan
     PgSelectRows126[["PgSelectRows[126∈5]"]]:::plan
     PgSelectRows126 --> First125
@@ -129,6 +145,22 @@ graph TD
     PgSelect36 --> PgSelectRows131
     First130 --> PgSelectSingle132
     PgSelectSingle132 --> PgClassExpression133
+    PgClassExpression135{{"PgClassExpression[135∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression135
+    PgClassExpression144{{"PgClassExpression[144∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression144
+    PgClassExpression145{{"PgClassExpression[145∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression145
+    PgClassExpression152{{"PgClassExpression[152∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression152
+    PgClassExpression153{{"PgClassExpression[153∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression153
+    PgClassExpression154{{"PgClassExpression[154∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression154
+    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression155
+    PgClassExpression156{{"PgClassExpression[156∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle132 --> PgClassExpression156
     First203{{"First[203∈5]"}}:::plan
     PgSelectRows204[["PgSelectRows[204∈5]<br />ᐳRelationalPost"]]:::plan
     PgSelectRows204 --> First203
@@ -147,6 +179,22 @@ graph TD
     PgSelect36 --> PgSelectRows215
     First214 --> PgSelectSingle216
     PgSelectSingle216 --> PgClassExpression217
+    PgClassExpression219{{"PgClassExpression[219∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression219
+    PgClassExpression228{{"PgClassExpression[228∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression228
+    PgClassExpression229{{"PgClassExpression[229∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression229
+    PgClassExpression236{{"PgClassExpression[236∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression236
+    PgClassExpression237{{"PgClassExpression[237∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression237
+    PgClassExpression238{{"PgClassExpression[238∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression238
+    PgClassExpression239{{"PgClassExpression[239∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression239
+    PgClassExpression240{{"PgClassExpression[240∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression240
     First287{{"First[287∈5]"}}:::plan
     PgSelectRows288[["PgSelectRows[288∈5]<br />ᐳRelationalDivider"]]:::plan
     PgSelectRows288 --> First287
@@ -165,6 +213,22 @@ graph TD
     PgSelect36 --> PgSelectRows299
     First298 --> PgSelectSingle300
     PgSelectSingle300 --> PgClassExpression301
+    PgClassExpression303{{"PgClassExpression[303∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression303
+    PgClassExpression312{{"PgClassExpression[312∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression312
+    PgClassExpression313{{"PgClassExpression[313∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression313
+    PgClassExpression320{{"PgClassExpression[320∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression320
+    PgClassExpression321{{"PgClassExpression[321∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression321
+    PgClassExpression322{{"PgClassExpression[322∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression322
+    PgClassExpression323{{"PgClassExpression[323∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression323
+    PgClassExpression324{{"PgClassExpression[324∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression324
     First371{{"First[371∈5]"}}:::plan
     PgSelectRows372[["PgSelectRows[372∈5]<br />ᐳRelationalChecklist"]]:::plan
     PgSelectRows372 --> First371
@@ -183,6 +247,22 @@ graph TD
     PgSelect36 --> PgSelectRows383
     First382 --> PgSelectSingle384
     PgSelectSingle384 --> PgClassExpression385
+    PgClassExpression387{{"PgClassExpression[387∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression387
+    PgClassExpression396{{"PgClassExpression[396∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression396
+    PgClassExpression397{{"PgClassExpression[397∈5]<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression397
+    PgClassExpression404{{"PgClassExpression[404∈5]<br />ᐸ__relation...”position”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression404
+    PgClassExpression405{{"PgClassExpression[405∈5]<br />ᐸ__relation...reated_at”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression405
+    PgClassExpression406{{"PgClassExpression[406∈5]<br />ᐸ__relation...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression406
+    PgClassExpression407{{"PgClassExpression[407∈5]<br />ᐸ__relation..._archived”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression407
+    PgClassExpression408{{"PgClassExpression[408∈5]<br />ᐸ__relation...chived_at”ᐳ"}}:::plan
+    PgSelectSingle384 --> PgClassExpression408
     First455{{"First[455∈5]"}}:::plan
     PgSelectRows456[["PgSelectRows[456∈5]<br />ᐳRelationalChecklistItem"]]:::plan
     PgSelectRows456 --> First455
@@ -190,10 +270,8 @@ graph TD
     PgSelectSingle457{{"PgSelectSingle[457∈5]<br />ᐸpeopleᐳ"}}:::plan
     First455 --> PgSelectSingle457
     PgSelect44[["PgSelect[44∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression43{{"PgClassExpression[43∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression43 --> PgSelect44
     PgSelect54[["PgSelect[54∈6]<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression53 --> PgSelect54
     PgSelect65[["PgSelect[65∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect65
@@ -203,32 +281,18 @@ graph TD
     Object9 & PgClassExpression43 --> PgSelect87
     PgSelect98[["PgSelect[98∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect98
-    PgSelectSingle40 --> PgClassExpression43
     First48{{"First[48∈6]"}}:::plan
     PgSelectRows49[["PgSelectRows[49∈6]"]]:::plan
     PgSelectRows49 --> First48
     PgSelect44 --> PgSelectRows49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸrelational_topicsᐳ"}}:::plan
     First48 --> PgSelectSingle50
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression52
-    PgSelectSingle40 --> PgClassExpression53
     First56{{"First[56∈6]"}}:::plan
     PgSelectRows57[["PgSelectRows[57∈6]<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgSelectRows57 --> First56
     PgSelect54 --> PgSelectRows57
     PgSelectSingle58{{"PgSelectSingle[58∈6]<br />ᐸpeopleᐳ"}}:::plan
     First56 --> PgSelectSingle58
-    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression60
-    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression61
-    PgClassExpression62{{"PgClassExpression[62∈6]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression62
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression64
     First67{{"First[67∈6]"}}:::plan
     PgSelectRows68[["PgSelectRows[68∈6]"]]:::plan
     PgSelectRows68 --> First67
@@ -290,10 +354,8 @@ graph TD
     PgClassExpression117{{"PgClassExpression[117∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle116 --> PgClassExpression117
     PgSelect136[["PgSelect[136∈13]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression135{{"PgClassExpression[135∈13]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression135 --> PgSelect136
     PgSelect146[["PgSelect[146∈13]<br />ᐸpeopleᐳ<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression145{{"PgClassExpression[145∈13]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression145 --> PgSelect146
     PgSelect157[["PgSelect[157∈13]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression135 --> PgSelect157
@@ -303,32 +365,18 @@ graph TD
     Object9 & PgClassExpression135 --> PgSelect179
     PgSelect190[["PgSelect[190∈13]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression135 --> PgSelect190
-    PgSelectSingle132 --> PgClassExpression135
     First140{{"First[140∈13]"}}:::plan
     PgSelectRows141[["PgSelectRows[141∈13]"]]:::plan
     PgSelectRows141 --> First140
     PgSelect136 --> PgSelectRows141
     PgSelectSingle142{{"PgSelectSingle[142∈13]<br />ᐸrelational_topicsᐳ"}}:::plan
     First140 --> PgSelectSingle142
-    PgClassExpression144{{"PgClassExpression[144∈13]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression144
-    PgSelectSingle132 --> PgClassExpression145
     First148{{"First[148∈13]"}}:::plan
     PgSelectRows149[["PgSelectRows[149∈13]<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgSelectRows149 --> First148
     PgSelect146 --> PgSelectRows149
     PgSelectSingle150{{"PgSelectSingle[150∈13]<br />ᐸpeopleᐳ"}}:::plan
     First148 --> PgSelectSingle150
-    PgClassExpression152{{"PgClassExpression[152∈13]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression152
-    PgClassExpression153{{"PgClassExpression[153∈13]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression153
-    PgClassExpression154{{"PgClassExpression[154∈13]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression154
-    PgClassExpression155{{"PgClassExpression[155∈13]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression155
-    PgClassExpression156{{"PgClassExpression[156∈13]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle132 --> PgClassExpression156
     First159{{"First[159∈13]"}}:::plan
     PgSelectRows160[["PgSelectRows[160∈13]"]]:::plan
     PgSelectRows160 --> First159
@@ -390,10 +438,8 @@ graph TD
     PgClassExpression206{{"PgClassExpression[206∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle205 --> PgClassExpression206
     PgSelect220[["PgSelect[220∈20]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression219{{"PgClassExpression[219∈20]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression219 --> PgSelect220
     PgSelect230[["PgSelect[230∈20]<br />ᐸpeopleᐳ<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression229{{"PgClassExpression[229∈20]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression229 --> PgSelect230
     PgSelect241[["PgSelect[241∈20]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression219 --> PgSelect241
@@ -403,32 +449,18 @@ graph TD
     Object9 & PgClassExpression219 --> PgSelect263
     PgSelect274[["PgSelect[274∈20]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression219 --> PgSelect274
-    PgSelectSingle216 --> PgClassExpression219
     First224{{"First[224∈20]"}}:::plan
     PgSelectRows225[["PgSelectRows[225∈20]"]]:::plan
     PgSelectRows225 --> First224
     PgSelect220 --> PgSelectRows225
     PgSelectSingle226{{"PgSelectSingle[226∈20]<br />ᐸrelational_topicsᐳ"}}:::plan
     First224 --> PgSelectSingle226
-    PgClassExpression228{{"PgClassExpression[228∈20]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression228
-    PgSelectSingle216 --> PgClassExpression229
     First232{{"First[232∈20]"}}:::plan
     PgSelectRows233[["PgSelectRows[233∈20]<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgSelectRows233 --> First232
     PgSelect230 --> PgSelectRows233
     PgSelectSingle234{{"PgSelectSingle[234∈20]<br />ᐸpeopleᐳ"}}:::plan
     First232 --> PgSelectSingle234
-    PgClassExpression236{{"PgClassExpression[236∈20]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression236
-    PgClassExpression237{{"PgClassExpression[237∈20]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression237
-    PgClassExpression238{{"PgClassExpression[238∈20]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression238
-    PgClassExpression239{{"PgClassExpression[239∈20]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression239
-    PgClassExpression240{{"PgClassExpression[240∈20]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle216 --> PgClassExpression240
     First243{{"First[243∈20]"}}:::plan
     PgSelectRows244[["PgSelectRows[244∈20]"]]:::plan
     PgSelectRows244 --> First243
@@ -490,10 +522,8 @@ graph TD
     PgClassExpression290{{"PgClassExpression[290∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle289 --> PgClassExpression290
     PgSelect304[["PgSelect[304∈27]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression303{{"PgClassExpression[303∈27]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression303 --> PgSelect304
     PgSelect314[["PgSelect[314∈27]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression313{{"PgClassExpression[313∈27]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression313 --> PgSelect314
     PgSelect325[["PgSelect[325∈27]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression303 --> PgSelect325
@@ -503,32 +533,18 @@ graph TD
     Object9 & PgClassExpression303 --> PgSelect347
     PgSelect358[["PgSelect[358∈27]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression303 --> PgSelect358
-    PgSelectSingle300 --> PgClassExpression303
     First308{{"First[308∈27]"}}:::plan
     PgSelectRows309[["PgSelectRows[309∈27]"]]:::plan
     PgSelectRows309 --> First308
     PgSelect304 --> PgSelectRows309
     PgSelectSingle310{{"PgSelectSingle[310∈27]<br />ᐸrelational_topicsᐳ"}}:::plan
     First308 --> PgSelectSingle310
-    PgClassExpression312{{"PgClassExpression[312∈27]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression312
-    PgSelectSingle300 --> PgClassExpression313
     First316{{"First[316∈27]"}}:::plan
     PgSelectRows317[["PgSelectRows[317∈27]<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgSelectRows317 --> First316
     PgSelect314 --> PgSelectRows317
     PgSelectSingle318{{"PgSelectSingle[318∈27]<br />ᐸpeopleᐳ"}}:::plan
     First316 --> PgSelectSingle318
-    PgClassExpression320{{"PgClassExpression[320∈27]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression320
-    PgClassExpression321{{"PgClassExpression[321∈27]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression321
-    PgClassExpression322{{"PgClassExpression[322∈27]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression322
-    PgClassExpression323{{"PgClassExpression[323∈27]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression323
-    PgClassExpression324{{"PgClassExpression[324∈27]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression324
     First327{{"First[327∈27]"}}:::plan
     PgSelectRows328[["PgSelectRows[328∈27]"]]:::plan
     PgSelectRows328 --> First327
@@ -590,10 +606,8 @@ graph TD
     PgClassExpression374{{"PgClassExpression[374∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle373 --> PgClassExpression374
     PgSelect388[["PgSelect[388∈34]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression387{{"PgClassExpression[387∈34]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression387 --> PgSelect388
     PgSelect398[["PgSelect[398∈34]<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression397{{"PgClassExpression[397∈34]<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression397 --> PgSelect398
     PgSelect409[["PgSelect[409∈34]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression387 --> PgSelect409
@@ -603,32 +617,18 @@ graph TD
     Object9 & PgClassExpression387 --> PgSelect431
     PgSelect442[["PgSelect[442∈34]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression387 --> PgSelect442
-    PgSelectSingle384 --> PgClassExpression387
     First392{{"First[392∈34]"}}:::plan
     PgSelectRows393[["PgSelectRows[393∈34]"]]:::plan
     PgSelectRows393 --> First392
     PgSelect388 --> PgSelectRows393
     PgSelectSingle394{{"PgSelectSingle[394∈34]<br />ᐸrelational_topicsᐳ"}}:::plan
     First392 --> PgSelectSingle394
-    PgClassExpression396{{"PgClassExpression[396∈34]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression396
-    PgSelectSingle384 --> PgClassExpression397
     First400{{"First[400∈34]"}}:::plan
     PgSelectRows401[["PgSelectRows[401∈34]<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgSelectRows401 --> First400
     PgSelect398 --> PgSelectRows401
     PgSelectSingle402{{"PgSelectSingle[402∈34]<br />ᐸpeopleᐳ"}}:::plan
     First400 --> PgSelectSingle402
-    PgClassExpression404{{"PgClassExpression[404∈34]<br />ᐸ__relation...”position”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression404
-    PgClassExpression405{{"PgClassExpression[405∈34]<br />ᐸ__relation...reated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression405
-    PgClassExpression406{{"PgClassExpression[406∈34]<br />ᐸ__relation...pdated_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression406
-    PgClassExpression407{{"PgClassExpression[407∈34]<br />ᐸ__relation..._archived”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression407
-    PgClassExpression408{{"PgClassExpression[408∈34]<br />ᐸ__relation...chived_at”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle384 --> PgClassExpression408
     First411{{"First[411∈34]"}}:::plan
     PgSelectRows412[["PgSelectRows[412∈34]"]]:::plan
     PgSelectRows412 --> First411
@@ -707,13 +707,13 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 35, 110, 111, 118, 119, 120, 121, 122<br />2: 28, 36, 112, 123, 207, 291, 375<br />3: 33, 39, 115, 126, 131, 204, 210, 215, 288, 294, 299, 372, 378, 383, 456<br />ᐳ: 32, 34, 38, 40, 41, 42, 114, 116, 125, 127, 130, 132, 133, 134, 203, 205, 209, 211, 214, 216, 217, 218, 287, 289, 293, 295, 298, 300, 301, 302, 371, 373, 377, 379, 382, 384, 385, 386, 455, 457"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression35,PgClassExpression110,PgClassExpression111,PgClassExpression118,PgClassExpression119,PgClassExpression120,PgClassExpression121,PgClassExpression122 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 35, 111, 26, 25, 110, 118, 119, 120, 121, 122<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 36, 112, 123, 207, 291, 375<br />2: 33, 39, 115, 126, 131, 204, 210, 215, 288, 294, 299, 372, 378, 383, 456<br />ᐳ: 32, 34, 38, 40, 41, 42, 43, 52, 53, 60, 61, 62, 63, 64, 114, 116, 125, 127, 130, 132, 133, 134, 135, 144, 145, 152, 153, 154, 155, 156, 203, 205, 209, 211, 214, 216, 217, 218, 219, 228, 229, 236, 237, 238, 239, 240, 287, 289, 293, 295, 298, 300, 301, 302, 303, 312, 313, 320, 321, 322, 323, 324, 371, 373, 377, 379, 382, 384, 385, 386, 387, 396, 397, 404, 405, 406, 407, 408, 455, 457"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression110,PgClassExpression111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgClassExpression118,PgClassExpression119,PgClassExpression120,PgClassExpression121,PgClassExpression122,PgSelect123,First125,PgSelectRows126,PgSelectSingle127,First130,PgSelectRows131,PgSelectSingle132,PgClassExpression133,PgPolymorphic134,First203,PgSelectRows204,PgSelectSingle205,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression217,PgPolymorphic218,First287,PgSelectRows288,PgSelectSingle289,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression301,PgPolymorphic302,First371,PgSelectRows372,PgSelectSingle373,PgSelect375,First377,PgSelectRows378,PgSelectSingle379,First382,PgSelectRows383,PgSelectSingle384,PgClassExpression385,PgPolymorphic386,First455,PgSelectRows456,PgSelectSingle457 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 40, 9, 42, 41<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 43, 52, 53, 60, 61, 62, 63, 64<br />2: 44, 54, 65, 76, 87, 98<br />3: 49, 57, 68, 73, 79, 84, 90, 95, 101, 106<br />ᐳ: 48, 50, 56, 58, 67, 69, 72, 74, 78, 80, 83, 85, 89, 91, 94, 96, 100, 102, 105, 107"):::bucket
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression43,PgClassExpression52,PgClassExpression53,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgSelect123,First125,PgSelectRows126,PgSelectSingle127,First130,PgSelectRows131,PgSelectSingle132,PgClassExpression133,PgPolymorphic134,PgClassExpression135,PgClassExpression144,PgClassExpression145,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156,First203,PgSelectRows204,PgSelectSingle205,PgSelect207,First209,PgSelectRows210,PgSelectSingle211,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression217,PgPolymorphic218,PgClassExpression219,PgClassExpression228,PgClassExpression229,PgClassExpression236,PgClassExpression237,PgClassExpression238,PgClassExpression239,PgClassExpression240,First287,PgSelectRows288,PgSelectSingle289,PgSelect291,First293,PgSelectRows294,PgSelectSingle295,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression301,PgPolymorphic302,PgClassExpression303,PgClassExpression312,PgClassExpression313,PgClassExpression320,PgClassExpression321,PgClassExpression322,PgClassExpression323,PgClassExpression324,First371,PgSelectRows372,PgSelectSingle373,PgSelect375,First377,PgSelectRows378,PgSelectSingle379,First382,PgSelectRows383,PgSelectSingle384,PgClassExpression385,PgPolymorphic386,PgClassExpression387,PgClassExpression396,PgClassExpression397,PgClassExpression404,PgClassExpression405,PgClassExpression406,PgClassExpression407,PgClassExpression408,First455,PgSelectRows456,PgSelectSingle457 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 43, 53, 42, 41, 52, 60, 61, 62, 63, 64<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 44, 54, 65, 76, 87, 98<br />2: 49, 57, 68, 73, 79, 84, 90, 95, 101, 106<br />ᐳ: 48, 50, 56, 58, 67, 69, 72, 74, 78, 80, 83, 85, 89, 91, 94, 96, 100, 102, 105, 107"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression52,PgClassExpression53,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgClassExpression60,PgClassExpression61,PgClassExpression62,PgClassExpression63,PgClassExpression64,PgSelect65,First67,PgSelectRows68,PgSelectSingle69,First72,PgSelectRows73,PgSelectSingle74,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,First83,PgSelectRows84,PgSelectSingle85,PgSelect87,First89,PgSelectRows90,PgSelectSingle91,First94,PgSelectRows95,PgSelectSingle96,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,First105,PgSelectRows106,PgSelectSingle107 bucket6
+    class Bucket6,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgSelect54,First56,PgSelectRows57,PgSelectSingle58,PgSelect65,First67,PgSelectRows68,PgSelectSingle69,First72,PgSelectRows73,PgSelectSingle74,PgSelect76,First78,PgSelectRows79,PgSelectSingle80,First83,PgSelectRows84,PgSelectSingle85,PgSelect87,First89,PgSelectRows90,PgSelectSingle91,First94,PgSelectRows95,PgSelectSingle96,PgSelect98,First100,PgSelectRows101,PgSelectSingle102,First105,PgSelectRows106,PgSelectSingle107 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 58<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[58]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression59 bucket7
@@ -732,9 +732,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 116<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[116]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression117 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 132, 9, 134, 133<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 135, 144, 145, 152, 153, 154, 155, 156<br />2: 136, 146, 157, 168, 179, 190<br />3: 141, 149, 160, 165, 171, 176, 182, 187, 193, 198<br />ᐳ: 140, 142, 148, 150, 159, 161, 164, 166, 170, 172, 175, 177, 181, 183, 186, 188, 192, 194, 197, 199"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 135, 145, 134, 133, 144, 152, 153, 154, 155, 156<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 136, 146, 157, 168, 179, 190<br />2: 141, 149, 160, 165, 171, 176, 182, 187, 193, 198<br />ᐳ: 140, 142, 148, 150, 159, 161, 164, 166, 170, 172, 175, 177, 181, 183, 186, 188, 192, 194, 197, 199"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression135,PgSelect136,First140,PgSelectRows141,PgSelectSingle142,PgClassExpression144,PgClassExpression145,PgSelect146,First148,PgSelectRows149,PgSelectSingle150,PgClassExpression152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgClassExpression156,PgSelect157,First159,PgSelectRows160,PgSelectSingle161,First164,PgSelectRows165,PgSelectSingle166,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgSelect179,First181,PgSelectRows182,PgSelectSingle183,First186,PgSelectRows187,PgSelectSingle188,PgSelect190,First192,PgSelectRows193,PgSelectSingle194,First197,PgSelectRows198,PgSelectSingle199 bucket13
+    class Bucket13,PgSelect136,First140,PgSelectRows141,PgSelectSingle142,PgSelect146,First148,PgSelectRows149,PgSelectSingle150,PgSelect157,First159,PgSelectRows160,PgSelectSingle161,First164,PgSelectRows165,PgSelectSingle166,PgSelect168,First170,PgSelectRows171,PgSelectSingle172,First175,PgSelectRows176,PgSelectSingle177,PgSelect179,First181,PgSelectRows182,PgSelectSingle183,First186,PgSelectRows187,PgSelectSingle188,PgSelect190,First192,PgSelectRows193,PgSelectSingle194,First197,PgSelectRows198,PgSelectSingle199 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 150<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[150]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression151 bucket14
@@ -753,9 +753,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 205<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[205]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression206 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 216, 9, 218, 217<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 219, 228, 229, 236, 237, 238, 239, 240<br />2: 220, 230, 241, 252, 263, 274<br />3: 225, 233, 244, 249, 255, 260, 266, 271, 277, 282<br />ᐳ: 224, 226, 232, 234, 243, 245, 248, 250, 254, 256, 259, 261, 265, 267, 270, 272, 276, 278, 281, 283"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 219, 229, 218, 217, 228, 236, 237, 238, 239, 240<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 220, 230, 241, 252, 263, 274<br />2: 225, 233, 244, 249, 255, 260, 266, 271, 277, 282<br />ᐳ: 224, 226, 232, 234, 243, 245, 248, 250, 254, 256, 259, 261, 265, 267, 270, 272, 276, 278, 281, 283"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression219,PgSelect220,First224,PgSelectRows225,PgSelectSingle226,PgClassExpression228,PgClassExpression229,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgClassExpression236,PgClassExpression237,PgClassExpression238,PgClassExpression239,PgClassExpression240,PgSelect241,First243,PgSelectRows244,PgSelectSingle245,First248,PgSelectRows249,PgSelectSingle250,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,First259,PgSelectRows260,PgSelectSingle261,PgSelect263,First265,PgSelectRows266,PgSelectSingle267,First270,PgSelectRows271,PgSelectSingle272,PgSelect274,First276,PgSelectRows277,PgSelectSingle278,First281,PgSelectRows282,PgSelectSingle283 bucket20
+    class Bucket20,PgSelect220,First224,PgSelectRows225,PgSelectSingle226,PgSelect230,First232,PgSelectRows233,PgSelectSingle234,PgSelect241,First243,PgSelectRows244,PgSelectSingle245,First248,PgSelectRows249,PgSelectSingle250,PgSelect252,First254,PgSelectRows255,PgSelectSingle256,First259,PgSelectRows260,PgSelectSingle261,PgSelect263,First265,PgSelectRows266,PgSelectSingle267,First270,PgSelectRows271,PgSelectSingle272,PgSelect274,First276,PgSelectRows277,PgSelectSingle278,First281,PgSelectRows282,PgSelectSingle283 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 234<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[234]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression235 bucket21
@@ -774,9 +774,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 289<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[289]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression290 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 300, 9, 302, 301<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 303, 312, 313, 320, 321, 322, 323, 324<br />2: 304, 314, 325, 336, 347, 358<br />3: 309, 317, 328, 333, 339, 344, 350, 355, 361, 366<br />ᐳ: 308, 310, 316, 318, 327, 329, 332, 334, 338, 340, 343, 345, 349, 351, 354, 356, 360, 362, 365, 367"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 303, 313, 302, 301, 312, 320, 321, 322, 323, 324<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 304, 314, 325, 336, 347, 358<br />2: 309, 317, 328, 333, 339, 344, 350, 355, 361, 366<br />ᐳ: 308, 310, 316, 318, 327, 329, 332, 334, 338, 340, 343, 345, 349, 351, 354, 356, 360, 362, 365, 367"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression303,PgSelect304,First308,PgSelectRows309,PgSelectSingle310,PgClassExpression312,PgClassExpression313,PgSelect314,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,PgClassExpression321,PgClassExpression322,PgClassExpression323,PgClassExpression324,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,First332,PgSelectRows333,PgSelectSingle334,PgSelect336,First338,PgSelectRows339,PgSelectSingle340,First343,PgSelectRows344,PgSelectSingle345,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,First354,PgSelectRows355,PgSelectSingle356,PgSelect358,First360,PgSelectRows361,PgSelectSingle362,First365,PgSelectRows366,PgSelectSingle367 bucket27
+    class Bucket27,PgSelect304,First308,PgSelectRows309,PgSelectSingle310,PgSelect314,First316,PgSelectRows317,PgSelectSingle318,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,First332,PgSelectRows333,PgSelectSingle334,PgSelect336,First338,PgSelectRows339,PgSelectSingle340,First343,PgSelectRows344,PgSelectSingle345,PgSelect347,First349,PgSelectRows350,PgSelectSingle351,First354,PgSelectRows355,PgSelectSingle356,PgSelect358,First360,PgSelectRows361,PgSelectSingle362,First365,PgSelectRows366,PgSelectSingle367 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 318<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[318]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression319 bucket28
@@ -795,9 +795,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 373<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[373]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression374 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 384, 9, 386, 385<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 387, 396, 397, 404, 405, 406, 407, 408<br />2: 388, 398, 409, 420, 431, 442<br />3: 393, 401, 412, 417, 423, 428, 434, 439, 445, 450<br />ᐳ: 392, 394, 400, 402, 411, 413, 416, 418, 422, 424, 427, 429, 433, 435, 438, 440, 444, 446, 449, 451"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 387, 397, 386, 385, 396, 404, 405, 406, 407, 408<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 388, 398, 409, 420, 431, 442<br />2: 393, 401, 412, 417, 423, 428, 434, 439, 445, 450<br />ᐳ: 392, 394, 400, 402, 411, 413, 416, 418, 422, 424, 427, 429, 433, 435, 438, 440, 444, 446, 449, 451"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression387,PgSelect388,First392,PgSelectRows393,PgSelectSingle394,PgClassExpression396,PgClassExpression397,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,PgClassExpression404,PgClassExpression405,PgClassExpression406,PgClassExpression407,PgClassExpression408,PgSelect409,First411,PgSelectRows412,PgSelectSingle413,First416,PgSelectRows417,PgSelectSingle418,PgSelect420,First422,PgSelectRows423,PgSelectSingle424,First427,PgSelectRows428,PgSelectSingle429,PgSelect431,First433,PgSelectRows434,PgSelectSingle435,First438,PgSelectRows439,PgSelectSingle440,PgSelect442,First444,PgSelectRows445,PgSelectSingle446,First449,PgSelectRows450,PgSelectSingle451 bucket34
+    class Bucket34,PgSelect388,First392,PgSelectRows393,PgSelectSingle394,PgSelect398,First400,PgSelectRows401,PgSelectSingle402,PgSelect409,First411,PgSelectRows412,PgSelectSingle413,First416,PgSelectRows417,PgSelectSingle418,PgSelect420,First422,PgSelectRows423,PgSelectSingle424,First427,PgSelectRows428,PgSelectSingle429,PgSelect431,First433,PgSelectRows434,PgSelectSingle435,First438,PgSelectRows439,PgSelectSingle440,PgSelect442,First444,PgSelectRows445,PgSelectSingle446,First449,PgSelectRows450,PgSelectSingle451 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 402<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[402]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression403 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.mermaid
@@ -47,56 +47,60 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression35
+    PgClassExpression74{{"PgClassExpression[74∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression74
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect36[["PgSelect[36∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression35 --> PgSelect36
     PgPolymorphic42{{"PgPolymorphic[42∈5]<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle40{{"PgSelectSingle[40∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle40 & PgClassExpression41 --> PgPolymorphic42
     PgSelect75[["PgSelect[75∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect75
     PgPolymorphic86{{"PgPolymorphic[86∈5]<br />ᐳRelationalPost"}}:::plan
     PgSelectSingle84{{"PgSelectSingle[84∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression85{{"PgClassExpression[85∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression85{{"PgClassExpression[85∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle84 & PgClassExpression85 --> PgPolymorphic86
     PgSelect117[["PgSelect[117∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect117
     PgPolymorphic128{{"PgPolymorphic[128∈5]<br />ᐳRelationalDivider"}}:::plan
     PgSelectSingle126{{"PgSelectSingle[126∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression127{{"PgClassExpression[127∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression127{{"PgClassExpression[127∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle126 & PgClassExpression127 --> PgPolymorphic128
     PgSelect159[["PgSelect[159∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect159
     PgPolymorphic170{{"PgPolymorphic[170∈5]<br />ᐳRelationalChecklist"}}:::plan
     PgSelectSingle168{{"PgSelectSingle[168∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression169{{"PgClassExpression[169∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression169{{"PgClassExpression[169∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle168 & PgClassExpression169 --> PgPolymorphic170
     PgSelect201[["PgSelect[201∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect201
     PgPolymorphic212{{"PgPolymorphic[212∈5]<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle210{{"PgSelectSingle[210∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression211{{"PgClassExpression[211∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression211{{"PgClassExpression[211∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle210 & PgClassExpression211 --> PgPolymorphic212
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgSelectSingle24 --> PgClassExpression35
     First38{{"First[38∈5]"}}:::plan
     PgSelectRows39[["PgSelectRows[39∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows39 --> First38
     PgSelect36 --> PgSelectRows39
     First38 --> PgSelectSingle40
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression74{{"PgClassExpression[74∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression74
+    PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression43
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression52
     First77{{"First[77∈5]"}}:::plan
     PgSelectRows78[["PgSelectRows[78∈5]"]]:::plan
     PgSelectRows78 --> First77
@@ -109,6 +113,10 @@ graph TD
     PgSelect36 --> PgSelectRows83
     First82 --> PgSelectSingle84
     PgSelectSingle84 --> PgClassExpression85
+    PgClassExpression87{{"PgClassExpression[87∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression87
+    PgClassExpression96{{"PgClassExpression[96∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression96
     First119{{"First[119∈5]"}}:::plan
     PgSelectRows120[["PgSelectRows[120∈5]"]]:::plan
     PgSelectRows120 --> First119
@@ -121,6 +129,10 @@ graph TD
     PgSelect36 --> PgSelectRows125
     First124 --> PgSelectSingle126
     PgSelectSingle126 --> PgClassExpression127
+    PgClassExpression129{{"PgClassExpression[129∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression129
+    PgClassExpression138{{"PgClassExpression[138∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression138
     First161{{"First[161∈5]"}}:::plan
     PgSelectRows162[["PgSelectRows[162∈5]"]]:::plan
     PgSelectRows162 --> First161
@@ -133,6 +145,10 @@ graph TD
     PgSelect36 --> PgSelectRows167
     First166 --> PgSelectSingle168
     PgSelectSingle168 --> PgClassExpression169
+    PgClassExpression171{{"PgClassExpression[171∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle168 --> PgClassExpression171
+    PgClassExpression180{{"PgClassExpression[180∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle168 --> PgClassExpression180
     First203{{"First[203∈5]"}}:::plan
     PgSelectRows204[["PgSelectRows[204∈5]"]]:::plan
     PgSelectRows204 --> First203
@@ -145,8 +161,11 @@ graph TD
     PgSelect36 --> PgSelectRows209
     First208 --> PgSelectSingle210
     PgSelectSingle210 --> PgClassExpression211
+    PgClassExpression213{{"PgClassExpression[213∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle210 --> PgClassExpression213
+    PgClassExpression222{{"PgClassExpression[222∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle210 --> PgClassExpression222
     PgSelect44[["PgSelect[44∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression43{{"PgClassExpression[43∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression43 --> PgSelect44
     PgSelect53[["PgSelect[53∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect53
@@ -156,15 +175,12 @@ graph TD
     Object9 & PgClassExpression43 --> PgSelect63
     PgSelect68[["PgSelect[68∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect68
-    PgSelectSingle40 --> PgClassExpression43
     First48{{"First[48∈6]"}}:::plan
     PgSelectRows49[["PgSelectRows[49∈6]"]]:::plan
     PgSelectRows49 --> First48
     PgSelect44 --> PgSelectRows49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸrelational_topicsᐳ"}}:::plan
     First48 --> PgSelectSingle50
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression52
     First55{{"First[55∈6]"}}:::plan
     PgSelectRows56[["PgSelectRows[56∈6]"]]:::plan
     PgSelectRows56 --> First55
@@ -190,7 +206,6 @@ graph TD
     PgSelectSingle72{{"PgSelectSingle[72∈6]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First70 --> PgSelectSingle72
     PgSelect88[["PgSelect[88∈7]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression87{{"PgClassExpression[87∈7]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression87 --> PgSelect88
     PgSelect97[["PgSelect[97∈7]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression87 --> PgSelect97
@@ -200,15 +215,12 @@ graph TD
     Object9 & PgClassExpression87 --> PgSelect107
     PgSelect112[["PgSelect[112∈7]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression87 --> PgSelect112
-    PgSelectSingle84 --> PgClassExpression87
     First92{{"First[92∈7]"}}:::plan
     PgSelectRows93[["PgSelectRows[93∈7]"]]:::plan
     PgSelectRows93 --> First92
     PgSelect88 --> PgSelectRows93
     PgSelectSingle94{{"PgSelectSingle[94∈7]<br />ᐸrelational_topicsᐳ"}}:::plan
     First92 --> PgSelectSingle94
-    PgClassExpression96{{"PgClassExpression[96∈7]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle84 --> PgClassExpression96
     First99{{"First[99∈7]"}}:::plan
     PgSelectRows100[["PgSelectRows[100∈7]"]]:::plan
     PgSelectRows100 --> First99
@@ -234,7 +246,6 @@ graph TD
     PgSelectSingle116{{"PgSelectSingle[116∈7]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First114 --> PgSelectSingle116
     PgSelect130[["PgSelect[130∈8]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression129{{"PgClassExpression[129∈8]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression129 --> PgSelect130
     PgSelect139[["PgSelect[139∈8]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression129 --> PgSelect139
@@ -244,15 +255,12 @@ graph TD
     Object9 & PgClassExpression129 --> PgSelect149
     PgSelect154[["PgSelect[154∈8]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression129 --> PgSelect154
-    PgSelectSingle126 --> PgClassExpression129
     First134{{"First[134∈8]"}}:::plan
     PgSelectRows135[["PgSelectRows[135∈8]"]]:::plan
     PgSelectRows135 --> First134
     PgSelect130 --> PgSelectRows135
     PgSelectSingle136{{"PgSelectSingle[136∈8]<br />ᐸrelational_topicsᐳ"}}:::plan
     First134 --> PgSelectSingle136
-    PgClassExpression138{{"PgClassExpression[138∈8]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle126 --> PgClassExpression138
     First141{{"First[141∈8]"}}:::plan
     PgSelectRows142[["PgSelectRows[142∈8]"]]:::plan
     PgSelectRows142 --> First141
@@ -278,7 +286,6 @@ graph TD
     PgSelectSingle158{{"PgSelectSingle[158∈8]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First156 --> PgSelectSingle158
     PgSelect172[["PgSelect[172∈9]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression171{{"PgClassExpression[171∈9]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression171 --> PgSelect172
     PgSelect181[["PgSelect[181∈9]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression171 --> PgSelect181
@@ -288,15 +295,12 @@ graph TD
     Object9 & PgClassExpression171 --> PgSelect191
     PgSelect196[["PgSelect[196∈9]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression171 --> PgSelect196
-    PgSelectSingle168 --> PgClassExpression171
     First176{{"First[176∈9]"}}:::plan
     PgSelectRows177[["PgSelectRows[177∈9]"]]:::plan
     PgSelectRows177 --> First176
     PgSelect172 --> PgSelectRows177
     PgSelectSingle178{{"PgSelectSingle[178∈9]<br />ᐸrelational_topicsᐳ"}}:::plan
     First176 --> PgSelectSingle178
-    PgClassExpression180{{"PgClassExpression[180∈9]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle168 --> PgClassExpression180
     First183{{"First[183∈9]"}}:::plan
     PgSelectRows184[["PgSelectRows[184∈9]"]]:::plan
     PgSelectRows184 --> First183
@@ -322,7 +326,6 @@ graph TD
     PgSelectSingle200{{"PgSelectSingle[200∈9]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First198 --> PgSelectSingle200
     PgSelect214[["PgSelect[214∈10]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression213{{"PgClassExpression[213∈10]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression213 --> PgSelect214
     PgSelect223[["PgSelect[223∈10]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression213 --> PgSelect223
@@ -332,15 +335,12 @@ graph TD
     Object9 & PgClassExpression213 --> PgSelect233
     PgSelect238[["PgSelect[238∈10]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression213 --> PgSelect238
-    PgSelectSingle210 --> PgClassExpression213
     First218{{"First[218∈10]"}}:::plan
     PgSelectRows219[["PgSelectRows[219∈10]"]]:::plan
     PgSelectRows219 --> First218
     PgSelect214 --> PgSelectRows219
     PgSelectSingle220{{"PgSelectSingle[220∈10]<br />ᐸrelational_topicsᐳ"}}:::plan
     First218 --> PgSelectSingle220
-    PgClassExpression222{{"PgClassExpression[222∈10]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle210 --> PgClassExpression222
     First225{{"First[225∈10]"}}:::plan
     PgSelectRows226[["PgSelectRows[226∈10]"]]:::plan
     PgSelectRows226 --> First225
@@ -383,25 +383,25 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 35, 74<br />2: 28, 36, 75, 117, 159, 201<br />3: 33, 39, 78, 83, 120, 125, 162, 167, 204, 209<br />ᐳ: 32, 34, 38, 40, 41, 42, 77, 79, 82, 84, 85, 86, 119, 121, 124, 126, 127, 128, 161, 163, 166, 168, 169, 170, 203, 205, 208, 210, 211, 212"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression35,PgClassExpression74 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 35, 26, 25, 74<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 36, 75, 117, 159, 201<br />2: 33, 39, 78, 83, 120, 125, 162, 167, 204, 209<br />ᐳ: 32, 34, 38, 40, 41, 42, 43, 52, 77, 79, 82, 84, 85, 86, 87, 96, 119, 121, 124, 126, 127, 128, 129, 138, 161, 163, 166, 168, 169, 170, 171, 180, 203, 205, 208, 210, 211, 212, 213, 222"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression74,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgSelect117,First119,PgSelectRows120,PgSelectSingle121,First124,PgSelectRows125,PgSelectSingle126,PgClassExpression127,PgPolymorphic128,PgSelect159,First161,PgSelectRows162,PgSelectSingle163,First166,PgSelectRows167,PgSelectSingle168,PgClassExpression169,PgPolymorphic170,PgSelect201,First203,PgSelectRows204,PgSelectSingle205,First208,PgSelectRows209,PgSelectSingle210,PgClassExpression211,PgPolymorphic212 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 40, 9, 42, 41<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 43, 52<br />2: 44, 53, 58, 63, 68<br />3: 49, 56, 61, 66, 71<br />ᐳ: 48, 50, 55, 57, 60, 62, 65, 67, 70, 72"):::bucket
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression43,PgClassExpression52,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgClassExpression87,PgClassExpression96,PgSelect117,First119,PgSelectRows120,PgSelectSingle121,First124,PgSelectRows125,PgSelectSingle126,PgClassExpression127,PgPolymorphic128,PgClassExpression129,PgClassExpression138,PgSelect159,First161,PgSelectRows162,PgSelectSingle163,First166,PgSelectRows167,PgSelectSingle168,PgClassExpression169,PgPolymorphic170,PgClassExpression171,PgClassExpression180,PgSelect201,First203,PgSelectRows204,PgSelectSingle205,First208,PgSelectRows209,PgSelectSingle210,PgClassExpression211,PgPolymorphic212,PgClassExpression213,PgClassExpression222 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 43, 42, 41, 52<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 44, 53, 58, 63, 68<br />2: 49, 56, 61, 66, 71<br />ᐳ: 48, 50, 55, 57, 60, 62, 65, 67, 70, 72"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression52,PgSelect53,First55,PgSelectRows56,PgSelectSingle57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgSelect63,First65,PgSelectRows66,PgSelectSingle67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 84, 9, 86, 85<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 87, 96<br />2: 88, 97, 102, 107, 112<br />3: 93, 100, 105, 110, 115<br />ᐳ: 92, 94, 99, 101, 104, 106, 109, 111, 114, 116"):::bucket
+    class Bucket6,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgSelect53,First55,PgSelectRows56,PgSelectSingle57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgSelect63,First65,PgSelectRows66,PgSelectSingle67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 87, 86, 85, 96<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 88, 97, 102, 107, 112<br />2: 93, 100, 105, 110, 115<br />ᐳ: 92, 94, 99, 101, 104, 106, 109, 111, 114, 116"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression87,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgClassExpression96,PgSelect97,First99,PgSelectRows100,PgSelectSingle101,PgSelect102,First104,PgSelectRows105,PgSelectSingle106,PgSelect107,First109,PgSelectRows110,PgSelectSingle111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 126, 9, 128, 127<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 129, 138<br />2: 130, 139, 144, 149, 154<br />3: 135, 142, 147, 152, 157<br />ᐳ: 134, 136, 141, 143, 146, 148, 151, 153, 156, 158"):::bucket
+    class Bucket7,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgSelect97,First99,PgSelectRows100,PgSelectSingle101,PgSelect102,First104,PgSelectRows105,PgSelectSingle106,PgSelect107,First109,PgSelectRows110,PgSelectSingle111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 129, 128, 127, 138<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 130, 139, 144, 149, 154<br />2: 135, 142, 147, 152, 157<br />ᐳ: 134, 136, 141, 143, 146, 148, 151, 153, 156, 158"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression129,PgSelect130,First134,PgSelectRows135,PgSelectSingle136,PgClassExpression138,PgSelect139,First141,PgSelectRows142,PgSelectSingle143,PgSelect144,First146,PgSelectRows147,PgSelectSingle148,PgSelect149,First151,PgSelectRows152,PgSelectSingle153,PgSelect154,First156,PgSelectRows157,PgSelectSingle158 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 168, 9, 170, 169<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 171, 180<br />2: 172, 181, 186, 191, 196<br />3: 177, 184, 189, 194, 199<br />ᐳ: 176, 178, 183, 185, 188, 190, 193, 195, 198, 200"):::bucket
+    class Bucket8,PgSelect130,First134,PgSelectRows135,PgSelectSingle136,PgSelect139,First141,PgSelectRows142,PgSelectSingle143,PgSelect144,First146,PgSelectRows147,PgSelectSingle148,PgSelect149,First151,PgSelectRows152,PgSelectSingle153,PgSelect154,First156,PgSelectRows157,PgSelectSingle158 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 171, 170, 169, 180<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 172, 181, 186, 191, 196<br />2: 177, 184, 189, 194, 199<br />ᐳ: 176, 178, 183, 185, 188, 190, 193, 195, 198, 200"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression171,PgSelect172,First176,PgSelectRows177,PgSelectSingle178,PgClassExpression180,PgSelect181,First183,PgSelectRows184,PgSelectSingle185,PgSelect186,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgSelect196,First198,PgSelectRows199,PgSelectSingle200 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 210, 9, 212, 211<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 213, 222<br />2: 214, 223, 228, 233, 238<br />3: 219, 226, 231, 236, 241<br />ᐳ: 218, 220, 225, 227, 230, 232, 235, 237, 240, 242"):::bucket
+    class Bucket9,PgSelect172,First176,PgSelectRows177,PgSelectSingle178,PgSelect181,First183,PgSelectRows184,PgSelectSingle185,PgSelect186,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgSelect196,First198,PgSelectRows199,PgSelectSingle200 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 213, 212, 211, 222<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 214, 223, 228, 233, 238<br />2: 219, 226, 231, 236, 241<br />ᐳ: 218, 220, 225, 227, 230, 232, 235, 237, 240, 242"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression213,PgSelect214,First218,PgSelectRows219,PgSelectSingle220,PgClassExpression222,PgSelect223,First225,PgSelectRows226,PgSelectSingle227,PgSelect228,First230,PgSelectRows231,PgSelectSingle232,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242 bucket10
+    class Bucket10,PgSelect214,First218,PgSelectRows219,PgSelectSingle220,PgSelect223,First225,PgSelectRows226,PgSelectSingle227,PgSelect228,First230,PgSelectRows231,PgSelectSingle232,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242 bucket10
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.mermaid
@@ -47,56 +47,60 @@ graph TD
     __ListTransform19 ==> __Item23
     __Item23 --> PgSelectSingle24
     PgSelectSingle24 --> PgClassExpression25
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression27
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression35
+    PgClassExpression74{{"PgClassExpression[74∈4]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression74
     PgSelect28[["PgSelect[28∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression27 --> PgSelect28
     PgSelect36[["PgSelect[36∈5]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression35 --> PgSelect36
     PgPolymorphic42{{"PgPolymorphic[42∈5]<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle40{{"PgSelectSingle[40∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle40 & PgClassExpression41 --> PgPolymorphic42
     PgSelect75[["PgSelect[75∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect75
     PgPolymorphic86{{"PgPolymorphic[86∈5]<br />ᐳRelationalPost"}}:::plan
     PgSelectSingle84{{"PgSelectSingle[84∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression85{{"PgClassExpression[85∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression85{{"PgClassExpression[85∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPost<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle84 & PgClassExpression85 --> PgPolymorphic86
     PgSelect117[["PgSelect[117∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect117
     PgPolymorphic128{{"PgPolymorphic[128∈5]<br />ᐳRelationalDivider"}}:::plan
     PgSelectSingle126{{"PgSelectSingle[126∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression127{{"PgClassExpression[127∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression127{{"PgClassExpression[127∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle126 & PgClassExpression127 --> PgPolymorphic128
     PgSelect159[["PgSelect[159∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect159
     PgPolymorphic170{{"PgPolymorphic[170∈5]<br />ᐳRelationalChecklist"}}:::plan
     PgSelectSingle168{{"PgSelectSingle[168∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression169{{"PgClassExpression[169∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression169{{"PgClassExpression[169∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle168 & PgClassExpression169 --> PgPolymorphic170
     PgSelect201[["PgSelect[201∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression27 --> PgSelect201
     PgPolymorphic212{{"PgPolymorphic[212∈5]<br />ᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle210{{"PgSelectSingle[210∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
-    PgClassExpression211{{"PgClassExpression[211∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgClassExpression211{{"PgClassExpression[211∈5]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItem<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgSelectSingle210 & PgClassExpression211 --> PgPolymorphic212
-    PgSelectSingle24 --> PgClassExpression27
     First32{{"First[32∈5]"}}:::plan
     PgSelectRows33[["PgSelectRows[33∈5]"]]:::plan
     PgSelectRows33 --> First32
     PgSelect28 --> PgSelectRows33
     PgSelectSingle34{{"PgSelectSingle[34∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
     First32 --> PgSelectSingle34
-    PgSelectSingle24 --> PgClassExpression35
     First38{{"First[38∈5]"}}:::plan
     PgSelectRows39[["PgSelectRows[39∈5]<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows39 --> First38
     PgSelect36 --> PgSelectRows39
     First38 --> PgSelectSingle40
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression74{{"PgClassExpression[74∈5]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression74
+    PgClassExpression43{{"PgClassExpression[43∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression43
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle40 --> PgClassExpression52
     First77{{"First[77∈5]"}}:::plan
     PgSelectRows78[["PgSelectRows[78∈5]"]]:::plan
     PgSelectRows78 --> First77
@@ -109,6 +113,10 @@ graph TD
     PgSelect36 --> PgSelectRows83
     First82 --> PgSelectSingle84
     PgSelectSingle84 --> PgClassExpression85
+    PgClassExpression87{{"PgClassExpression[87∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression87
+    PgClassExpression96{{"PgClassExpression[96∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression96
     First119{{"First[119∈5]"}}:::plan
     PgSelectRows120[["PgSelectRows[120∈5]"]]:::plan
     PgSelectRows120 --> First119
@@ -121,6 +129,10 @@ graph TD
     PgSelect36 --> PgSelectRows125
     First124 --> PgSelectSingle126
     PgSelectSingle126 --> PgClassExpression127
+    PgClassExpression129{{"PgClassExpression[129∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression129
+    PgClassExpression138{{"PgClassExpression[138∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression138
     First161{{"First[161∈5]"}}:::plan
     PgSelectRows162[["PgSelectRows[162∈5]"]]:::plan
     PgSelectRows162 --> First161
@@ -133,6 +145,10 @@ graph TD
     PgSelect36 --> PgSelectRows167
     First166 --> PgSelectSingle168
     PgSelectSingle168 --> PgClassExpression169
+    PgClassExpression171{{"PgClassExpression[171∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle168 --> PgClassExpression171
+    PgClassExpression180{{"PgClassExpression[180∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle168 --> PgClassExpression180
     First203{{"First[203∈5]"}}:::plan
     PgSelectRows204[["PgSelectRows[204∈5]"]]:::plan
     PgSelectRows204 --> First203
@@ -145,8 +161,11 @@ graph TD
     PgSelect36 --> PgSelectRows209
     First208 --> PgSelectSingle210
     PgSelectSingle210 --> PgClassExpression211
+    PgClassExpression213{{"PgClassExpression[213∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle210 --> PgClassExpression213
+    PgClassExpression222{{"PgClassExpression[222∈5]<br />ᐸ__relation...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle210 --> PgClassExpression222
     PgSelect44[["PgSelect[44∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression43{{"PgClassExpression[43∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression43 --> PgSelect44
     PgSelect53[["PgSelect[53∈6]<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect53
@@ -156,15 +175,12 @@ graph TD
     Object9 & PgClassExpression43 --> PgSelect63
     PgSelect68[["PgSelect[68∈6]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression43 --> PgSelect68
-    PgSelectSingle40 --> PgClassExpression43
     First48{{"First[48∈6]"}}:::plan
     PgSelectRows49[["PgSelectRows[49∈6]"]]:::plan
     PgSelectRows49 --> First48
     PgSelect44 --> PgSelectRows49
     PgSelectSingle50{{"PgSelectSingle[50∈6]<br />ᐸrelational_topicsᐳ"}}:::plan
     First48 --> PgSelectSingle50
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle40 --> PgClassExpression52
     First55{{"First[55∈6]"}}:::plan
     PgSelectRows56[["PgSelectRows[56∈6]"]]:::plan
     PgSelectRows56 --> First55
@@ -190,7 +206,6 @@ graph TD
     PgSelectSingle72{{"PgSelectSingle[72∈6]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First70 --> PgSelectSingle72
     PgSelect88[["PgSelect[88∈7]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression87{{"PgClassExpression[87∈7]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression87 --> PgSelect88
     PgSelect97[["PgSelect[97∈7]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression87 --> PgSelect97
@@ -200,15 +215,12 @@ graph TD
     Object9 & PgClassExpression87 --> PgSelect107
     PgSelect112[["PgSelect[112∈7]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression87 --> PgSelect112
-    PgSelectSingle84 --> PgClassExpression87
     First92{{"First[92∈7]"}}:::plan
     PgSelectRows93[["PgSelectRows[93∈7]"]]:::plan
     PgSelectRows93 --> First92
     PgSelect88 --> PgSelectRows93
     PgSelectSingle94{{"PgSelectSingle[94∈7]<br />ᐸrelational_topicsᐳ"}}:::plan
     First92 --> PgSelectSingle94
-    PgClassExpression96{{"PgClassExpression[96∈7]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle84 --> PgClassExpression96
     First99{{"First[99∈7]"}}:::plan
     PgSelectRows100[["PgSelectRows[100∈7]"]]:::plan
     PgSelectRows100 --> First99
@@ -234,7 +246,6 @@ graph TD
     PgSelectSingle116{{"PgSelectSingle[116∈7]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First114 --> PgSelectSingle116
     PgSelect130[["PgSelect[130∈8]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression129{{"PgClassExpression[129∈8]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression129 --> PgSelect130
     PgSelect139[["PgSelect[139∈8]<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression129 --> PgSelect139
@@ -244,15 +255,12 @@ graph TD
     Object9 & PgClassExpression129 --> PgSelect149
     PgSelect154[["PgSelect[154∈8]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression129 --> PgSelect154
-    PgSelectSingle126 --> PgClassExpression129
     First134{{"First[134∈8]"}}:::plan
     PgSelectRows135[["PgSelectRows[135∈8]"]]:::plan
     PgSelectRows135 --> First134
     PgSelect130 --> PgSelectRows135
     PgSelectSingle136{{"PgSelectSingle[136∈8]<br />ᐸrelational_topicsᐳ"}}:::plan
     First134 --> PgSelectSingle136
-    PgClassExpression138{{"PgClassExpression[138∈8]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle126 --> PgClassExpression138
     First141{{"First[141∈8]"}}:::plan
     PgSelectRows142[["PgSelectRows[142∈8]"]]:::plan
     PgSelectRows142 --> First141
@@ -278,7 +286,6 @@ graph TD
     PgSelectSingle158{{"PgSelectSingle[158∈8]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First156 --> PgSelectSingle158
     PgSelect172[["PgSelect[172∈9]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression171{{"PgClassExpression[171∈9]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression171 --> PgSelect172
     PgSelect181[["PgSelect[181∈9]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression171 --> PgSelect181
@@ -288,15 +295,12 @@ graph TD
     Object9 & PgClassExpression171 --> PgSelect191
     PgSelect196[["PgSelect[196∈9]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression171 --> PgSelect196
-    PgSelectSingle168 --> PgClassExpression171
     First176{{"First[176∈9]"}}:::plan
     PgSelectRows177[["PgSelectRows[177∈9]"]]:::plan
     PgSelectRows177 --> First176
     PgSelect172 --> PgSelectRows177
     PgSelectSingle178{{"PgSelectSingle[178∈9]<br />ᐸrelational_topicsᐳ"}}:::plan
     First176 --> PgSelectSingle178
-    PgClassExpression180{{"PgClassExpression[180∈9]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle168 --> PgClassExpression180
     First183{{"First[183∈9]"}}:::plan
     PgSelectRows184[["PgSelectRows[184∈9]"]]:::plan
     PgSelectRows184 --> First183
@@ -322,7 +326,6 @@ graph TD
     PgSelectSingle200{{"PgSelectSingle[200∈9]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
     First198 --> PgSelectSingle200
     PgSelect214[["PgSelect[214∈10]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression213{{"PgClassExpression[213∈10]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object9 & PgClassExpression213 --> PgSelect214
     PgSelect223[["PgSelect[223∈10]<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object9 & PgClassExpression213 --> PgSelect223
@@ -332,15 +335,12 @@ graph TD
     Object9 & PgClassExpression213 --> PgSelect233
     PgSelect238[["PgSelect[238∈10]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object9 & PgClassExpression213 --> PgSelect238
-    PgSelectSingle210 --> PgClassExpression213
     First218{{"First[218∈10]"}}:::plan
     PgSelectRows219[["PgSelectRows[219∈10]"]]:::plan
     PgSelectRows219 --> First218
     PgSelect214 --> PgSelectRows219
     PgSelectSingle220{{"PgSelectSingle[220∈10]<br />ᐸrelational_topicsᐳ"}}:::plan
     First218 --> PgSelectSingle220
-    PgClassExpression222{{"PgClassExpression[222∈10]<br />ᐸ__relation...__.”type2”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle210 --> PgClassExpression222
     First225{{"First[225∈10]"}}:::plan
     PgSelectRows226[["PgSelectRows[226∈10]"]]:::plan
     PgSelectRows226 --> First225
@@ -383,25 +383,25 @@ graph TD
     class Bucket3,__Item21,PgSelectSingle22 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 24, 9, 26, 25<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 27, 35, 74<br />2: 28, 36, 75, 117, 159, 201<br />3: 33, 39, 78, 83, 120, 125, 162, 167, 204, 209<br />ᐳ: 32, 34, 38, 40, 41, 42, 77, 79, 82, 84, 85, 86, 119, 121, 124, 126, 127, 128, 161, 163, 166, 168, 169, 170, 203, 205, 208, 210, 211, 212"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,PgPolymorphic26,PgClassExpression27,PgClassExpression35,PgClassExpression74 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 27, 35, 26, 25, 74<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 28, 36, 75, 117, 159, 201<br />2: 33, 39, 78, 83, 120, 125, 162, 167, 204, 209<br />ᐳ: 32, 34, 38, 40, 41, 42, 43, 52, 77, 79, 82, 84, 85, 86, 87, 96, 119, 121, 124, 126, 127, 128, 129, 138, 161, 163, 166, 168, 169, 170, 171, 180, 203, 205, 208, 210, 211, 212, 213, 222"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgClassExpression35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression74,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgSelect117,First119,PgSelectRows120,PgSelectSingle121,First124,PgSelectRows125,PgSelectSingle126,PgClassExpression127,PgPolymorphic128,PgSelect159,First161,PgSelectRows162,PgSelectSingle163,First166,PgSelectRows167,PgSelectSingle168,PgClassExpression169,PgPolymorphic170,PgSelect201,First203,PgSelectRows204,PgSelectSingle205,First208,PgSelectRows209,PgSelectSingle210,PgClassExpression211,PgPolymorphic212 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 40, 9, 42, 41<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 43, 52<br />2: 44, 53, 58, 63, 68<br />3: 49, 56, 61, 66, 71<br />ᐳ: 48, 50, 55, 57, 60, 62, 65, 67, 70, 72"):::bucket
+    class Bucket5,PgSelect28,First32,PgSelectRows33,PgSelectSingle34,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgPolymorphic42,PgClassExpression43,PgClassExpression52,PgSelect75,First77,PgSelectRows78,PgSelectSingle79,First82,PgSelectRows83,PgSelectSingle84,PgClassExpression85,PgPolymorphic86,PgClassExpression87,PgClassExpression96,PgSelect117,First119,PgSelectRows120,PgSelectSingle121,First124,PgSelectRows125,PgSelectSingle126,PgClassExpression127,PgPolymorphic128,PgClassExpression129,PgClassExpression138,PgSelect159,First161,PgSelectRows162,PgSelectSingle163,First166,PgSelectRows167,PgSelectSingle168,PgClassExpression169,PgPolymorphic170,PgClassExpression171,PgClassExpression180,PgSelect201,First203,PgSelectRows204,PgSelectSingle205,First208,PgSelectRows209,PgSelectSingle210,PgClassExpression211,PgPolymorphic212,PgClassExpression213,PgClassExpression222 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 43, 42, 41, 52<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 44, 53, 58, 63, 68<br />2: 49, 56, 61, 66, 71<br />ᐳ: 48, 50, 55, 57, 60, 62, 65, 67, 70, 72"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression43,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgClassExpression52,PgSelect53,First55,PgSelectRows56,PgSelectSingle57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgSelect63,First65,PgSelectRows66,PgSelectSingle67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 84, 9, 86, 85<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 87, 96<br />2: 88, 97, 102, 107, 112<br />3: 93, 100, 105, 110, 115<br />ᐳ: 92, 94, 99, 101, 104, 106, 109, 111, 114, 116"):::bucket
+    class Bucket6,PgSelect44,First48,PgSelectRows49,PgSelectSingle50,PgSelect53,First55,PgSelectRows56,PgSelectSingle57,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,PgSelect63,First65,PgSelectRows66,PgSelectSingle67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 87, 86, 85, 96<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 88, 97, 102, 107, 112<br />2: 93, 100, 105, 110, 115<br />ᐳ: 92, 94, 99, 101, 104, 106, 109, 111, 114, 116"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression87,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgClassExpression96,PgSelect97,First99,PgSelectRows100,PgSelectSingle101,PgSelect102,First104,PgSelectRows105,PgSelectSingle106,PgSelect107,First109,PgSelectRows110,PgSelectSingle111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 126, 9, 128, 127<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 129, 138<br />2: 130, 139, 144, 149, 154<br />3: 135, 142, 147, 152, 157<br />ᐳ: 134, 136, 141, 143, 146, 148, 151, 153, 156, 158"):::bucket
+    class Bucket7,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgSelect97,First99,PgSelectRows100,PgSelectSingle101,PgSelect102,First104,PgSelectRows105,PgSelectSingle106,PgSelect107,First109,PgSelectRows110,PgSelectSingle111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 129, 128, 127, 138<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 130, 139, 144, 149, 154<br />2: 135, 142, 147, 152, 157<br />ᐳ: 134, 136, 141, 143, 146, 148, 151, 153, 156, 158"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression129,PgSelect130,First134,PgSelectRows135,PgSelectSingle136,PgClassExpression138,PgSelect139,First141,PgSelectRows142,PgSelectSingle143,PgSelect144,First146,PgSelectRows147,PgSelectSingle148,PgSelect149,First151,PgSelectRows152,PgSelectSingle153,PgSelect154,First156,PgSelectRows157,PgSelectSingle158 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 168, 9, 170, 169<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 171, 180<br />2: 172, 181, 186, 191, 196<br />3: 177, 184, 189, 194, 199<br />ᐳ: 176, 178, 183, 185, 188, 190, 193, 195, 198, 200"):::bucket
+    class Bucket8,PgSelect130,First134,PgSelectRows135,PgSelectSingle136,PgSelect139,First141,PgSelectRows142,PgSelectSingle143,PgSelect144,First146,PgSelectRows147,PgSelectSingle148,PgSelect149,First151,PgSelectRows152,PgSelectSingle153,PgSelect154,First156,PgSelectRows157,PgSelectSingle158 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 171, 170, 169, 180<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 172, 181, 186, 191, 196<br />2: 177, 184, 189, 194, 199<br />ᐳ: 176, 178, 183, 185, 188, 190, 193, 195, 198, 200"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression171,PgSelect172,First176,PgSelectRows177,PgSelectSingle178,PgClassExpression180,PgSelect181,First183,PgSelectRows184,PgSelectSingle185,PgSelect186,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgSelect196,First198,PgSelectRows199,PgSelectSingle200 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 210, 9, 212, 211<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 213, 222<br />2: 214, 223, 228, 233, 238<br />3: 219, 226, 231, 236, 241<br />ᐳ: 218, 220, 225, 227, 230, 232, 235, 237, 240, 242"):::bucket
+    class Bucket9,PgSelect172,First176,PgSelectRows177,PgSelectSingle178,PgSelect181,First183,PgSelectRows184,PgSelectSingle185,PgSelect186,First188,PgSelectRows189,PgSelectSingle190,PgSelect191,First193,PgSelectRows194,PgSelectSingle195,PgSelect196,First198,PgSelectRows199,PgSelectSingle200 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 9, 213, 212, 211, 222<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 214, 223, 228, 233, 238<br />2: 219, 226, 231, 236, 241<br />ᐳ: 218, 220, 225, 227, 230, 232, 235, 237, 240, 242"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression213,PgSelect214,First218,PgSelectRows219,PgSelectSingle220,PgClassExpression222,PgSelect223,First225,PgSelectRows226,PgSelectSingle227,PgSelect228,First230,PgSelectRows231,PgSelectSingle232,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242 bucket10
+    class Bucket10,PgSelect214,First218,PgSelectRows219,PgSelectSingle220,PgSelect223,First225,PgSelectRows226,PgSelectSingle227,PgSelect228,First230,PgSelectRows231,PgSelectSingle232,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,PgSelect238,First240,PgSelectRows241,PgSelectSingle242 bucket10
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.deopt.mermaid
@@ -29,12 +29,14 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
+    PgClassExpression24{{"PgClassExpression[24∈0] ➊<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression24
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect25[["PgSelect[25∈1] ➊<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression24{{"PgClassExpression[24∈1] ➊<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression24 --> PgSelect25
     PgPolymorphic31{{"PgPolymorphic[31∈1] ➊<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle29{{"PgSelectSingle[29∈1] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -64,20 +66,22 @@ graph TD
     PgSelectSingle313{{"PgSelectSingle[313∈1] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression314{{"PgClassExpression[314∈1] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
     PgSelectSingle313 & PgClassExpression314 --> PgPolymorphic315
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
     PgSelect17 --> PgSelectRows22
     PgSelectSingle23{{"PgSelectSingle[23∈1] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First21 --> PgSelectSingle23
-    PgSelectSingle13 --> PgClassExpression24
     First27{{"First[27∈1] ➊"}}:::plan
     PgSelectRows28[["PgSelectRows[28∈1] ➊<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows28 --> First27
     PgSelect25 --> PgSelectRows28
     First27 --> PgSelectSingle29
     PgSelectSingle29 --> PgClassExpression30
+    PgClassExpression32{{"PgClassExpression[32∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle29 --> PgClassExpression32
+    PgClassExpression40{{"PgClassExpression[40∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle29 --> PgClassExpression40
     First93{{"First[93∈1] ➊"}}:::plan
     PgSelectRows94[["PgSelectRows[94∈1] ➊"]]:::plan
     PgSelectRows94 --> First93
@@ -90,6 +94,10 @@ graph TD
     PgSelect25 --> PgSelectRows99
     First98 --> PgSelectSingle100
     PgSelectSingle100 --> PgClassExpression101
+    PgClassExpression103{{"PgClassExpression[103∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle100 --> PgClassExpression103
+    PgClassExpression111{{"PgClassExpression[111∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle100 --> PgClassExpression111
     First164{{"First[164∈1] ➊"}}:::plan
     PgSelectRows165[["PgSelectRows[165∈1] ➊"]]:::plan
     PgSelectRows165 --> First164
@@ -102,6 +110,10 @@ graph TD
     PgSelect25 --> PgSelectRows170
     First169 --> PgSelectSingle171
     PgSelectSingle171 --> PgClassExpression172
+    PgClassExpression174{{"PgClassExpression[174∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle171 --> PgClassExpression174
+    PgClassExpression182{{"PgClassExpression[182∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle171 --> PgClassExpression182
     First235{{"First[235∈1] ➊"}}:::plan
     PgSelectRows236[["PgSelectRows[236∈1] ➊"]]:::plan
     PgSelectRows236 --> First235
@@ -114,6 +126,10 @@ graph TD
     PgSelect25 --> PgSelectRows241
     First240 --> PgSelectSingle242
     PgSelectSingle242 --> PgClassExpression243
+    PgClassExpression245{{"PgClassExpression[245∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle242 --> PgClassExpression245
+    PgClassExpression253{{"PgClassExpression[253∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle242 --> PgClassExpression253
     First306{{"First[306∈1] ➊"}}:::plan
     PgSelectRows307[["PgSelectRows[307∈1] ➊"]]:::plan
     PgSelectRows307 --> First306
@@ -126,11 +142,13 @@ graph TD
     PgSelect25 --> PgSelectRows312
     First311 --> PgSelectSingle313
     PgSelectSingle313 --> PgClassExpression314
+    PgClassExpression316{{"PgClassExpression[316∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle313 --> PgClassExpression316
+    PgClassExpression324{{"PgClassExpression[324∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle313 --> PgClassExpression324
     PgSelect33[["PgSelect[33∈2] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression32{{"PgClassExpression[32∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression32 --> PgSelect33
     PgSelect41[["PgSelect[41∈2] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression40{{"PgClassExpression[40∈2] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression40 --> PgSelect41
     PgSelect47[["PgSelect[47∈2] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression32 --> PgSelect47
@@ -140,14 +158,12 @@ graph TD
     Object10 & PgClassExpression32 --> PgSelect69
     PgSelect80[["PgSelect[80∈2] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression32 --> PgSelect80
-    PgSelectSingle29 --> PgClassExpression32
     First37{{"First[37∈2] ➊"}}:::plan
     PgSelectRows38[["PgSelectRows[38∈2] ➊"]]:::plan
     PgSelectRows38 --> First37
     PgSelect33 --> PgSelectRows38
     PgSelectSingle39{{"PgSelectSingle[39∈2] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First37 --> PgSelectSingle39
-    PgSelectSingle29 --> PgClassExpression40
     First43{{"First[43∈2] ➊"}}:::plan
     PgSelectRows44[["PgSelectRows[44∈2] ➊<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgSelectRows44 --> First43
@@ -213,10 +229,8 @@ graph TD
     PgClassExpression90{{"PgClassExpression[90∈7] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle89 --> PgClassExpression90
     PgSelect104[["PgSelect[104∈8] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression103{{"PgClassExpression[103∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression103 --> PgSelect104
     PgSelect112[["PgSelect[112∈8] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈8] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression111 --> PgSelect112
     PgSelect118[["PgSelect[118∈8] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression103 --> PgSelect118
@@ -226,14 +240,12 @@ graph TD
     Object10 & PgClassExpression103 --> PgSelect140
     PgSelect151[["PgSelect[151∈8] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression103 --> PgSelect151
-    PgSelectSingle100 --> PgClassExpression103
     First108{{"First[108∈8] ➊"}}:::plan
     PgSelectRows109[["PgSelectRows[109∈8] ➊"]]:::plan
     PgSelectRows109 --> First108
     PgSelect104 --> PgSelectRows109
     PgSelectSingle110{{"PgSelectSingle[110∈8] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First108 --> PgSelectSingle110
-    PgSelectSingle100 --> PgClassExpression111
     First114{{"First[114∈8] ➊"}}:::plan
     PgSelectRows115[["PgSelectRows[115∈8] ➊<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgSelectRows115 --> First114
@@ -299,10 +311,8 @@ graph TD
     PgClassExpression161{{"PgClassExpression[161∈13] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle160 --> PgClassExpression161
     PgSelect175[["PgSelect[175∈14] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression174{{"PgClassExpression[174∈14] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression174 --> PgSelect175
     PgSelect183[["PgSelect[183∈14] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression182{{"PgClassExpression[182∈14] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression182 --> PgSelect183
     PgSelect189[["PgSelect[189∈14] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression174 --> PgSelect189
@@ -312,14 +322,12 @@ graph TD
     Object10 & PgClassExpression174 --> PgSelect211
     PgSelect222[["PgSelect[222∈14] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression174 --> PgSelect222
-    PgSelectSingle171 --> PgClassExpression174
     First179{{"First[179∈14] ➊"}}:::plan
     PgSelectRows180[["PgSelectRows[180∈14] ➊"]]:::plan
     PgSelectRows180 --> First179
     PgSelect175 --> PgSelectRows180
     PgSelectSingle181{{"PgSelectSingle[181∈14] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First179 --> PgSelectSingle181
-    PgSelectSingle171 --> PgClassExpression182
     First185{{"First[185∈14] ➊"}}:::plan
     PgSelectRows186[["PgSelectRows[186∈14] ➊<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgSelectRows186 --> First185
@@ -385,10 +393,8 @@ graph TD
     PgClassExpression232{{"PgClassExpression[232∈19] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle231 --> PgClassExpression232
     PgSelect246[["PgSelect[246∈20] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression245{{"PgClassExpression[245∈20] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression245 --> PgSelect246
     PgSelect254[["PgSelect[254∈20] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression253{{"PgClassExpression[253∈20] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression253 --> PgSelect254
     PgSelect260[["PgSelect[260∈20] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression245 --> PgSelect260
@@ -398,14 +404,12 @@ graph TD
     Object10 & PgClassExpression245 --> PgSelect282
     PgSelect293[["PgSelect[293∈20] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression245 --> PgSelect293
-    PgSelectSingle242 --> PgClassExpression245
     First250{{"First[250∈20] ➊"}}:::plan
     PgSelectRows251[["PgSelectRows[251∈20] ➊"]]:::plan
     PgSelectRows251 --> First250
     PgSelect246 --> PgSelectRows251
     PgSelectSingle252{{"PgSelectSingle[252∈20] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First250 --> PgSelectSingle252
-    PgSelectSingle242 --> PgClassExpression253
     First256{{"First[256∈20] ➊"}}:::plan
     PgSelectRows257[["PgSelectRows[257∈20] ➊<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgSelectRows257 --> First256
@@ -471,10 +475,8 @@ graph TD
     PgClassExpression303{{"PgClassExpression[303∈25] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle302 --> PgClassExpression303
     PgSelect317[["PgSelect[317∈26] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression316{{"PgClassExpression[316∈26] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression316 --> PgSelect317
     PgSelect325[["PgSelect[325∈26] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression324{{"PgClassExpression[324∈26] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression324 --> PgSelect325
     PgSelect331[["PgSelect[331∈26] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression316 --> PgSelect331
@@ -484,14 +486,12 @@ graph TD
     Object10 & PgClassExpression316 --> PgSelect353
     PgSelect364[["PgSelect[364∈26] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression316 --> PgSelect364
-    PgSelectSingle313 --> PgClassExpression316
     First321{{"First[321∈26] ➊"}}:::plan
     PgSelectRows322[["PgSelectRows[322∈26] ➊"]]:::plan
     PgSelectRows322 --> First321
     PgSelect317 --> PgSelectRows322
     PgSelectSingle323{{"PgSelectSingle[323∈26] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First321 --> PgSelectSingle323
-    PgSelectSingle313 --> PgClassExpression324
     First327{{"First[327∈26] ➊"}}:::plan
     PgSelectRows328[["PgSelectRows[328∈26] ➊<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgSelectRows328 --> First327
@@ -560,15 +560,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 375, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 375, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15, 16, 24"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,Constant375 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 13, 10, 15<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 16, 24<br />2: 17, 25, 91, 162, 233, 304<br />3: 22, 28, 94, 99, 165, 170, 236, 241, 307, 312<br />ᐳ: 21, 23, 27, 29, 30, 31, 93, 95, 98, 100, 101, 102, 164, 166, 169, 171, 172, 173, 235, 237, 240, 242, 243, 244, 306, 308, 311, 313, 314, 315"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,PgClassExpression24,Constant375 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 16, 24, 15<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 17, 25, 91, 162, 233, 304<br />2: 22, 28, 94, 99, 165, 170, 236, 241, 307, 312<br />ᐳ: 21, 23, 27, 29, 30, 31, 32, 40, 93, 95, 98, 100, 101, 102, 103, 111, 164, 166, 169, 171, 172, 173, 174, 182, 235, 237, 240, 242, 243, 244, 245, 253, 306, 308, 311, 313, 314, 315, 316, 324"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgSelect25,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgPolymorphic31,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression101,PgPolymorphic102,PgSelect162,First164,PgSelectRows165,PgSelectSingle166,First169,PgSelectRows170,PgSelectSingle171,PgClassExpression172,PgPolymorphic173,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,First240,PgSelectRows241,PgSelectSingle242,PgClassExpression243,PgPolymorphic244,PgSelect304,First306,PgSelectRows307,PgSelectSingle308,First311,PgSelectRows312,PgSelectSingle313,PgClassExpression314,PgPolymorphic315 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 29, 10, 31<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 32, 40<br />2: 33, 41, 47, 58, 69, 80<br />3: 38, 44, 50, 55, 61, 66, 72, 77, 83, 88<br />ᐳ: 37, 39, 43, 45, 49, 51, 54, 56, 60, 62, 65, 67, 71, 73, 76, 78, 82, 84, 87, 89"):::bucket
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgSelect25,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgPolymorphic31,PgClassExpression32,PgClassExpression40,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression101,PgPolymorphic102,PgClassExpression103,PgClassExpression111,PgSelect162,First164,PgSelectRows165,PgSelectSingle166,First169,PgSelectRows170,PgSelectSingle171,PgClassExpression172,PgPolymorphic173,PgClassExpression174,PgClassExpression182,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,First240,PgSelectRows241,PgSelectSingle242,PgClassExpression243,PgPolymorphic244,PgClassExpression245,PgClassExpression253,PgSelect304,First306,PgSelectRows307,PgSelectSingle308,First311,PgSelectRows312,PgSelectSingle313,PgClassExpression314,PgPolymorphic315,PgClassExpression316,PgClassExpression324 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 32, 40, 31<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 33, 41, 47, 58, 69, 80<br />2: 38, 44, 50, 55, 61, 66, 72, 77, 83, 88<br />ᐳ: 37, 39, 43, 45, 49, 51, 54, 56, 60, 62, 65, 67, 71, 73, 76, 78, 82, 84, 87, 89"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression32,PgSelect33,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgSelect41,First43,PgSelectRows44,PgSelectSingle45,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,First54,PgSelectRows55,PgSelectSingle56,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,First65,PgSelectRows66,PgSelectSingle67,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,First76,PgSelectRows77,PgSelectSingle78,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89 bucket2
+    class Bucket2,PgSelect33,First37,PgSelectRows38,PgSelectSingle39,PgSelect41,First43,PgSelectRows44,PgSelectSingle45,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,First54,PgSelectRows55,PgSelectSingle56,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,First65,PgSelectRows66,PgSelectSingle67,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,First76,PgSelectRows77,PgSelectSingle78,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[45]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression46 bucket3
@@ -584,9 +584,9 @@ graph TD
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 89<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[89]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression90 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 100, 10, 102<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 103, 111<br />2: 104, 112, 118, 129, 140, 151<br />3: 109, 115, 121, 126, 132, 137, 143, 148, 154, 159<br />ᐳ: 108, 110, 114, 116, 120, 122, 125, 127, 131, 133, 136, 138, 142, 144, 147, 149, 153, 155, 158, 160"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 103, 111, 102<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 104, 112, 118, 129, 140, 151<br />2: 109, 115, 121, 126, 132, 137, 143, 148, 154, 159<br />ᐳ: 108, 110, 114, 116, 120, 122, 125, 127, 131, 133, 136, 138, 142, 144, 147, 149, 153, 155, 158, 160"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression103,PgSelect104,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgSelect118,First120,PgSelectRows121,PgSelectSingle122,First125,PgSelectRows126,PgSelectSingle127,PgSelect129,First131,PgSelectRows132,PgSelectSingle133,First136,PgSelectRows137,PgSelectSingle138,PgSelect140,First142,PgSelectRows143,PgSelectSingle144,First147,PgSelectRows148,PgSelectSingle149,PgSelect151,First153,PgSelectRows154,PgSelectSingle155,First158,PgSelectRows159,PgSelectSingle160 bucket8
+    class Bucket8,PgSelect104,First108,PgSelectRows109,PgSelectSingle110,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgSelect118,First120,PgSelectRows121,PgSelectSingle122,First125,PgSelectRows126,PgSelectSingle127,PgSelect129,First131,PgSelectRows132,PgSelectSingle133,First136,PgSelectRows137,PgSelectSingle138,PgSelect140,First142,PgSelectRows143,PgSelectSingle144,First147,PgSelectRows148,PgSelectSingle149,PgSelect151,First153,PgSelectRows154,PgSelectSingle155,First158,PgSelectRows159,PgSelectSingle160 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 116<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[116]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression117 bucket9
@@ -602,9 +602,9 @@ graph TD
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 160<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[160]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression161 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 171, 10, 173<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 174, 182<br />2: 175, 183, 189, 200, 211, 222<br />3: 180, 186, 192, 197, 203, 208, 214, 219, 225, 230<br />ᐳ: 179, 181, 185, 187, 191, 193, 196, 198, 202, 204, 207, 209, 213, 215, 218, 220, 224, 226, 229, 231"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 174, 182, 173<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 175, 183, 189, 200, 211, 222<br />2: 180, 186, 192, 197, 203, 208, 214, 219, 225, 230<br />ᐳ: 179, 181, 185, 187, 191, 193, 196, 198, 202, 204, 207, 209, 213, 215, 218, 220, 224, 226, 229, 231"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression174,PgSelect175,First179,PgSelectRows180,PgSelectSingle181,PgClassExpression182,PgSelect183,First185,PgSelectRows186,PgSelectSingle187,PgSelect189,First191,PgSelectRows192,PgSelectSingle193,First196,PgSelectRows197,PgSelectSingle198,PgSelect200,First202,PgSelectRows203,PgSelectSingle204,First207,PgSelectRows208,PgSelectSingle209,PgSelect211,First213,PgSelectRows214,PgSelectSingle215,First218,PgSelectRows219,PgSelectSingle220,PgSelect222,First224,PgSelectRows225,PgSelectSingle226,First229,PgSelectRows230,PgSelectSingle231 bucket14
+    class Bucket14,PgSelect175,First179,PgSelectRows180,PgSelectSingle181,PgSelect183,First185,PgSelectRows186,PgSelectSingle187,PgSelect189,First191,PgSelectRows192,PgSelectSingle193,First196,PgSelectRows197,PgSelectSingle198,PgSelect200,First202,PgSelectRows203,PgSelectSingle204,First207,PgSelectRows208,PgSelectSingle209,PgSelect211,First213,PgSelectRows214,PgSelectSingle215,First218,PgSelectRows219,PgSelectSingle220,PgSelect222,First224,PgSelectRows225,PgSelectSingle226,First229,PgSelectRows230,PgSelectSingle231 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 187<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[187]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression188 bucket15
@@ -620,9 +620,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 231<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[231]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression232 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 242, 10, 244<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 245, 253<br />2: 246, 254, 260, 271, 282, 293<br />3: 251, 257, 263, 268, 274, 279, 285, 290, 296, 301<br />ᐳ: 250, 252, 256, 258, 262, 264, 267, 269, 273, 275, 278, 280, 284, 286, 289, 291, 295, 297, 300, 302"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 245, 253, 244<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 246, 254, 260, 271, 282, 293<br />2: 251, 257, 263, 268, 274, 279, 285, 290, 296, 301<br />ᐳ: 250, 252, 256, 258, 262, 264, 267, 269, 273, 275, 278, 280, 284, 286, 289, 291, 295, 297, 300, 302"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression245,PgSelect246,First250,PgSelectRows251,PgSelectSingle252,PgClassExpression253,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgSelect260,First262,PgSelectRows263,PgSelectSingle264,First267,PgSelectRows268,PgSelectSingle269,PgSelect271,First273,PgSelectRows274,PgSelectSingle275,First278,PgSelectRows279,PgSelectSingle280,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,First289,PgSelectRows290,PgSelectSingle291,PgSelect293,First295,PgSelectRows296,PgSelectSingle297,First300,PgSelectRows301,PgSelectSingle302 bucket20
+    class Bucket20,PgSelect246,First250,PgSelectRows251,PgSelectSingle252,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgSelect260,First262,PgSelectRows263,PgSelectSingle264,First267,PgSelectRows268,PgSelectSingle269,PgSelect271,First273,PgSelectRows274,PgSelectSingle275,First278,PgSelectRows279,PgSelectSingle280,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,First289,PgSelectRows290,PgSelectSingle291,PgSelect293,First295,PgSelectRows296,PgSelectSingle297,First300,PgSelectRows301,PgSelectSingle302 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 258<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[258]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression259 bucket21
@@ -638,9 +638,9 @@ graph TD
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 302<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[302]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgClassExpression303 bucket25
-    Bucket26("Bucket 26 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 313, 10, 315<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 316, 324<br />2: 317, 325, 331, 342, 353, 364<br />3: 322, 328, 334, 339, 345, 350, 356, 361, 367, 372<br />ᐳ: 321, 323, 327, 329, 333, 335, 338, 340, 344, 346, 349, 351, 355, 357, 360, 362, 366, 368, 371, 373"):::bucket
+    Bucket26("Bucket 26 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 316, 324, 315<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 317, 325, 331, 342, 353, 364<br />2: 322, 328, 334, 339, 345, 350, 356, 361, 367, 372<br />ᐳ: 321, 323, 327, 329, 333, 335, 338, 340, 344, 346, 349, 351, 355, 357, 360, 362, 366, 368, 371, 373"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,PgClassExpression316,PgSelect317,First321,PgSelectRows322,PgSelectSingle323,PgClassExpression324,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,PgSelect331,First333,PgSelectRows334,PgSelectSingle335,First338,PgSelectRows339,PgSelectSingle340,PgSelect342,First344,PgSelectRows345,PgSelectSingle346,First349,PgSelectRows350,PgSelectSingle351,PgSelect353,First355,PgSelectRows356,PgSelectSingle357,First360,PgSelectRows361,PgSelectSingle362,PgSelect364,First366,PgSelectRows367,PgSelectSingle368,First371,PgSelectRows372,PgSelectSingle373 bucket26
+    class Bucket26,PgSelect317,First321,PgSelectRows322,PgSelectSingle323,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,PgSelect331,First333,PgSelectRows334,PgSelectSingle335,First338,PgSelectRows339,PgSelectSingle340,PgSelect342,First344,PgSelectRows345,PgSelectSingle346,First349,PgSelectRows350,PgSelectSingle351,PgSelect353,First355,PgSelectRows356,PgSelectSingle357,First360,PgSelectRows361,PgSelectSingle362,PgSelect364,First366,PgSelectRows367,PgSelectSingle368,First371,PgSelectRows372,PgSelectSingle373 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 329<br /><br />ROOT PgSelectSingle{26}ᐸpeopleᐳ[329]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgClassExpression330 bucket27

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/relation.mermaid
@@ -29,12 +29,14 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
+    PgClassExpression24{{"PgClassExpression[24∈0] ➊<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression24
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect25[["PgSelect[25∈1] ➊<br />ᐸrelational_itemsᐳ<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression24{{"PgClassExpression[24∈1] ➊<br />ᐸ__relation...parent_id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression24 --> PgSelect25
     PgPolymorphic31{{"PgPolymorphic[31∈1] ➊<br />ᐳRelationalTopic"}}:::plan
     PgSelectSingle29{{"PgSelectSingle[29∈1] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
@@ -64,20 +66,22 @@ graph TD
     PgSelectSingle313{{"PgSelectSingle[313∈1] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     PgClassExpression314{{"PgClassExpression[314∈1] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
     PgSelectSingle313 & PgClassExpression314 --> PgPolymorphic315
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
     PgSelect17 --> PgSelectRows22
     PgSelectSingle23{{"PgSelectSingle[23∈1] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First21 --> PgSelectSingle23
-    PgSelectSingle13 --> PgClassExpression24
     First27{{"First[27∈1] ➊"}}:::plan
     PgSelectRows28[["PgSelectRows[28∈1] ➊<br />ᐳRelationalTopic"]]:::plan
     PgSelectRows28 --> First27
     PgSelect25 --> PgSelectRows28
     First27 --> PgSelectSingle29
     PgSelectSingle29 --> PgClassExpression30
+    PgClassExpression32{{"PgClassExpression[32∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle29 --> PgClassExpression32
+    PgClassExpression40{{"PgClassExpression[40∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle29 --> PgClassExpression40
     First93{{"First[93∈1] ➊"}}:::plan
     PgSelectRows94[["PgSelectRows[94∈1] ➊"]]:::plan
     PgSelectRows94 --> First93
@@ -90,6 +94,10 @@ graph TD
     PgSelect25 --> PgSelectRows99
     First98 --> PgSelectSingle100
     PgSelectSingle100 --> PgClassExpression101
+    PgClassExpression103{{"PgClassExpression[103∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle100 --> PgClassExpression103
+    PgClassExpression111{{"PgClassExpression[111∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle100 --> PgClassExpression111
     First164{{"First[164∈1] ➊"}}:::plan
     PgSelectRows165[["PgSelectRows[165∈1] ➊"]]:::plan
     PgSelectRows165 --> First164
@@ -102,6 +110,10 @@ graph TD
     PgSelect25 --> PgSelectRows170
     First169 --> PgSelectSingle171
     PgSelectSingle171 --> PgClassExpression172
+    PgClassExpression174{{"PgClassExpression[174∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle171 --> PgClassExpression174
+    PgClassExpression182{{"PgClassExpression[182∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle171 --> PgClassExpression182
     First235{{"First[235∈1] ➊"}}:::plan
     PgSelectRows236[["PgSelectRows[236∈1] ➊"]]:::plan
     PgSelectRows236 --> First235
@@ -114,6 +126,10 @@ graph TD
     PgSelect25 --> PgSelectRows241
     First240 --> PgSelectSingle242
     PgSelectSingle242 --> PgClassExpression243
+    PgClassExpression245{{"PgClassExpression[245∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle242 --> PgClassExpression245
+    PgClassExpression253{{"PgClassExpression[253∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle242 --> PgClassExpression253
     First306{{"First[306∈1] ➊"}}:::plan
     PgSelectRows307[["PgSelectRows[307∈1] ➊"]]:::plan
     PgSelectRows307 --> First306
@@ -126,11 +142,13 @@ graph TD
     PgSelect25 --> PgSelectRows312
     First311 --> PgSelectSingle313
     PgSelectSingle313 --> PgClassExpression314
+    PgClassExpression316{{"PgClassExpression[316∈1] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle313 --> PgClassExpression316
+    PgClassExpression324{{"PgClassExpression[324∈1] ➊<br />ᐸ__relation...author_id”ᐳ"}}:::plan
+    PgSelectSingle313 --> PgClassExpression324
     PgSelect33[["PgSelect[33∈2] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression32{{"PgClassExpression[32∈2] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression32 --> PgSelect33
     PgSelect41[["PgSelect[41∈2] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression40{{"PgClassExpression[40∈2] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression40 --> PgSelect41
     PgSelect47[["PgSelect[47∈2] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalTopicᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression32 --> PgSelect47
@@ -140,14 +158,12 @@ graph TD
     Object10 & PgClassExpression32 --> PgSelect69
     PgSelect80[["PgSelect[80∈2] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression32 --> PgSelect80
-    PgSelectSingle29 --> PgClassExpression32
     First37{{"First[37∈2] ➊"}}:::plan
     PgSelectRows38[["PgSelectRows[38∈2] ➊"]]:::plan
     PgSelectRows38 --> First37
     PgSelect33 --> PgSelectRows38
     PgSelectSingle39{{"PgSelectSingle[39∈2] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First37 --> PgSelectSingle39
-    PgSelectSingle29 --> PgClassExpression40
     First43{{"First[43∈2] ➊"}}:::plan
     PgSelectRows44[["PgSelectRows[44∈2] ➊<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
     PgSelectRows44 --> First43
@@ -213,10 +229,8 @@ graph TD
     PgClassExpression90{{"PgClassExpression[90∈7] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle89 --> PgClassExpression90
     PgSelect104[["PgSelect[104∈8] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression103{{"PgClassExpression[103∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression103 --> PgSelect104
     PgSelect112[["PgSelect[112∈8] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈8] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression111 --> PgSelect112
     PgSelect118[["PgSelect[118∈8] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalPostᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression103 --> PgSelect118
@@ -226,14 +240,12 @@ graph TD
     Object10 & PgClassExpression103 --> PgSelect140
     PgSelect151[["PgSelect[151∈8] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression103 --> PgSelect151
-    PgSelectSingle100 --> PgClassExpression103
     First108{{"First[108∈8] ➊"}}:::plan
     PgSelectRows109[["PgSelectRows[109∈8] ➊"]]:::plan
     PgSelectRows109 --> First108
     PgSelect104 --> PgSelectRows109
     PgSelectSingle110{{"PgSelectSingle[110∈8] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First108 --> PgSelectSingle110
-    PgSelectSingle100 --> PgClassExpression111
     First114{{"First[114∈8] ➊"}}:::plan
     PgSelectRows115[["PgSelectRows[115∈8] ➊<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
     PgSelectRows115 --> First114
@@ -299,10 +311,8 @@ graph TD
     PgClassExpression161{{"PgClassExpression[161∈13] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle160 --> PgClassExpression161
     PgSelect175[["PgSelect[175∈14] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression174{{"PgClassExpression[174∈14] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression174 --> PgSelect175
     PgSelect183[["PgSelect[183∈14] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression182{{"PgClassExpression[182∈14] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression182 --> PgSelect183
     PgSelect189[["PgSelect[189∈14] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalDividerᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression174 --> PgSelect189
@@ -312,14 +322,12 @@ graph TD
     Object10 & PgClassExpression174 --> PgSelect211
     PgSelect222[["PgSelect[222∈14] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression174 --> PgSelect222
-    PgSelectSingle171 --> PgClassExpression174
     First179{{"First[179∈14] ➊"}}:::plan
     PgSelectRows180[["PgSelectRows[180∈14] ➊"]]:::plan
     PgSelectRows180 --> First179
     PgSelect175 --> PgSelectRows180
     PgSelectSingle181{{"PgSelectSingle[181∈14] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First179 --> PgSelectSingle181
-    PgSelectSingle171 --> PgClassExpression182
     First185{{"First[185∈14] ➊"}}:::plan
     PgSelectRows186[["PgSelectRows[186∈14] ➊<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
     PgSelectRows186 --> First185
@@ -385,10 +393,8 @@ graph TD
     PgClassExpression232{{"PgClassExpression[232∈19] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle231 --> PgClassExpression232
     PgSelect246[["PgSelect[246∈20] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression245{{"PgClassExpression[245∈20] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression245 --> PgSelect246
     PgSelect254[["PgSelect[254∈20] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression253{{"PgClassExpression[253∈20] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression253 --> PgSelect254
     PgSelect260[["PgSelect[260∈20] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression245 --> PgSelect260
@@ -398,14 +404,12 @@ graph TD
     Object10 & PgClassExpression245 --> PgSelect282
     PgSelect293[["PgSelect[293∈20] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression245 --> PgSelect293
-    PgSelectSingle242 --> PgClassExpression245
     First250{{"First[250∈20] ➊"}}:::plan
     PgSelectRows251[["PgSelectRows[251∈20] ➊"]]:::plan
     PgSelectRows251 --> First250
     PgSelect246 --> PgSelectRows251
     PgSelectSingle252{{"PgSelectSingle[252∈20] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First250 --> PgSelectSingle252
-    PgSelectSingle242 --> PgClassExpression253
     First256{{"First[256∈20] ➊"}}:::plan
     PgSelectRows257[["PgSelectRows[257∈20] ➊<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
     PgSelectRows257 --> First256
@@ -471,10 +475,8 @@ graph TD
     PgClassExpression303{{"PgClassExpression[303∈25] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle302 --> PgClassExpression303
     PgSelect317[["PgSelect[317∈26] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression316{{"PgClassExpression[316∈26] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression316 --> PgSelect317
     PgSelect325[["PgSelect[325∈26] ➊<br />ᐸpeopleᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
-    PgClassExpression324{{"PgClassExpression[324∈26] ➊<br />ᐸ__relation...author_id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression324 --> PgSelect325
     PgSelect331[["PgSelect[331∈26] ➊<br />ᐸrelational_postsᐳ<br />ᐳRelationalChecklistItemᐳRelationalPost"]]:::plan
     Object10 & PgClassExpression316 --> PgSelect331
@@ -484,14 +486,12 @@ graph TD
     Object10 & PgClassExpression316 --> PgSelect353
     PgSelect364[["PgSelect[364∈26] ➊<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"]]:::plan
     Object10 & PgClassExpression316 --> PgSelect364
-    PgSelectSingle313 --> PgClassExpression316
     First321{{"First[321∈26] ➊"}}:::plan
     PgSelectRows322[["PgSelectRows[322∈26] ➊"]]:::plan
     PgSelectRows322 --> First321
     PgSelect317 --> PgSelectRows322
     PgSelectSingle323{{"PgSelectSingle[323∈26] ➊<br />ᐸrelational_topicsᐳ"}}:::plan
     First321 --> PgSelectSingle323
-    PgSelectSingle313 --> PgClassExpression324
     First327{{"First[327∈26] ➊"}}:::plan
     PgSelectRows328[["PgSelectRows[328∈26] ➊<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
     PgSelectRows328 --> First327
@@ -560,15 +560,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-relational/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 375, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 375, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15, 16, 24"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,Constant375 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 13, 10, 15<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 16, 24<br />2: 17, 25, 91, 162, 233, 304<br />3: 22, 28, 94, 99, 165, 170, 236, 241, 307, 312<br />ᐳ: 21, 23, 27, 29, 30, 31, 93, 95, 98, 100, 101, 102, 164, 166, 169, 171, 172, 173, 235, 237, 240, 242, 243, 244, 306, 308, 311, 313, 314, 315"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,PgClassExpression24,Constant375 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 16, 24, 15<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 17, 25, 91, 162, 233, 304<br />2: 22, 28, 94, 99, 165, 170, 236, 241, 307, 312<br />ᐳ: 21, 23, 27, 29, 30, 31, 32, 40, 93, 95, 98, 100, 101, 102, 103, 111, 164, 166, 169, 171, 172, 173, 174, 182, 235, 237, 240, 242, 243, 244, 245, 253, 306, 308, 311, 313, 314, 315, 316, 324"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgSelect25,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgPolymorphic31,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression101,PgPolymorphic102,PgSelect162,First164,PgSelectRows165,PgSelectSingle166,First169,PgSelectRows170,PgSelectSingle171,PgClassExpression172,PgPolymorphic173,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,First240,PgSelectRows241,PgSelectSingle242,PgClassExpression243,PgPolymorphic244,PgSelect304,First306,PgSelectRows307,PgSelectSingle308,First311,PgSelectRows312,PgSelectSingle313,PgClassExpression314,PgPolymorphic315 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 29, 10, 31<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 32, 40<br />2: 33, 41, 47, 58, 69, 80<br />3: 38, 44, 50, 55, 61, 66, 72, 77, 83, 88<br />ᐳ: 37, 39, 43, 45, 49, 51, 54, 56, 60, 62, 65, 67, 71, 73, 76, 78, 82, 84, 87, 89"):::bucket
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgSelect25,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgPolymorphic31,PgClassExpression32,PgClassExpression40,PgSelect91,First93,PgSelectRows94,PgSelectSingle95,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression101,PgPolymorphic102,PgClassExpression103,PgClassExpression111,PgSelect162,First164,PgSelectRows165,PgSelectSingle166,First169,PgSelectRows170,PgSelectSingle171,PgClassExpression172,PgPolymorphic173,PgClassExpression174,PgClassExpression182,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,First240,PgSelectRows241,PgSelectSingle242,PgClassExpression243,PgPolymorphic244,PgClassExpression245,PgClassExpression253,PgSelect304,First306,PgSelectRows307,PgSelectSingle308,First311,PgSelectRows312,PgSelectSingle313,PgClassExpression314,PgPolymorphic315,PgClassExpression316,PgClassExpression324 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 32, 40, 31<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 33, 41, 47, 58, 69, 80<br />2: 38, 44, 50, 55, 61, 66, 72, 77, 83, 88<br />ᐳ: 37, 39, 43, 45, 49, 51, 54, 56, 60, 62, 65, 67, 71, 73, 76, 78, 82, 84, 87, 89"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression32,PgSelect33,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgSelect41,First43,PgSelectRows44,PgSelectSingle45,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,First54,PgSelectRows55,PgSelectSingle56,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,First65,PgSelectRows66,PgSelectSingle67,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,First76,PgSelectRows77,PgSelectSingle78,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89 bucket2
+    class Bucket2,PgSelect33,First37,PgSelectRows38,PgSelectSingle39,PgSelect41,First43,PgSelectRows44,PgSelectSingle45,PgSelect47,First49,PgSelectRows50,PgSelectSingle51,First54,PgSelectRows55,PgSelectSingle56,PgSelect58,First60,PgSelectRows61,PgSelectSingle62,First65,PgSelectRows66,PgSelectSingle67,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,First76,PgSelectRows77,PgSelectSingle78,PgSelect80,First82,PgSelectRows83,PgSelectSingle84,First87,PgSelectRows88,PgSelectSingle89 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 45<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[45]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression46 bucket3
@@ -584,9 +584,9 @@ graph TD
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 89<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[89]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression90 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 100, 10, 102<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 103, 111<br />2: 104, 112, 118, 129, 140, 151<br />3: 109, 115, 121, 126, 132, 137, 143, 148, 154, 159<br />ᐳ: 108, 110, 114, 116, 120, 122, 125, 127, 131, 133, 136, 138, 142, 144, 147, 149, 153, 155, 158, 160"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 103, 111, 102<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 104, 112, 118, 129, 140, 151<br />2: 109, 115, 121, 126, 132, 137, 143, 148, 154, 159<br />ᐳ: 108, 110, 114, 116, 120, 122, 125, 127, 131, 133, 136, 138, 142, 144, 147, 149, 153, 155, 158, 160"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression103,PgSelect104,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgSelect118,First120,PgSelectRows121,PgSelectSingle122,First125,PgSelectRows126,PgSelectSingle127,PgSelect129,First131,PgSelectRows132,PgSelectSingle133,First136,PgSelectRows137,PgSelectSingle138,PgSelect140,First142,PgSelectRows143,PgSelectSingle144,First147,PgSelectRows148,PgSelectSingle149,PgSelect151,First153,PgSelectRows154,PgSelectSingle155,First158,PgSelectRows159,PgSelectSingle160 bucket8
+    class Bucket8,PgSelect104,First108,PgSelectRows109,PgSelectSingle110,PgSelect112,First114,PgSelectRows115,PgSelectSingle116,PgSelect118,First120,PgSelectRows121,PgSelectSingle122,First125,PgSelectRows126,PgSelectSingle127,PgSelect129,First131,PgSelectRows132,PgSelectSingle133,First136,PgSelectRows137,PgSelectSingle138,PgSelect140,First142,PgSelectRows143,PgSelectSingle144,First147,PgSelectRows148,PgSelectSingle149,PgSelect151,First153,PgSelectRows154,PgSelectSingle155,First158,PgSelectRows159,PgSelectSingle160 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 116<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[116]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression117 bucket9
@@ -602,9 +602,9 @@ graph TD
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 160<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[160]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression161 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 171, 10, 173<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 174, 182<br />2: 175, 183, 189, 200, 211, 222<br />3: 180, 186, 192, 197, 203, 208, 214, 219, 225, 230<br />ᐳ: 179, 181, 185, 187, 191, 193, 196, 198, 202, 204, 207, 209, 213, 215, 218, 220, 224, 226, 229, 231"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 174, 182, 173<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 175, 183, 189, 200, 211, 222<br />2: 180, 186, 192, 197, 203, 208, 214, 219, 225, 230<br />ᐳ: 179, 181, 185, 187, 191, 193, 196, 198, 202, 204, 207, 209, 213, 215, 218, 220, 224, 226, 229, 231"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression174,PgSelect175,First179,PgSelectRows180,PgSelectSingle181,PgClassExpression182,PgSelect183,First185,PgSelectRows186,PgSelectSingle187,PgSelect189,First191,PgSelectRows192,PgSelectSingle193,First196,PgSelectRows197,PgSelectSingle198,PgSelect200,First202,PgSelectRows203,PgSelectSingle204,First207,PgSelectRows208,PgSelectSingle209,PgSelect211,First213,PgSelectRows214,PgSelectSingle215,First218,PgSelectRows219,PgSelectSingle220,PgSelect222,First224,PgSelectRows225,PgSelectSingle226,First229,PgSelectRows230,PgSelectSingle231 bucket14
+    class Bucket14,PgSelect175,First179,PgSelectRows180,PgSelectSingle181,PgSelect183,First185,PgSelectRows186,PgSelectSingle187,PgSelect189,First191,PgSelectRows192,PgSelectSingle193,First196,PgSelectRows197,PgSelectSingle198,PgSelect200,First202,PgSelectRows203,PgSelectSingle204,First207,PgSelectRows208,PgSelectSingle209,PgSelect211,First213,PgSelectRows214,PgSelectSingle215,First218,PgSelectRows219,PgSelectSingle220,PgSelect222,First224,PgSelectRows225,PgSelectSingle226,First229,PgSelectRows230,PgSelectSingle231 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 187<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[187]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression188 bucket15
@@ -620,9 +620,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 231<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[231]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression232 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 242, 10, 244<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 245, 253<br />2: 246, 254, 260, 271, 282, 293<br />3: 251, 257, 263, 268, 274, 279, 285, 290, 296, 301<br />ᐳ: 250, 252, 256, 258, 262, 264, 267, 269, 273, 275, 278, 280, 284, 286, 289, 291, 295, 297, 300, 302"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 245, 253, 244<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 246, 254, 260, 271, 282, 293<br />2: 251, 257, 263, 268, 274, 279, 285, 290, 296, 301<br />ᐳ: 250, 252, 256, 258, 262, 264, 267, 269, 273, 275, 278, 280, 284, 286, 289, 291, 295, 297, 300, 302"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression245,PgSelect246,First250,PgSelectRows251,PgSelectSingle252,PgClassExpression253,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgSelect260,First262,PgSelectRows263,PgSelectSingle264,First267,PgSelectRows268,PgSelectSingle269,PgSelect271,First273,PgSelectRows274,PgSelectSingle275,First278,PgSelectRows279,PgSelectSingle280,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,First289,PgSelectRows290,PgSelectSingle291,PgSelect293,First295,PgSelectRows296,PgSelectSingle297,First300,PgSelectRows301,PgSelectSingle302 bucket20
+    class Bucket20,PgSelect246,First250,PgSelectRows251,PgSelectSingle252,PgSelect254,First256,PgSelectRows257,PgSelectSingle258,PgSelect260,First262,PgSelectRows263,PgSelectSingle264,First267,PgSelectRows268,PgSelectSingle269,PgSelect271,First273,PgSelectRows274,PgSelectSingle275,First278,PgSelectRows279,PgSelectSingle280,PgSelect282,First284,PgSelectRows285,PgSelectSingle286,First289,PgSelectRows290,PgSelectSingle291,PgSelect293,First295,PgSelectRows296,PgSelectSingle297,First300,PgSelectRows301,PgSelectSingle302 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 258<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[258]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression259 bucket21
@@ -638,9 +638,9 @@ graph TD
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 302<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[302]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgClassExpression303 bucket25
-    Bucket26("Bucket 26 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 313, 10, 315<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 316, 324<br />2: 317, 325, 331, 342, 353, 364<br />3: 322, 328, 334, 339, 345, 350, 356, 361, 367, 372<br />ᐳ: 321, 323, 327, 329, 333, 335, 338, 340, 344, 346, 349, 351, 355, 357, 360, 362, 366, 368, 371, 373"):::bucket
+    Bucket26("Bucket 26 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 10, 316, 324, 315<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 317, 325, 331, 342, 353, 364<br />2: 322, 328, 334, 339, 345, 350, 356, 361, 367, 372<br />ᐳ: 321, 323, 327, 329, 333, 335, 338, 340, 344, 346, 349, 351, 355, 357, 360, 362, 366, 368, 371, 373"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,PgClassExpression316,PgSelect317,First321,PgSelectRows322,PgSelectSingle323,PgClassExpression324,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,PgSelect331,First333,PgSelectRows334,PgSelectSingle335,First338,PgSelectRows339,PgSelectSingle340,PgSelect342,First344,PgSelectRows345,PgSelectSingle346,First349,PgSelectRows350,PgSelectSingle351,PgSelect353,First355,PgSelectRows356,PgSelectSingle357,First360,PgSelectRows361,PgSelectSingle362,PgSelect364,First366,PgSelectRows367,PgSelectSingle368,First371,PgSelectRows372,PgSelectSingle373 bucket26
+    class Bucket26,PgSelect317,First321,PgSelectRows322,PgSelectSingle323,PgSelect325,First327,PgSelectRows328,PgSelectSingle329,PgSelect331,First333,PgSelectRows334,PgSelectSingle335,First338,PgSelectRows339,PgSelectSingle340,PgSelect342,First344,PgSelectRows345,PgSelectSingle346,First349,PgSelectRows350,PgSelectSingle351,PgSelect353,First355,PgSelectRows356,PgSelectSingle357,First360,PgSelectRows361,PgSelectSingle362,PgSelect364,First366,PgSelectRows367,PgSelectSingle368,First371,PgSelectRows372,PgSelectSingle373 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 329<br /><br />ROOT PgSelectSingle{26}ᐸpeopleᐳ[329]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgClassExpression330 bucket27

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.mermaid
@@ -49,25 +49,25 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression28
-    PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression30{{"PgClassExpression[30∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression30
-    PgClassExpression31{{"PgClassExpression[31∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression31
-    PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression32
-    PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression33
-    PgClassExpression34{{"PgClassExpression[34∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression34
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle24 --> PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression38
     PgClassExpression39{{"PgClassExpression[39∈5]<br />ᐸ__single_t...__.”color”ᐳ<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle24 --> PgClassExpression39
@@ -87,12 +87,12 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 28, 30, 31, 32, 33, 34, 35<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 27, 28, 25, 30, 31, 32, 33, 34, 35<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39 bucket5
+    class Bucket5,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.mermaid
@@ -49,25 +49,25 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression28
-    PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression30{{"PgClassExpression[30∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression30
-    PgClassExpression31{{"PgClassExpression[31∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression31
-    PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression32
-    PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression33
-    PgClassExpression34{{"PgClassExpression[34∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression34
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle24 --> PgClassExpression36
-    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression37{{"PgClassExpression[37∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression38{{"PgClassExpression[38∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression38
     PgClassExpression39{{"PgClassExpression[39∈5]<br />ᐸ__single_t...__.”color”ᐳ<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle24 --> PgClassExpression39
@@ -87,12 +87,12 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 28, 30, 31, 32, 33, 34, 35<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 27, 28, 25, 30, 31, 32, 33, 34, 35<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39 bucket5
+    class Bucket5,PgClassExpression36,PgClassExpression37,PgClassExpression38,PgClassExpression39 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.mermaid
@@ -49,19 +49,19 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression28
-    PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression30{{"PgClassExpression[30∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression30
-    PgClassExpression31{{"PgClassExpression[31∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression31
-    PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression32
-    PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression33
-    PgClassExpression34{{"PgClassExpression[34∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression34
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression35
 
     %% define steps
@@ -79,12 +79,12 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 28, 30, 31, 32, 33, 34, 35<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 27, 24, 28, 25, 30, 31, 32, 33, 34, 35<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket5
+    class Bucket5 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.mermaid
@@ -49,19 +49,19 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression28
-    PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression30{{"PgClassExpression[30∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression30
-    PgClassExpression31{{"PgClassExpression[31∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression31
-    PgClassExpression32{{"PgClassExpression[32∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression32
-    PgClassExpression33{{"PgClassExpression[33∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression33
-    PgClassExpression34{{"PgClassExpression[34∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression34
-    PgClassExpression35{{"PgClassExpression[35∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression35
 
     %% define steps
@@ -79,12 +79,12 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 28, 30, 31, 32, 33, 34, 35<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 27, 24, 28, 25, 30, 31, 32, 33, 34, 35<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35 bucket5
+    class Bucket5 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.mermaid
@@ -49,30 +49,45 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
+    PgClassExpression84{{"PgClassExpression[84∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression84
+    PgClassExpression86{{"PgClassExpression[86∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression86
+    PgClassExpression87{{"PgClassExpression[87∈4]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression87
+    PgClassExpression94{{"PgClassExpression[94∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression94
+    PgClassExpression95{{"PgClassExpression[95∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression95
+    PgClassExpression96{{"PgClassExpression[96∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression96
+    PgClassExpression97{{"PgClassExpression[97∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression97
+    PgClassExpression98{{"PgClassExpression[98∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression98
     PgSelect29[["PgSelect[29∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object9 & PgClassExpression28 --> PgSelect29
     PgSingleTablePolymorphic38["PgSingleTablePolymorphic[38∈5]<br />ᐳSingleTableTopic"]:::plan
-    Lambda37{{"Lambda[37∈5]"}}:::plan
+    Lambda37{{"Lambda[37∈5]<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle35{{"PgSelectSingle[35∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda37 & PgSelectSingle35 --> PgSingleTablePolymorphic38
     PgSelect88[["PgSelect[88∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression87{{"PgClassExpression[87∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression87 --> PgSelect88
     PgSingleTablePolymorphic107["PgSingleTablePolymorphic[107∈5]<br />ᐳSingleTablePost"]:::plan
-    Lambda106{{"Lambda[106∈5]"}}:::plan
+    Lambda106{{"Lambda[106∈5]<br />ᐳSingleTablePost"}}:::plan
     PgSelectSingle104{{"PgSelectSingle[104∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda106 & PgSelectSingle104 --> PgSingleTablePolymorphic107
     PgSingleTablePolymorphic168["PgSingleTablePolymorphic[168∈5]<br />ᐳSingleTableDivider"]:::plan
-    Lambda167{{"Lambda[167∈5]"}}:::plan
+    Lambda167{{"Lambda[167∈5]<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle165{{"PgSelectSingle[165∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda167 & PgSelectSingle165 --> PgSingleTablePolymorphic168
     PgSingleTablePolymorphic228["PgSingleTablePolymorphic[228∈5]<br />ᐳSingleTableChecklist"]:::plan
-    Lambda227{{"Lambda[227∈5]"}}:::plan
+    Lambda227{{"Lambda[227∈5]<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle225{{"PgSelectSingle[225∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda227 & PgSelectSingle225 --> PgSingleTablePolymorphic228
     PgSingleTablePolymorphic287["PgSingleTablePolymorphic[287∈5]<br />ᐳSingleTableChecklistItem"]:::plan
-    Lambda286{{"Lambda[286∈5]"}}:::plan
+    Lambda286{{"Lambda[286∈5]<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284{{"PgSelectSingle[284∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda286 & PgSelectSingle284 --> PgSingleTablePolymorphic287
     PgSelectSingle24 --> PgClassExpression28
@@ -81,58 +96,85 @@ graph TD
     PgSelectRows34 --> First33
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression36 --> Lambda37
-    PgClassExpression84{{"PgClassExpression[84∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression84
-    PgClassExpression86{{"PgClassExpression[86∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression86
-    PgSelectSingle24 --> PgClassExpression87
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression41
+    PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression42
+    PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression51
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression53
+    PgClassExpression54{{"PgClassExpression[54∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression54
+    PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression55
     First90{{"First[90∈5]"}}:::plan
     PgSelectRows91[["PgSelectRows[91∈5]<br />ᐳSingleTableTopic"]]:::plan
     PgSelectRows91 --> First90
     PgSelect88 --> PgSelectRows91
     PgSelectSingle92{{"PgSelectSingle[92∈5]<br />ᐸpeopleᐳ"}}:::plan
     First90 --> PgSelectSingle92
-    PgClassExpression94{{"PgClassExpression[94∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression94
-    PgClassExpression95{{"PgClassExpression[95∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression95
-    PgClassExpression96{{"PgClassExpression[96∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression96
-    PgClassExpression97{{"PgClassExpression[97∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression97
-    PgClassExpression98{{"PgClassExpression[98∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression98
-    PgClassExpression99{{"PgClassExpression[99∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression99{{"PgClassExpression[99∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle24 --> PgClassExpression99
     First102{{"First[102∈5]"}}:::plan
     PgSelectRows103[["PgSelectRows[103∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows103 --> First102
     PgSelect29 --> PgSelectRows103
     First102 --> PgSelectSingle104
-    PgClassExpression105{{"PgClassExpression[105∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression105{{"PgClassExpression[105∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle104 --> PgClassExpression105
     PgClassExpression105 --> Lambda106
+    PgClassExpression110{{"PgClassExpression[110∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression110
+    PgClassExpression111{{"PgClassExpression[111∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression111
+    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression120
+    PgClassExpression121{{"PgClassExpression[121∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression121
+    PgClassExpression122{{"PgClassExpression[122∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression122
+    PgClassExpression123{{"PgClassExpression[123∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression123
+    PgClassExpression124{{"PgClassExpression[124∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression124
     First155{{"First[155∈5]"}}:::plan
     PgSelectRows156[["PgSelectRows[156∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows156 --> First155
     PgSelect88 --> PgSelectRows156
     PgSelectSingle157{{"PgSelectSingle[157∈5]<br />ᐸpeopleᐳ"}}:::plan
     First155 --> PgSelectSingle157
-    PgClassExpression159{{"PgClassExpression[159∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression159{{"PgClassExpression[159∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression159
-    PgClassExpression160{{"PgClassExpression[160∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression160{{"PgClassExpression[160∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression160
     First163{{"First[163∈5]"}}:::plan
     PgSelectRows164[["PgSelectRows[164∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows164 --> First163
     PgSelect29 --> PgSelectRows164
     First163 --> PgSelectSingle165
-    PgClassExpression166{{"PgClassExpression[166∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression166{{"PgClassExpression[166∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle165 --> PgClassExpression166
     PgClassExpression166 --> Lambda167
+    PgClassExpression171{{"PgClassExpression[171∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression171
+    PgClassExpression172{{"PgClassExpression[172∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression172
+    PgClassExpression181{{"PgClassExpression[181∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression181
+    PgClassExpression182{{"PgClassExpression[182∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression182
+    PgClassExpression183{{"PgClassExpression[183∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression183
+    PgClassExpression184{{"PgClassExpression[184∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression184
+    PgClassExpression185{{"PgClassExpression[185∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression185
     First216{{"First[216∈5]"}}:::plan
     PgSelectRows217[["PgSelectRows[217∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows217 --> First216
@@ -146,9 +188,23 @@ graph TD
     PgSelectRows224 --> First223
     PgSelect29 --> PgSelectRows224
     First223 --> PgSelectSingle225
-    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle225 --> PgClassExpression226
     PgClassExpression226 --> Lambda227
+    PgClassExpression231{{"PgClassExpression[231∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression231
+    PgClassExpression232{{"PgClassExpression[232∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression232
+    PgClassExpression241{{"PgClassExpression[241∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression241
+    PgClassExpression242{{"PgClassExpression[242∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression242
+    PgClassExpression243{{"PgClassExpression[243∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression243
+    PgClassExpression244{{"PgClassExpression[244∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression244
+    PgClassExpression245{{"PgClassExpression[245∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression245
     First276{{"First[276∈5]"}}:::plan
     PgSelectRows277[["PgSelectRows[277∈5]<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows277 --> First276
@@ -160,9 +216,23 @@ graph TD
     PgSelectRows283 --> First282
     PgSelect29 --> PgSelectRows283
     First282 --> PgSelectSingle284
-    PgClassExpression285{{"PgClassExpression[285∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression285{{"PgClassExpression[285∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284 --> PgClassExpression285
     PgClassExpression285 --> Lambda286
+    PgClassExpression290{{"PgClassExpression[290∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression290
+    PgClassExpression291{{"PgClassExpression[291∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression291
+    PgClassExpression300{{"PgClassExpression[300∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression300
+    PgClassExpression301{{"PgClassExpression[301∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression301
+    PgClassExpression302{{"PgClassExpression[302∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression302
+    PgClassExpression303{{"PgClassExpression[303∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression303
+    PgClassExpression304{{"PgClassExpression[304∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression304
     First335{{"First[335∈5]"}}:::plan
     PgSelectRows336[["PgSelectRows[336∈5]<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows336 --> First335
@@ -170,28 +240,14 @@ graph TD
     PgSelectSingle337{{"PgSelectSingle[337∈5]<br />ᐸpeopleᐳ"}}:::plan
     First335 --> PgSelectSingle337
     PgSelect43[["PgSelect[43∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression42{{"PgClassExpression[42∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression42 --> PgSelect43
-    PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression41
-    PgSelectSingle35 --> PgClassExpression42
     First47{{"First[47∈6]"}}:::plan
     PgSelectRows48[["PgSelectRows[48∈6]<br />ᐳSingleTableTopicᐳSingleTableTopic"]]:::plan
     PgSelectRows48 --> First47
     PgSelect43 --> PgSelectRows48
     PgSelectSingle49{{"PgSelectSingle[49∈6]<br />ᐸpeopleᐳ"}}:::plan
     First47 --> PgSelectSingle49
-    PgClassExpression51{{"PgClassExpression[51∈6]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression51
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression52
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression53
-    PgClassExpression54{{"PgClassExpression[54∈6]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression54
-    PgClassExpression55{{"PgClassExpression[55∈6]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression55
-    PgClassExpression56{{"PgClassExpression[56∈6]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
+    PgClassExpression56{{"PgClassExpression[56∈6]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist"}}:::plan
     PgSelectSingle35 --> PgClassExpression56
     First59{{"First[59∈6]"}}:::plan
     PgSelectRows60[["PgSelectRows[60∈6]<br />ᐳSingleTableTopicᐳSingleTablePost"]]:::plan
@@ -199,9 +255,9 @@ graph TD
     PgSelect43 --> PgSelectRows60
     PgSelectSingle61{{"PgSelectSingle[61∈6]<br />ᐸpeopleᐳ"}}:::plan
     First59 --> PgSelectSingle61
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost"}}:::plan
+    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost"}}:::plan
+    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression64
     First67{{"First[67∈6]"}}:::plan
     PgSelectRows68[["PgSelectRows[68∈6]<br />ᐳSingleTableTopicᐳSingleTableDivider"]]:::plan
@@ -236,28 +292,14 @@ graph TD
     PgClassExpression93{{"PgClassExpression[93∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle92 --> PgClassExpression93
     PgSelect112[["PgSelect[112∈13]<br />ᐸpeopleᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈13]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression111 --> PgSelect112
-    PgClassExpression110{{"PgClassExpression[110∈13]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression110
-    PgSelectSingle104 --> PgClassExpression111
     First116{{"First[116∈13]"}}:::plan
     PgSelectRows117[["PgSelectRows[117∈13]<br />ᐳSingleTablePostᐳSingleTableTopic"]]:::plan
     PgSelectRows117 --> First116
     PgSelect112 --> PgSelectRows117
     PgSelectSingle118{{"PgSelectSingle[118∈13]<br />ᐸpeopleᐳ"}}:::plan
     First116 --> PgSelectSingle118
-    PgClassExpression120{{"PgClassExpression[120∈13]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression120
-    PgClassExpression121{{"PgClassExpression[121∈13]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression121
-    PgClassExpression122{{"PgClassExpression[122∈13]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression122
-    PgClassExpression123{{"PgClassExpression[123∈13]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression123
-    PgClassExpression124{{"PgClassExpression[124∈13]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression124
-    PgClassExpression125{{"PgClassExpression[125∈13]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
+    PgClassExpression125{{"PgClassExpression[125∈13]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist"}}:::plan
     PgSelectSingle104 --> PgClassExpression125
     First128{{"First[128∈13]"}}:::plan
     PgSelectRows129[["PgSelectRows[129∈13]<br />ᐳSingleTablePostᐳSingleTablePost"]]:::plan
@@ -265,9 +307,9 @@ graph TD
     PgSelect112 --> PgSelectRows129
     PgSelectSingle130{{"PgSelectSingle[130∈13]<br />ᐸpeopleᐳ"}}:::plan
     First128 --> PgSelectSingle130
-    PgClassExpression132{{"PgClassExpression[132∈13]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost"}}:::plan
+    PgClassExpression132{{"PgClassExpression[132∈13]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle104 --> PgClassExpression132
-    PgClassExpression133{{"PgClassExpression[133∈13]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost"}}:::plan
+    PgClassExpression133{{"PgClassExpression[133∈13]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle104 --> PgClassExpression133
     First136{{"First[136∈13]"}}:::plan
     PgSelectRows137[["PgSelectRows[137∈13]<br />ᐳSingleTablePostᐳSingleTableDivider"]]:::plan
@@ -302,28 +344,14 @@ graph TD
     PgClassExpression158{{"PgClassExpression[158∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression158
     PgSelect173[["PgSelect[173∈20]<br />ᐸpeopleᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression172{{"PgClassExpression[172∈20]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression172 --> PgSelect173
-    PgClassExpression171{{"PgClassExpression[171∈20]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression171
-    PgSelectSingle165 --> PgClassExpression172
     First177{{"First[177∈20]"}}:::plan
     PgSelectRows178[["PgSelectRows[178∈20]<br />ᐳSingleTableDividerᐳSingleTableTopic"]]:::plan
     PgSelectRows178 --> First177
     PgSelect173 --> PgSelectRows178
     PgSelectSingle179{{"PgSelectSingle[179∈20]<br />ᐸpeopleᐳ"}}:::plan
     First177 --> PgSelectSingle179
-    PgClassExpression181{{"PgClassExpression[181∈20]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression181
-    PgClassExpression182{{"PgClassExpression[182∈20]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression182
-    PgClassExpression183{{"PgClassExpression[183∈20]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression183
-    PgClassExpression184{{"PgClassExpression[184∈20]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression184
-    PgClassExpression185{{"PgClassExpression[185∈20]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression185
-    PgClassExpression186{{"PgClassExpression[186∈20]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
+    PgClassExpression186{{"PgClassExpression[186∈20]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist"}}:::plan
     PgSelectSingle165 --> PgClassExpression186
     First189{{"First[189∈20]"}}:::plan
     PgSelectRows190[["PgSelectRows[190∈20]<br />ᐳSingleTableDividerᐳSingleTablePost"]]:::plan
@@ -331,9 +359,9 @@ graph TD
     PgSelect173 --> PgSelectRows190
     PgSelectSingle191{{"PgSelectSingle[191∈20]<br />ᐸpeopleᐳ"}}:::plan
     First189 --> PgSelectSingle191
-    PgClassExpression193{{"PgClassExpression[193∈20]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost"}}:::plan
+    PgClassExpression193{{"PgClassExpression[193∈20]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle165 --> PgClassExpression193
-    PgClassExpression194{{"PgClassExpression[194∈20]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost"}}:::plan
+    PgClassExpression194{{"PgClassExpression[194∈20]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle165 --> PgClassExpression194
     First197{{"First[197∈20]"}}:::plan
     PgSelectRows198[["PgSelectRows[198∈20]<br />ᐳSingleTableDividerᐳSingleTableDivider"]]:::plan
@@ -368,28 +396,14 @@ graph TD
     PgClassExpression219{{"PgClassExpression[219∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle218 --> PgClassExpression219
     PgSelect233[["PgSelect[233∈27]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression232{{"PgClassExpression[232∈27]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression232 --> PgSelect233
-    PgClassExpression231{{"PgClassExpression[231∈27]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression231
-    PgSelectSingle225 --> PgClassExpression232
     First237{{"First[237∈27]"}}:::plan
     PgSelectRows238[["PgSelectRows[238∈27]<br />ᐳSingleTableChecklistᐳSingleTableTopic"]]:::plan
     PgSelectRows238 --> First237
     PgSelect233 --> PgSelectRows238
     PgSelectSingle239{{"PgSelectSingle[239∈27]<br />ᐸpeopleᐳ"}}:::plan
     First237 --> PgSelectSingle239
-    PgClassExpression241{{"PgClassExpression[241∈27]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression241
-    PgClassExpression242{{"PgClassExpression[242∈27]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression242
-    PgClassExpression243{{"PgClassExpression[243∈27]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression243
-    PgClassExpression244{{"PgClassExpression[244∈27]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression244
-    PgClassExpression245{{"PgClassExpression[245∈27]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression245
-    PgClassExpression246{{"PgClassExpression[246∈27]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
+    PgClassExpression246{{"PgClassExpression[246∈27]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist"}}:::plan
     PgSelectSingle225 --> PgClassExpression246
     First249{{"First[249∈27]"}}:::plan
     PgSelectRows250[["PgSelectRows[250∈27]<br />ᐳSingleTableChecklistᐳSingleTablePost"]]:::plan
@@ -397,9 +411,9 @@ graph TD
     PgSelect233 --> PgSelectRows250
     PgSelectSingle251{{"PgSelectSingle[251∈27]<br />ᐸpeopleᐳ"}}:::plan
     First249 --> PgSelectSingle251
-    PgClassExpression253{{"PgClassExpression[253∈27]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost"}}:::plan
+    PgClassExpression253{{"PgClassExpression[253∈27]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle225 --> PgClassExpression253
-    PgClassExpression254{{"PgClassExpression[254∈27]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost"}}:::plan
+    PgClassExpression254{{"PgClassExpression[254∈27]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle225 --> PgClassExpression254
     First257{{"First[257∈27]"}}:::plan
     PgSelectRows258[["PgSelectRows[258∈27]<br />ᐳSingleTableChecklistᐳSingleTableDivider"]]:::plan
@@ -434,28 +448,14 @@ graph TD
     PgClassExpression279{{"PgClassExpression[279∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle278 --> PgClassExpression279
     PgSelect292[["PgSelect[292∈34]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression291{{"PgClassExpression[291∈34]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression291 --> PgSelect292
-    PgClassExpression290{{"PgClassExpression[290∈34]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression290
-    PgSelectSingle284 --> PgClassExpression291
     First296{{"First[296∈34]"}}:::plan
     PgSelectRows297[["PgSelectRows[297∈34]<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"]]:::plan
     PgSelectRows297 --> First296
     PgSelect292 --> PgSelectRows297
     PgSelectSingle298{{"PgSelectSingle[298∈34]<br />ᐸpeopleᐳ"}}:::plan
     First296 --> PgSelectSingle298
-    PgClassExpression300{{"PgClassExpression[300∈34]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression300
-    PgClassExpression301{{"PgClassExpression[301∈34]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression301
-    PgClassExpression302{{"PgClassExpression[302∈34]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression302
-    PgClassExpression303{{"PgClassExpression[303∈34]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression303
-    PgClassExpression304{{"PgClassExpression[304∈34]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression304
-    PgClassExpression305{{"PgClassExpression[305∈34]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
+    PgClassExpression305{{"PgClassExpression[305∈34]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist"}}:::plan
     PgSelectSingle284 --> PgClassExpression305
     First308{{"First[308∈34]"}}:::plan
     PgSelectRows309[["PgSelectRows[309∈34]<br />ᐳSingleTableChecklistItemᐳSingleTablePost"]]:::plan
@@ -463,9 +463,9 @@ graph TD
     PgSelect292 --> PgSelectRows309
     PgSelectSingle310{{"PgSelectSingle[310∈34]<br />ᐸpeopleᐳ"}}:::plan
     First308 --> PgSelectSingle310
-    PgClassExpression312{{"PgClassExpression[312∈34]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost"}}:::plan
+    PgClassExpression312{{"PgClassExpression[312∈34]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284 --> PgClassExpression312
-    PgClassExpression313{{"PgClassExpression[313∈34]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost"}}:::plan
+    PgClassExpression313{{"PgClassExpression[313∈34]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284 --> PgClassExpression313
     First316{{"First[316∈34]"}}:::plan
     PgSelectRows317[["PgSelectRows[317∈34]<br />ᐳSingleTableChecklistItemᐳSingleTableDivider"]]:::plan
@@ -515,15 +515,15 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 84, 86, 87, 94, 95, 96, 97, 98<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 28, 84, 86, 87, 94, 95, 96, 97, 98, 99, 159, 160, 220<br />2: PgSelect[29], PgSelect[88]<br />3: 34, 91, 103, 156, 164, 217, 224, 277, 283, 336<br />ᐳ: 33, 35, 36, 37, 90, 92, 102, 104, 105, 106, 155, 157, 163, 165, 166, 167, 216, 218, 223, 225, 226, 227, 276, 278, 282, 284, 285, 286, 335, 337<br />4: 38, 107, 168, 228, 287"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression84,PgClassExpression86,PgClassExpression87,PgClassExpression94,PgClassExpression95,PgClassExpression96,PgClassExpression97,PgClassExpression98 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 87, 27, 84, 25, 86, 94, 95, 96, 97, 98<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[88]<br />ᐳ: 28, 99, 159, 160, 220<br />2: 29, 91, 156, 217, 277, 336<br />ᐳ: 90, 92, 155, 157, 216, 218, 276, 278, 335, 337<br />3: 34, 103, 164, 224, 283<br />ᐳ: 33, 35, 36, 37, 41, 42, 51, 52, 53, 54, 55, 102, 104, 105, 106, 110, 111, 120, 121, 122, 123, 124, 163, 165, 166, 167, 171, 172, 181, 182, 183, 184, 185, 223, 225, 226, 227, 231, 232, 241, 242, 243, 244, 245, 282, 284, 285, 286, 290, 291, 300, 301, 302, 303, 304<br />4: 38, 107, 168, 228, 287"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression84,PgClassExpression86,PgClassExpression87,PgSelect88,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression94,PgClassExpression95,PgClassExpression96,PgClassExpression97,PgClassExpression98,PgClassExpression99,First102,PgSelectRows103,PgSelectSingle104,PgClassExpression105,Lambda106,PgSingleTablePolymorphic107,First155,PgSelectRows156,PgSelectSingle157,PgClassExpression159,PgClassExpression160,First163,PgSelectRows164,PgSelectSingle165,PgClassExpression166,Lambda167,PgSingleTablePolymorphic168,First216,PgSelectRows217,PgSelectSingle218,PgClassExpression220,First223,PgSelectRows224,PgSelectSingle225,PgClassExpression226,Lambda227,PgSingleTablePolymorphic228,First276,PgSelectRows277,PgSelectSingle278,First282,PgSelectRows283,PgSelectSingle284,PgClassExpression285,Lambda286,PgSingleTablePolymorphic287,First335,PgSelectRows336,PgSelectSingle337 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 35, 9, 38, 28, 36<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 41, 42, 51, 52, 53, 54, 55, 56, 63, 64, 71<br />2: PgSelect[43]<br />3: 48, 60, 68, 75, 81<br />ᐳ: 47, 49, 59, 61, 67, 69, 74, 76, 80, 82"):::bucket
+    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression41,PgClassExpression42,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgSelect88,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression99,First102,PgSelectRows103,PgSelectSingle104,PgClassExpression105,Lambda106,PgSingleTablePolymorphic107,PgClassExpression110,PgClassExpression111,PgClassExpression120,PgClassExpression121,PgClassExpression122,PgClassExpression123,PgClassExpression124,First155,PgSelectRows156,PgSelectSingle157,PgClassExpression159,PgClassExpression160,First163,PgSelectRows164,PgSelectSingle165,PgClassExpression166,Lambda167,PgSingleTablePolymorphic168,PgClassExpression171,PgClassExpression172,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,First216,PgSelectRows217,PgSelectSingle218,PgClassExpression220,First223,PgSelectRows224,PgSelectSingle225,PgClassExpression226,Lambda227,PgSingleTablePolymorphic228,PgClassExpression231,PgClassExpression232,PgClassExpression241,PgClassExpression242,PgClassExpression243,PgClassExpression244,PgClassExpression245,First276,PgSelectRows277,PgSelectSingle278,First282,PgSelectRows283,PgSelectSingle284,PgClassExpression285,Lambda286,PgSingleTablePolymorphic287,PgClassExpression290,PgClassExpression291,PgClassExpression300,PgClassExpression301,PgClassExpression302,PgClassExpression303,PgClassExpression304,First335,PgSelectRows336,PgSelectSingle337 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 42, 35, 38, 28, 36, 41, 51, 52, 53, 54, 55<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: PgSelect[43]<br />ᐳ: 56, 63, 64, 71<br />2: 48, 60, 68, 75, 81<br />ᐳ: 47, 49, 59, 61, 67, 69, 74, 76, 80, 82"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgClassExpression56,First59,PgSelectRows60,PgSelectSingle61,PgClassExpression63,PgClassExpression64,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression71,First74,PgSelectRows75,PgSelectSingle76,First80,PgSelectRows81,PgSelectSingle82 bucket6
+    class Bucket6,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression56,First59,PgSelectRows60,PgSelectSingle61,PgClassExpression63,PgClassExpression64,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression71,First74,PgSelectRows75,PgSelectSingle76,First80,PgSelectRows81,PgSelectSingle82 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[49]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression50 bucket7
@@ -542,9 +542,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 92<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[92]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression93 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 104, 9, 107, 28, 105<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 110, 111, 120, 121, 122, 123, 124, 125, 132, 133, 140<br />2: PgSelect[112]<br />3: 117, 129, 137, 144, 150<br />ᐳ: 116, 118, 128, 130, 136, 138, 143, 145, 149, 151"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 111, 104, 107, 28, 105, 110, 120, 121, 122, 123, 124<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: PgSelect[112]<br />ᐳ: 125, 132, 133, 140<br />2: 117, 129, 137, 144, 150<br />ᐳ: 116, 118, 128, 130, 136, 138, 143, 145, 149, 151"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression110,PgClassExpression111,PgSelect112,First116,PgSelectRows117,PgSelectSingle118,PgClassExpression120,PgClassExpression121,PgClassExpression122,PgClassExpression123,PgClassExpression124,PgClassExpression125,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,PgClassExpression133,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression140,First143,PgSelectRows144,PgSelectSingle145,First149,PgSelectRows150,PgSelectSingle151 bucket13
+    class Bucket13,PgSelect112,First116,PgSelectRows117,PgSelectSingle118,PgClassExpression125,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,PgClassExpression133,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression140,First143,PgSelectRows144,PgSelectSingle145,First149,PgSelectRows150,PgSelectSingle151 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 118<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[118]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression119 bucket14
@@ -563,9 +563,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 157<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[157]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression158 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 165, 9, 168, 28, 166<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 171, 172, 181, 182, 183, 184, 185, 186, 193, 194, 201<br />2: PgSelect[173]<br />3: 178, 190, 198, 205, 211<br />ᐳ: 177, 179, 189, 191, 197, 199, 204, 206, 210, 212"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 172, 165, 168, 28, 166, 171, 181, 182, 183, 184, 185<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: PgSelect[173]<br />ᐳ: 186, 193, 194, 201<br />2: 178, 190, 198, 205, 211<br />ᐳ: 177, 179, 189, 191, 197, 199, 204, 206, 210, 212"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression171,PgClassExpression172,PgSelect173,First177,PgSelectRows178,PgSelectSingle179,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,First197,PgSelectRows198,PgSelectSingle199,PgClassExpression201,First204,PgSelectRows205,PgSelectSingle206,First210,PgSelectRows211,PgSelectSingle212 bucket20
+    class Bucket20,PgSelect173,First177,PgSelectRows178,PgSelectSingle179,PgClassExpression186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,First197,PgSelectRows198,PgSelectSingle199,PgClassExpression201,First204,PgSelectRows205,PgSelectSingle206,First210,PgSelectRows211,PgSelectSingle212 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 179<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[179]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression180 bucket21
@@ -584,9 +584,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 218<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[218]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression219 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 225, 9, 228, 28, 226<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 231, 232, 241, 242, 243, 244, 245, 246, 253, 254, 261<br />2: PgSelect[233]<br />3: 238, 250, 258, 265, 271<br />ᐳ: 237, 239, 249, 251, 257, 259, 264, 266, 270, 272"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 232, 225, 228, 28, 226, 231, 241, 242, 243, 244, 245<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: PgSelect[233]<br />ᐳ: 246, 253, 254, 261<br />2: 238, 250, 258, 265, 271<br />ᐳ: 237, 239, 249, 251, 257, 259, 264, 266, 270, 272"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression231,PgClassExpression232,PgSelect233,First237,PgSelectRows238,PgSelectSingle239,PgClassExpression241,PgClassExpression242,PgClassExpression243,PgClassExpression244,PgClassExpression245,PgClassExpression246,First249,PgSelectRows250,PgSelectSingle251,PgClassExpression253,PgClassExpression254,First257,PgSelectRows258,PgSelectSingle259,PgClassExpression261,First264,PgSelectRows265,PgSelectSingle266,First270,PgSelectRows271,PgSelectSingle272 bucket27
+    class Bucket27,PgSelect233,First237,PgSelectRows238,PgSelectSingle239,PgClassExpression246,First249,PgSelectRows250,PgSelectSingle251,PgClassExpression253,PgClassExpression254,First257,PgSelectRows258,PgSelectSingle259,PgClassExpression261,First264,PgSelectRows265,PgSelectSingle266,First270,PgSelectRows271,PgSelectSingle272 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 239<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[239]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression240 bucket28
@@ -605,9 +605,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 278<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[278]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression279 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 284, 9, 287, 28, 285<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 290, 291, 300, 301, 302, 303, 304, 305, 312, 313, 320<br />2: PgSelect[292]<br />3: 297, 309, 317, 324, 330<br />ᐳ: 296, 298, 308, 310, 316, 318, 323, 325, 329, 331"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 291, 284, 287, 28, 285, 290, 300, 301, 302, 303, 304<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: PgSelect[292]<br />ᐳ: 305, 312, 313, 320<br />2: 297, 309, 317, 324, 330<br />ᐳ: 296, 298, 308, 310, 316, 318, 323, 325, 329, 331"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression290,PgClassExpression291,PgSelect292,First296,PgSelectRows297,PgSelectSingle298,PgClassExpression300,PgClassExpression301,PgClassExpression302,PgClassExpression303,PgClassExpression304,PgClassExpression305,First308,PgSelectRows309,PgSelectSingle310,PgClassExpression312,PgClassExpression313,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,First323,PgSelectRows324,PgSelectSingle325,First329,PgSelectRows330,PgSelectSingle331 bucket34
+    class Bucket34,PgSelect292,First296,PgSelectRows297,PgSelectSingle298,PgClassExpression305,First308,PgSelectRows309,PgSelectSingle310,PgClassExpression312,PgClassExpression313,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,First323,PgSelectRows324,PgSelectSingle325,First329,PgSelectRows330,PgSelectSingle331 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 298<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[298]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression299 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.sql
@@ -36,6 +36,21 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."username" as "0",
+    __people_identifiers__.idx as "1"
+  from interfaces_and_unions.people as __people__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __people__."person_id" = __people_identifiers__."id0"
+    )
+) as __people_result__;
+
 select __single_table_items_result__.*
 from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
 lateral (
@@ -61,21 +76,6 @@ lateral (
       __single_table_items__."id" = __single_table_items_identifiers__."id0"
     )
 ) as __single_table_items_result__;
-
-select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
-lateral (
-  select
-    __people__."username" as "0",
-    __people_identifiers__.idx as "1"
-  from interfaces_and_unions.people as __people__
-  where
-    (
-      true /* authorization checks */
-    ) and (
-      __people__."person_id" = __people_identifiers__."id0"
-    )
-) as __people_result__;
 
 select
   __people__."username" as "0"

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.mermaid
@@ -49,30 +49,45 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
+    PgClassExpression84{{"PgClassExpression[84∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression84
+    PgClassExpression86{{"PgClassExpression[86∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression86
+    PgClassExpression87{{"PgClassExpression[87∈4]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression87
+    PgClassExpression94{{"PgClassExpression[94∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression94
+    PgClassExpression95{{"PgClassExpression[95∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression95
+    PgClassExpression96{{"PgClassExpression[96∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression96
+    PgClassExpression97{{"PgClassExpression[97∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression97
+    PgClassExpression98{{"PgClassExpression[98∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression98
     PgSelect29[["PgSelect[29∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object9 & PgClassExpression28 --> PgSelect29
     PgSingleTablePolymorphic38["PgSingleTablePolymorphic[38∈5]<br />ᐳSingleTableTopic"]:::plan
-    Lambda37{{"Lambda[37∈5]"}}:::plan
+    Lambda37{{"Lambda[37∈5]<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle35{{"PgSelectSingle[35∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda37 & PgSelectSingle35 --> PgSingleTablePolymorphic38
     PgSelect88[["PgSelect[88∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression87{{"PgClassExpression[87∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression87 --> PgSelect88
     PgSingleTablePolymorphic107["PgSingleTablePolymorphic[107∈5]<br />ᐳSingleTablePost"]:::plan
-    Lambda106{{"Lambda[106∈5]"}}:::plan
+    Lambda106{{"Lambda[106∈5]<br />ᐳSingleTablePost"}}:::plan
     PgSelectSingle104{{"PgSelectSingle[104∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda106 & PgSelectSingle104 --> PgSingleTablePolymorphic107
     PgSingleTablePolymorphic168["PgSingleTablePolymorphic[168∈5]<br />ᐳSingleTableDivider"]:::plan
-    Lambda167{{"Lambda[167∈5]"}}:::plan
+    Lambda167{{"Lambda[167∈5]<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle165{{"PgSelectSingle[165∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda167 & PgSelectSingle165 --> PgSingleTablePolymorphic168
     PgSingleTablePolymorphic228["PgSingleTablePolymorphic[228∈5]<br />ᐳSingleTableChecklist"]:::plan
-    Lambda227{{"Lambda[227∈5]"}}:::plan
+    Lambda227{{"Lambda[227∈5]<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle225{{"PgSelectSingle[225∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda227 & PgSelectSingle225 --> PgSingleTablePolymorphic228
     PgSingleTablePolymorphic287["PgSingleTablePolymorphic[287∈5]<br />ᐳSingleTableChecklistItem"]:::plan
-    Lambda286{{"Lambda[286∈5]"}}:::plan
+    Lambda286{{"Lambda[286∈5]<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284{{"PgSelectSingle[284∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda286 & PgSelectSingle284 --> PgSingleTablePolymorphic287
     PgSelectSingle24 --> PgClassExpression28
@@ -81,58 +96,85 @@ graph TD
     PgSelectRows34 --> First33
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression36 --> Lambda37
-    PgClassExpression84{{"PgClassExpression[84∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression84
-    PgClassExpression86{{"PgClassExpression[86∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression86
-    PgSelectSingle24 --> PgClassExpression87
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression41
+    PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression42
+    PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression51
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression53
+    PgClassExpression54{{"PgClassExpression[54∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression54
+    PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression55
     First90{{"First[90∈5]"}}:::plan
     PgSelectRows91[["PgSelectRows[91∈5]<br />ᐳSingleTableTopic"]]:::plan
     PgSelectRows91 --> First90
     PgSelect88 --> PgSelectRows91
     PgSelectSingle92{{"PgSelectSingle[92∈5]<br />ᐸpeopleᐳ"}}:::plan
     First90 --> PgSelectSingle92
-    PgClassExpression94{{"PgClassExpression[94∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression94
-    PgClassExpression95{{"PgClassExpression[95∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression95
-    PgClassExpression96{{"PgClassExpression[96∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression96
-    PgClassExpression97{{"PgClassExpression[97∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression97
-    PgClassExpression98{{"PgClassExpression[98∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression98
-    PgClassExpression99{{"PgClassExpression[99∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression99{{"PgClassExpression[99∈5]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle24 --> PgClassExpression99
     First102{{"First[102∈5]"}}:::plan
     PgSelectRows103[["PgSelectRows[103∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows103 --> First102
     PgSelect29 --> PgSelectRows103
     First102 --> PgSelectSingle104
-    PgClassExpression105{{"PgClassExpression[105∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression105{{"PgClassExpression[105∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle104 --> PgClassExpression105
     PgClassExpression105 --> Lambda106
+    PgClassExpression110{{"PgClassExpression[110∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression110
+    PgClassExpression111{{"PgClassExpression[111∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression111
+    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression120
+    PgClassExpression121{{"PgClassExpression[121∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression121
+    PgClassExpression122{{"PgClassExpression[122∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression122
+    PgClassExpression123{{"PgClassExpression[123∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression123
+    PgClassExpression124{{"PgClassExpression[124∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle104 --> PgClassExpression124
     First155{{"First[155∈5]"}}:::plan
     PgSelectRows156[["PgSelectRows[156∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows156 --> First155
     PgSelect88 --> PgSelectRows156
     PgSelectSingle157{{"PgSelectSingle[157∈5]<br />ᐸpeopleᐳ"}}:::plan
     First155 --> PgSelectSingle157
-    PgClassExpression159{{"PgClassExpression[159∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression159{{"PgClassExpression[159∈5]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression159
-    PgClassExpression160{{"PgClassExpression[160∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost"}}:::plan
+    PgClassExpression160{{"PgClassExpression[160∈5]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle24 --> PgClassExpression160
     First163{{"First[163∈5]"}}:::plan
     PgSelectRows164[["PgSelectRows[164∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows164 --> First163
     PgSelect29 --> PgSelectRows164
     First163 --> PgSelectSingle165
-    PgClassExpression166{{"PgClassExpression[166∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression166{{"PgClassExpression[166∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle165 --> PgClassExpression166
     PgClassExpression166 --> Lambda167
+    PgClassExpression171{{"PgClassExpression[171∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression171
+    PgClassExpression172{{"PgClassExpression[172∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression172
+    PgClassExpression181{{"PgClassExpression[181∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression181
+    PgClassExpression182{{"PgClassExpression[182∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression182
+    PgClassExpression183{{"PgClassExpression[183∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression183
+    PgClassExpression184{{"PgClassExpression[184∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression184
+    PgClassExpression185{{"PgClassExpression[185∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle165 --> PgClassExpression185
     First216{{"First[216∈5]"}}:::plan
     PgSelectRows217[["PgSelectRows[217∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows217 --> First216
@@ -146,9 +188,23 @@ graph TD
     PgSelectRows224 --> First223
     PgSelect29 --> PgSelectRows224
     First223 --> PgSelectSingle225
-    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle225 --> PgClassExpression226
     PgClassExpression226 --> Lambda227
+    PgClassExpression231{{"PgClassExpression[231∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression231
+    PgClassExpression232{{"PgClassExpression[232∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression232
+    PgClassExpression241{{"PgClassExpression[241∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression241
+    PgClassExpression242{{"PgClassExpression[242∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression242
+    PgClassExpression243{{"PgClassExpression[243∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression243
+    PgClassExpression244{{"PgClassExpression[244∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression244
+    PgClassExpression245{{"PgClassExpression[245∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle225 --> PgClassExpression245
     First276{{"First[276∈5]"}}:::plan
     PgSelectRows277[["PgSelectRows[277∈5]<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows277 --> First276
@@ -160,9 +216,23 @@ graph TD
     PgSelectRows283 --> First282
     PgSelect29 --> PgSelectRows283
     First282 --> PgSelectSingle284
-    PgClassExpression285{{"PgClassExpression[285∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression285{{"PgClassExpression[285∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284 --> PgClassExpression285
     PgClassExpression285 --> Lambda286
+    PgClassExpression290{{"PgClassExpression[290∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression290
+    PgClassExpression291{{"PgClassExpression[291∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression291
+    PgClassExpression300{{"PgClassExpression[300∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression300
+    PgClassExpression301{{"PgClassExpression[301∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression301
+    PgClassExpression302{{"PgClassExpression[302∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression302
+    PgClassExpression303{{"PgClassExpression[303∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression303
+    PgClassExpression304{{"PgClassExpression[304∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle284 --> PgClassExpression304
     First335{{"First[335∈5]"}}:::plan
     PgSelectRows336[["PgSelectRows[336∈5]<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows336 --> First335
@@ -170,28 +240,14 @@ graph TD
     PgSelectSingle337{{"PgSelectSingle[337∈5]<br />ᐸpeopleᐳ"}}:::plan
     First335 --> PgSelectSingle337
     PgSelect43[["PgSelect[43∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression42{{"PgClassExpression[42∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression42 --> PgSelect43
-    PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression41
-    PgSelectSingle35 --> PgClassExpression42
     First47{{"First[47∈6]"}}:::plan
     PgSelectRows48[["PgSelectRows[48∈6]<br />ᐳSingleTableTopicᐳSingleTableTopic"]]:::plan
     PgSelectRows48 --> First47
     PgSelect43 --> PgSelectRows48
     PgSelectSingle49{{"PgSelectSingle[49∈6]<br />ᐸpeopleᐳ"}}:::plan
     First47 --> PgSelectSingle49
-    PgClassExpression51{{"PgClassExpression[51∈6]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression51
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression52
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression53
-    PgClassExpression54{{"PgClassExpression[54∈6]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression54
-    PgClassExpression55{{"PgClassExpression[55∈6]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression55
-    PgClassExpression56{{"PgClassExpression[56∈6]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
+    PgClassExpression56{{"PgClassExpression[56∈6]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist"}}:::plan
     PgSelectSingle35 --> PgClassExpression56
     First59{{"First[59∈6]"}}:::plan
     PgSelectRows60[["PgSelectRows[60∈6]<br />ᐳSingleTableTopicᐳSingleTablePost"]]:::plan
@@ -199,9 +255,9 @@ graph TD
     PgSelect43 --> PgSelectRows60
     PgSelectSingle61{{"PgSelectSingle[61∈6]<br />ᐸpeopleᐳ"}}:::plan
     First59 --> PgSelectSingle61
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost"}}:::plan
+    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost"}}:::plan
+    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression64
     First67{{"First[67∈6]"}}:::plan
     PgSelectRows68[["PgSelectRows[68∈6]<br />ᐳSingleTableTopicᐳSingleTableDivider"]]:::plan
@@ -236,28 +292,14 @@ graph TD
     PgClassExpression93{{"PgClassExpression[93∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle92 --> PgClassExpression93
     PgSelect112[["PgSelect[112∈13]<br />ᐸpeopleᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈13]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression111 --> PgSelect112
-    PgClassExpression110{{"PgClassExpression[110∈13]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression110
-    PgSelectSingle104 --> PgClassExpression111
     First116{{"First[116∈13]"}}:::plan
     PgSelectRows117[["PgSelectRows[117∈13]<br />ᐳSingleTablePostᐳSingleTableTopic"]]:::plan
     PgSelectRows117 --> First116
     PgSelect112 --> PgSelectRows117
     PgSelectSingle118{{"PgSelectSingle[118∈13]<br />ᐸpeopleᐳ"}}:::plan
     First116 --> PgSelectSingle118
-    PgClassExpression120{{"PgClassExpression[120∈13]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression120
-    PgClassExpression121{{"PgClassExpression[121∈13]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression121
-    PgClassExpression122{{"PgClassExpression[122∈13]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression122
-    PgClassExpression123{{"PgClassExpression[123∈13]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression123
-    PgClassExpression124{{"PgClassExpression[124∈13]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle104 --> PgClassExpression124
-    PgClassExpression125{{"PgClassExpression[125∈13]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
+    PgClassExpression125{{"PgClassExpression[125∈13]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist"}}:::plan
     PgSelectSingle104 --> PgClassExpression125
     First128{{"First[128∈13]"}}:::plan
     PgSelectRows129[["PgSelectRows[129∈13]<br />ᐳSingleTablePostᐳSingleTablePost"]]:::plan
@@ -265,9 +307,9 @@ graph TD
     PgSelect112 --> PgSelectRows129
     PgSelectSingle130{{"PgSelectSingle[130∈13]<br />ᐸpeopleᐳ"}}:::plan
     First128 --> PgSelectSingle130
-    PgClassExpression132{{"PgClassExpression[132∈13]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost"}}:::plan
+    PgClassExpression132{{"PgClassExpression[132∈13]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle104 --> PgClassExpression132
-    PgClassExpression133{{"PgClassExpression[133∈13]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost"}}:::plan
+    PgClassExpression133{{"PgClassExpression[133∈13]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle104 --> PgClassExpression133
     First136{{"First[136∈13]"}}:::plan
     PgSelectRows137[["PgSelectRows[137∈13]<br />ᐳSingleTablePostᐳSingleTableDivider"]]:::plan
@@ -302,28 +344,14 @@ graph TD
     PgClassExpression158{{"PgClassExpression[158∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle157 --> PgClassExpression158
     PgSelect173[["PgSelect[173∈20]<br />ᐸpeopleᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression172{{"PgClassExpression[172∈20]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression172 --> PgSelect173
-    PgClassExpression171{{"PgClassExpression[171∈20]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression171
-    PgSelectSingle165 --> PgClassExpression172
     First177{{"First[177∈20]"}}:::plan
     PgSelectRows178[["PgSelectRows[178∈20]<br />ᐳSingleTableDividerᐳSingleTableTopic"]]:::plan
     PgSelectRows178 --> First177
     PgSelect173 --> PgSelectRows178
     PgSelectSingle179{{"PgSelectSingle[179∈20]<br />ᐸpeopleᐳ"}}:::plan
     First177 --> PgSelectSingle179
-    PgClassExpression181{{"PgClassExpression[181∈20]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression181
-    PgClassExpression182{{"PgClassExpression[182∈20]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression182
-    PgClassExpression183{{"PgClassExpression[183∈20]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression183
-    PgClassExpression184{{"PgClassExpression[184∈20]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression184
-    PgClassExpression185{{"PgClassExpression[185∈20]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle165 --> PgClassExpression185
-    PgClassExpression186{{"PgClassExpression[186∈20]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
+    PgClassExpression186{{"PgClassExpression[186∈20]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist"}}:::plan
     PgSelectSingle165 --> PgClassExpression186
     First189{{"First[189∈20]"}}:::plan
     PgSelectRows190[["PgSelectRows[190∈20]<br />ᐳSingleTableDividerᐳSingleTablePost"]]:::plan
@@ -331,9 +359,9 @@ graph TD
     PgSelect173 --> PgSelectRows190
     PgSelectSingle191{{"PgSelectSingle[191∈20]<br />ᐸpeopleᐳ"}}:::plan
     First189 --> PgSelectSingle191
-    PgClassExpression193{{"PgClassExpression[193∈20]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost"}}:::plan
+    PgClassExpression193{{"PgClassExpression[193∈20]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle165 --> PgClassExpression193
-    PgClassExpression194{{"PgClassExpression[194∈20]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost"}}:::plan
+    PgClassExpression194{{"PgClassExpression[194∈20]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle165 --> PgClassExpression194
     First197{{"First[197∈20]"}}:::plan
     PgSelectRows198[["PgSelectRows[198∈20]<br />ᐳSingleTableDividerᐳSingleTableDivider"]]:::plan
@@ -368,28 +396,14 @@ graph TD
     PgClassExpression219{{"PgClassExpression[219∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle218 --> PgClassExpression219
     PgSelect233[["PgSelect[233∈27]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression232{{"PgClassExpression[232∈27]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression232 --> PgSelect233
-    PgClassExpression231{{"PgClassExpression[231∈27]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression231
-    PgSelectSingle225 --> PgClassExpression232
     First237{{"First[237∈27]"}}:::plan
     PgSelectRows238[["PgSelectRows[238∈27]<br />ᐳSingleTableChecklistᐳSingleTableTopic"]]:::plan
     PgSelectRows238 --> First237
     PgSelect233 --> PgSelectRows238
     PgSelectSingle239{{"PgSelectSingle[239∈27]<br />ᐸpeopleᐳ"}}:::plan
     First237 --> PgSelectSingle239
-    PgClassExpression241{{"PgClassExpression[241∈27]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression241
-    PgClassExpression242{{"PgClassExpression[242∈27]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression242
-    PgClassExpression243{{"PgClassExpression[243∈27]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression243
-    PgClassExpression244{{"PgClassExpression[244∈27]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression244
-    PgClassExpression245{{"PgClassExpression[245∈27]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle225 --> PgClassExpression245
-    PgClassExpression246{{"PgClassExpression[246∈27]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
+    PgClassExpression246{{"PgClassExpression[246∈27]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist"}}:::plan
     PgSelectSingle225 --> PgClassExpression246
     First249{{"First[249∈27]"}}:::plan
     PgSelectRows250[["PgSelectRows[250∈27]<br />ᐳSingleTableChecklistᐳSingleTablePost"]]:::plan
@@ -397,9 +411,9 @@ graph TD
     PgSelect233 --> PgSelectRows250
     PgSelectSingle251{{"PgSelectSingle[251∈27]<br />ᐸpeopleᐳ"}}:::plan
     First249 --> PgSelectSingle251
-    PgClassExpression253{{"PgClassExpression[253∈27]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost"}}:::plan
+    PgClassExpression253{{"PgClassExpression[253∈27]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle225 --> PgClassExpression253
-    PgClassExpression254{{"PgClassExpression[254∈27]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost"}}:::plan
+    PgClassExpression254{{"PgClassExpression[254∈27]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle225 --> PgClassExpression254
     First257{{"First[257∈27]"}}:::plan
     PgSelectRows258[["PgSelectRows[258∈27]<br />ᐳSingleTableChecklistᐳSingleTableDivider"]]:::plan
@@ -434,28 +448,14 @@ graph TD
     PgClassExpression279{{"PgClassExpression[279∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle278 --> PgClassExpression279
     PgSelect292[["PgSelect[292∈34]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression291{{"PgClassExpression[291∈34]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression291 --> PgSelect292
-    PgClassExpression290{{"PgClassExpression[290∈34]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression290
-    PgSelectSingle284 --> PgClassExpression291
     First296{{"First[296∈34]"}}:::plan
     PgSelectRows297[["PgSelectRows[297∈34]<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"]]:::plan
     PgSelectRows297 --> First296
     PgSelect292 --> PgSelectRows297
     PgSelectSingle298{{"PgSelectSingle[298∈34]<br />ᐸpeopleᐳ"}}:::plan
     First296 --> PgSelectSingle298
-    PgClassExpression300{{"PgClassExpression[300∈34]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression300
-    PgClassExpression301{{"PgClassExpression[301∈34]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression301
-    PgClassExpression302{{"PgClassExpression[302∈34]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression302
-    PgClassExpression303{{"PgClassExpression[303∈34]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression303
-    PgClassExpression304{{"PgClassExpression[304∈34]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle284 --> PgClassExpression304
-    PgClassExpression305{{"PgClassExpression[305∈34]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
+    PgClassExpression305{{"PgClassExpression[305∈34]<br />ᐸ__single_t...__.”title”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist"}}:::plan
     PgSelectSingle284 --> PgClassExpression305
     First308{{"First[308∈34]"}}:::plan
     PgSelectRows309[["PgSelectRows[309∈34]<br />ᐳSingleTableChecklistItemᐳSingleTablePost"]]:::plan
@@ -463,9 +463,9 @@ graph TD
     PgSelect292 --> PgSelectRows309
     PgSelectSingle310{{"PgSelectSingle[310∈34]<br />ᐸpeopleᐳ"}}:::plan
     First308 --> PgSelectSingle310
-    PgClassExpression312{{"PgClassExpression[312∈34]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost"}}:::plan
+    PgClassExpression312{{"PgClassExpression[312∈34]<br />ᐸ__single_t...scription”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284 --> PgClassExpression312
-    PgClassExpression313{{"PgClassExpression[313∈34]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost"}}:::plan
+    PgClassExpression313{{"PgClassExpression[313∈34]<br />ᐸ__single_t...s__.”note”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle284 --> PgClassExpression313
     First316{{"First[316∈34]"}}:::plan
     PgSelectRows317[["PgSelectRows[317∈34]<br />ᐳSingleTableChecklistItemᐳSingleTableDivider"]]:::plan
@@ -515,15 +515,15 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 84, 86, 87, 94, 95, 96, 97, 98<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 28, 84, 86, 87, 94, 95, 96, 97, 98, 99, 159, 160, 220<br />2: PgSelect[29], PgSelect[88]<br />3: 34, 91, 103, 156, 164, 217, 224, 277, 283, 336<br />ᐳ: 33, 35, 36, 37, 90, 92, 102, 104, 105, 106, 155, 157, 163, 165, 166, 167, 216, 218, 223, 225, 226, 227, 276, 278, 282, 284, 285, 286, 335, 337<br />4: 38, 107, 168, 228, 287"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression84,PgClassExpression86,PgClassExpression87,PgClassExpression94,PgClassExpression95,PgClassExpression96,PgClassExpression97,PgClassExpression98 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 87, 27, 84, 25, 86, 94, 95, 96, 97, 98<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[88]<br />ᐳ: 28, 99, 159, 160, 220<br />2: 29, 91, 156, 217, 277, 336<br />ᐳ: 90, 92, 155, 157, 216, 218, 276, 278, 335, 337<br />3: 34, 103, 164, 224, 283<br />ᐳ: 33, 35, 36, 37, 41, 42, 51, 52, 53, 54, 55, 102, 104, 105, 106, 110, 111, 120, 121, 122, 123, 124, 163, 165, 166, 167, 171, 172, 181, 182, 183, 184, 185, 223, 225, 226, 227, 231, 232, 241, 242, 243, 244, 245, 282, 284, 285, 286, 290, 291, 300, 301, 302, 303, 304<br />4: 38, 107, 168, 228, 287"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression84,PgClassExpression86,PgClassExpression87,PgSelect88,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression94,PgClassExpression95,PgClassExpression96,PgClassExpression97,PgClassExpression98,PgClassExpression99,First102,PgSelectRows103,PgSelectSingle104,PgClassExpression105,Lambda106,PgSingleTablePolymorphic107,First155,PgSelectRows156,PgSelectSingle157,PgClassExpression159,PgClassExpression160,First163,PgSelectRows164,PgSelectSingle165,PgClassExpression166,Lambda167,PgSingleTablePolymorphic168,First216,PgSelectRows217,PgSelectSingle218,PgClassExpression220,First223,PgSelectRows224,PgSelectSingle225,PgClassExpression226,Lambda227,PgSingleTablePolymorphic228,First276,PgSelectRows277,PgSelectSingle278,First282,PgSelectRows283,PgSelectSingle284,PgClassExpression285,Lambda286,PgSingleTablePolymorphic287,First335,PgSelectRows336,PgSelectSingle337 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 35, 9, 38, 28, 36<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 41, 42, 51, 52, 53, 54, 55, 56, 63, 64, 71<br />2: PgSelect[43]<br />3: 48, 60, 68, 75, 81<br />ᐳ: 47, 49, 59, 61, 67, 69, 74, 76, 80, 82"):::bucket
+    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression41,PgClassExpression42,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgSelect88,First90,PgSelectRows91,PgSelectSingle92,PgClassExpression99,First102,PgSelectRows103,PgSelectSingle104,PgClassExpression105,Lambda106,PgSingleTablePolymorphic107,PgClassExpression110,PgClassExpression111,PgClassExpression120,PgClassExpression121,PgClassExpression122,PgClassExpression123,PgClassExpression124,First155,PgSelectRows156,PgSelectSingle157,PgClassExpression159,PgClassExpression160,First163,PgSelectRows164,PgSelectSingle165,PgClassExpression166,Lambda167,PgSingleTablePolymorphic168,PgClassExpression171,PgClassExpression172,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,First216,PgSelectRows217,PgSelectSingle218,PgClassExpression220,First223,PgSelectRows224,PgSelectSingle225,PgClassExpression226,Lambda227,PgSingleTablePolymorphic228,PgClassExpression231,PgClassExpression232,PgClassExpression241,PgClassExpression242,PgClassExpression243,PgClassExpression244,PgClassExpression245,First276,PgSelectRows277,PgSelectSingle278,First282,PgSelectRows283,PgSelectSingle284,PgClassExpression285,Lambda286,PgSingleTablePolymorphic287,PgClassExpression290,PgClassExpression291,PgClassExpression300,PgClassExpression301,PgClassExpression302,PgClassExpression303,PgClassExpression304,First335,PgSelectRows336,PgSelectSingle337 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 42, 35, 38, 28, 36, 41, 51, 52, 53, 54, 55<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: PgSelect[43]<br />ᐳ: 56, 63, 64, 71<br />2: 48, 60, 68, 75, 81<br />ᐳ: 47, 49, 59, 61, 67, 69, 74, 76, 80, 82"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgClassExpression56,First59,PgSelectRows60,PgSelectSingle61,PgClassExpression63,PgClassExpression64,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression71,First74,PgSelectRows75,PgSelectSingle76,First80,PgSelectRows81,PgSelectSingle82 bucket6
+    class Bucket6,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression56,First59,PgSelectRows60,PgSelectSingle61,PgClassExpression63,PgClassExpression64,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression71,First74,PgSelectRows75,PgSelectSingle76,First80,PgSelectRows81,PgSelectSingle82 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[49]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression50 bucket7
@@ -542,9 +542,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 92<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[92]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression93 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 104, 9, 107, 28, 105<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 110, 111, 120, 121, 122, 123, 124, 125, 132, 133, 140<br />2: PgSelect[112]<br />3: 117, 129, 137, 144, 150<br />ᐳ: 116, 118, 128, 130, 136, 138, 143, 145, 149, 151"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 111, 104, 107, 28, 105, 110, 120, 121, 122, 123, 124<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: PgSelect[112]<br />ᐳ: 125, 132, 133, 140<br />2: 117, 129, 137, 144, 150<br />ᐳ: 116, 118, 128, 130, 136, 138, 143, 145, 149, 151"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression110,PgClassExpression111,PgSelect112,First116,PgSelectRows117,PgSelectSingle118,PgClassExpression120,PgClassExpression121,PgClassExpression122,PgClassExpression123,PgClassExpression124,PgClassExpression125,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,PgClassExpression133,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression140,First143,PgSelectRows144,PgSelectSingle145,First149,PgSelectRows150,PgSelectSingle151 bucket13
+    class Bucket13,PgSelect112,First116,PgSelectRows117,PgSelectSingle118,PgClassExpression125,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,PgClassExpression133,First136,PgSelectRows137,PgSelectSingle138,PgClassExpression140,First143,PgSelectRows144,PgSelectSingle145,First149,PgSelectRows150,PgSelectSingle151 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 118<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[118]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression119 bucket14
@@ -563,9 +563,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 157<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[157]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression158 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 165, 9, 168, 28, 166<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 171, 172, 181, 182, 183, 184, 185, 186, 193, 194, 201<br />2: PgSelect[173]<br />3: 178, 190, 198, 205, 211<br />ᐳ: 177, 179, 189, 191, 197, 199, 204, 206, 210, 212"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 172, 165, 168, 28, 166, 171, 181, 182, 183, 184, 185<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: PgSelect[173]<br />ᐳ: 186, 193, 194, 201<br />2: 178, 190, 198, 205, 211<br />ᐳ: 177, 179, 189, 191, 197, 199, 204, 206, 210, 212"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression171,PgClassExpression172,PgSelect173,First177,PgSelectRows178,PgSelectSingle179,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgClassExpression184,PgClassExpression185,PgClassExpression186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,First197,PgSelectRows198,PgSelectSingle199,PgClassExpression201,First204,PgSelectRows205,PgSelectSingle206,First210,PgSelectRows211,PgSelectSingle212 bucket20
+    class Bucket20,PgSelect173,First177,PgSelectRows178,PgSelectSingle179,PgClassExpression186,First189,PgSelectRows190,PgSelectSingle191,PgClassExpression193,PgClassExpression194,First197,PgSelectRows198,PgSelectSingle199,PgClassExpression201,First204,PgSelectRows205,PgSelectSingle206,First210,PgSelectRows211,PgSelectSingle212 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 179<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[179]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression180 bucket21
@@ -584,9 +584,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 218<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[218]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression219 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 225, 9, 228, 28, 226<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 231, 232, 241, 242, 243, 244, 245, 246, 253, 254, 261<br />2: PgSelect[233]<br />3: 238, 250, 258, 265, 271<br />ᐳ: 237, 239, 249, 251, 257, 259, 264, 266, 270, 272"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 232, 225, 228, 28, 226, 231, 241, 242, 243, 244, 245<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: PgSelect[233]<br />ᐳ: 246, 253, 254, 261<br />2: 238, 250, 258, 265, 271<br />ᐳ: 237, 239, 249, 251, 257, 259, 264, 266, 270, 272"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression231,PgClassExpression232,PgSelect233,First237,PgSelectRows238,PgSelectSingle239,PgClassExpression241,PgClassExpression242,PgClassExpression243,PgClassExpression244,PgClassExpression245,PgClassExpression246,First249,PgSelectRows250,PgSelectSingle251,PgClassExpression253,PgClassExpression254,First257,PgSelectRows258,PgSelectSingle259,PgClassExpression261,First264,PgSelectRows265,PgSelectSingle266,First270,PgSelectRows271,PgSelectSingle272 bucket27
+    class Bucket27,PgSelect233,First237,PgSelectRows238,PgSelectSingle239,PgClassExpression246,First249,PgSelectRows250,PgSelectSingle251,PgClassExpression253,PgClassExpression254,First257,PgSelectRows258,PgSelectSingle259,PgClassExpression261,First264,PgSelectRows265,PgSelectSingle266,First270,PgSelectRows271,PgSelectSingle272 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 239<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[239]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression240 bucket28
@@ -605,9 +605,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 278<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[278]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression279 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 284, 9, 287, 28, 285<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 290, 291, 300, 301, 302, 303, 304, 305, 312, 313, 320<br />2: PgSelect[292]<br />3: 297, 309, 317, 324, 330<br />ᐳ: 296, 298, 308, 310, 316, 318, 323, 325, 329, 331"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 291, 284, 287, 28, 285, 290, 300, 301, 302, 303, 304<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: PgSelect[292]<br />ᐳ: 305, 312, 313, 320<br />2: 297, 309, 317, 324, 330<br />ᐳ: 296, 298, 308, 310, 316, 318, 323, 325, 329, 331"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression290,PgClassExpression291,PgSelect292,First296,PgSelectRows297,PgSelectSingle298,PgClassExpression300,PgClassExpression301,PgClassExpression302,PgClassExpression303,PgClassExpression304,PgClassExpression305,First308,PgSelectRows309,PgSelectSingle310,PgClassExpression312,PgClassExpression313,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,First323,PgSelectRows324,PgSelectSingle325,First329,PgSelectRows330,PgSelectSingle331 bucket34
+    class Bucket34,PgSelect292,First296,PgSelectRows297,PgSelectSingle298,PgClassExpression305,First308,PgSelectRows309,PgSelectSingle310,PgClassExpression312,PgClassExpression313,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,First323,PgSelectRows324,PgSelectSingle325,First329,PgSelectRows330,PgSelectSingle331 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 298<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[298]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression299 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.sql
@@ -36,6 +36,21 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."username" as "0",
+    __people_identifiers__.idx as "1"
+  from interfaces_and_unions.people as __people__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __people__."person_id" = __people_identifiers__."id0"
+    )
+) as __people_result__;
+
 select __single_table_items_result__.*
 from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
 lateral (
@@ -61,21 +76,6 @@ lateral (
       __single_table_items__."id" = __single_table_items_identifiers__."id0"
     )
 ) as __single_table_items_result__;
-
-select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
-lateral (
-  select
-    __people__."username" as "0",
-    __people_identifiers__.idx as "1"
-  from interfaces_and_unions.people as __people__
-  where
-    (
-      true /* authorization checks */
-    ) and (
-      __people__."person_id" = __people_identifiers__."id0"
-    )
-) as __people_result__;
 
 select
   __people__."username" as "0"

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.mermaid
@@ -49,30 +49,45 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
+    PgClassExpression80{{"PgClassExpression[80∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression80
+    PgClassExpression82{{"PgClassExpression[82∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression82
+    PgClassExpression83{{"PgClassExpression[83∈4]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression83
+    PgClassExpression90{{"PgClassExpression[90∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression90
+    PgClassExpression91{{"PgClassExpression[91∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression91
+    PgClassExpression92{{"PgClassExpression[92∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression92
+    PgClassExpression93{{"PgClassExpression[93∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression93
+    PgClassExpression94{{"PgClassExpression[94∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression94
     PgSelect29[["PgSelect[29∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object9 & PgClassExpression28 --> PgSelect29
     PgSingleTablePolymorphic38["PgSingleTablePolymorphic[38∈5]<br />ᐳSingleTableTopic"]:::plan
-    Lambda37{{"Lambda[37∈5]"}}:::plan
+    Lambda37{{"Lambda[37∈5]<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle35{{"PgSelectSingle[35∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda37 & PgSelectSingle35 --> PgSingleTablePolymorphic38
     PgSelect84[["PgSelect[84∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression83{{"PgClassExpression[83∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression83 --> PgSelect84
     PgSingleTablePolymorphic102["PgSingleTablePolymorphic[102∈5]<br />ᐳSingleTablePost"]:::plan
-    Lambda101{{"Lambda[101∈5]"}}:::plan
+    Lambda101{{"Lambda[101∈5]<br />ᐳSingleTablePost"}}:::plan
     PgSelectSingle99{{"PgSelectSingle[99∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda101 & PgSelectSingle99 --> PgSingleTablePolymorphic102
     PgSingleTablePolymorphic157["PgSingleTablePolymorphic[157∈5]<br />ᐳSingleTableDivider"]:::plan
-    Lambda156{{"Lambda[156∈5]"}}:::plan
+    Lambda156{{"Lambda[156∈5]<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle154{{"PgSelectSingle[154∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda156 & PgSelectSingle154 --> PgSingleTablePolymorphic157
     PgSingleTablePolymorphic212["PgSingleTablePolymorphic[212∈5]<br />ᐳSingleTableChecklist"]:::plan
-    Lambda211{{"Lambda[211∈5]"}}:::plan
+    Lambda211{{"Lambda[211∈5]<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle209{{"PgSelectSingle[209∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda211 & PgSelectSingle209 --> PgSingleTablePolymorphic212
     PgSingleTablePolymorphic267["PgSingleTablePolymorphic[267∈5]<br />ᐳSingleTableChecklistItem"]:::plan
-    Lambda266{{"Lambda[266∈5]"}}:::plan
+    Lambda266{{"Lambda[266∈5]<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle264{{"PgSelectSingle[264∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda266 & PgSelectSingle264 --> PgSingleTablePolymorphic267
     PgSelectSingle24 --> PgClassExpression28
@@ -81,38 +96,51 @@ graph TD
     PgSelectRows34 --> First33
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression36 --> Lambda37
-    PgClassExpression80{{"PgClassExpression[80∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression80
-    PgClassExpression82{{"PgClassExpression[82∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression82
-    PgSelectSingle24 --> PgClassExpression83
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression41
+    PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression42
+    PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression51
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression53
+    PgClassExpression54{{"PgClassExpression[54∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression54
+    PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression55
     First86{{"First[86∈5]"}}:::plan
     PgSelectRows87[["PgSelectRows[87∈5]<br />ᐳSingleTableTopic"]]:::plan
     PgSelectRows87 --> First86
     PgSelect84 --> PgSelectRows87
     PgSelectSingle88{{"PgSelectSingle[88∈5]<br />ᐸpeopleᐳ"}}:::plan
     First86 --> PgSelectSingle88
-    PgClassExpression90{{"PgClassExpression[90∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression90
-    PgClassExpression91{{"PgClassExpression[91∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression91
-    PgClassExpression92{{"PgClassExpression[92∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression92
-    PgClassExpression93{{"PgClassExpression[93∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression93
-    PgClassExpression94{{"PgClassExpression[94∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression94
     First97{{"First[97∈5]"}}:::plan
     PgSelectRows98[["PgSelectRows[98∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows98 --> First97
     PgSelect29 --> PgSelectRows98
     First97 --> PgSelectSingle99
-    PgClassExpression100{{"PgClassExpression[100∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression100{{"PgClassExpression[100∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle99 --> PgClassExpression100
     PgClassExpression100 --> Lambda101
+    PgClassExpression105{{"PgClassExpression[105∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression106
+    PgClassExpression115{{"PgClassExpression[115∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression115
+    PgClassExpression116{{"PgClassExpression[116∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression117
+    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression118
+    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression119
     First146{{"First[146∈5]"}}:::plan
     PgSelectRows147[["PgSelectRows[147∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows147 --> First146
@@ -124,9 +152,23 @@ graph TD
     PgSelectRows153 --> First152
     PgSelect29 --> PgSelectRows153
     First152 --> PgSelectSingle154
-    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle154 --> PgClassExpression155
     PgClassExpression155 --> Lambda156
+    PgClassExpression160{{"PgClassExpression[160∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression160
+    PgClassExpression161{{"PgClassExpression[161∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression161
+    PgClassExpression170{{"PgClassExpression[170∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression170
+    PgClassExpression171{{"PgClassExpression[171∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression171
+    PgClassExpression172{{"PgClassExpression[172∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression172
+    PgClassExpression173{{"PgClassExpression[173∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression173
+    PgClassExpression174{{"PgClassExpression[174∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression174
     First201{{"First[201∈5]"}}:::plan
     PgSelectRows202[["PgSelectRows[202∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows202 --> First201
@@ -138,9 +180,23 @@ graph TD
     PgSelectRows208 --> First207
     PgSelect29 --> PgSelectRows208
     First207 --> PgSelectSingle209
-    PgClassExpression210{{"PgClassExpression[210∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression210{{"PgClassExpression[210∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle209 --> PgClassExpression210
     PgClassExpression210 --> Lambda211
+    PgClassExpression215{{"PgClassExpression[215∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression215
+    PgClassExpression216{{"PgClassExpression[216∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression216
+    PgClassExpression225{{"PgClassExpression[225∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression225
+    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression226
+    PgClassExpression227{{"PgClassExpression[227∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression227
+    PgClassExpression228{{"PgClassExpression[228∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression228
+    PgClassExpression229{{"PgClassExpression[229∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression229
     First256{{"First[256∈5]"}}:::plan
     PgSelectRows257[["PgSelectRows[257∈5]<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows257 --> First256
@@ -152,9 +208,23 @@ graph TD
     PgSelectRows263 --> First262
     PgSelect29 --> PgSelectRows263
     First262 --> PgSelectSingle264
-    PgClassExpression265{{"PgClassExpression[265∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression265{{"PgClassExpression[265∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle264 --> PgClassExpression265
     PgClassExpression265 --> Lambda266
+    PgClassExpression270{{"PgClassExpression[270∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression270
+    PgClassExpression271{{"PgClassExpression[271∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression271
+    PgClassExpression280{{"PgClassExpression[280∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression280
+    PgClassExpression281{{"PgClassExpression[281∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression281
+    PgClassExpression282{{"PgClassExpression[282∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression282
+    PgClassExpression283{{"PgClassExpression[283∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression283
+    PgClassExpression284{{"PgClassExpression[284∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression284
     First311{{"First[311∈5]"}}:::plan
     PgSelectRows312[["PgSelectRows[312∈5]<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows312 --> First311
@@ -162,27 +232,13 @@ graph TD
     PgSelectSingle313{{"PgSelectSingle[313∈5]<br />ᐸpeopleᐳ"}}:::plan
     First311 --> PgSelectSingle313
     PgSelect43[["PgSelect[43∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression42{{"PgClassExpression[42∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression42 --> PgSelect43
-    PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression41
-    PgSelectSingle35 --> PgClassExpression42
     First47{{"First[47∈6]"}}:::plan
     PgSelectRows48[["PgSelectRows[48∈6]<br />ᐳSingleTableTopicᐳSingleTableTopic"]]:::plan
     PgSelectRows48 --> First47
     PgSelect43 --> PgSelectRows48
     PgSelectSingle49{{"PgSelectSingle[49∈6]<br />ᐸpeopleᐳ"}}:::plan
     First47 --> PgSelectSingle49
-    PgClassExpression51{{"PgClassExpression[51∈6]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression51
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression52
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression53
-    PgClassExpression54{{"PgClassExpression[54∈6]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression54
-    PgClassExpression55{{"PgClassExpression[55∈6]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression55
     First58{{"First[58∈6]"}}:::plan
     PgSelectRows59[["PgSelectRows[59∈6]<br />ᐳSingleTableTopicᐳSingleTablePost"]]:::plan
     PgSelectRows59 --> First58
@@ -220,27 +276,13 @@ graph TD
     PgClassExpression89{{"PgClassExpression[89∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle88 --> PgClassExpression89
     PgSelect107[["PgSelect[107∈13]<br />ᐸpeopleᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression106{{"PgClassExpression[106∈13]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression106 --> PgSelect107
-    PgClassExpression105{{"PgClassExpression[105∈13]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression105
-    PgSelectSingle99 --> PgClassExpression106
     First111{{"First[111∈13]"}}:::plan
     PgSelectRows112[["PgSelectRows[112∈13]<br />ᐳSingleTablePostᐳSingleTableTopic"]]:::plan
     PgSelectRows112 --> First111
     PgSelect107 --> PgSelectRows112
     PgSelectSingle113{{"PgSelectSingle[113∈13]<br />ᐸpeopleᐳ"}}:::plan
     First111 --> PgSelectSingle113
-    PgClassExpression115{{"PgClassExpression[115∈13]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression115
-    PgClassExpression116{{"PgClassExpression[116∈13]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression116
-    PgClassExpression117{{"PgClassExpression[117∈13]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression117
-    PgClassExpression118{{"PgClassExpression[118∈13]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression118
-    PgClassExpression119{{"PgClassExpression[119∈13]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression119
     First122{{"First[122∈13]"}}:::plan
     PgSelectRows123[["PgSelectRows[123∈13]<br />ᐳSingleTablePostᐳSingleTablePost"]]:::plan
     PgSelectRows123 --> First122
@@ -278,27 +320,13 @@ graph TD
     PgClassExpression149{{"PgClassExpression[149∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle148 --> PgClassExpression149
     PgSelect162[["PgSelect[162∈20]<br />ᐸpeopleᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression161{{"PgClassExpression[161∈20]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression161 --> PgSelect162
-    PgClassExpression160{{"PgClassExpression[160∈20]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression160
-    PgSelectSingle154 --> PgClassExpression161
     First166{{"First[166∈20]"}}:::plan
     PgSelectRows167[["PgSelectRows[167∈20]<br />ᐳSingleTableDividerᐳSingleTableTopic"]]:::plan
     PgSelectRows167 --> First166
     PgSelect162 --> PgSelectRows167
     PgSelectSingle168{{"PgSelectSingle[168∈20]<br />ᐸpeopleᐳ"}}:::plan
     First166 --> PgSelectSingle168
-    PgClassExpression170{{"PgClassExpression[170∈20]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression170
-    PgClassExpression171{{"PgClassExpression[171∈20]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression171
-    PgClassExpression172{{"PgClassExpression[172∈20]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression172
-    PgClassExpression173{{"PgClassExpression[173∈20]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression173
-    PgClassExpression174{{"PgClassExpression[174∈20]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression174
     First177{{"First[177∈20]"}}:::plan
     PgSelectRows178[["PgSelectRows[178∈20]<br />ᐳSingleTableDividerᐳSingleTablePost"]]:::plan
     PgSelectRows178 --> First177
@@ -336,27 +364,13 @@ graph TD
     PgClassExpression204{{"PgClassExpression[204∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle203 --> PgClassExpression204
     PgSelect217[["PgSelect[217∈27]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression216{{"PgClassExpression[216∈27]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression216 --> PgSelect217
-    PgClassExpression215{{"PgClassExpression[215∈27]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression215
-    PgSelectSingle209 --> PgClassExpression216
     First221{{"First[221∈27]"}}:::plan
     PgSelectRows222[["PgSelectRows[222∈27]<br />ᐳSingleTableChecklistᐳSingleTableTopic"]]:::plan
     PgSelectRows222 --> First221
     PgSelect217 --> PgSelectRows222
     PgSelectSingle223{{"PgSelectSingle[223∈27]<br />ᐸpeopleᐳ"}}:::plan
     First221 --> PgSelectSingle223
-    PgClassExpression225{{"PgClassExpression[225∈27]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression225
-    PgClassExpression226{{"PgClassExpression[226∈27]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression226
-    PgClassExpression227{{"PgClassExpression[227∈27]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression227
-    PgClassExpression228{{"PgClassExpression[228∈27]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression228
-    PgClassExpression229{{"PgClassExpression[229∈27]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression229
     First232{{"First[232∈27]"}}:::plan
     PgSelectRows233[["PgSelectRows[233∈27]<br />ᐳSingleTableChecklistᐳSingleTablePost"]]:::plan
     PgSelectRows233 --> First232
@@ -394,27 +408,13 @@ graph TD
     PgClassExpression259{{"PgClassExpression[259∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle258 --> PgClassExpression259
     PgSelect272[["PgSelect[272∈34]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression271{{"PgClassExpression[271∈34]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression271 --> PgSelect272
-    PgClassExpression270{{"PgClassExpression[270∈34]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression270
-    PgSelectSingle264 --> PgClassExpression271
     First276{{"First[276∈34]"}}:::plan
     PgSelectRows277[["PgSelectRows[277∈34]<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"]]:::plan
     PgSelectRows277 --> First276
     PgSelect272 --> PgSelectRows277
     PgSelectSingle278{{"PgSelectSingle[278∈34]<br />ᐸpeopleᐳ"}}:::plan
     First276 --> PgSelectSingle278
-    PgClassExpression280{{"PgClassExpression[280∈34]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression280
-    PgClassExpression281{{"PgClassExpression[281∈34]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression281
-    PgClassExpression282{{"PgClassExpression[282∈34]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression282
-    PgClassExpression283{{"PgClassExpression[283∈34]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression283
-    PgClassExpression284{{"PgClassExpression[284∈34]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression284
     First287{{"First[287∈34]"}}:::plan
     PgSelectRows288[["PgSelectRows[288∈34]<br />ᐳSingleTableChecklistItemᐳSingleTablePost"]]:::plan
     PgSelectRows288 --> First287
@@ -467,15 +467,15 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 80, 82, 83, 90, 91, 92, 93, 94<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 28, 80, 82, 83, 90, 91, 92, 93, 94<br />2: PgSelect[29], PgSelect[84]<br />3: 34, 87, 98, 147, 153, 202, 208, 257, 263, 312<br />ᐳ: 33, 35, 36, 37, 86, 88, 97, 99, 100, 101, 146, 148, 152, 154, 155, 156, 201, 203, 207, 209, 210, 211, 256, 258, 262, 264, 265, 266, 311, 313<br />4: 38, 102, 157, 212, 267"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression80,PgClassExpression82,PgClassExpression83,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 83, 27, 80, 25, 82, 90, 91, 92, 93, 94<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[84]<br />ᐳ: PgClassExpression[28]<br />2: 29, 87, 147, 202, 257, 312<br />ᐳ: 86, 88, 146, 148, 201, 203, 256, 258, 311, 313<br />3: 34, 98, 153, 208, 263<br />ᐳ: 33, 35, 36, 37, 41, 42, 51, 52, 53, 54, 55, 97, 99, 100, 101, 105, 106, 115, 116, 117, 118, 119, 152, 154, 155, 156, 160, 161, 170, 171, 172, 173, 174, 207, 209, 210, 211, 215, 216, 225, 226, 227, 228, 229, 262, 264, 265, 266, 270, 271, 280, 281, 282, 283, 284<br />4: 38, 102, 157, 212, 267"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression80,PgClassExpression82,PgClassExpression83,PgSelect84,First86,PgSelectRows87,PgSelectSingle88,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,Lambda101,PgSingleTablePolymorphic102,First146,PgSelectRows147,PgSelectSingle148,First152,PgSelectRows153,PgSelectSingle154,PgClassExpression155,Lambda156,PgSingleTablePolymorphic157,First201,PgSelectRows202,PgSelectSingle203,First207,PgSelectRows208,PgSelectSingle209,PgClassExpression210,Lambda211,PgSingleTablePolymorphic212,First256,PgSelectRows257,PgSelectSingle258,First262,PgSelectRows263,PgSelectSingle264,PgClassExpression265,Lambda266,PgSingleTablePolymorphic267,First311,PgSelectRows312,PgSelectSingle313 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 35, 9, 38, 28, 36<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 41, 42, 51, 52, 53, 54, 55<br />2: PgSelect[43]<br />3: 48, 59, 65, 71, 77<br />ᐳ: 47, 49, 58, 60, 64, 66, 70, 72, 76, 78"):::bucket
+    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression41,PgClassExpression42,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgSelect84,First86,PgSelectRows87,PgSelectSingle88,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,Lambda101,PgSingleTablePolymorphic102,PgClassExpression105,PgClassExpression106,PgClassExpression115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119,First146,PgSelectRows147,PgSelectSingle148,First152,PgSelectRows153,PgSelectSingle154,PgClassExpression155,Lambda156,PgSingleTablePolymorphic157,PgClassExpression160,PgClassExpression161,PgClassExpression170,PgClassExpression171,PgClassExpression172,PgClassExpression173,PgClassExpression174,First201,PgSelectRows202,PgSelectSingle203,First207,PgSelectRows208,PgSelectSingle209,PgClassExpression210,Lambda211,PgSingleTablePolymorphic212,PgClassExpression215,PgClassExpression216,PgClassExpression225,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgClassExpression229,First256,PgSelectRows257,PgSelectSingle258,First262,PgSelectRows263,PgSelectSingle264,PgClassExpression265,Lambda266,PgSingleTablePolymorphic267,PgClassExpression270,PgClassExpression271,PgClassExpression280,PgClassExpression281,PgClassExpression282,PgClassExpression283,PgClassExpression284,First311,PgSelectRows312,PgSelectSingle313 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 42, 38, 35, 28, 36, 41, 51, 52, 53, 54, 55<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: PgSelect[43]<br />2: 48, 59, 65, 71, 77<br />ᐳ: 47, 49, 58, 60, 64, 66, 70, 72, 76, 78"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,First58,PgSelectRows59,PgSelectSingle60,First64,PgSelectRows65,PgSelectSingle66,First70,PgSelectRows71,PgSelectSingle72,First76,PgSelectRows77,PgSelectSingle78 bucket6
+    class Bucket6,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,First58,PgSelectRows59,PgSelectSingle60,First64,PgSelectRows65,PgSelectSingle66,First70,PgSelectRows71,PgSelectSingle72,First76,PgSelectRows77,PgSelectSingle78 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[49]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression50 bucket7
@@ -494,9 +494,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 88<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[88]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression89 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 99, 9, 102, 28, 100<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 105, 106, 115, 116, 117, 118, 119<br />2: PgSelect[107]<br />3: 112, 123, 129, 135, 141<br />ᐳ: 111, 113, 122, 124, 128, 130, 134, 136, 140, 142"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 106, 102, 99, 28, 100, 105, 115, 116, 117, 118, 119<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: PgSelect[107]<br />2: 112, 123, 129, 135, 141<br />ᐳ: 111, 113, 122, 124, 128, 130, 134, 136, 140, 142"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression105,PgClassExpression106,PgSelect107,First111,PgSelectRows112,PgSelectSingle113,PgClassExpression115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119,First122,PgSelectRows123,PgSelectSingle124,First128,PgSelectRows129,PgSelectSingle130,First134,PgSelectRows135,PgSelectSingle136,First140,PgSelectRows141,PgSelectSingle142 bucket13
+    class Bucket13,PgSelect107,First111,PgSelectRows112,PgSelectSingle113,First122,PgSelectRows123,PgSelectSingle124,First128,PgSelectRows129,PgSelectSingle130,First134,PgSelectRows135,PgSelectSingle136,First140,PgSelectRows141,PgSelectSingle142 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 113<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[113]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression114 bucket14
@@ -515,9 +515,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 148<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[148]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression149 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 154, 9, 157, 28, 155<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 160, 161, 170, 171, 172, 173, 174<br />2: PgSelect[162]<br />3: 167, 178, 184, 190, 196<br />ᐳ: 166, 168, 177, 179, 183, 185, 189, 191, 195, 197"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 161, 157, 154, 28, 155, 160, 170, 171, 172, 173, 174<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: PgSelect[162]<br />2: 167, 178, 184, 190, 196<br />ᐳ: 166, 168, 177, 179, 183, 185, 189, 191, 195, 197"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression160,PgClassExpression161,PgSelect162,First166,PgSelectRows167,PgSelectSingle168,PgClassExpression170,PgClassExpression171,PgClassExpression172,PgClassExpression173,PgClassExpression174,First177,PgSelectRows178,PgSelectSingle179,First183,PgSelectRows184,PgSelectSingle185,First189,PgSelectRows190,PgSelectSingle191,First195,PgSelectRows196,PgSelectSingle197 bucket20
+    class Bucket20,PgSelect162,First166,PgSelectRows167,PgSelectSingle168,First177,PgSelectRows178,PgSelectSingle179,First183,PgSelectRows184,PgSelectSingle185,First189,PgSelectRows190,PgSelectSingle191,First195,PgSelectRows196,PgSelectSingle197 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 168<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[168]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression169 bucket21
@@ -536,9 +536,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 203<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[203]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression204 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 209, 9, 212, 28, 210<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 215, 216, 225, 226, 227, 228, 229<br />2: PgSelect[217]<br />3: 222, 233, 239, 245, 251<br />ᐳ: 221, 223, 232, 234, 238, 240, 244, 246, 250, 252"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 216, 212, 209, 28, 210, 215, 225, 226, 227, 228, 229<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: PgSelect[217]<br />2: 222, 233, 239, 245, 251<br />ᐳ: 221, 223, 232, 234, 238, 240, 244, 246, 250, 252"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression215,PgClassExpression216,PgSelect217,First221,PgSelectRows222,PgSelectSingle223,PgClassExpression225,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgClassExpression229,First232,PgSelectRows233,PgSelectSingle234,First238,PgSelectRows239,PgSelectSingle240,First244,PgSelectRows245,PgSelectSingle246,First250,PgSelectRows251,PgSelectSingle252 bucket27
+    class Bucket27,PgSelect217,First221,PgSelectRows222,PgSelectSingle223,First232,PgSelectRows233,PgSelectSingle234,First238,PgSelectRows239,PgSelectSingle240,First244,PgSelectRows245,PgSelectSingle246,First250,PgSelectRows251,PgSelectSingle252 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 223<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[223]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression224 bucket28
@@ -557,9 +557,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 258<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[258]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression259 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 264, 9, 267, 28, 265<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 270, 271, 280, 281, 282, 283, 284<br />2: PgSelect[272]<br />3: 277, 288, 294, 300, 306<br />ᐳ: 276, 278, 287, 289, 293, 295, 299, 301, 305, 307"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 271, 267, 264, 28, 265, 270, 280, 281, 282, 283, 284<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: PgSelect[272]<br />2: 277, 288, 294, 300, 306<br />ᐳ: 276, 278, 287, 289, 293, 295, 299, 301, 305, 307"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression270,PgClassExpression271,PgSelect272,First276,PgSelectRows277,PgSelectSingle278,PgClassExpression280,PgClassExpression281,PgClassExpression282,PgClassExpression283,PgClassExpression284,First287,PgSelectRows288,PgSelectSingle289,First293,PgSelectRows294,PgSelectSingle295,First299,PgSelectRows300,PgSelectSingle301,First305,PgSelectRows306,PgSelectSingle307 bucket34
+    class Bucket34,PgSelect272,First276,PgSelectRows277,PgSelectSingle278,First287,PgSelectRows288,PgSelectSingle289,First293,PgSelectRows294,PgSelectSingle295,First299,PgSelectRows300,PgSelectSingle301,First305,PgSelectRows306,PgSelectSingle307 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 278<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[278]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression279 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.sql
@@ -32,6 +32,21 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."username" as "0",
+    __people_identifiers__.idx as "1"
+  from interfaces_and_unions.people as __people__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __people__."person_id" = __people_identifiers__."id0"
+    )
+) as __people_result__;
+
 select __single_table_items_result__.*
 from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
 lateral (
@@ -53,21 +68,6 @@ lateral (
       __single_table_items__."id" = __single_table_items_identifiers__."id0"
     )
 ) as __single_table_items_result__;
-
-select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
-lateral (
-  select
-    __people__."username" as "0",
-    __people_identifiers__.idx as "1"
-  from interfaces_and_unions.people as __people__
-  where
-    (
-      true /* authorization checks */
-    ) and (
-      __people__."person_id" = __people_identifiers__."id0"
-    )
-) as __people_result__;
 
 select
   __people__."username" as "0"

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.mermaid
@@ -49,30 +49,45 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
+    PgClassExpression80{{"PgClassExpression[80∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression80
+    PgClassExpression82{{"PgClassExpression[82∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression82
+    PgClassExpression83{{"PgClassExpression[83∈4]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression83
+    PgClassExpression90{{"PgClassExpression[90∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression90
+    PgClassExpression91{{"PgClassExpression[91∈4]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression91
+    PgClassExpression92{{"PgClassExpression[92∈4]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression92
+    PgClassExpression93{{"PgClassExpression[93∈4]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression93
+    PgClassExpression94{{"PgClassExpression[94∈4]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression94
     PgSelect29[["PgSelect[29∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object9 & PgClassExpression28 --> PgSelect29
     PgSingleTablePolymorphic38["PgSingleTablePolymorphic[38∈5]<br />ᐳSingleTableTopic"]:::plan
-    Lambda37{{"Lambda[37∈5]"}}:::plan
+    Lambda37{{"Lambda[37∈5]<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle35{{"PgSelectSingle[35∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda37 & PgSelectSingle35 --> PgSingleTablePolymorphic38
     PgSelect84[["PgSelect[84∈5]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression83{{"PgClassExpression[83∈5]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression83 --> PgSelect84
     PgSingleTablePolymorphic102["PgSingleTablePolymorphic[102∈5]<br />ᐳSingleTablePost"]:::plan
-    Lambda101{{"Lambda[101∈5]"}}:::plan
+    Lambda101{{"Lambda[101∈5]<br />ᐳSingleTablePost"}}:::plan
     PgSelectSingle99{{"PgSelectSingle[99∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda101 & PgSelectSingle99 --> PgSingleTablePolymorphic102
     PgSingleTablePolymorphic157["PgSingleTablePolymorphic[157∈5]<br />ᐳSingleTableDivider"]:::plan
-    Lambda156{{"Lambda[156∈5]"}}:::plan
+    Lambda156{{"Lambda[156∈5]<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle154{{"PgSelectSingle[154∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda156 & PgSelectSingle154 --> PgSingleTablePolymorphic157
     PgSingleTablePolymorphic212["PgSingleTablePolymorphic[212∈5]<br />ᐳSingleTableChecklist"]:::plan
-    Lambda211{{"Lambda[211∈5]"}}:::plan
+    Lambda211{{"Lambda[211∈5]<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle209{{"PgSelectSingle[209∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda211 & PgSelectSingle209 --> PgSingleTablePolymorphic212
     PgSingleTablePolymorphic267["PgSingleTablePolymorphic[267∈5]<br />ᐳSingleTableChecklistItem"]:::plan
-    Lambda266{{"Lambda[266∈5]"}}:::plan
+    Lambda266{{"Lambda[266∈5]<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle264{{"PgSelectSingle[264∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda266 & PgSelectSingle264 --> PgSingleTablePolymorphic267
     PgSelectSingle24 --> PgClassExpression28
@@ -81,38 +96,51 @@ graph TD
     PgSelectRows34 --> First33
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression36 --> Lambda37
-    PgClassExpression80{{"PgClassExpression[80∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression80
-    PgClassExpression82{{"PgClassExpression[82∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression82
-    PgSelectSingle24 --> PgClassExpression83
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression41
+    PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression42
+    PgClassExpression51{{"PgClassExpression[51∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression51
+    PgClassExpression52{{"PgClassExpression[52∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression53
+    PgClassExpression54{{"PgClassExpression[54∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression54
+    PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression55
     First86{{"First[86∈5]"}}:::plan
     PgSelectRows87[["PgSelectRows[87∈5]<br />ᐳSingleTableTopic"]]:::plan
     PgSelectRows87 --> First86
     PgSelect84 --> PgSelectRows87
     PgSelectSingle88{{"PgSelectSingle[88∈5]<br />ᐸpeopleᐳ"}}:::plan
     First86 --> PgSelectSingle88
-    PgClassExpression90{{"PgClassExpression[90∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression90
-    PgClassExpression91{{"PgClassExpression[91∈5]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression91
-    PgClassExpression92{{"PgClassExpression[92∈5]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression92
-    PgClassExpression93{{"PgClassExpression[93∈5]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression93
-    PgClassExpression94{{"PgClassExpression[94∈5]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression94
     First97{{"First[97∈5]"}}:::plan
     PgSelectRows98[["PgSelectRows[98∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows98 --> First97
     PgSelect29 --> PgSelectRows98
     First97 --> PgSelectSingle99
-    PgClassExpression100{{"PgClassExpression[100∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression100{{"PgClassExpression[100∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle99 --> PgClassExpression100
     PgClassExpression100 --> Lambda101
+    PgClassExpression105{{"PgClassExpression[105∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression106
+    PgClassExpression115{{"PgClassExpression[115∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression115
+    PgClassExpression116{{"PgClassExpression[116∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression117
+    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression118
+    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression119
     First146{{"First[146∈5]"}}:::plan
     PgSelectRows147[["PgSelectRows[147∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows147 --> First146
@@ -124,9 +152,23 @@ graph TD
     PgSelectRows153 --> First152
     PgSelect29 --> PgSelectRows153
     First152 --> PgSelectSingle154
-    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression155{{"PgClassExpression[155∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle154 --> PgClassExpression155
     PgClassExpression155 --> Lambda156
+    PgClassExpression160{{"PgClassExpression[160∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression160
+    PgClassExpression161{{"PgClassExpression[161∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression161
+    PgClassExpression170{{"PgClassExpression[170∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression170
+    PgClassExpression171{{"PgClassExpression[171∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression171
+    PgClassExpression172{{"PgClassExpression[172∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression172
+    PgClassExpression173{{"PgClassExpression[173∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression173
+    PgClassExpression174{{"PgClassExpression[174∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression174
     First201{{"First[201∈5]"}}:::plan
     PgSelectRows202[["PgSelectRows[202∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows202 --> First201
@@ -138,9 +180,23 @@ graph TD
     PgSelectRows208 --> First207
     PgSelect29 --> PgSelectRows208
     First207 --> PgSelectSingle209
-    PgClassExpression210{{"PgClassExpression[210∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression210{{"PgClassExpression[210∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle209 --> PgClassExpression210
     PgClassExpression210 --> Lambda211
+    PgClassExpression215{{"PgClassExpression[215∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression215
+    PgClassExpression216{{"PgClassExpression[216∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression216
+    PgClassExpression225{{"PgClassExpression[225∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression225
+    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression226
+    PgClassExpression227{{"PgClassExpression[227∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression227
+    PgClassExpression228{{"PgClassExpression[228∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression228
+    PgClassExpression229{{"PgClassExpression[229∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression229
     First256{{"First[256∈5]"}}:::plan
     PgSelectRows257[["PgSelectRows[257∈5]<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows257 --> First256
@@ -152,9 +208,23 @@ graph TD
     PgSelectRows263 --> First262
     PgSelect29 --> PgSelectRows263
     First262 --> PgSelectSingle264
-    PgClassExpression265{{"PgClassExpression[265∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression265{{"PgClassExpression[265∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle264 --> PgClassExpression265
     PgClassExpression265 --> Lambda266
+    PgClassExpression270{{"PgClassExpression[270∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression270
+    PgClassExpression271{{"PgClassExpression[271∈5]<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression271
+    PgClassExpression280{{"PgClassExpression[280∈5]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression280
+    PgClassExpression281{{"PgClassExpression[281∈5]<br />ᐸ__single_t...reated_at”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression281
+    PgClassExpression282{{"PgClassExpression[282∈5]<br />ᐸ__single_t...pdated_at”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression282
+    PgClassExpression283{{"PgClassExpression[283∈5]<br />ᐸ__single_t..._archived”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression283
+    PgClassExpression284{{"PgClassExpression[284∈5]<br />ᐸ__single_t...chived_at”ᐳ"}}:::plan
+    PgSelectSingle264 --> PgClassExpression284
     First311{{"First[311∈5]"}}:::plan
     PgSelectRows312[["PgSelectRows[312∈5]<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows312 --> First311
@@ -162,27 +232,13 @@ graph TD
     PgSelectSingle313{{"PgSelectSingle[313∈5]<br />ᐸpeopleᐳ"}}:::plan
     First311 --> PgSelectSingle313
     PgSelect43[["PgSelect[43∈6]<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression42{{"PgClassExpression[42∈6]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression42 --> PgSelect43
-    PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression41
-    PgSelectSingle35 --> PgClassExpression42
     First47{{"First[47∈6]"}}:::plan
     PgSelectRows48[["PgSelectRows[48∈6]<br />ᐳSingleTableTopicᐳSingleTableTopic"]]:::plan
     PgSelectRows48 --> First47
     PgSelect43 --> PgSelectRows48
     PgSelectSingle49{{"PgSelectSingle[49∈6]<br />ᐸpeopleᐳ"}}:::plan
     First47 --> PgSelectSingle49
-    PgClassExpression51{{"PgClassExpression[51∈6]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression51
-    PgClassExpression52{{"PgClassExpression[52∈6]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression52
-    PgClassExpression53{{"PgClassExpression[53∈6]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression53
-    PgClassExpression54{{"PgClassExpression[54∈6]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression54
-    PgClassExpression55{{"PgClassExpression[55∈6]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression55
     First58{{"First[58∈6]"}}:::plan
     PgSelectRows59[["PgSelectRows[59∈6]<br />ᐳSingleTableTopicᐳSingleTablePost"]]:::plan
     PgSelectRows59 --> First58
@@ -220,27 +276,13 @@ graph TD
     PgClassExpression89{{"PgClassExpression[89∈12]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle88 --> PgClassExpression89
     PgSelect107[["PgSelect[107∈13]<br />ᐸpeopleᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression106{{"PgClassExpression[106∈13]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression106 --> PgSelect107
-    PgClassExpression105{{"PgClassExpression[105∈13]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression105
-    PgSelectSingle99 --> PgClassExpression106
     First111{{"First[111∈13]"}}:::plan
     PgSelectRows112[["PgSelectRows[112∈13]<br />ᐳSingleTablePostᐳSingleTableTopic"]]:::plan
     PgSelectRows112 --> First111
     PgSelect107 --> PgSelectRows112
     PgSelectSingle113{{"PgSelectSingle[113∈13]<br />ᐸpeopleᐳ"}}:::plan
     First111 --> PgSelectSingle113
-    PgClassExpression115{{"PgClassExpression[115∈13]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression115
-    PgClassExpression116{{"PgClassExpression[116∈13]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression116
-    PgClassExpression117{{"PgClassExpression[117∈13]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression117
-    PgClassExpression118{{"PgClassExpression[118∈13]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression118
-    PgClassExpression119{{"PgClassExpression[119∈13]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle99 --> PgClassExpression119
     First122{{"First[122∈13]"}}:::plan
     PgSelectRows123[["PgSelectRows[123∈13]<br />ᐳSingleTablePostᐳSingleTablePost"]]:::plan
     PgSelectRows123 --> First122
@@ -278,27 +320,13 @@ graph TD
     PgClassExpression149{{"PgClassExpression[149∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle148 --> PgClassExpression149
     PgSelect162[["PgSelect[162∈20]<br />ᐸpeopleᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression161{{"PgClassExpression[161∈20]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression161 --> PgSelect162
-    PgClassExpression160{{"PgClassExpression[160∈20]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression160
-    PgSelectSingle154 --> PgClassExpression161
     First166{{"First[166∈20]"}}:::plan
     PgSelectRows167[["PgSelectRows[167∈20]<br />ᐳSingleTableDividerᐳSingleTableTopic"]]:::plan
     PgSelectRows167 --> First166
     PgSelect162 --> PgSelectRows167
     PgSelectSingle168{{"PgSelectSingle[168∈20]<br />ᐸpeopleᐳ"}}:::plan
     First166 --> PgSelectSingle168
-    PgClassExpression170{{"PgClassExpression[170∈20]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression170
-    PgClassExpression171{{"PgClassExpression[171∈20]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression171
-    PgClassExpression172{{"PgClassExpression[172∈20]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression172
-    PgClassExpression173{{"PgClassExpression[173∈20]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression173
-    PgClassExpression174{{"PgClassExpression[174∈20]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle154 --> PgClassExpression174
     First177{{"First[177∈20]"}}:::plan
     PgSelectRows178[["PgSelectRows[178∈20]<br />ᐳSingleTableDividerᐳSingleTablePost"]]:::plan
     PgSelectRows178 --> First177
@@ -336,27 +364,13 @@ graph TD
     PgClassExpression204{{"PgClassExpression[204∈26]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle203 --> PgClassExpression204
     PgSelect217[["PgSelect[217∈27]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression216{{"PgClassExpression[216∈27]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression216 --> PgSelect217
-    PgClassExpression215{{"PgClassExpression[215∈27]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression215
-    PgSelectSingle209 --> PgClassExpression216
     First221{{"First[221∈27]"}}:::plan
     PgSelectRows222[["PgSelectRows[222∈27]<br />ᐳSingleTableChecklistᐳSingleTableTopic"]]:::plan
     PgSelectRows222 --> First221
     PgSelect217 --> PgSelectRows222
     PgSelectSingle223{{"PgSelectSingle[223∈27]<br />ᐸpeopleᐳ"}}:::plan
     First221 --> PgSelectSingle223
-    PgClassExpression225{{"PgClassExpression[225∈27]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression225
-    PgClassExpression226{{"PgClassExpression[226∈27]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression226
-    PgClassExpression227{{"PgClassExpression[227∈27]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression227
-    PgClassExpression228{{"PgClassExpression[228∈27]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression228
-    PgClassExpression229{{"PgClassExpression[229∈27]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle209 --> PgClassExpression229
     First232{{"First[232∈27]"}}:::plan
     PgSelectRows233[["PgSelectRows[233∈27]<br />ᐳSingleTableChecklistᐳSingleTablePost"]]:::plan
     PgSelectRows233 --> First232
@@ -394,27 +408,13 @@ graph TD
     PgClassExpression259{{"PgClassExpression[259∈33]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle258 --> PgClassExpression259
     PgSelect272[["PgSelect[272∈34]<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression271{{"PgClassExpression[271∈34]<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Object9 & PgClassExpression271 --> PgSelect272
-    PgClassExpression270{{"PgClassExpression[270∈34]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression270
-    PgSelectSingle264 --> PgClassExpression271
     First276{{"First[276∈34]"}}:::plan
     PgSelectRows277[["PgSelectRows[277∈34]<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"]]:::plan
     PgSelectRows277 --> First276
     PgSelect272 --> PgSelectRows277
     PgSelectSingle278{{"PgSelectSingle[278∈34]<br />ᐸpeopleᐳ"}}:::plan
     First276 --> PgSelectSingle278
-    PgClassExpression280{{"PgClassExpression[280∈34]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression280
-    PgClassExpression281{{"PgClassExpression[281∈34]<br />ᐸ__single_t...reated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression281
-    PgClassExpression282{{"PgClassExpression[282∈34]<br />ᐸ__single_t...pdated_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression282
-    PgClassExpression283{{"PgClassExpression[283∈34]<br />ᐸ__single_t..._archived”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression283
-    PgClassExpression284{{"PgClassExpression[284∈34]<br />ᐸ__single_t...chived_at”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle264 --> PgClassExpression284
     First287{{"First[287∈34]"}}:::plan
     PgSelectRows288[["PgSelectRows[288∈34]<br />ᐳSingleTableChecklistItemᐳSingleTablePost"]]:::plan
     PgSelectRows288 --> First287
@@ -467,15 +467,15 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 80, 82, 83, 90, 91, 92, 93, 94<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 28, 80, 82, 83, 90, 91, 92, 93, 94<br />2: PgSelect[29], PgSelect[84]<br />3: 34, 87, 98, 147, 153, 202, 208, 257, 263, 312<br />ᐳ: 33, 35, 36, 37, 86, 88, 97, 99, 100, 101, 146, 148, 152, 154, 155, 156, 201, 203, 207, 209, 210, 211, 256, 258, 262, 264, 265, 266, 311, 313<br />4: 38, 102, 157, 212, 267"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression80,PgClassExpression82,PgClassExpression83,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 83, 27, 80, 25, 82, 90, 91, 92, 93, 94<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[84]<br />ᐳ: PgClassExpression[28]<br />2: 29, 87, 147, 202, 257, 312<br />ᐳ: 86, 88, 146, 148, 201, 203, 256, 258, 311, 313<br />3: 34, 98, 153, 208, 263<br />ᐳ: 33, 35, 36, 37, 41, 42, 51, 52, 53, 54, 55, 97, 99, 100, 101, 105, 106, 115, 116, 117, 118, 119, 152, 154, 155, 156, 160, 161, 170, 171, 172, 173, 174, 207, 209, 210, 211, 215, 216, 225, 226, 227, 228, 229, 262, 264, 265, 266, 270, 271, 280, 281, 282, 283, 284<br />4: 38, 102, 157, 212, 267"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression80,PgClassExpression82,PgClassExpression83,PgSelect84,First86,PgSelectRows87,PgSelectSingle88,PgClassExpression90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,Lambda101,PgSingleTablePolymorphic102,First146,PgSelectRows147,PgSelectSingle148,First152,PgSelectRows153,PgSelectSingle154,PgClassExpression155,Lambda156,PgSingleTablePolymorphic157,First201,PgSelectRows202,PgSelectSingle203,First207,PgSelectRows208,PgSelectSingle209,PgClassExpression210,Lambda211,PgSingleTablePolymorphic212,First256,PgSelectRows257,PgSelectSingle258,First262,PgSelectRows263,PgSelectSingle264,PgClassExpression265,Lambda266,PgSingleTablePolymorphic267,First311,PgSelectRows312,PgSelectSingle313 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 35, 9, 38, 28, 36<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 41, 42, 51, 52, 53, 54, 55<br />2: PgSelect[43]<br />3: 48, 59, 65, 71, 77<br />ᐳ: 47, 49, 58, 60, 64, 66, 70, 72, 76, 78"):::bucket
+    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression41,PgClassExpression42,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgSelect84,First86,PgSelectRows87,PgSelectSingle88,First97,PgSelectRows98,PgSelectSingle99,PgClassExpression100,Lambda101,PgSingleTablePolymorphic102,PgClassExpression105,PgClassExpression106,PgClassExpression115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119,First146,PgSelectRows147,PgSelectSingle148,First152,PgSelectRows153,PgSelectSingle154,PgClassExpression155,Lambda156,PgSingleTablePolymorphic157,PgClassExpression160,PgClassExpression161,PgClassExpression170,PgClassExpression171,PgClassExpression172,PgClassExpression173,PgClassExpression174,First201,PgSelectRows202,PgSelectSingle203,First207,PgSelectRows208,PgSelectSingle209,PgClassExpression210,Lambda211,PgSingleTablePolymorphic212,PgClassExpression215,PgClassExpression216,PgClassExpression225,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgClassExpression229,First256,PgSelectRows257,PgSelectSingle258,First262,PgSelectRows263,PgSelectSingle264,PgClassExpression265,Lambda266,PgSingleTablePolymorphic267,PgClassExpression270,PgClassExpression271,PgClassExpression280,PgClassExpression281,PgClassExpression282,PgClassExpression283,PgClassExpression284,First311,PgSelectRows312,PgSelectSingle313 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 42, 38, 35, 28, 36, 41, 51, 52, 53, 54, 55<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: PgSelect[43]<br />2: 48, 59, 65, 71, 77<br />ᐳ: 47, 49, 58, 60, 64, 66, 70, 72, 76, 78"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression41,PgClassExpression42,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression51,PgClassExpression52,PgClassExpression53,PgClassExpression54,PgClassExpression55,First58,PgSelectRows59,PgSelectSingle60,First64,PgSelectRows65,PgSelectSingle66,First70,PgSelectRows71,PgSelectSingle72,First76,PgSelectRows77,PgSelectSingle78 bucket6
+    class Bucket6,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,First58,PgSelectRows59,PgSelectSingle60,First64,PgSelectRows65,PgSelectSingle66,First70,PgSelectRows71,PgSelectSingle72,First76,PgSelectRows77,PgSelectSingle78 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 49<br /><br />ROOT PgSelectSingle{6}ᐸpeopleᐳ[49]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression50 bucket7
@@ -494,9 +494,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 88<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[88]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression89 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 99, 9, 102, 28, 100<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 105, 106, 115, 116, 117, 118, 119<br />2: PgSelect[107]<br />3: 112, 123, 129, 135, 141<br />ᐳ: 111, 113, 122, 124, 128, 130, 134, 136, 140, 142"):::bucket
+    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 106, 102, 99, 28, 100, 105, 115, 116, 117, 118, 119<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: PgSelect[107]<br />2: 112, 123, 129, 135, 141<br />ᐳ: 111, 113, 122, 124, 128, 130, 134, 136, 140, 142"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression105,PgClassExpression106,PgSelect107,First111,PgSelectRows112,PgSelectSingle113,PgClassExpression115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119,First122,PgSelectRows123,PgSelectSingle124,First128,PgSelectRows129,PgSelectSingle130,First134,PgSelectRows135,PgSelectSingle136,First140,PgSelectRows141,PgSelectSingle142 bucket13
+    class Bucket13,PgSelect107,First111,PgSelectRows112,PgSelectSingle113,First122,PgSelectRows123,PgSelectSingle124,First128,PgSelectRows129,PgSelectSingle130,First134,PgSelectRows135,PgSelectSingle136,First140,PgSelectRows141,PgSelectSingle142 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 113<br /><br />ROOT PgSelectSingle{13}ᐸpeopleᐳ[113]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,PgClassExpression114 bucket14
@@ -515,9 +515,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 148<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[148]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression149 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 154, 9, 157, 28, 155<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 160, 161, 170, 171, 172, 173, 174<br />2: PgSelect[162]<br />3: 167, 178, 184, 190, 196<br />ᐳ: 166, 168, 177, 179, 183, 185, 189, 191, 195, 197"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 161, 157, 154, 28, 155, 160, 170, 171, 172, 173, 174<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: PgSelect[162]<br />2: 167, 178, 184, 190, 196<br />ᐳ: 166, 168, 177, 179, 183, 185, 189, 191, 195, 197"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression160,PgClassExpression161,PgSelect162,First166,PgSelectRows167,PgSelectSingle168,PgClassExpression170,PgClassExpression171,PgClassExpression172,PgClassExpression173,PgClassExpression174,First177,PgSelectRows178,PgSelectSingle179,First183,PgSelectRows184,PgSelectSingle185,First189,PgSelectRows190,PgSelectSingle191,First195,PgSelectRows196,PgSelectSingle197 bucket20
+    class Bucket20,PgSelect162,First166,PgSelectRows167,PgSelectSingle168,First177,PgSelectRows178,PgSelectSingle179,First183,PgSelectRows184,PgSelectSingle185,First189,PgSelectRows190,PgSelectSingle191,First195,PgSelectRows196,PgSelectSingle197 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 168<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[168]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression169 bucket21
@@ -536,9 +536,9 @@ graph TD
     Bucket26("Bucket 26 (nullableBoundary)<br />Deps: 203<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[203]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,PgClassExpression204 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 209, 9, 212, 28, 210<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 215, 216, 225, 226, 227, 228, 229<br />2: PgSelect[217]<br />3: 222, 233, 239, 245, 251<br />ᐳ: 221, 223, 232, 234, 238, 240, 244, 246, 250, 252"):::bucket
+    Bucket27("Bucket 27 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 216, 212, 209, 28, 210, 215, 225, 226, 227, 228, 229<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: PgSelect[217]<br />2: 222, 233, 239, 245, 251<br />ᐳ: 221, 223, 232, 234, 238, 240, 244, 246, 250, 252"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression215,PgClassExpression216,PgSelect217,First221,PgSelectRows222,PgSelectSingle223,PgClassExpression225,PgClassExpression226,PgClassExpression227,PgClassExpression228,PgClassExpression229,First232,PgSelectRows233,PgSelectSingle234,First238,PgSelectRows239,PgSelectSingle240,First244,PgSelectRows245,PgSelectSingle246,First250,PgSelectRows251,PgSelectSingle252 bucket27
+    class Bucket27,PgSelect217,First221,PgSelectRows222,PgSelectSingle223,First232,PgSelectRows233,PgSelectSingle234,First238,PgSelectRows239,PgSelectSingle240,First244,PgSelectRows245,PgSelectSingle246,First250,PgSelectRows251,PgSelectSingle252 bucket27
     Bucket28("Bucket 28 (nullableBoundary)<br />Deps: 223<br /><br />ROOT PgSelectSingle{27}ᐸpeopleᐳ[223]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression224 bucket28
@@ -557,9 +557,9 @@ graph TD
     Bucket33("Bucket 33 (nullableBoundary)<br />Deps: 258<br /><br />ROOT PgSelectSingle{5}ᐸpeopleᐳ[258]"):::bucket
     classDef bucket33 stroke:#f5deb3
     class Bucket33,PgClassExpression259 bucket33
-    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 264, 9, 267, 28, 265<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 270, 271, 280, 281, 282, 283, 284<br />2: PgSelect[272]<br />3: 277, 288, 294, 300, 306<br />ᐳ: 276, 278, 287, 289, 293, 295, 299, 301, 305, 307"):::bucket
+    Bucket34("Bucket 34 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 9, 271, 267, 264, 28, 265, 270, 280, 281, 282, 283, 284<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: PgSelect[272]<br />2: 277, 288, 294, 300, 306<br />ᐳ: 276, 278, 287, 289, 293, 295, 299, 301, 305, 307"):::bucket
     classDef bucket34 stroke:#696969
-    class Bucket34,PgClassExpression270,PgClassExpression271,PgSelect272,First276,PgSelectRows277,PgSelectSingle278,PgClassExpression280,PgClassExpression281,PgClassExpression282,PgClassExpression283,PgClassExpression284,First287,PgSelectRows288,PgSelectSingle289,First293,PgSelectRows294,PgSelectSingle295,First299,PgSelectRows300,PgSelectSingle301,First305,PgSelectRows306,PgSelectSingle307 bucket34
+    class Bucket34,PgSelect272,First276,PgSelectRows277,PgSelectSingle278,First287,PgSelectRows288,PgSelectSingle289,First293,PgSelectRows294,PgSelectSingle295,First299,PgSelectRows300,PgSelectSingle301,First305,PgSelectRows306,PgSelectSingle307 bucket34
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 278<br /><br />ROOT PgSelectSingle{34}ᐸpeopleᐳ[278]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression279 bucket35

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.sql
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.sql
@@ -32,6 +32,21 @@ lateral (
   order by __single_table_items__."id" asc
 ) as __single_table_items_result__;
 
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."username" as "0",
+    __people_identifiers__.idx as "1"
+  from interfaces_and_unions.people as __people__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __people__."person_id" = __people_identifiers__."id0"
+    )
+) as __people_result__;
+
 select __single_table_items_result__.*
 from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __single_table_items_identifiers__,
 lateral (
@@ -53,21 +68,6 @@ lateral (
       __single_table_items__."id" = __single_table_items_identifiers__."id0"
     )
 ) as __single_table_items_result__;
-
-select __people_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
-lateral (
-  select
-    __people__."username" as "0",
-    __people_identifiers__.idx as "1"
-  from interfaces_and_unions.people as __people__
-  where
-    (
-      true /* authorization checks */
-    ) and (
-      __people__."person_id" = __people_identifiers__."id0"
-    )
-) as __people_result__;
 
 select
   __people__."username" as "0"

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.mermaid
@@ -49,27 +49,31 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
+    PgClassExpression42{{"PgClassExpression[42∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression42
+    PgClassExpression44{{"PgClassExpression[44∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression44
     PgSelect29[["PgSelect[29∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object9 & PgClassExpression28 --> PgSelect29
     PgSingleTablePolymorphic38["PgSingleTablePolymorphic[38∈5]<br />ᐳSingleTableTopic"]:::plan
-    Lambda37{{"Lambda[37∈5]"}}:::plan
+    Lambda37{{"Lambda[37∈5]<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle35{{"PgSelectSingle[35∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda37 & PgSelectSingle35 --> PgSingleTablePolymorphic38
     PgSingleTablePolymorphic52["PgSingleTablePolymorphic[52∈5]<br />ᐳSingleTablePost"]:::plan
-    Lambda51{{"Lambda[51∈5]"}}:::plan
+    Lambda51{{"Lambda[51∈5]<br />ᐳSingleTablePost"}}:::plan
     PgSelectSingle49{{"PgSelectSingle[49∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda51 & PgSelectSingle49 --> PgSingleTablePolymorphic52
     PgSingleTablePolymorphic63["PgSingleTablePolymorphic[63∈5]<br />ᐳSingleTableDivider"]:::plan
-    Lambda62{{"Lambda[62∈5]"}}:::plan
+    Lambda62{{"Lambda[62∈5]<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle60{{"PgSelectSingle[60∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda62 & PgSelectSingle60 --> PgSingleTablePolymorphic63
     PgSingleTablePolymorphic74["PgSingleTablePolymorphic[74∈5]<br />ᐳSingleTableChecklist"]:::plan
-    Lambda73{{"Lambda[73∈5]"}}:::plan
+    Lambda73{{"Lambda[73∈5]<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle71{{"PgSelectSingle[71∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda73 & PgSelectSingle71 --> PgSingleTablePolymorphic74
     PgSingleTablePolymorphic85["PgSingleTablePolymorphic[85∈5]<br />ᐳSingleTableChecklistItem"]:::plan
-    Lambda84{{"Lambda[84∈5]"}}:::plan
+    Lambda84{{"Lambda[84∈5]<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle82{{"PgSelectSingle[82∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda84 & PgSelectSingle82 --> PgSingleTablePolymorphic85
     PgSelectSingle24 --> PgClassExpression28
@@ -78,54 +82,50 @@ graph TD
     PgSelectRows34 --> First33
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression36 --> Lambda37
-    PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression42
-    PgClassExpression44{{"PgClassExpression[44∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression44
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression41
     First47{{"First[47∈5]"}}:::plan
     PgSelectRows48[["PgSelectRows[48∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows48 --> First47
     PgSelect29 --> PgSelectRows48
     First47 --> PgSelectSingle49
-    PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression50 --> Lambda51
+    PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle49 --> PgClassExpression55
     First58{{"First[58∈5]"}}:::plan
     PgSelectRows59[["PgSelectRows[59∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows59 --> First58
     PgSelect29 --> PgSelectRows59
     First58 --> PgSelectSingle60
-    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle60 --> PgClassExpression61
     PgClassExpression61 --> Lambda62
+    PgClassExpression66{{"PgClassExpression[66∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression66
     First69{{"First[69∈5]"}}:::plan
     PgSelectRows70[["PgSelectRows[70∈5]<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows70 --> First69
     PgSelect29 --> PgSelectRows70
     First69 --> PgSelectSingle71
-    PgClassExpression72{{"PgClassExpression[72∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression72{{"PgClassExpression[72∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle71 --> PgClassExpression72
     PgClassExpression72 --> Lambda73
+    PgClassExpression77{{"PgClassExpression[77∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle71 --> PgClassExpression77
     First80{{"First[80∈5]"}}:::plan
     PgSelectRows81[["PgSelectRows[81∈5]<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows81 --> First80
     PgSelect29 --> PgSelectRows81
     First80 --> PgSelectSingle82
-    PgClassExpression83{{"PgClassExpression[83∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression83{{"PgClassExpression[83∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle82 --> PgClassExpression83
     PgClassExpression83 --> Lambda84
-    PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression41
-    PgClassExpression55{{"PgClassExpression[55∈7]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle49 --> PgClassExpression55
-    PgClassExpression66{{"PgClassExpression[66∈8]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle60 --> PgClassExpression66
-    PgClassExpression77{{"PgClassExpression[77∈9]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle71 --> PgClassExpression77
-    PgClassExpression88{{"PgClassExpression[88∈10]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
+    PgClassExpression88{{"PgClassExpression[88∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
     PgSelectSingle82 --> PgClassExpression88
 
     %% define steps
@@ -143,27 +143,27 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 42, 44<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 28, 42, 44<br />2: PgSelect[29]<br />3: 34, 48, 59, 70, 81<br />ᐳ: 33, 35, 36, 37, 47, 49, 50, 51, 58, 60, 61, 62, 69, 71, 72, 73, 80, 82, 83, 84<br />4: 38, 52, 63, 74, 85"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression42,PgClassExpression44 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 42, 25, 44<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[28]<br />2: PgSelect[29]<br />3: 34, 48, 59, 70, 81<br />ᐳ: 33, 35, 36, 37, 41, 47, 49, 50, 51, 55, 58, 60, 61, 62, 66, 69, 71, 72, 73, 77, 80, 82, 83, 84, 88<br />4: 38, 52, 63, 74, 85"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression42,PgClassExpression44,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression50,Lambda51,PgSingleTablePolymorphic52,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,Lambda62,PgSingleTablePolymorphic63,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,Lambda73,PgSingleTablePolymorphic74,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,Lambda84,PgSingleTablePolymorphic85 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 35, 38, 28, 36<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
+    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression41,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression50,Lambda51,PgSingleTablePolymorphic52,PgClassExpression55,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,Lambda62,PgSingleTablePolymorphic63,PgClassExpression66,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,Lambda73,PgSingleTablePolymorphic74,PgClassExpression77,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,Lambda84,PgSingleTablePolymorphic85,PgClassExpression88 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 38, 35, 28, 36, 41<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression41 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 49, 52, 28, 50<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
+    class Bucket6 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 52, 49, 28, 50, 55<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression55 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 60, 63, 28, 61<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
+    class Bucket7 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 63, 60, 28, 61, 66<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression66 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 71, 74, 28, 72<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
+    class Bucket8 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 74, 71, 28, 72, 77<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression77 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 82, 85, 28, 83<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
+    class Bucket9 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 85, 82, 28, 83, 88<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression88 bucket10
+    class Bucket10 bucket10
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.mermaid
@@ -49,27 +49,31 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
+    PgClassExpression42{{"PgClassExpression[42∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression42
+    PgClassExpression44{{"PgClassExpression[44∈4]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression44
     PgSelect29[["PgSelect[29∈5]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object9 & PgClassExpression28 --> PgSelect29
     PgSingleTablePolymorphic38["PgSingleTablePolymorphic[38∈5]<br />ᐳSingleTableTopic"]:::plan
-    Lambda37{{"Lambda[37∈5]"}}:::plan
+    Lambda37{{"Lambda[37∈5]<br />ᐳSingleTableTopic"}}:::plan
     PgSelectSingle35{{"PgSelectSingle[35∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda37 & PgSelectSingle35 --> PgSingleTablePolymorphic38
     PgSingleTablePolymorphic52["PgSingleTablePolymorphic[52∈5]<br />ᐳSingleTablePost"]:::plan
-    Lambda51{{"Lambda[51∈5]"}}:::plan
+    Lambda51{{"Lambda[51∈5]<br />ᐳSingleTablePost"}}:::plan
     PgSelectSingle49{{"PgSelectSingle[49∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda51 & PgSelectSingle49 --> PgSingleTablePolymorphic52
     PgSingleTablePolymorphic63["PgSingleTablePolymorphic[63∈5]<br />ᐳSingleTableDivider"]:::plan
-    Lambda62{{"Lambda[62∈5]"}}:::plan
+    Lambda62{{"Lambda[62∈5]<br />ᐳSingleTableDivider"}}:::plan
     PgSelectSingle60{{"PgSelectSingle[60∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda62 & PgSelectSingle60 --> PgSingleTablePolymorphic63
     PgSingleTablePolymorphic74["PgSingleTablePolymorphic[74∈5]<br />ᐳSingleTableChecklist"]:::plan
-    Lambda73{{"Lambda[73∈5]"}}:::plan
+    Lambda73{{"Lambda[73∈5]<br />ᐳSingleTableChecklist"}}:::plan
     PgSelectSingle71{{"PgSelectSingle[71∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda73 & PgSelectSingle71 --> PgSingleTablePolymorphic74
     PgSingleTablePolymorphic85["PgSingleTablePolymorphic[85∈5]<br />ᐳSingleTableChecklistItem"]:::plan
-    Lambda84{{"Lambda[84∈5]"}}:::plan
+    Lambda84{{"Lambda[84∈5]<br />ᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle82{{"PgSelectSingle[82∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     Lambda84 & PgSelectSingle82 --> PgSingleTablePolymorphic85
     PgSelectSingle24 --> PgClassExpression28
@@ -78,54 +82,50 @@ graph TD
     PgSelectRows34 --> First33
     PgSelect29 --> PgSelectRows34
     First33 --> PgSelectSingle35
-    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression36{{"PgClassExpression[36∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
     PgClassExpression36 --> Lambda37
-    PgClassExpression42{{"PgClassExpression[42∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression42
-    PgClassExpression44{{"PgClassExpression[44∈5]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle24 --> PgClassExpression44
+    PgClassExpression41{{"PgClassExpression[41∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle35 --> PgClassExpression41
     First47{{"First[47∈5]"}}:::plan
     PgSelectRows48[["PgSelectRows[48∈5]<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows48 --> First47
     PgSelect29 --> PgSelectRows48
     First47 --> PgSelectSingle49
-    PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle49 --> PgClassExpression50
     PgClassExpression50 --> Lambda51
+    PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle49 --> PgClassExpression55
     First58{{"First[58∈5]"}}:::plan
     PgSelectRows59[["PgSelectRows[59∈5]<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows59 --> First58
     PgSelect29 --> PgSelectRows59
     First58 --> PgSelectSingle60
-    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle60 --> PgClassExpression61
     PgClassExpression61 --> Lambda62
+    PgClassExpression66{{"PgClassExpression[66∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression66
     First69{{"First[69∈5]"}}:::plan
     PgSelectRows70[["PgSelectRows[70∈5]<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows70 --> First69
     PgSelect29 --> PgSelectRows70
     First69 --> PgSelectSingle71
-    PgClassExpression72{{"PgClassExpression[72∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression72{{"PgClassExpression[72∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle71 --> PgClassExpression72
     PgClassExpression72 --> Lambda73
+    PgClassExpression77{{"PgClassExpression[77∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
+    PgSelectSingle71 --> PgClassExpression77
     First80{{"First[80∈5]"}}:::plan
     PgSelectRows81[["PgSelectRows[81∈5]<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows81 --> First80
     PgSelect29 --> PgSelectRows81
     First80 --> PgSelectSingle82
-    PgClassExpression83{{"PgClassExpression[83∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgClassExpression83{{"PgClassExpression[83∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     PgSelectSingle82 --> PgClassExpression83
     PgClassExpression83 --> Lambda84
-    PgClassExpression41{{"PgClassExpression[41∈6]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle35 --> PgClassExpression41
-    PgClassExpression55{{"PgClassExpression[55∈7]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle49 --> PgClassExpression55
-    PgClassExpression66{{"PgClassExpression[66∈8]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle60 --> PgClassExpression66
-    PgClassExpression77{{"PgClassExpression[77∈9]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle71 --> PgClassExpression77
-    PgClassExpression88{{"PgClassExpression[88∈10]<br />ᐸ__single_t...__.”type2”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
+    PgClassExpression88{{"PgClassExpression[88∈5]<br />ᐸ__single_t...__.”type2”ᐳ"}}:::plan
     PgSelectSingle82 --> PgClassExpression88
 
     %% define steps
@@ -143,27 +143,27 @@ graph TD
     Bucket3("Bucket 3 (subroutine)<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item21,PgSelectSingle22 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26<br />2: PgSingleTablePolymorphic[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br />Deps: 9<br /><br />ROOT __Item{4}ᐸ19ᐳ[23]<br />1: <br />ᐳ: 24, 25, 26, 42, 44<br />2: PgSingleTablePolymorphic[27]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 25<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 28, 42, 44<br />2: PgSelect[29]<br />3: 34, 48, 59, 70, 81<br />ᐳ: 33, 35, 36, 37, 47, 49, 50, 51, 58, 60, 61, 62, 69, 71, 72, 73, 80, 82, 83, 84<br />4: 38, 52, 63, 74, 85"):::bucket
+    class Bucket4,__Item23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression42,PgClassExpression44 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 9, 27, 42, 25, 44<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[28]<br />2: PgSelect[29]<br />3: 34, 48, 59, 70, 81<br />ᐳ: 33, 35, 36, 37, 41, 47, 49, 50, 51, 55, 58, 60, 61, 62, 66, 69, 71, 72, 73, 77, 80, 82, 83, 84, 88<br />4: 38, 52, 63, 74, 85"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression42,PgClassExpression44,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression50,Lambda51,PgSingleTablePolymorphic52,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,Lambda62,PgSingleTablePolymorphic63,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,Lambda73,PgSingleTablePolymorphic74,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,Lambda84,PgSingleTablePolymorphic85 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 35, 38, 28, 36<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
+    class Bucket5,PgClassExpression28,PgSelect29,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Lambda37,PgSingleTablePolymorphic38,PgClassExpression41,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression50,Lambda51,PgSingleTablePolymorphic52,PgClassExpression55,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression61,Lambda62,PgSingleTablePolymorphic63,PgClassExpression66,First69,PgSelectRows70,PgSelectSingle71,PgClassExpression72,Lambda73,PgSingleTablePolymorphic74,PgClassExpression77,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,Lambda84,PgSingleTablePolymorphic85,PgClassExpression88 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 38, 35, 28, 36, 41<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression41 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 49, 52, 28, 50<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
+    class Bucket6 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 52, 49, 28, 50, 55<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression55 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 60, 63, 28, 61<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
+    class Bucket7 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 63, 60, 28, 61, 66<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression66 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 71, 74, 28, 72<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
+    class Bucket8 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 74, 71, 28, 72, 77<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression77 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 82, 85, 28, 83<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
+    class Bucket9 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 85, 82, 28, 83, 88<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression88 bucket10
+    class Bucket10 bucket10
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3 & Bucket4

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.deopt.mermaid
@@ -31,9 +31,11 @@ graph TD
     PgClassExpression14{{"PgClassExpression[14∈0] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression14 --> Lambda15
+    PgClassExpression62{{"PgClassExpression[62∈0] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression62
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect18[["PgSelect[18∈1] ➊<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object10 & PgClassExpression17 --> PgSelect18
     PgSingleTablePolymorphic27["PgSingleTablePolymorphic[27∈1] ➊<br />ᐳSingleTableTopic"]:::plan
     Lambda26{{"Lambda[26∈1] ➊"}}:::plan
@@ -64,8 +66,8 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
-    PgClassExpression62{{"PgClassExpression[62∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle13 --> PgClassExpression62
+    PgClassExpression29{{"PgClassExpression[29∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression29
     First65{{"First[65∈1] ➊"}}:::plan
     PgSelectRows66[["PgSelectRows[66∈1] ➊<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows66 --> First65
@@ -74,6 +76,8 @@ graph TD
     PgClassExpression68{{"PgClassExpression[68∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression68
     PgClassExpression68 --> Lambda69
+    PgClassExpression72{{"PgClassExpression[72∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle67 --> PgClassExpression72
     First107{{"First[107∈1] ➊"}}:::plan
     PgSelectRows108[["PgSelectRows[108∈1] ➊<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows108 --> First107
@@ -82,6 +86,8 @@ graph TD
     PgClassExpression110{{"PgClassExpression[110∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle109 --> PgClassExpression110
     PgClassExpression110 --> Lambda111
+    PgClassExpression114{{"PgClassExpression[114∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle109 --> PgClassExpression114
     First149{{"First[149∈1] ➊"}}:::plan
     PgSelectRows150[["PgSelectRows[150∈1] ➊<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows150 --> First149
@@ -90,6 +96,8 @@ graph TD
     PgClassExpression152{{"PgClassExpression[152∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle151 --> PgClassExpression152
     PgClassExpression152 --> Lambda153
+    PgClassExpression156{{"PgClassExpression[156∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle151 --> PgClassExpression156
     First191{{"First[191∈1] ➊"}}:::plan
     PgSelectRows192[["PgSelectRows[192∈1] ➊<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows192 --> First191
@@ -98,10 +106,10 @@ graph TD
     PgClassExpression194{{"PgClassExpression[194∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle193 --> PgClassExpression194
     PgClassExpression194 --> Lambda195
+    PgClassExpression198{{"PgClassExpression[198∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle193 --> PgClassExpression198
     PgSelect30[["PgSelect[30∈2] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression29{{"PgClassExpression[29∈2] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression29 --> PgSelect30
-    PgSelectSingle24 --> PgClassExpression29
     First34{{"First[34∈2] ➊"}}:::plan
     PgSelectRows35[["PgSelectRows[35∈2] ➊<br />ᐳSingleTableTopicᐳSingleTableTopic"]]:::plan
     PgSelectRows35 --> First34
@@ -143,9 +151,7 @@ graph TD
     PgClassExpression61{{"PgClassExpression[61∈7] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle60 --> PgClassExpression61
     PgSelect73[["PgSelect[73∈8] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression72{{"PgClassExpression[72∈8] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression72 --> PgSelect73
-    PgSelectSingle67 --> PgClassExpression72
     First77{{"First[77∈8] ➊"}}:::plan
     PgSelectRows78[["PgSelectRows[78∈8] ➊<br />ᐳSingleTablePostᐳSingleTableTopic"]]:::plan
     PgSelectRows78 --> First77
@@ -187,9 +193,7 @@ graph TD
     PgClassExpression104{{"PgClassExpression[104∈13] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle103 --> PgClassExpression104
     PgSelect115[["PgSelect[115∈14] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression114{{"PgClassExpression[114∈14] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression114 --> PgSelect115
-    PgSelectSingle109 --> PgClassExpression114
     First119{{"First[119∈14] ➊"}}:::plan
     PgSelectRows120[["PgSelectRows[120∈14] ➊<br />ᐳSingleTableDividerᐳSingleTableTopic"]]:::plan
     PgSelectRows120 --> First119
@@ -231,9 +235,7 @@ graph TD
     PgClassExpression146{{"PgClassExpression[146∈19] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle145 --> PgClassExpression146
     PgSelect157[["PgSelect[157∈20] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression156{{"PgClassExpression[156∈20] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression156 --> PgSelect157
-    PgSelectSingle151 --> PgClassExpression156
     First161{{"First[161∈20] ➊"}}:::plan
     PgSelectRows162[["PgSelectRows[162∈20] ➊<br />ᐳSingleTableChecklistᐳSingleTableTopic"]]:::plan
     PgSelectRows162 --> First161
@@ -275,9 +277,7 @@ graph TD
     PgClassExpression188{{"PgClassExpression[188∈25] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle187 --> PgClassExpression188
     PgSelect199[["PgSelect[199∈26] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression198{{"PgClassExpression[198∈26] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression198 --> PgSelect199
-    PgSelectSingle193 --> PgClassExpression198
     First203{{"First[203∈26] ➊"}}:::plan
     PgSelectRows204[["PgSelectRows[204∈26] ➊<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"]]:::plan
     PgSelectRows204 --> First203
@@ -322,15 +322,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 231, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15<br />4: PgSingleTablePolymorphic[16]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 231, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15, 62<br />4: PgSingleTablePolymorphic[16]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,Lambda15,PgSingleTablePolymorphic16,Constant231 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 13, 10, 16<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 17, 62<br />2: PgSelect[18]<br />3: 23, 66, 108, 150, 192<br />ᐳ: 22, 24, 25, 26, 65, 67, 68, 69, 107, 109, 110, 111, 149, 151, 152, 153, 191, 193, 194, 195<br />4: 27, 70, 112, 154, 196"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,Lambda15,PgSingleTablePolymorphic16,PgClassExpression62,Constant231 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 13, 10, 16, 62<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[17]<br />2: PgSelect[18]<br />3: 23, 66, 108, 150, 192<br />ᐳ: 22, 24, 25, 26, 29, 65, 67, 68, 69, 72, 107, 109, 110, 111, 114, 149, 151, 152, 153, 156, 191, 193, 194, 195, 198<br />4: 27, 70, 112, 154, 196"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression17,PgSelect18,First22,PgSelectRows23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression62,First65,PgSelectRows66,PgSelectSingle67,PgClassExpression68,Lambda69,PgSingleTablePolymorphic70,First107,PgSelectRows108,PgSelectSingle109,PgClassExpression110,Lambda111,PgSingleTablePolymorphic112,First149,PgSelectRows150,PgSelectSingle151,PgClassExpression152,Lambda153,PgSingleTablePolymorphic154,First191,PgSelectRows192,PgSelectSingle193,PgClassExpression194,Lambda195,PgSingleTablePolymorphic196 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 10, 27, 17<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[29]<br />2: PgSelect[30]<br />3: 35, 41, 47, 53, 59<br />ᐳ: 34, 36, 40, 42, 46, 48, 52, 54, 58, 60"):::bucket
+    class Bucket1,PgClassExpression17,PgSelect18,First22,PgSelectRows23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression29,First65,PgSelectRows66,PgSelectSingle67,PgClassExpression68,Lambda69,PgSingleTablePolymorphic70,PgClassExpression72,First107,PgSelectRows108,PgSelectSingle109,PgClassExpression110,Lambda111,PgSingleTablePolymorphic112,PgClassExpression114,First149,PgSelectRows150,PgSelectSingle151,PgClassExpression152,Lambda153,PgSingleTablePolymorphic154,PgClassExpression156,First191,PgSelectRows192,PgSelectSingle193,PgClassExpression194,Lambda195,PgSingleTablePolymorphic196,PgClassExpression198 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 29, 27, 24, 17<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: PgSelect[30]<br />2: 35, 41, 47, 53, 59<br />ᐳ: 34, 36, 40, 42, 46, 48, 52, 54, 58, 60"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression29,PgSelect30,First34,PgSelectRows35,PgSelectSingle36,First40,PgSelectRows41,PgSelectSingle42,First46,PgSelectRows47,PgSelectSingle48,First52,PgSelectRows53,PgSelectSingle54,First58,PgSelectRows59,PgSelectSingle60 bucket2
+    class Bucket2,PgSelect30,First34,PgSelectRows35,PgSelectSingle36,First40,PgSelectRows41,PgSelectSingle42,First46,PgSelectRows47,PgSelectSingle48,First52,PgSelectRows53,PgSelectSingle54,First58,PgSelectRows59,PgSelectSingle60 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression37 bucket3
@@ -346,9 +346,9 @@ graph TD
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 60<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[60]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression61 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 67, 10, 70, 17<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[72]<br />2: PgSelect[73]<br />3: 78, 84, 90, 96, 102<br />ᐳ: 77, 79, 83, 85, 89, 91, 95, 97, 101, 103"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 72, 70, 67, 17<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: PgSelect[73]<br />2: 78, 84, 90, 96, 102<br />ᐳ: 77, 79, 83, 85, 89, 91, 95, 97, 101, 103"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression72,PgSelect73,First77,PgSelectRows78,PgSelectSingle79,First83,PgSelectRows84,PgSelectSingle85,First89,PgSelectRows90,PgSelectSingle91,First95,PgSelectRows96,PgSelectSingle97,First101,PgSelectRows102,PgSelectSingle103 bucket8
+    class Bucket8,PgSelect73,First77,PgSelectRows78,PgSelectSingle79,First83,PgSelectRows84,PgSelectSingle85,First89,PgSelectRows90,PgSelectSingle91,First95,PgSelectRows96,PgSelectSingle97,First101,PgSelectRows102,PgSelectSingle103 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 79<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[79]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression80 bucket9
@@ -364,9 +364,9 @@ graph TD
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 103<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[103]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression104 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 109, 10, 112, 17<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[114]<br />2: PgSelect[115]<br />3: 120, 126, 132, 138, 144<br />ᐳ: 119, 121, 125, 127, 131, 133, 137, 139, 143, 145"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 114, 112, 109, 17<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: PgSelect[115]<br />2: 120, 126, 132, 138, 144<br />ᐳ: 119, 121, 125, 127, 131, 133, 137, 139, 143, 145"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression114,PgSelect115,First119,PgSelectRows120,PgSelectSingle121,First125,PgSelectRows126,PgSelectSingle127,First131,PgSelectRows132,PgSelectSingle133,First137,PgSelectRows138,PgSelectSingle139,First143,PgSelectRows144,PgSelectSingle145 bucket14
+    class Bucket14,PgSelect115,First119,PgSelectRows120,PgSelectSingle121,First125,PgSelectRows126,PgSelectSingle127,First131,PgSelectRows132,PgSelectSingle133,First137,PgSelectRows138,PgSelectSingle139,First143,PgSelectRows144,PgSelectSingle145 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 121<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[121]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression122 bucket15
@@ -382,9 +382,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 145<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[145]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression146 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 151, 10, 154, 17<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[156]<br />2: PgSelect[157]<br />3: 162, 168, 174, 180, 186<br />ᐳ: 161, 163, 167, 169, 173, 175, 179, 181, 185, 187"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 156, 154, 151, 17<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: PgSelect[157]<br />2: 162, 168, 174, 180, 186<br />ᐳ: 161, 163, 167, 169, 173, 175, 179, 181, 185, 187"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression156,PgSelect157,First161,PgSelectRows162,PgSelectSingle163,First167,PgSelectRows168,PgSelectSingle169,First173,PgSelectRows174,PgSelectSingle175,First179,PgSelectRows180,PgSelectSingle181,First185,PgSelectRows186,PgSelectSingle187 bucket20
+    class Bucket20,PgSelect157,First161,PgSelectRows162,PgSelectSingle163,First167,PgSelectRows168,PgSelectSingle169,First173,PgSelectRows174,PgSelectSingle175,First179,PgSelectRows180,PgSelectSingle181,First185,PgSelectRows186,PgSelectSingle187 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 163<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[163]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression164 bucket21
@@ -400,9 +400,9 @@ graph TD
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 187<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[187]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgClassExpression188 bucket25
-    Bucket26("Bucket 26 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 193, 10, 196, 17<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[198]<br />2: PgSelect[199]<br />3: 204, 210, 216, 222, 228<br />ᐳ: 203, 205, 209, 211, 215, 217, 221, 223, 227, 229"):::bucket
+    Bucket26("Bucket 26 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 198, 196, 193, 17<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: PgSelect[199]<br />2: 204, 210, 216, 222, 228<br />ᐳ: 203, 205, 209, 211, 215, 217, 221, 223, 227, 229"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,PgClassExpression198,PgSelect199,First203,PgSelectRows204,PgSelectSingle205,First209,PgSelectRows210,PgSelectSingle211,First215,PgSelectRows216,PgSelectSingle217,First221,PgSelectRows222,PgSelectSingle223,First227,PgSelectRows228,PgSelectSingle229 bucket26
+    class Bucket26,PgSelect199,First203,PgSelectRows204,PgSelectSingle205,First209,PgSelectRows210,PgSelectSingle211,First215,PgSelectRows216,PgSelectSingle217,First221,PgSelectRows222,PgSelectSingle223,First227,PgSelectRows228,PgSelectSingle229 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 205<br /><br />ROOT PgSelectSingle{26}ᐸpeopleᐳ[205]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgClassExpression206 bucket27

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/relation.mermaid
@@ -31,9 +31,11 @@ graph TD
     PgClassExpression14{{"PgClassExpression[14∈0] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle13 --> PgClassExpression14
     PgClassExpression14 --> Lambda15
+    PgClassExpression62{{"PgClassExpression[62∈0] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression62
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect18[["PgSelect[18∈1] ➊<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression17{{"PgClassExpression[17∈1] ➊<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br />ᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br />ᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItem<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Object10 & PgClassExpression17 --> PgSelect18
     PgSingleTablePolymorphic27["PgSingleTablePolymorphic[27∈1] ➊<br />ᐳSingleTableTopic"]:::plan
     Lambda26{{"Lambda[26∈1] ➊"}}:::plan
@@ -64,8 +66,8 @@ graph TD
     PgClassExpression25{{"PgClassExpression[25∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle24 --> PgClassExpression25
     PgClassExpression25 --> Lambda26
-    PgClassExpression62{{"PgClassExpression[62∈1] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle13 --> PgClassExpression62
+    PgClassExpression29{{"PgClassExpression[29∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression29
     First65{{"First[65∈1] ➊"}}:::plan
     PgSelectRows66[["PgSelectRows[66∈1] ➊<br />ᐳSingleTablePost"]]:::plan
     PgSelectRows66 --> First65
@@ -74,6 +76,8 @@ graph TD
     PgClassExpression68{{"PgClassExpression[68∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle67 --> PgClassExpression68
     PgClassExpression68 --> Lambda69
+    PgClassExpression72{{"PgClassExpression[72∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle67 --> PgClassExpression72
     First107{{"First[107∈1] ➊"}}:::plan
     PgSelectRows108[["PgSelectRows[108∈1] ➊<br />ᐳSingleTableDivider"]]:::plan
     PgSelectRows108 --> First107
@@ -82,6 +86,8 @@ graph TD
     PgClassExpression110{{"PgClassExpression[110∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle109 --> PgClassExpression110
     PgClassExpression110 --> Lambda111
+    PgClassExpression114{{"PgClassExpression[114∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle109 --> PgClassExpression114
     First149{{"First[149∈1] ➊"}}:::plan
     PgSelectRows150[["PgSelectRows[150∈1] ➊<br />ᐳSingleTableChecklist"]]:::plan
     PgSelectRows150 --> First149
@@ -90,6 +96,8 @@ graph TD
     PgClassExpression152{{"PgClassExpression[152∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle151 --> PgClassExpression152
     PgClassExpression152 --> Lambda153
+    PgClassExpression156{{"PgClassExpression[156∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle151 --> PgClassExpression156
     First191{{"First[191∈1] ➊"}}:::plan
     PgSelectRows192[["PgSelectRows[192∈1] ➊<br />ᐳSingleTableChecklistItem"]]:::plan
     PgSelectRows192 --> First191
@@ -98,10 +106,10 @@ graph TD
     PgClassExpression194{{"PgClassExpression[194∈1] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle193 --> PgClassExpression194
     PgClassExpression194 --> Lambda195
+    PgClassExpression198{{"PgClassExpression[198∈1] ➊<br />ᐸ__single_t...author_id”ᐳ"}}:::plan
+    PgSelectSingle193 --> PgClassExpression198
     PgSelect30[["PgSelect[30∈2] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression29{{"PgClassExpression[29∈2] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression29 --> PgSelect30
-    PgSelectSingle24 --> PgClassExpression29
     First34{{"First[34∈2] ➊"}}:::plan
     PgSelectRows35[["PgSelectRows[35∈2] ➊<br />ᐳSingleTableTopicᐳSingleTableTopic"]]:::plan
     PgSelectRows35 --> First34
@@ -143,9 +151,7 @@ graph TD
     PgClassExpression61{{"PgClassExpression[61∈7] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle60 --> PgClassExpression61
     PgSelect73[["PgSelect[73∈8] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression72{{"PgClassExpression[72∈8] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression72 --> PgSelect73
-    PgSelectSingle67 --> PgClassExpression72
     First77{{"First[77∈8] ➊"}}:::plan
     PgSelectRows78[["PgSelectRows[78∈8] ➊<br />ᐳSingleTablePostᐳSingleTableTopic"]]:::plan
     PgSelectRows78 --> First77
@@ -187,9 +193,7 @@ graph TD
     PgClassExpression104{{"PgClassExpression[104∈13] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle103 --> PgClassExpression104
     PgSelect115[["PgSelect[115∈14] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression114{{"PgClassExpression[114∈14] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression114 --> PgSelect115
-    PgSelectSingle109 --> PgClassExpression114
     First119{{"First[119∈14] ➊"}}:::plan
     PgSelectRows120[["PgSelectRows[120∈14] ➊<br />ᐳSingleTableDividerᐳSingleTableTopic"]]:::plan
     PgSelectRows120 --> First119
@@ -231,9 +235,7 @@ graph TD
     PgClassExpression146{{"PgClassExpression[146∈19] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle145 --> PgClassExpression146
     PgSelect157[["PgSelect[157∈20] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression156{{"PgClassExpression[156∈20] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression156 --> PgSelect157
-    PgSelectSingle151 --> PgClassExpression156
     First161{{"First[161∈20] ➊"}}:::plan
     PgSelectRows162[["PgSelectRows[162∈20] ➊<br />ᐳSingleTableChecklistᐳSingleTableTopic"]]:::plan
     PgSelectRows162 --> First161
@@ -275,9 +277,7 @@ graph TD
     PgClassExpression188{{"PgClassExpression[188∈25] ➊<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle187 --> PgClassExpression188
     PgSelect199[["PgSelect[199∈26] ➊<br />ᐸpeopleᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression198{{"PgClassExpression[198∈26] ➊<br />ᐸ__single_t...author_id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Object10 & PgClassExpression198 --> PgSelect199
-    PgSelectSingle193 --> PgClassExpression198
     First203{{"First[203∈26] ➊"}}:::plan
     PgSelectRows204[["PgSelectRows[204∈26] ➊<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"]]:::plan
     PgSelectRows204 --> First203
@@ -322,15 +322,15 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/interfaces-single-table/relation"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 231, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15<br />4: PgSingleTablePolymorphic[16]"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 231, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15, 62<br />4: PgSingleTablePolymorphic[16]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,Lambda15,PgSingleTablePolymorphic16,Constant231 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 13, 10, 16<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 17, 62<br />2: PgSelect[18]<br />3: 23, 66, 108, 150, 192<br />ᐳ: 22, 24, 25, 26, 65, 67, 68, 69, 107, 109, 110, 111, 149, 151, 152, 153, 191, 193, 194, 195<br />4: 27, 70, 112, 154, 196"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,Lambda15,PgSingleTablePolymorphic16,PgClassExpression62,Constant231 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 13, 10, 16, 62<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[17]<br />2: PgSelect[18]<br />3: 23, 66, 108, 150, 192<br />ᐳ: 22, 24, 25, 26, 29, 65, 67, 68, 69, 72, 107, 109, 110, 111, 114, 149, 151, 152, 153, 156, 191, 193, 194, 195, 198<br />4: 27, 70, 112, 154, 196"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression17,PgSelect18,First22,PgSelectRows23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression62,First65,PgSelectRows66,PgSelectSingle67,PgClassExpression68,Lambda69,PgSingleTablePolymorphic70,First107,PgSelectRows108,PgSelectSingle109,PgClassExpression110,Lambda111,PgSingleTablePolymorphic112,First149,PgSelectRows150,PgSelectSingle151,PgClassExpression152,Lambda153,PgSingleTablePolymorphic154,First191,PgSelectRows192,PgSelectSingle193,PgClassExpression194,Lambda195,PgSingleTablePolymorphic196 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 24, 10, 27, 17<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[29]<br />2: PgSelect[30]<br />3: 35, 41, 47, 53, 59<br />ᐳ: 34, 36, 40, 42, 46, 48, 52, 54, 58, 60"):::bucket
+    class Bucket1,PgClassExpression17,PgSelect18,First22,PgSelectRows23,PgSelectSingle24,PgClassExpression25,Lambda26,PgSingleTablePolymorphic27,PgClassExpression29,First65,PgSelectRows66,PgSelectSingle67,PgClassExpression68,Lambda69,PgSingleTablePolymorphic70,PgClassExpression72,First107,PgSelectRows108,PgSelectSingle109,PgClassExpression110,Lambda111,PgSingleTablePolymorphic112,PgClassExpression114,First149,PgSelectRows150,PgSelectSingle151,PgClassExpression152,Lambda153,PgSingleTablePolymorphic154,PgClassExpression156,First191,PgSelectRows192,PgSelectSingle193,PgClassExpression194,Lambda195,PgSingleTablePolymorphic196,PgClassExpression198 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 29, 27, 24, 17<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem<br /><br />1: PgSelect[30]<br />2: 35, 41, 47, 53, 59<br />ᐳ: 34, 36, 40, 42, 46, 48, 52, 54, 58, 60"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression29,PgSelect30,First34,PgSelectRows35,PgSelectSingle36,First40,PgSelectRows41,PgSelectSingle42,First46,PgSelectRows47,PgSelectSingle48,First52,PgSelectRows53,PgSelectSingle54,First58,PgSelectRows59,PgSelectSingle60 bucket2
+    class Bucket2,PgSelect30,First34,PgSelectRows35,PgSelectSingle36,First40,PgSelectRows41,PgSelectSingle42,First46,PgSelectRows47,PgSelectSingle48,First52,PgSelectRows53,PgSelectSingle54,First58,PgSelectRows59,PgSelectSingle60 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[36]"):::bucket
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression37 bucket3
@@ -346,9 +346,9 @@ graph TD
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 60<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[60]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,PgClassExpression61 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 67, 10, 70, 17<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[72]<br />2: PgSelect[73]<br />3: 78, 84, 90, 96, 102<br />ᐳ: 77, 79, 83, 85, 89, 91, 95, 97, 101, 103"):::bucket
+    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 72, 70, 67, 17<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem<br /><br />1: PgSelect[73]<br />2: 78, 84, 90, 96, 102<br />ᐳ: 77, 79, 83, 85, 89, 91, 95, 97, 101, 103"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression72,PgSelect73,First77,PgSelectRows78,PgSelectSingle79,First83,PgSelectRows84,PgSelectSingle85,First89,PgSelectRows90,PgSelectSingle91,First95,PgSelectRows96,PgSelectSingle97,First101,PgSelectRows102,PgSelectSingle103 bucket8
+    class Bucket8,PgSelect73,First77,PgSelectRows78,PgSelectSingle79,First83,PgSelectRows84,PgSelectSingle85,First89,PgSelectRows90,PgSelectSingle91,First95,PgSelectRows96,PgSelectSingle97,First101,PgSelectRows102,PgSelectSingle103 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 79<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[79]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression80 bucket9
@@ -364,9 +364,9 @@ graph TD
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 103<br /><br />ROOT PgSelectSingle{8}ᐸpeopleᐳ[103]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,PgClassExpression104 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 109, 10, 112, 17<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[114]<br />2: PgSelect[115]<br />3: 120, 126, 132, 138, 144<br />ᐳ: 119, 121, 125, 127, 131, 133, 137, 139, 143, 145"):::bucket
+    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 114, 112, 109, 17<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem<br /><br />1: PgSelect[115]<br />2: 120, 126, 132, 138, 144<br />ᐳ: 119, 121, 125, 127, 131, 133, 137, 139, 143, 145"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression114,PgSelect115,First119,PgSelectRows120,PgSelectSingle121,First125,PgSelectRows126,PgSelectSingle127,First131,PgSelectRows132,PgSelectSingle133,First137,PgSelectRows138,PgSelectSingle139,First143,PgSelectRows144,PgSelectSingle145 bucket14
+    class Bucket14,PgSelect115,First119,PgSelectRows120,PgSelectSingle121,First125,PgSelectRows126,PgSelectSingle127,First131,PgSelectRows132,PgSelectSingle133,First137,PgSelectRows138,PgSelectSingle139,First143,PgSelectRows144,PgSelectSingle145 bucket14
     Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 121<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[121]"):::bucket
     classDef bucket15 stroke:#ff00ff
     class Bucket15,PgClassExpression122 bucket15
@@ -382,9 +382,9 @@ graph TD
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 145<br /><br />ROOT PgSelectSingle{14}ᐸpeopleᐳ[145]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,PgClassExpression146 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 151, 10, 154, 17<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[156]<br />2: PgSelect[157]<br />3: 162, 168, 174, 180, 186<br />ᐳ: 161, 163, 167, 169, 173, 175, 179, 181, 185, 187"):::bucket
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 156, 154, 151, 17<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem<br /><br />1: PgSelect[157]<br />2: 162, 168, 174, 180, 186<br />ᐳ: 161, 163, 167, 169, 173, 175, 179, 181, 185, 187"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression156,PgSelect157,First161,PgSelectRows162,PgSelectSingle163,First167,PgSelectRows168,PgSelectSingle169,First173,PgSelectRows174,PgSelectSingle175,First179,PgSelectRows180,PgSelectSingle181,First185,PgSelectRows186,PgSelectSingle187 bucket20
+    class Bucket20,PgSelect157,First161,PgSelectRows162,PgSelectSingle163,First167,PgSelectRows168,PgSelectSingle169,First173,PgSelectRows174,PgSelectSingle175,First179,PgSelectRows180,PgSelectSingle181,First185,PgSelectRows186,PgSelectSingle187 bucket20
     Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 163<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[163]"):::bucket
     classDef bucket21 stroke:#0000ff
     class Bucket21,PgClassExpression164 bucket21
@@ -400,9 +400,9 @@ graph TD
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 187<br /><br />ROOT PgSelectSingle{20}ᐸpeopleᐳ[187]"):::bucket
     classDef bucket25 stroke:#dda0dd
     class Bucket25,PgClassExpression188 bucket25
-    Bucket26("Bucket 26 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 193, 10, 196, 17<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[198]<br />2: PgSelect[199]<br />3: 204, 210, 216, 222, 228<br />ᐳ: 203, 205, 209, 211, 215, 217, 221, 223, 227, 229"):::bucket
+    Bucket26("Bucket 26 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 10, 198, 196, 193, 17<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem<br /><br />1: PgSelect[199]<br />2: 204, 210, 216, 222, 228<br />ᐳ: 203, 205, 209, 211, 215, 217, 221, 223, 227, 229"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,PgClassExpression198,PgSelect199,First203,PgSelectRows204,PgSelectSingle205,First209,PgSelectRows210,PgSelectSingle211,First215,PgSelectRows216,PgSelectSingle217,First221,PgSelectRows222,PgSelectSingle223,First227,PgSelectRows228,PgSelectSingle229 bucket26
+    class Bucket26,PgSelect199,First203,PgSelectRows204,PgSelectSingle205,First209,PgSelectRows210,PgSelectSingle211,First215,PgSelectRows216,PgSelectSingle217,First221,PgSelectRows222,PgSelectSingle223,First227,PgSelectRows228,PgSelectSingle229 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 205<br /><br />ROOT PgSelectSingle{26}ᐸpeopleᐳ[205]"):::bucket
     classDef bucket27 stroke:#ffff00
     class Bucket27,PgClassExpression206 bucket27

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.deopt.mermaid
@@ -28,15 +28,15 @@ graph TD
     Access41 ==> __Item14
     PgUnionAllSingle15["PgUnionAllSingle[15∈1]"]:::plan
     __Item14 --> PgUnionAllSingle15
+    Access16{{"Access[16∈1]<br />ᐸ15.1ᐳ"}}:::plan
+    PgUnionAllSingle15 --> Access16
     PgSelect19[["PgSelect[19∈2]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access18{{"Access[18∈2]<br />ᐸ17.0ᐳ"}}:::plan
     Object11 & Access18 --> PgSelect19
     PgSelect32[["PgSelect[32∈2]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access31{{"Access[31∈2]<br />ᐸ30.0ᐳ"}}:::plan
     Object11 & Access31 --> PgSelect32
-    Access16{{"Access[16∈2]<br />ᐸ15.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle15 --> Access16
-    JSONParse17[["JSONParse[17∈2]<br />ᐸ16ᐳ"]]:::plan
+    JSONParse17[["JSONParse[17∈2]<br />ᐸ16ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access16 --> JSONParse17
     JSONParse17 --> Access18
     First23{{"First[23∈2]"}}:::plan
@@ -79,10 +79,10 @@ graph TD
     class Bucket0,__Value2,__Value4,PgUnionAll8,Access9,Access10,Object11,Constant12,Access41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 11<br /><br />ROOT __Item{1}ᐸ41ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item14,PgUnionAllSingle15 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 15, 11<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[16]<br />2: JSONParse[17], JSONParse[30]<br />ᐳ: Access[18], Access[31]<br />3: PgSelect[19], PgSelect[32]<br />4: PgSelectRows[24], PgSelectRows[35]<br />ᐳ: 23, 25, 26, 27, 28, 29, 34, 36, 37, 38, 39, 40"):::bucket
+    class Bucket1,__Item14,PgUnionAllSingle15,Access16 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 16, 11, 15<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[17], JSONParse[30]<br />ᐳ: Access[18], Access[31]<br />2: PgSelect[19], PgSelect[32]<br />3: PgSelectRows[24], PgSelectRows[35]<br />ᐳ: 23, 25, 26, 27, 28, 29, 34, 36, 37, 38, 39, 40"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access16,JSONParse17,Access18,PgSelect19,First23,PgSelectRows24,PgSelectSingle25,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression29,JSONParse30,Access31,PgSelect32,First34,PgSelectRows35,PgSelectSingle36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40 bucket2
+    class Bucket2,JSONParse17,Access18,PgSelect19,First23,PgSelectRows24,PgSelectSingle25,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression29,JSONParse30,Access31,PgSelect32,First34,PgSelectRows35,PgSelectSingle36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40 bucket2
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilities.mermaid
@@ -28,15 +28,15 @@ graph TD
     Access41 ==> __Item14
     PgUnionAllSingle15["PgUnionAllSingle[15∈1]"]:::plan
     __Item14 --> PgUnionAllSingle15
+    Access16{{"Access[16∈1]<br />ᐸ15.1ᐳ"}}:::plan
+    PgUnionAllSingle15 --> Access16
     PgSelect19[["PgSelect[19∈2]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access18{{"Access[18∈2]<br />ᐸ17.0ᐳ"}}:::plan
     Object11 & Access18 --> PgSelect19
     PgSelect32[["PgSelect[32∈2]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access31{{"Access[31∈2]<br />ᐸ30.0ᐳ"}}:::plan
     Object11 & Access31 --> PgSelect32
-    Access16{{"Access[16∈2]<br />ᐸ15.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle15 --> Access16
-    JSONParse17[["JSONParse[17∈2]<br />ᐸ16ᐳ"]]:::plan
+    JSONParse17[["JSONParse[17∈2]<br />ᐸ16ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access16 --> JSONParse17
     JSONParse17 --> Access18
     First23{{"First[23∈2]"}}:::plan
@@ -79,10 +79,10 @@ graph TD
     class Bucket0,__Value2,__Value4,PgUnionAll8,Access9,Access10,Object11,Constant12,Access41,Constant42,Constant43 bucket0
     Bucket1("Bucket 1 (listItem)<br />Deps: 11<br /><br />ROOT __Item{1}ᐸ41ᐳ[14]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,__Item14,PgUnionAllSingle15 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 15, 11<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[16]<br />2: JSONParse[17], JSONParse[30]<br />ᐳ: Access[18], Access[31]<br />3: PgSelect[19], PgSelect[32]<br />4: PgSelectRows[24], PgSelectRows[35]<br />ᐳ: 23, 25, 26, 27, 28, 29, 34, 36, 37, 38, 39, 40"):::bucket
+    class Bucket1,__Item14,PgUnionAllSingle15,Access16 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 16, 11, 15<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[17], JSONParse[30]<br />ᐳ: Access[18], Access[31]<br />2: PgSelect[19], PgSelect[32]<br />3: PgSelectRows[24], PgSelectRows[35]<br />ᐳ: 23, 25, 26, 27, 28, 29, 34, 36, 37, 38, 39, 40"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access16,JSONParse17,Access18,PgSelect19,First23,PgSelectRows24,PgSelectSingle25,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression29,JSONParse30,Access31,PgSelect32,First34,PgSelectRows35,PgSelectSingle36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40 bucket2
+    class Bucket2,JSONParse17,Access18,PgSelect19,First23,PgSelectRows24,PgSelectSingle25,PgClassExpression26,PgClassExpression27,PgClassExpression28,PgClassExpression29,JSONParse30,Access31,PgSelect32,First34,PgSelectRows35,PgSelectSingle36,PgClassExpression37,PgClassExpression38,PgClassExpression39,PgClassExpression40 bucket2
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.deopt.mermaid
@@ -35,15 +35,15 @@ graph TD
     __Item19 --> PgUnionAllSingle20
     PgCursor22{{"PgCursor[22∈3]"}}:::plan
     PgUnionAllSingle20 & Access21 --> PgCursor22
+    Access23{{"Access[23∈3]<br />ᐸ20.1ᐳ"}}:::plan
+    PgUnionAllSingle20 --> Access23
     PgSelect26[["PgSelect[26∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access25{{"Access[25∈4]<br />ᐸ24.0ᐳ"}}:::plan
     Object14 & Access25 --> PgSelect26
     PgSelect39[["PgSelect[39∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access38{{"Access[38∈4]<br />ᐸ37.0ᐳ"}}:::plan
     Object14 & Access38 --> PgSelect39
-    Access23{{"Access[23∈4]<br />ᐸ20.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle20 --> Access23
-    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ"]]:::plan
+    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access23 --> JSONParse24
     JSONParse24 --> Access25
     First30{{"First[30∈4]"}}:::plan
@@ -92,10 +92,10 @@ graph TD
     class Bucket2,__Item19,PgUnionAllSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 21, 14<br /><br />ROOT PgUnionAllSingle{2}[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor22 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 14<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[23]<br />2: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />3: PgSelect[26], PgSelect[39]<br />4: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
+    class Bucket3,PgCursor22,Access23 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 14, 20<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />2: PgSelect[26], PgSelect[39]<br />3: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access23,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
+    class Bucket4,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.after1.mermaid
@@ -35,15 +35,15 @@ graph TD
     __Item19 --> PgUnionAllSingle20
     PgCursor22{{"PgCursor[22∈3]"}}:::plan
     PgUnionAllSingle20 & Access21 --> PgCursor22
+    Access23{{"Access[23∈3]<br />ᐸ20.1ᐳ"}}:::plan
+    PgUnionAllSingle20 --> Access23
     PgSelect26[["PgSelect[26∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access25{{"Access[25∈4]<br />ᐸ24.0ᐳ"}}:::plan
     Object14 & Access25 --> PgSelect26
     PgSelect39[["PgSelect[39∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access38{{"Access[38∈4]<br />ᐸ37.0ᐳ"}}:::plan
     Object14 & Access38 --> PgSelect39
-    Access23{{"Access[23∈4]<br />ᐸ20.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle20 --> Access23
-    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ"]]:::plan
+    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access23 --> JSONParse24
     JSONParse24 --> Access25
     First30{{"First[30∈4]"}}:::plan
@@ -92,10 +92,10 @@ graph TD
     class Bucket2,__Item19,PgUnionAllSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 21, 14<br /><br />ROOT PgUnionAllSingle{2}[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor22 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 14<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[23]<br />2: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />3: PgSelect[26], PgSelect[39]<br />4: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
+    class Bucket3,PgCursor22,Access23 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 14, 20<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />2: PgSelect[26], PgSelect[39]<br />3: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access23,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
+    class Bucket4,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.deopt.mermaid
@@ -35,15 +35,15 @@ graph TD
     __Item19 --> PgUnionAllSingle20
     PgCursor22{{"PgCursor[22∈3]"}}:::plan
     PgUnionAllSingle20 & Access21 --> PgCursor22
+    Access23{{"Access[23∈3]<br />ᐸ20.1ᐳ"}}:::plan
+    PgUnionAllSingle20 --> Access23
     PgSelect26[["PgSelect[26∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access25{{"Access[25∈4]<br />ᐸ24.0ᐳ"}}:::plan
     Object14 & Access25 --> PgSelect26
     PgSelect39[["PgSelect[39∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access38{{"Access[38∈4]<br />ᐸ37.0ᐳ"}}:::plan
     Object14 & Access38 --> PgSelect39
-    Access23{{"Access[23∈4]<br />ᐸ20.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle20 --> Access23
-    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ"]]:::plan
+    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access23 --> JSONParse24
     JSONParse24 --> Access25
     First30{{"First[30∈4]"}}:::plan
@@ -92,10 +92,10 @@ graph TD
     class Bucket2,__Item19,PgUnionAllSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 21, 14<br /><br />ROOT PgUnionAllSingle{2}[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor22 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 14<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[23]<br />2: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />3: PgSelect[26], PgSelect[39]<br />4: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
+    class Bucket3,PgCursor22,Access23 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 14, 20<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />2: PgSelect[26], PgSelect[39]<br />3: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access23,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
+    class Bucket4,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.before1.mermaid
@@ -35,15 +35,15 @@ graph TD
     __Item19 --> PgUnionAllSingle20
     PgCursor22{{"PgCursor[22∈3]"}}:::plan
     PgUnionAllSingle20 & Access21 --> PgCursor22
+    Access23{{"Access[23∈3]<br />ᐸ20.1ᐳ"}}:::plan
+    PgUnionAllSingle20 --> Access23
     PgSelect26[["PgSelect[26∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access25{{"Access[25∈4]<br />ᐸ24.0ᐳ"}}:::plan
     Object14 & Access25 --> PgSelect26
     PgSelect39[["PgSelect[39∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access38{{"Access[38∈4]<br />ᐸ37.0ᐳ"}}:::plan
     Object14 & Access38 --> PgSelect39
-    Access23{{"Access[23∈4]<br />ᐸ20.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle20 --> Access23
-    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ"]]:::plan
+    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access23 --> JSONParse24
     JSONParse24 --> Access25
     First30{{"First[30∈4]"}}:::plan
@@ -92,10 +92,10 @@ graph TD
     class Bucket2,__Item19,PgUnionAllSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 21, 14<br /><br />ROOT PgUnionAllSingle{2}[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor22 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 14<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[23]<br />2: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />3: PgSelect[26], PgSelect[39]<br />4: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
+    class Bucket3,PgCursor22,Access23 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 14, 20<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[24], JSONParse[37]<br />ᐳ: Access[25], Access[38]<br />2: PgSelect[26], PgSelect[39]<br />3: PgSelectRows[31], PgSelectRows[42]<br />ᐳ: 30, 32, 33, 34, 35, 36, 41, 43, 44, 45, 46, 47"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access23,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
+    class Bucket4,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,JSONParse37,Access38,PgSelect39,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,PgClassExpression47 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.deopt.mermaid
@@ -30,15 +30,15 @@ graph TD
     __Item16 --> PgUnionAllSingle17
     PgCursor19{{"PgCursor[19∈3]"}}:::plan
     PgUnionAllSingle17 & Access18 --> PgCursor19
+    Access20{{"Access[20∈3]<br />ᐸ17.1ᐳ"}}:::plan
+    PgUnionAllSingle17 --> Access20
     PgSelect23[["PgSelect[23∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access22{{"Access[22∈4]<br />ᐸ21.0ᐳ"}}:::plan
     Object12 & Access22 --> PgSelect23
     PgSelect36[["PgSelect[36∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access35{{"Access[35∈4]<br />ᐸ34.0ᐳ"}}:::plan
     Object12 & Access35 --> PgSelect36
-    Access20{{"Access[20∈4]<br />ᐸ17.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle17 --> Access20
-    JSONParse21[["JSONParse[21∈4]<br />ᐸ20ᐳ"]]:::plan
+    JSONParse21[["JSONParse[21∈4]<br />ᐸ20ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access20 --> JSONParse21
     JSONParse21 --> Access22
     First27{{"First[27∈4]"}}:::plan
@@ -87,10 +87,10 @@ graph TD
     class Bucket2,__Item16,PgUnionAllSingle17 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 18, 12<br /><br />ROOT PgUnionAllSingle{2}[17]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor19 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 17, 12<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[20]<br />2: JSONParse[21], JSONParse[34]<br />ᐳ: Access[22], Access[35]<br />3: PgSelect[23], PgSelect[36]<br />4: PgSelectRows[28], PgSelectRows[39]<br />ᐳ: 27, 29, 30, 31, 32, 33, 38, 40, 41, 42, 43, 44"):::bucket
+    class Bucket3,PgCursor19,Access20 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 12, 17<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[21], JSONParse[34]<br />ᐳ: Access[22], Access[35]<br />2: PgSelect[23], PgSelect[36]<br />3: PgSelectRows[28], PgSelectRows[39]<br />ᐳ: 27, 29, 30, 31, 32, 33, 38, 40, 41, 42, 43, 44"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access20,JSONParse21,Access22,PgSelect23,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,JSONParse34,Access35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44 bucket4
+    class Bucket4,JSONParse21,Access22,PgSelect23,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,JSONParse34,Access35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-via-union-all/vulnerabilitiesConnection.mermaid
@@ -30,15 +30,15 @@ graph TD
     __Item16 --> PgUnionAllSingle17
     PgCursor19{{"PgCursor[19∈3]"}}:::plan
     PgUnionAllSingle17 & Access18 --> PgCursor19
+    Access20{{"Access[20∈3]<br />ᐸ17.1ᐳ"}}:::plan
+    PgUnionAllSingle17 --> Access20
     PgSelect23[["PgSelect[23∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access22{{"Access[22∈4]<br />ᐸ21.0ᐳ"}}:::plan
     Object12 & Access22 --> PgSelect23
     PgSelect36[["PgSelect[36∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access35{{"Access[35∈4]<br />ᐸ34.0ᐳ"}}:::plan
     Object12 & Access35 --> PgSelect36
-    Access20{{"Access[20∈4]<br />ᐸ17.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle17 --> Access20
-    JSONParse21[["JSONParse[21∈4]<br />ᐸ20ᐳ"]]:::plan
+    JSONParse21[["JSONParse[21∈4]<br />ᐸ20ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access20 --> JSONParse21
     JSONParse21 --> Access22
     First27{{"First[27∈4]"}}:::plan
@@ -87,10 +87,10 @@ graph TD
     class Bucket2,__Item16,PgUnionAllSingle17 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 18, 12<br /><br />ROOT PgUnionAllSingle{2}[17]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor19 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 17, 12<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[20]<br />2: JSONParse[21], JSONParse[34]<br />ᐳ: Access[22], Access[35]<br />3: PgSelect[23], PgSelect[36]<br />4: PgSelectRows[28], PgSelectRows[39]<br />ᐳ: 27, 29, 30, 31, 32, 33, 38, 40, 41, 42, 43, 44"):::bucket
+    class Bucket3,PgCursor19,Access20 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 12, 17<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[21], JSONParse[34]<br />ᐳ: Access[22], Access[35]<br />2: PgSelect[23], PgSelect[36]<br />3: PgSelectRows[28], PgSelectRows[39]<br />ᐳ: 27, 29, 30, 31, 32, 33, 38, 40, 41, 42, 43, 44"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access20,JSONParse21,Access22,PgSelect23,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,JSONParse34,Access35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44 bucket4
+    class Bucket4,JSONParse21,Access22,PgSelect23,First27,PgSelectRows28,PgSelectSingle29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,JSONParse34,Access35,PgSelect36,First38,PgSelectRows39,PgSelectSingle40,PgClassExpression41,PgClassExpression42,PgClassExpression43,PgClassExpression44 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.deopt.mermaid
@@ -29,9 +29,10 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect26[["PgSelect[26∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect26
@@ -41,7 +42,6 @@ graph TD
     Object10 & PgClassExpression16 --> PgSelect43
     PgSelect50[["PgSelect[50∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect50
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
@@ -104,11 +104,11 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15, 16"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,Constant58 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 13, 10, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[16]<br />2: 17, 26, 35, 43, 50<br />3: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,Constant58 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 16, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 17, 26, 35, 43, 50<br />2: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
     Bucket0 --> Bucket1
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-1.mermaid
@@ -29,9 +29,10 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect26[["PgSelect[26∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect26
@@ -41,7 +42,6 @@ graph TD
     Object10 & PgClassExpression16 --> PgSelect43
     PgSelect50[["PgSelect[50∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect50
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
@@ -104,11 +104,11 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-1"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 58, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: 11, 13, 14, 15, 16"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,Constant58 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 13, 10, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[16]<br />2: 17, 26, 35, 43, 50<br />3: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,Constant58 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 16, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 17, 26, 35, 43, 50<br />2: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
     Bucket0 --> Bucket1
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.mermaid
@@ -31,15 +31,18 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
     First61{{"First[61∈0] ➊"}}:::plan
     Access116{{"Access[116∈0] ➊<br />ᐸ59.itemsᐳ"}}:::plan
     Access116 --> First61
     PgUnionAllSingle63["PgUnionAllSingle[63∈0] ➊"]:::plan
     First61 --> PgUnionAllSingle63
+    Access64{{"Access[64∈0] ➊<br />ᐸ63.1ᐳ"}}:::plan
+    PgUnionAllSingle63 --> Access64
     PgUnionAll59 --> Access116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect26[["PgSelect[26∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect26
@@ -49,7 +52,6 @@ graph TD
     Object10 & PgClassExpression16 --> PgSelect43
     PgSelect50[["PgSelect[50∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect50
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
@@ -123,9 +125,7 @@ graph TD
     PgSelect108[["PgSelect[108∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access107{{"Access[107∈2] ➊<br />ᐸ106.0ᐳ"}}:::plan
     Object10 & Access107 --> PgSelect108
-    Access64{{"Access[64∈2] ➊<br />ᐸ63.1ᐳ<br />ᐳUnionTopic"}}:::plan
-    PgUnionAllSingle63 --> Access64
-    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ"]]:::plan
+    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ<br />ᐳUnionTopic"]]:::plan
     Access64 --> JSONParse65
     JSONParse65 --> Access66
     First71{{"First[71∈2] ➊"}}:::plan
@@ -202,14 +202,14 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-18"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15, 16, 64"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgUnionAll59,First61,PgUnionAllSingle63,Access116,Constant117 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 13, 10, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[16]<br />2: 17, 26, 35, 43, 50<br />3: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,PgUnionAll59,First61,PgUnionAllSingle63,Access64,Access116,Constant117 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 16, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 17, 26, 35, 43, 50<br />2: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 63, 10<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[64]<br />2: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />3: 67, 78, 89, 99, 108<br />4: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 64, 10, 63<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />2: 67, 78, 89, 99, 108<br />3: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access64,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
+    class Bucket2,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
     Bucket0 --> Bucket1 & Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.mermaid
@@ -31,15 +31,18 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
     First61{{"First[61∈0] ➊"}}:::plan
     Access116{{"Access[116∈0] ➊<br />ᐸ59.itemsᐳ"}}:::plan
     Access116 --> First61
     PgUnionAllSingle63["PgUnionAllSingle[63∈0] ➊"]:::plan
     First61 --> PgUnionAllSingle63
+    Access64{{"Access[64∈0] ➊<br />ᐸ63.1ᐳ"}}:::plan
+    PgUnionAllSingle63 --> Access64
     PgUnionAll59 --> Access116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect26[["PgSelect[26∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect26
@@ -49,7 +52,6 @@ graph TD
     Object10 & PgClassExpression16 --> PgSelect43
     PgSelect50[["PgSelect[50∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect50
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
@@ -123,9 +125,7 @@ graph TD
     PgSelect108[["PgSelect[108∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access107{{"Access[107∈2] ➊<br />ᐸ106.0ᐳ"}}:::plan
     Object10 & Access107 --> PgSelect108
-    Access64{{"Access[64∈2] ➊<br />ᐸ63.1ᐳ<br />ᐳUnionTopic"}}:::plan
-    PgUnionAllSingle63 --> Access64
-    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ"]]:::plan
+    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ<br />ᐳUnionTopic"]]:::plan
     Access64 --> JSONParse65
     JSONParse65 --> Access66
     First71{{"First[71∈2] ➊"}}:::plan
@@ -202,14 +202,14 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-18"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15, 16, 64"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgUnionAll59,First61,PgUnionAllSingle63,Access116,Constant117 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 13, 10, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[16]<br />2: 17, 26, 35, 43, 50<br />3: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,PgUnionAll59,First61,PgUnionAllSingle63,Access64,Access116,Constant117 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 16, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 17, 26, 35, 43, 50<br />2: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 63, 10<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[64]<br />2: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />3: 67, 78, 89, 99, 108<br />4: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 64, 10, 63<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />2: 67, 78, 89, 99, 108<br />3: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access64,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
+    class Bucket2,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
     Bucket0 --> Bucket1 & Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.mermaid
@@ -31,15 +31,18 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
     First61{{"First[61∈0] ➊"}}:::plan
     Access116{{"Access[116∈0] ➊<br />ᐸ59.itemsᐳ"}}:::plan
     Access116 --> First61
     PgUnionAllSingle63["PgUnionAllSingle[63∈0] ➊"]:::plan
     First61 --> PgUnionAllSingle63
+    Access64{{"Access[64∈0] ➊<br />ᐸ63.1ᐳ"}}:::plan
+    PgUnionAllSingle63 --> Access64
     PgUnionAll59 --> Access116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect26[["PgSelect[26∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect26
@@ -49,7 +52,6 @@ graph TD
     Object10 & PgClassExpression16 --> PgSelect43
     PgSelect50[["PgSelect[50∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect50
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
@@ -123,9 +125,7 @@ graph TD
     PgSelect108[["PgSelect[108∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access107{{"Access[107∈2] ➊<br />ᐸ106.0ᐳ"}}:::plan
     Object10 & Access107 --> PgSelect108
-    Access64{{"Access[64∈2] ➊<br />ᐸ63.1ᐳ<br />ᐳUnionTopic"}}:::plan
-    PgUnionAllSingle63 --> Access64
-    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ"]]:::plan
+    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ<br />ᐳUnionTopic"]]:::plan
     Access64 --> JSONParse65
     JSONParse65 --> Access66
     First71{{"First[71∈2] ➊"}}:::plan
@@ -202,14 +202,14 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-987654321"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15, 16, 64"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgUnionAll59,First61,PgUnionAllSingle63,Access116,Constant117 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 13, 10, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[16]<br />2: 17, 26, 35, 43, 50<br />3: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,PgUnionAll59,First61,PgUnionAllSingle63,Access64,Access116,Constant117 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 16, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 17, 26, 35, 43, 50<br />2: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 63, 10<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[64]<br />2: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />3: 67, 78, 89, 99, 108<br />4: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 64, 10, 63<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />2: 67, 78, 89, 99, 108<br />3: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access64,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
+    class Bucket2,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
     Bucket0 --> Bucket1 & Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.mermaid
@@ -31,15 +31,18 @@ graph TD
     PgSelect7 --> PgSelectRows12
     First11 --> PgSelectSingle13
     PgSelectSingle13 --> PgClassExpression14
+    PgClassExpression16{{"PgClassExpression[16∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression16
     First61{{"First[61∈0] ➊"}}:::plan
     Access116{{"Access[116∈0] ➊<br />ᐸ59.itemsᐳ"}}:::plan
     Access116 --> First61
     PgUnionAllSingle63["PgUnionAllSingle[63∈0] ➊"]:::plan
     First61 --> PgUnionAllSingle63
+    Access64{{"Access[64∈0] ➊<br />ᐸ63.1ᐳ"}}:::plan
+    PgUnionAllSingle63 --> Access64
     PgUnionAll59 --> Access116
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect17[["PgSelect[17∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
-    PgClassExpression16{{"PgClassExpression[16∈1] ➊<br />ᐸ__union_items__.”id”ᐳ<br />ᐳUnionTopic"}}:::plan
     Object10 & PgClassExpression16 --> PgSelect17
     PgSelect26[["PgSelect[26∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect26
@@ -49,7 +52,6 @@ graph TD
     Object10 & PgClassExpression16 --> PgSelect43
     PgSelect50[["PgSelect[50∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Object10 & PgClassExpression16 --> PgSelect50
-    PgSelectSingle13 --> PgClassExpression16
     First21{{"First[21∈1] ➊"}}:::plan
     PgSelectRows22[["PgSelectRows[22∈1] ➊"]]:::plan
     PgSelectRows22 --> First21
@@ -123,9 +125,7 @@ graph TD
     PgSelect108[["PgSelect[108∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
     Access107{{"Access[107∈2] ➊<br />ᐸ106.0ᐳ"}}:::plan
     Object10 & Access107 --> PgSelect108
-    Access64{{"Access[64∈2] ➊<br />ᐸ63.1ᐳ<br />ᐳUnionTopic"}}:::plan
-    PgUnionAllSingle63 --> Access64
-    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ"]]:::plan
+    JSONParse65[["JSONParse[65∈2] ➊<br />ᐸ64ᐳ<br />ᐳUnionTopic"]]:::plan
     Access64 --> JSONParse65
     JSONParse65 --> Access66
     First71{{"First[71∈2] ➊"}}:::plan
@@ -202,14 +202,14 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-987654321"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 117, 10<br />2: PgSelect[7], PgUnionAll[59]<br />ᐳ: Access[116], First[61]<br />3: PgSelectRows[12], PgUnionAllSingle[63]<br />ᐳ: 11, 13, 14, 15, 16, 64"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgUnionAll59,First61,PgUnionAllSingle63,Access116,Constant117 bucket0
-    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 13, 10, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: PgClassExpression[16]<br />2: 17, 26, 35, 43, 50<br />3: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectRows12,PgSelectSingle13,PgClassExpression14,PgPolymorphic15,PgClassExpression16,PgUnionAll59,First61,PgUnionAllSingle63,Access64,Access116,Constant117 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 16, 15<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 17, 26, 35, 43, 50<br />2: 22, 29, 38, 46, 53<br />ᐳ: 21, 23, 24, 25, 28, 30, 31, 32, 33, 34, 37, 39, 40, 41, 42, 45, 47, 48, 49, 52, 54, 55, 56, 57"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgClassExpression16,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
-    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 63, 10<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: <br />ᐳ: Access[64]<br />2: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />3: 67, 78, 89, 99, 108<br />4: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
+    class Bucket1,PgSelect17,First21,PgSelectRows22,PgSelectSingle23,PgClassExpression24,PgClassExpression25,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,PgClassExpression41,PgClassExpression42,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgClassExpression48,PgClassExpression49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 64, 10, 63<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 65, 76, 87, 97, 106<br />ᐳ: 66, 77, 88, 98, 107<br />2: 67, 78, 89, 99, 108<br />3: 72, 81, 92, 102, 111<br />ᐳ: 71, 73, 74, 75, 80, 82, 83, 84, 85, 86, 91, 93, 94, 95, 96, 101, 103, 104, 105, 110, 112, 113, 114, 115"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access64,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
+    class Bucket2,JSONParse65,Access66,PgSelect67,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,JSONParse87,Access88,PgSelect89,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,JSONParse106,Access107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression113,PgClassExpression114,PgClassExpression115 bucket2
     Bucket0 --> Bucket1 & Bucket2
     end

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -99,6 +99,7 @@ import type {
 import { LayerPlan } from "./LayerPlan.js";
 import {
   currentLayerPlan,
+  currentPolymorphicPaths,
   withGlobalLayerPlan,
 } from "./lib/withGlobalLayerPlan.js";
 import { lock, unlock } from "./lock.js";
@@ -3845,8 +3846,11 @@ export class OperationPlan {
     cb: () => T,
   ): T {
     const layerPlan = currentLayerPlan();
+    const paths = currentPolymorphicPaths();
     const cache = (this._cacheStepStoreByLayerPlanAndActionKey[
-      `${actionKey}|${layerPlan.id}|${ownerStep.id}`
+      `${actionKey}|${layerPlan.id}|${ownerStep.id}|${
+        paths ? [...paths].join(",") : ""
+      }`
     ] ??= new Map());
 
     const cacheIt = () => {

--- a/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.custom_delete.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.custom_delete.mermaid
@@ -88,8 +88,11 @@ graph TD
     PgSelectRows62 ==> __Item63
     PgSelectSingle64{{"PgSelectSingle[64∈5]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item63 --> PgSelectSingle64
+    PgClassExpression65{{"PgClassExpression[65∈5]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle64 --> PgClassExpression65
+    PgClassExpression77{{"PgClassExpression[77∈5]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle64 --> PgClassExpression77
     PgSelect66[["PgSelect[66∈6]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression65{{"PgClassExpression[65∈6]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object38 & PgClassExpression65 --> PgSelect66
     List75{{"List[75∈6]<br />ᐸ73,74ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression74{{"PgClassExpression[74∈6]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -114,7 +117,6 @@ graph TD
     List112{{"List[112∈6]<br />ᐸ110,111ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression111{{"PgClassExpression[111∈6]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant110 & PgClassExpression111 --> List112
-    PgSelectSingle64 --> PgClassExpression65
     First70{{"First[70∈6]"}}:::plan
     PgSelectRows71[["PgSelectRows[71∈6]"]]:::plan
     PgSelectRows71 --> First70
@@ -124,8 +126,6 @@ graph TD
     PgSelectSingle72 --> PgClassExpression74
     Lambda76{{"Lambda[76∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List75 --> Lambda76
-    PgClassExpression77{{"PgClassExpression[77∈6]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle64 --> PgClassExpression77
     First80{{"First[80∈6]"}}:::plan
     PgSelectRows81[["PgSelectRows[81∈6]"]]:::plan
     PgSelectRows81 --> First80
@@ -183,10 +183,10 @@ graph TD
     class Bucket4,PgSelect61,PgSelectRows62 bucket4
     Bucket5("Bucket 5 (listItem)<br />Deps: 38, 73, 83, 92, 101, 110<br /><br />ROOT __Item{5}ᐸ62ᐳ[63]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,__Item63,PgSelectSingle64 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 64, 38, 73, 83, 92, 101, 110<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 65, 77<br />2: 66, 78, 87, 96, 105<br />3: 71, 81, 90, 99, 108<br />ᐳ: 70, 72, 74, 75, 76, 80, 82, 84, 85, 86, 89, 91, 93, 94, 95, 98, 100, 102, 103, 104, 107, 109, 111, 112, 113"):::bucket
+    class Bucket5,__Item63,PgSelectSingle64,PgClassExpression65,PgClassExpression77 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 38, 65, 73, 83, 92, 101, 110, 64, 77<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 66, 78, 87, 96, 105<br />2: 71, 81, 90, 99, 108<br />ᐳ: 70, 72, 74, 75, 76, 80, 82, 84, 85, 86, 89, 91, 93, 94, 95, 98, 100, 102, 103, 104, 107, 109, 111, 112, 113"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression65,PgSelect66,First70,PgSelectRows71,PgSelectSingle72,PgClassExpression74,List75,Lambda76,PgClassExpression77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression84,List85,Lambda86,PgSelect87,First89,PgSelectRows90,PgSelectSingle91,PgClassExpression93,List94,Lambda95,PgSelect96,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression102,List103,Lambda104,PgSelect105,First107,PgSelectRows108,PgSelectSingle109,PgClassExpression111,List112,Lambda113 bucket6
+    class Bucket6,PgSelect66,First70,PgSelectRows71,PgSelectSingle72,PgClassExpression74,List75,Lambda76,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression84,List85,Lambda86,PgSelect87,First89,PgSelectRows90,PgSelectSingle91,PgClassExpression93,List94,Lambda95,PgSelect96,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression102,List103,Lambda104,PgSelect105,First107,PgSelectRows108,PgSelectSingle109,PgClassExpression111,List112,Lambda113 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.mermaid
@@ -134,6 +134,10 @@ graph TD
     PgSelect79 --> PgSelectRows84
     PgSelectSingle85{{"PgSelectSingle[85∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First83 --> PgSelectSingle85
+    PgClassExpression86{{"PgClassExpression[86∈3] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle85 --> PgClassExpression86
+    PgClassExpression98{{"PgClassExpression[98∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle85 --> PgClassExpression98
     PgInsertSingle11 --> PgClassExpression135
     First138{{"First[138∈3] ➊"}}:::plan
     PgSelectRows139[["PgSelectRows[139∈3] ➊"]]:::plan
@@ -141,8 +145,11 @@ graph TD
     PgSelect136 --> PgSelectRows139
     PgSelectSingle140{{"PgSelectSingle[140∈3] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First138 --> PgSelectSingle140
+    PgClassExpression141{{"PgClassExpression[141∈3] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle140 --> PgClassExpression141
+    PgClassExpression153{{"PgClassExpression[153∈3] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle140 --> PgClassExpression153
     PgSelect87[["PgSelect[87∈4] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression86{{"PgClassExpression[86∈4] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object14 & PgClassExpression86 --> PgSelect87
     List96{{"List[96∈4] ➊<br />ᐸ94,95ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression95{{"PgClassExpression[95∈4] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -167,7 +174,6 @@ graph TD
     List133{{"List[133∈4] ➊<br />ᐸ131,132ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression132{{"PgClassExpression[132∈4] ➊<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant131 & PgClassExpression132 --> List133
-    PgSelectSingle85 --> PgClassExpression86
     First91{{"First[91∈4] ➊"}}:::plan
     PgSelectRows92[["PgSelectRows[92∈4] ➊"]]:::plan
     PgSelectRows92 --> First91
@@ -177,8 +183,6 @@ graph TD
     PgSelectSingle93 --> PgClassExpression95
     Lambda97{{"Lambda[97∈4] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List96 --> Lambda97
-    PgClassExpression98{{"PgClassExpression[98∈4] ➊<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle85 --> PgClassExpression98
     First101{{"First[101∈4] ➊"}}:::plan
     PgSelectRows102[["PgSelectRows[102∈4] ➊"]]:::plan
     PgSelectRows102 --> First101
@@ -216,7 +220,6 @@ graph TD
     Lambda134{{"Lambda[134∈4] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List133 --> Lambda134
     PgSelect142[["PgSelect[142∈5] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression141{{"PgClassExpression[141∈5] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object14 & PgClassExpression141 --> PgSelect142
     List151{{"List[151∈5] ➊<br />ᐸ94,150ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression150{{"PgClassExpression[150∈5] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -241,7 +244,6 @@ graph TD
     List188{{"List[188∈5] ➊<br />ᐸ131,187ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression187{{"PgClassExpression[187∈5] ➊<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant131 & PgClassExpression187 --> List188
-    PgSelectSingle140 --> PgClassExpression141
     First146{{"First[146∈5] ➊"}}:::plan
     PgSelectRows147[["PgSelectRows[147∈5] ➊"]]:::plan
     PgSelectRows147 --> First146
@@ -251,8 +253,6 @@ graph TD
     PgSelectSingle148 --> PgClassExpression150
     Lambda152{{"Lambda[152∈5] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List151 --> Lambda152
-    PgClassExpression153{{"PgClassExpression[153∈5] ➊<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle140 --> PgClassExpression153
     First156{{"First[156∈5] ➊"}}:::plan
     PgSelectRows157[["PgSelectRows[157∈5] ➊"]]:::plan
     PgSelectRows157 --> First156
@@ -393,14 +393,21 @@ graph TD
     PgSelect264 --> PgSelectRows269
     PgSelectSingle270{{"PgSelectSingle[270∈8] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First268 --> PgSelectSingle270
+    PgClassExpression271{{"PgClassExpression[271∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle270 --> PgClassExpression271
+    PgClassExpression283{{"PgClassExpression[283∈8] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle270 --> PgClassExpression283
     First323{{"First[323∈8] ➊"}}:::plan
     PgSelectRows324[["PgSelectRows[324∈8] ➊"]]:::plan
     PgSelectRows324 --> First323
     PgSelect321 --> PgSelectRows324
     PgSelectSingle325{{"PgSelectSingle[325∈8] ➊<br />ᐸrelational_itemsᐳ"}}:::plan
     First323 --> PgSelectSingle325
+    PgClassExpression326{{"PgClassExpression[326∈8] ➊<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle325 --> PgClassExpression326
+    PgClassExpression338{{"PgClassExpression[338∈8] ➊<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle325 --> PgClassExpression338
     PgSelect272[["PgSelect[272∈9] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression271{{"PgClassExpression[271∈9] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object198 & PgClassExpression271 --> PgSelect272
     List281{{"List[281∈9] ➊<br />ᐸ94,280ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression280{{"PgClassExpression[280∈9] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -425,7 +432,6 @@ graph TD
     List318{{"List[318∈9] ➊<br />ᐸ131,317ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression317{{"PgClassExpression[317∈9] ➊<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant131 & PgClassExpression317 --> List318
-    PgSelectSingle270 --> PgClassExpression271
     First276{{"First[276∈9] ➊"}}:::plan
     PgSelectRows277[["PgSelectRows[277∈9] ➊"]]:::plan
     PgSelectRows277 --> First276
@@ -435,8 +441,6 @@ graph TD
     PgSelectSingle278 --> PgClassExpression280
     Lambda282{{"Lambda[282∈9] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List281 --> Lambda282
-    PgClassExpression283{{"PgClassExpression[283∈9] ➊<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle270 --> PgClassExpression283
     First286{{"First[286∈9] ➊"}}:::plan
     PgSelectRows287[["PgSelectRows[287∈9] ➊"]]:::plan
     PgSelectRows287 --> First286
@@ -474,7 +478,6 @@ graph TD
     Lambda319{{"Lambda[319∈9] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List318 --> Lambda319
     PgSelect327[["PgSelect[327∈10] ➊<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression326{{"PgClassExpression[326∈10] ➊<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object198 & PgClassExpression326 --> PgSelect327
     List336{{"List[336∈10] ➊<br />ᐸ94,335ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression335{{"PgClassExpression[335∈10] ➊<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -499,7 +502,6 @@ graph TD
     List373{{"List[373∈10] ➊<br />ᐸ131,372ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression372{{"PgClassExpression[372∈10] ➊<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant131 & PgClassExpression372 --> List373
-    PgSelectSingle325 --> PgClassExpression326
     First331{{"First[331∈10] ➊"}}:::plan
     PgSelectRows332[["PgSelectRows[332∈10] ➊"]]:::plan
     PgSelectRows332 --> First331
@@ -509,8 +511,6 @@ graph TD
     PgSelectSingle333 --> PgClassExpression335
     Lambda337{{"Lambda[337∈10] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List336 --> Lambda337
-    PgClassExpression338{{"PgClassExpression[338∈10] ➊<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle325 --> PgClassExpression338
     First341{{"First[341∈10] ➊"}}:::plan
     PgSelectRows342[["PgSelectRows[342∈10] ➊"]]:::plan
     PgSelectRows342 --> First341
@@ -652,6 +652,10 @@ graph TD
     PgSelect448 --> PgSelectRows453
     PgSelectSingle454{{"PgSelectSingle[454∈13] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First452 --> PgSelectSingle454
+    PgClassExpression456{{"PgClassExpression[456∈13] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle454 --> PgClassExpression456
+    PgClassExpression459{{"PgClassExpression[459∈13] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle454 --> PgClassExpression459
     PgInsertSingle380 --> PgClassExpression472
     First475{{"First[475∈13] ➊"}}:::plan
     PgSelectRows476[["PgSelectRows[476∈13] ➊"]]:::plan
@@ -659,8 +663,11 @@ graph TD
     PgSelect473 --> PgSelectRows476
     PgSelectSingle477{{"PgSelectSingle[477∈13] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First475 --> PgSelectSingle477
+    PgClassExpression479{{"PgClassExpression[479∈13] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle477 --> PgClassExpression479
+    PgClassExpression482{{"PgClassExpression[482∈13] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle477 --> PgClassExpression482
     List457{{"List[457∈14] ➊<br />ᐸ455,456ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression456{{"PgClassExpression[456∈14] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant455 & PgClassExpression456 --> List457
     List461{{"List[461∈14] ➊<br />ᐸ460,456ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant460 & PgClassExpression456 --> List461
@@ -670,11 +677,8 @@ graph TD
     Constant466 & PgClassExpression456 --> List467
     List470{{"List[470∈14] ➊<br />ᐸ469,456ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant469 & PgClassExpression456 --> List470
-    PgSelectSingle454 --> PgClassExpression456
     Lambda458{{"Lambda[458∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List457 --> Lambda458
-    PgClassExpression459{{"PgClassExpression[459∈14] ➊<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle454 --> PgClassExpression459
     Lambda462{{"Lambda[462∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List461 --> Lambda462
     Lambda465{{"Lambda[465∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -684,7 +688,6 @@ graph TD
     Lambda471{{"Lambda[471∈14] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List470 --> Lambda471
     List480{{"List[480∈15] ➊<br />ᐸ455,479ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression479{{"PgClassExpression[479∈15] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant455 & PgClassExpression479 --> List480
     List484{{"List[484∈15] ➊<br />ᐸ460,479ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant460 & PgClassExpression479 --> List484
@@ -694,11 +697,8 @@ graph TD
     Constant466 & PgClassExpression479 --> List490
     List493{{"List[493∈15] ➊<br />ᐸ469,479ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant469 & PgClassExpression479 --> List493
-    PgSelectSingle477 --> PgClassExpression479
     Lambda481{{"Lambda[481∈15] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List480 --> Lambda481
-    PgClassExpression482{{"PgClassExpression[482∈15] ➊<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle477 --> PgClassExpression482
     Lambda485{{"Lambda[485∈15] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List484 --> Lambda485
     Lambda488{{"Lambda[488∈15] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -811,14 +811,21 @@ graph TD
     PgSelect569 --> PgSelectRows574
     PgSelectSingle575{{"PgSelectSingle[575∈18] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First573 --> PgSelectSingle575
+    PgClassExpression577{{"PgClassExpression[577∈18] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle575 --> PgClassExpression577
+    PgClassExpression580{{"PgClassExpression[580∈18] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle575 --> PgClassExpression580
     First596{{"First[596∈18] ➊"}}:::plan
     PgSelectRows597[["PgSelectRows[597∈18] ➊"]]:::plan
     PgSelectRows597 --> First596
     PgSelect594 --> PgSelectRows597
     PgSelectSingle598{{"PgSelectSingle[598∈18] ➊<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First596 --> PgSelectSingle598
+    PgClassExpression600{{"PgClassExpression[600∈18] ➊<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle598 --> PgClassExpression600
+    PgClassExpression603{{"PgClassExpression[603∈18] ➊<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle598 --> PgClassExpression603
     List578{{"List[578∈19] ➊<br />ᐸ455,577ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression577{{"PgClassExpression[577∈19] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant455 & PgClassExpression577 --> List578
     List582{{"List[582∈19] ➊<br />ᐸ460,577ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant460 & PgClassExpression577 --> List582
@@ -828,11 +835,8 @@ graph TD
     Constant466 & PgClassExpression577 --> List588
     List591{{"List[591∈19] ➊<br />ᐸ469,577ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant469 & PgClassExpression577 --> List591
-    PgSelectSingle575 --> PgClassExpression577
     Lambda579{{"Lambda[579∈19] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List578 --> Lambda579
-    PgClassExpression580{{"PgClassExpression[580∈19] ➊<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle575 --> PgClassExpression580
     Lambda583{{"Lambda[583∈19] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List582 --> Lambda583
     Lambda586{{"Lambda[586∈19] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -842,7 +846,6 @@ graph TD
     Lambda592{{"Lambda[592∈19] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List591 --> Lambda592
     List601{{"List[601∈20] ➊<br />ᐸ455,600ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression600{{"PgClassExpression[600∈20] ➊<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant455 & PgClassExpression600 --> List601
     List605{{"List[605∈20] ➊<br />ᐸ460,600ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant460 & PgClassExpression600 --> List605
@@ -852,11 +855,8 @@ graph TD
     Constant466 & PgClassExpression600 --> List611
     List614{{"List[614∈20] ➊<br />ᐸ469,600ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant469 & PgClassExpression600 --> List614
-    PgSelectSingle598 --> PgClassExpression600
     Lambda602{{"Lambda[602∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List601 --> Lambda602
-    PgClassExpression603{{"PgClassExpression[603∈20] ➊<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle598 --> PgClassExpression603
     Lambda606{{"Lambda[606∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List605 --> Lambda606
     Lambda609{{"Lambda[609∈20] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -878,60 +878,60 @@ graph TD
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 15, 11, 74, 14, 94, 104, 113, 122, 131<br /><br />ROOT Object{1}ᐸ{result}ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 74, 14, 94, 104, 113, 122, 131<br /><br />ROOT PgInsertSingle{1}ᐸrelational_item_relations(child_id,parent_id)ᐳ[11]<br />1: <br />ᐳ: 75, 78, 135, 76, 77<br />2: PgSelect[79], PgSelect[136]<br />3: PgSelectRows[84], PgSelectRows[139]<br />ᐳ: 83, 85, 138, 140"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 11, 74, 14, 94, 104, 113, 122, 131<br /><br />ROOT PgInsertSingle{1}ᐸrelational_item_relations(child_id,parent_id)ᐳ[11]<br />1: <br />ᐳ: 75, 78, 135, 76, 77<br />2: PgSelect[79], PgSelect[136]<br />3: PgSelectRows[84], PgSelectRows[139]<br />ᐳ: 83, 85, 86, 98, 138, 140, 141, 153"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression75,List76,Lambda77,PgClassExpression78,PgSelect79,First83,PgSelectRows84,PgSelectSingle85,PgClassExpression135,PgSelect136,First138,PgSelectRows139,PgSelectSingle140 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 85, 14, 94, 104, 113, 122, 131<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 86, 98<br />2: 87, 99, 108, 117, 126<br />3: 92, 102, 111, 120, 129<br />ᐳ: 91, 93, 95, 96, 97, 101, 103, 105, 106, 107, 110, 112, 114, 115, 116, 119, 121, 123, 124, 125, 128, 130, 132, 133, 134"):::bucket
+    class Bucket3,PgClassExpression75,List76,Lambda77,PgClassExpression78,PgSelect79,First83,PgSelectRows84,PgSelectSingle85,PgClassExpression86,PgClassExpression98,PgClassExpression135,PgSelect136,First138,PgSelectRows139,PgSelectSingle140,PgClassExpression141,PgClassExpression153 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 14, 86, 94, 104, 113, 122, 131, 85, 98<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 87, 99, 108, 117, 126<br />2: 92, 102, 111, 120, 129<br />ᐳ: 91, 93, 95, 96, 97, 101, 103, 105, 106, 107, 110, 112, 114, 115, 116, 119, 121, 123, 124, 125, 128, 130, 132, 133, 134"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression86,PgSelect87,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression95,List96,Lambda97,PgClassExpression98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression105,List106,Lambda107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression114,List115,Lambda116,PgSelect117,First119,PgSelectRows120,PgSelectSingle121,PgClassExpression123,List124,Lambda125,PgSelect126,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,List133,Lambda134 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 140, 14, 94, 104, 113, 122, 131<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 141, 153<br />2: 142, 154, 163, 172, 181<br />3: 147, 157, 166, 175, 184<br />ᐳ: 146, 148, 150, 151, 152, 156, 158, 160, 161, 162, 165, 167, 169, 170, 171, 174, 176, 178, 179, 180, 183, 185, 187, 188, 189"):::bucket
+    class Bucket4,PgSelect87,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression95,List96,Lambda97,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression105,List106,Lambda107,PgSelect108,First110,PgSelectRows111,PgSelectSingle112,PgClassExpression114,List115,Lambda116,PgSelect117,First119,PgSelectRows120,PgSelectSingle121,PgClassExpression123,List124,Lambda125,PgSelect126,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,List133,Lambda134 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 14, 141, 94, 104, 113, 122, 131, 140, 153<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 142, 154, 163, 172, 181<br />2: 147, 157, 166, 175, 184<br />ᐳ: 146, 148, 150, 151, 152, 156, 158, 160, 161, 162, 165, 167, 169, 170, 171, 174, 176, 178, 179, 180, 183, 185, 187, 188, 189"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression141,PgSelect142,First146,PgSelectRows147,PgSelectSingle148,PgClassExpression150,List151,Lambda152,PgClassExpression153,PgSelect154,First156,PgSelectRows157,PgSelectSingle158,PgClassExpression160,List161,Lambda162,PgSelect163,First165,PgSelectRows166,PgSelectSingle167,PgClassExpression169,List170,Lambda171,PgSelect172,First174,PgSelectRows175,PgSelectSingle176,PgClassExpression178,List179,Lambda180,PgSelect181,First183,PgSelectRows184,PgSelectSingle185,PgClassExpression187,List188,Lambda189 bucket5
+    class Bucket5,PgSelect142,First146,PgSelectRows147,PgSelectSingle148,PgClassExpression150,List151,Lambda152,PgSelect154,First156,PgSelectRows157,PgSelectSingle158,PgClassExpression160,List161,Lambda162,PgSelect163,First165,PgSelectRows166,PgSelectSingle167,PgClassExpression169,List170,Lambda171,PgSelect172,First174,PgSelectRows175,PgSelectSingle176,PgClassExpression178,List179,Lambda180,PgSelect181,First183,PgSelectRows184,PgSelectSingle185,PgClassExpression187,List188,Lambda189 bucket5
     Bucket6("Bucket 6 (mutationField)<br />Deps: 2, 617, 619, 258, 94, 104, 113, 122, 131<br /><br />1: Access[196]<br />2: Access[197]<br />3: Object[198]<br />4: Lambda[201]<br />5: Lambda[205]<br />6: Access[620]<br />7: List[206]<br />8: Object[207]<br />9: Lambda[209]<br />10: Object[211]<br />11: Lambda[213]<br />12: Object[215]<br />13: Lambda[217]<br />14: Object[219]<br />15: Lambda[221]<br />16: Object[223]<br />17: List[224]<br />18: Lambda[225]<br />19: Access[226]<br />20: __Flag[227]<br />21: Condition[200]<br />22: __Flag[228]<br />23: Lambda[230]<br />24: Lambda[234]<br />25: Access[621]<br />26: List[235]<br />27: Object[236]<br />28: Lambda[238]<br />29: Object[240]<br />30: Lambda[242]<br />31: Object[244]<br />32: Lambda[246]<br />33: Object[248]<br />34: Lambda[250]<br />35: Object[252]<br />36: List[253]<br />37: Lambda[254]<br />38: Access[255]<br />39: __Flag[256]<br />40: Condition[229]<br />41: __Flag[257]<br />42: PgInsertSingle[195]<br />43: <br />ᐳ: Object[199]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgInsertSingle195,Access196,Access197,Object198,Object199,Condition200,Lambda201,Lambda205,List206,Object207,Lambda209,Object211,Lambda213,Object215,Lambda217,Object219,Lambda221,Object223,List224,Lambda225,Access226,__Flag227,__Flag228,Condition229,Lambda230,Lambda234,List235,Object236,Lambda238,Object240,Lambda242,Object244,Lambda246,Object248,Lambda250,Object252,List253,Lambda254,Access255,__Flag256,__Flag257,Access620,Access621 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 199, 195, 258, 198, 94, 104, 113, 122, 131<br /><br />ROOT Object{6}ᐸ{result}ᐳ[199]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 195, 258, 198, 94, 104, 113, 122, 131<br /><br />ROOT PgInsertSingle{6}ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ[195]<br />1: <br />ᐳ: 259, 260, 261, 262<br />2: PgSelect[264], PgSelect[321]<br />3: PgSelectRows[269], PgSelectRows[324]<br />ᐳ: 268, 270, 323, 325"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 195, 258, 198, 94, 104, 113, 122, 131<br /><br />ROOT PgInsertSingle{6}ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ[195]<br />1: <br />ᐳ: 259, 260, 261, 262<br />2: PgSelect[264], PgSelect[321]<br />3: PgSelectRows[269], PgSelectRows[324]<br />ᐳ: 268, 270, 271, 283, 323, 325, 326, 338"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression259,PgClassExpression260,List261,Lambda262,PgSelect264,First268,PgSelectRows269,PgSelectSingle270,PgSelect321,First323,PgSelectRows324,PgSelectSingle325 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 270, 198, 94, 104, 113, 122, 131<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 271, 283<br />2: 272, 284, 293, 302, 311<br />3: 277, 287, 296, 305, 314<br />ᐳ: 276, 278, 280, 281, 282, 286, 288, 290, 291, 292, 295, 297, 299, 300, 301, 304, 306, 308, 309, 310, 313, 315, 317, 318, 319"):::bucket
+    class Bucket8,PgClassExpression259,PgClassExpression260,List261,Lambda262,PgSelect264,First268,PgSelectRows269,PgSelectSingle270,PgClassExpression271,PgClassExpression283,PgSelect321,First323,PgSelectRows324,PgSelectSingle325,PgClassExpression326,PgClassExpression338 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 198, 271, 94, 104, 113, 122, 131, 270, 283<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 272, 284, 293, 302, 311<br />2: 277, 287, 296, 305, 314<br />ᐳ: 276, 278, 280, 281, 282, 286, 288, 290, 291, 292, 295, 297, 299, 300, 301, 304, 306, 308, 309, 310, 313, 315, 317, 318, 319"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression271,PgSelect272,First276,PgSelectRows277,PgSelectSingle278,PgClassExpression280,List281,Lambda282,PgClassExpression283,PgSelect284,First286,PgSelectRows287,PgSelectSingle288,PgClassExpression290,List291,Lambda292,PgSelect293,First295,PgSelectRows296,PgSelectSingle297,PgClassExpression299,List300,Lambda301,PgSelect302,First304,PgSelectRows305,PgSelectSingle306,PgClassExpression308,List309,Lambda310,PgSelect311,First313,PgSelectRows314,PgSelectSingle315,PgClassExpression317,List318,Lambda319 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 325, 198, 94, 104, 113, 122, 131<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 326, 338<br />2: 327, 339, 348, 357, 366<br />3: 332, 342, 351, 360, 369<br />ᐳ: 331, 333, 335, 336, 337, 341, 343, 345, 346, 347, 350, 352, 354, 355, 356, 359, 361, 363, 364, 365, 368, 370, 372, 373, 374"):::bucket
+    class Bucket9,PgSelect272,First276,PgSelectRows277,PgSelectSingle278,PgClassExpression280,List281,Lambda282,PgSelect284,First286,PgSelectRows287,PgSelectSingle288,PgClassExpression290,List291,Lambda292,PgSelect293,First295,PgSelectRows296,PgSelectSingle297,PgClassExpression299,List300,Lambda301,PgSelect302,First304,PgSelectRows305,PgSelectSingle306,PgClassExpression308,List309,Lambda310,PgSelect311,First313,PgSelectRows314,PgSelectSingle315,PgClassExpression317,List318,Lambda319 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 198, 326, 94, 104, 113, 122, 131, 325, 338<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 327, 339, 348, 357, 366<br />2: 332, 342, 351, 360, 369<br />ᐳ: 331, 333, 335, 336, 337, 341, 343, 345, 346, 347, 350, 352, 354, 355, 356, 359, 361, 363, 364, 365, 368, 370, 372, 373, 374"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression326,PgSelect327,First331,PgSelectRows332,PgSelectSingle333,PgClassExpression335,List336,Lambda337,PgClassExpression338,PgSelect339,First341,PgSelectRows342,PgSelectSingle343,PgClassExpression345,List346,Lambda347,PgSelect348,First350,PgSelectRows351,PgSelectSingle352,PgClassExpression354,List355,Lambda356,PgSelect357,First359,PgSelectRows360,PgSelectSingle361,PgClassExpression363,List364,Lambda365,PgSelect366,First368,PgSelectRows369,PgSelectSingle370,PgClassExpression372,List373,Lambda374 bucket10
+    class Bucket10,PgSelect327,First331,PgSelectRows332,PgSelectSingle333,PgClassExpression335,List336,Lambda337,PgSelect339,First341,PgSelectRows342,PgSelectSingle343,PgClassExpression345,List346,Lambda347,PgSelect348,First350,PgSelectRows351,PgSelectSingle352,PgClassExpression354,List355,Lambda356,PgSelect357,First359,PgSelectRows360,PgSelectSingle361,PgClassExpression363,List364,Lambda365,PgSelect366,First368,PgSelectRows369,PgSelectSingle370,PgClassExpression372,List373,Lambda374 bucket10
     Bucket11("Bucket 11 (mutationField)<br />Deps: 2, 623, 625, 443, 455, 460, 463, 466, 469<br /><br />1: Access[381]<br />2: Access[382]<br />3: Object[383]<br />4: Lambda[386]<br />5: Lambda[390]<br />6: Access[622]<br />7: List[391]<br />8: Object[392]<br />9: Lambda[394]<br />10: Object[396]<br />11: Lambda[398]<br />12: Object[400]<br />13: Lambda[402]<br />14: Object[404]<br />15: Lambda[406]<br />16: Object[408]<br />17: List[409]<br />18: Lambda[410]<br />19: Access[411]<br />20: __Flag[412]<br />21: Condition[385]<br />22: __Flag[413]<br />23: Lambda[415]<br />24: Lambda[419]<br />25: Access[624]<br />26: List[420]<br />27: Object[421]<br />28: Lambda[423]<br />29: Object[425]<br />30: Lambda[427]<br />31: Object[429]<br />32: Lambda[431]<br />33: Object[433]<br />34: Lambda[435]<br />35: Object[437]<br />36: List[438]<br />37: Lambda[439]<br />38: Access[440]<br />39: __Flag[441]<br />40: Condition[414]<br />41: __Flag[442]<br />42: PgInsertSingle[380]<br />43: <br />ᐳ: Object[384]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,PgInsertSingle380,Access381,Access382,Object383,Object384,Condition385,Lambda386,Lambda390,List391,Object392,Lambda394,Object396,Lambda398,Object400,Lambda402,Object404,Lambda406,Object408,List409,Lambda410,Access411,__Flag412,__Flag413,Condition414,Lambda415,Lambda419,List420,Object421,Lambda423,Object425,Lambda427,Object429,Lambda431,Object433,Lambda435,Object437,List438,Lambda439,Access440,__Flag441,__Flag442,Access622,Access624 bucket11
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 384, 380, 443, 383, 455, 460, 463, 466, 469<br /><br />ROOT Object{11}ᐸ{result}ᐳ[384]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 380, 443, 383, 455, 460, 463, 466, 469<br /><br />ROOT PgInsertSingle{11}ᐸsingle_table_item_relations(child_id,parent_id)ᐳ[380]<br />1: <br />ᐳ: 444, 447, 472, 445, 446<br />2: PgSelect[448], PgSelect[473]<br />3: PgSelectRows[453], PgSelectRows[476]<br />ᐳ: 452, 454, 475, 477"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 380, 443, 383, 455, 460, 463, 466, 469<br /><br />ROOT PgInsertSingle{11}ᐸsingle_table_item_relations(child_id,parent_id)ᐳ[380]<br />1: <br />ᐳ: 444, 447, 472, 445, 446<br />2: PgSelect[448], PgSelect[473]<br />3: PgSelectRows[453], PgSelectRows[476]<br />ᐳ: 452, 454, 456, 459, 475, 477, 479, 482"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression444,List445,Lambda446,PgClassExpression447,PgSelect448,First452,PgSelectRows453,PgSelectSingle454,PgClassExpression472,PgSelect473,First475,PgSelectRows476,PgSelectSingle477 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 454, 455, 460, 463, 466, 469<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket13,PgClassExpression444,List445,Lambda446,PgClassExpression447,PgSelect448,First452,PgSelectRows453,PgSelectSingle454,PgClassExpression456,PgClassExpression459,PgClassExpression472,PgSelect473,First475,PgSelectRows476,PgSelectSingle477,PgClassExpression479,PgClassExpression482 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 455, 456, 460, 463, 466, 469, 454, 459<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression456,List457,Lambda458,PgClassExpression459,List461,Lambda462,List464,Lambda465,List467,Lambda468,List470,Lambda471 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 477, 455, 460, 463, 466, 469<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket14,List457,Lambda458,List461,Lambda462,List464,Lambda465,List467,Lambda468,List470,Lambda471 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 455, 479, 460, 463, 466, 469, 477, 482<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression479,List480,Lambda481,PgClassExpression482,List484,Lambda485,List487,Lambda488,List490,Lambda491,List493,Lambda494 bucket15
+    class Bucket15,List480,Lambda481,List484,Lambda485,List487,Lambda488,List490,Lambda491,List493,Lambda494 bucket15
     Bucket16("Bucket 16 (mutationField)<br />Deps: 2, 623, 625, 563, 455, 460, 463, 466, 469<br /><br />1: Access[501]<br />2: Access[502]<br />3: Object[503]<br />4: Lambda[506]<br />5: Lambda[510]<br />6: Access[626]<br />7: List[511]<br />8: Object[512]<br />9: Lambda[514]<br />10: Object[516]<br />11: Lambda[518]<br />12: Object[520]<br />13: Lambda[522]<br />14: Object[524]<br />15: Lambda[526]<br />16: Object[528]<br />17: List[529]<br />18: Lambda[530]<br />19: Access[531]<br />20: __Flag[532]<br />21: Condition[505]<br />22: __Flag[533]<br />23: Lambda[535]<br />24: Lambda[539]<br />25: Access[627]<br />26: List[540]<br />27: Object[541]<br />28: Lambda[543]<br />29: Object[545]<br />30: Lambda[547]<br />31: Object[549]<br />32: Lambda[551]<br />33: Object[553]<br />34: Lambda[555]<br />35: Object[557]<br />36: List[558]<br />37: Lambda[559]<br />38: Access[560]<br />39: __Flag[561]<br />40: Condition[534]<br />41: __Flag[562]<br />42: PgInsertSingle[500]<br />43: <br />ᐳ: Object[504]"):::bucket
     classDef bucket16 stroke:#f5deb3
     class Bucket16,PgInsertSingle500,Access501,Access502,Object503,Object504,Condition505,Lambda506,Lambda510,List511,Object512,Lambda514,Object516,Lambda518,Object520,Lambda522,Object524,Lambda526,Object528,List529,Lambda530,Access531,__Flag532,__Flag533,Condition534,Lambda535,Lambda539,List540,Object541,Lambda543,Object545,Lambda547,Object549,Lambda551,Object553,Lambda555,Object557,List558,Lambda559,Access560,__Flag561,__Flag562,Access626,Access627 bucket16
     Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 504, 500, 563, 503, 455, 460, 463, 466, 469<br /><br />ROOT Object{16}ᐸ{result}ᐳ[504]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 500, 563, 503, 455, 460, 463, 466, 469<br /><br />ROOT PgInsertSingle{16}ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ[500]<br />1: <br />ᐳ: 564, 565, 566, 567<br />2: PgSelect[569], PgSelect[594]<br />3: PgSelectRows[574], PgSelectRows[597]<br />ᐳ: 573, 575, 596, 598"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 500, 563, 503, 455, 460, 463, 466, 469<br /><br />ROOT PgInsertSingle{16}ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ[500]<br />1: <br />ᐳ: 564, 565, 566, 567<br />2: PgSelect[569], PgSelect[594]<br />3: PgSelectRows[574], PgSelectRows[597]<br />ᐳ: 573, 575, 577, 580, 596, 598, 600, 603"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PgClassExpression564,PgClassExpression565,List566,Lambda567,PgSelect569,First573,PgSelectRows574,PgSelectSingle575,PgSelect594,First596,PgSelectRows597,PgSelectSingle598 bucket18
-    Bucket19("Bucket 19 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 575, 455, 460, 463, 466, 469<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket18,PgClassExpression564,PgClassExpression565,List566,Lambda567,PgSelect569,First573,PgSelectRows574,PgSelectSingle575,PgClassExpression577,PgClassExpression580,PgSelect594,First596,PgSelectRows597,PgSelectSingle598,PgClassExpression600,PgClassExpression603 bucket18
+    Bucket19("Bucket 19 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 455, 577, 460, 463, 466, 469, 575, 580<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgClassExpression577,List578,Lambda579,PgClassExpression580,List582,Lambda583,List585,Lambda586,List588,Lambda589,List591,Lambda592 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 598, 455, 460, 463, 466, 469<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket19,List578,Lambda579,List582,Lambda583,List585,Lambda586,List588,Lambda589,List591,Lambda592 bucket19
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 455, 600, 460, 463, 466, 469, 598, 603<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression600,List601,Lambda602,PgClassExpression603,List605,Lambda606,List608,Lambda609,List611,Lambda612,List614,Lambda615 bucket20
+    class Bucket20,List601,Lambda602,List605,Lambda606,List608,Lambda609,List611,Lambda612,List614,Lambda615 bucket20
     Bucket0 --> Bucket1 & Bucket6 & Bucket11 & Bucket16
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.mermaid
@@ -26,6 +26,8 @@ graph TD
     Access106 ==> __Item17
     PgUnionAllSingle18["PgUnionAllSingle[18∈2]"]:::plan
     __Item17 --> PgUnionAllSingle18
+    Access19{{"Access[19∈2]<br />ᐸ18.1ᐳ"}}:::plan
+    PgUnionAllSingle18 --> Access19
     PgUnionAll36[["PgUnionAll[36∈3]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection35{{"Connection[35∈3] ➊<br />ᐸ33ᐳ<br />ᐳAwsApplication"}}:::plan
@@ -40,9 +42,7 @@ graph TD
     PgSelect65[["PgSelect[65∈3]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access64{{"Access[64∈3]<br />ᐸ63.0ᐳ"}}:::plan
     Object13 & Access64 --> PgSelect65
-    Access19{{"Access[19∈3]<br />ᐸ18.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle18 --> Access19
-    JSONParse20[["JSONParse[20∈3]<br />ᐸ19ᐳ"]]:::plan
+    JSONParse20[["JSONParse[20∈3]<br />ᐸ19ᐳ<br />ᐳAwsApplication"]]:::plan
     Access19 --> JSONParse20
     JSONParse20 --> Access21
     First26{{"First[26∈3]"}}:::plan
@@ -74,15 +74,15 @@ graph TD
     Access104 ==> __Item38
     PgUnionAllSingle39["PgUnionAllSingle[39∈4]"]:::plan
     __Item38 --> PgUnionAllSingle39
+    Access40{{"Access[40∈4]<br />ᐸ39.1ᐳ"}}:::plan
+    PgUnionAllSingle39 --> Access40
     PgSelect43[["PgSelect[43∈5]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access42{{"Access[42∈5]<br />ᐸ41.0ᐳ"}}:::plan
     Object13 & Access42 --> PgSelect43
     PgSelect55[["PgSelect[55∈5]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access54{{"Access[54∈5]<br />ᐸ53.0ᐳ"}}:::plan
     Object13 & Access54 --> PgSelect55
-    Access40{{"Access[40∈5]<br />ᐸ39.1ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle39 --> Access40
-    JSONParse41[["JSONParse[41∈5]<br />ᐸ40ᐳ"]]:::plan
+    JSONParse41[["JSONParse[41∈5]<br />ᐸ40ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access40 --> JSONParse41
     JSONParse41 --> Access42
     First47{{"First[47∈5]"}}:::plan
@@ -116,15 +116,15 @@ graph TD
     Access105 ==> __Item79
     PgUnionAllSingle80["PgUnionAllSingle[80∈6]"]:::plan
     __Item79 --> PgUnionAllSingle80
+    Access81{{"Access[81∈6]<br />ᐸ80.1ᐳ"}}:::plan
+    PgUnionAllSingle80 --> Access81
     PgSelect84[["PgSelect[84∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access83{{"Access[83∈7]<br />ᐸ82.0ᐳ"}}:::plan
     Object13 & Access83 --> PgSelect84
     PgSelect96[["PgSelect[96∈7]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access95{{"Access[95∈7]<br />ᐸ94.0ᐳ"}}:::plan
     Object13 & Access95 --> PgSelect96
-    Access81{{"Access[81∈7]<br />ᐸ80.1ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle80 --> Access81
-    JSONParse82[["JSONParse[82∈7]<br />ᐸ81ᐳ"]]:::plan
+    JSONParse82[["JSONParse[82∈7]<br />ᐸ81ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access81 --> JSONParse82
     JSONParse82 --> Access83
     First88{{"First[88∈7]"}}:::plan
@@ -166,22 +166,22 @@ graph TD
     class Bucket1,PgUnionAll15,Access106 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 13<br /><br />ROOT __Item{2}ᐸ106ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item17,PgUnionAllSingle18 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 18, 13<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 19, 35, 76<br />2: JSONParse[20], JSONParse[63]<br />ᐳ: Access[21], Access[64]<br />3: PgSelect[22], PgSelect[65]<br />4: PgSelectRows[27], PgSelectRows[68]<br />ᐳ: 26, 28, 29, 32, 67, 69, 70, 73<br />5: PgUnionAll[36], PgUnionAll[77]<br />ᐳ: Access[104], Access[105]"):::bucket
+    class Bucket2,__Item17,PgUnionAllSingle18,Access19 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 19, 13, 18<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[20], JSONParse[63]<br />ᐳ: 35, 76, 21, 64<br />2: PgSelect[22], PgSelect[65]<br />3: PgSelectRows[27], PgSelectRows[68]<br />ᐳ: 26, 28, 29, 32, 67, 69, 70, 73<br />4: PgUnionAll[36], PgUnionAll[77]<br />ᐳ: Access[104], Access[105]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Access19,JSONParse20,Access21,PgSelect22,First26,PgSelectRows27,PgSelectSingle28,PgClassExpression29,PgClassExpression32,Connection35,PgUnionAll36,JSONParse63,Access64,PgSelect65,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression70,PgClassExpression73,Connection76,PgUnionAll77,Access104,Access105 bucket3
+    class Bucket3,JSONParse20,Access21,PgSelect22,First26,PgSelectRows27,PgSelectSingle28,PgClassExpression29,PgClassExpression32,Connection35,PgUnionAll36,JSONParse63,Access64,PgSelect65,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression70,PgClassExpression73,Connection76,PgUnionAll77,Access104,Access105 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 13<br /><br />ROOT __Item{4}ᐸ104ᐳ[38]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item38,PgUnionAllSingle39 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 39, 13<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[40]<br />2: JSONParse[41], JSONParse[53]<br />ᐳ: Access[42], Access[54]<br />3: PgSelect[43], PgSelect[55]<br />4: PgSelectRows[48], PgSelectRows[58]<br />ᐳ: 47, 49, 50, 51, 52, 57, 59, 60, 61, 62"):::bucket
+    class Bucket4,__Item38,PgUnionAllSingle39,Access40 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 40, 13, 39<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[41], JSONParse[53]<br />ᐳ: Access[42], Access[54]<br />2: PgSelect[43], PgSelect[55]<br />3: PgSelectRows[48], PgSelectRows[58]<br />ᐳ: 47, 49, 50, 51, 52, 57, 59, 60, 61, 62"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Access40,JSONParse41,Access42,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,PgClassExpression52,JSONParse53,Access54,PgSelect55,First57,PgSelectRows58,PgSelectSingle59,PgClassExpression60,PgClassExpression61,PgClassExpression62 bucket5
+    class Bucket5,JSONParse41,Access42,PgSelect43,First47,PgSelectRows48,PgSelectSingle49,PgClassExpression50,PgClassExpression51,PgClassExpression52,JSONParse53,Access54,PgSelect55,First57,PgSelectRows58,PgSelectSingle59,PgClassExpression60,PgClassExpression61,PgClassExpression62 bucket5
     Bucket6("Bucket 6 (listItem)<br />Deps: 13<br /><br />ROOT __Item{6}ᐸ105ᐳ[79]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,__Item79,PgUnionAllSingle80 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 80, 13<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[81]<br />2: JSONParse[82], JSONParse[94]<br />ᐳ: Access[83], Access[95]<br />3: PgSelect[84], PgSelect[96]<br />4: PgSelectRows[89], PgSelectRows[99]<br />ᐳ: 88, 90, 91, 92, 93, 98, 100, 101, 102, 103"):::bucket
+    class Bucket6,__Item79,PgUnionAllSingle80,Access81 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 81, 13, 80<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[82], JSONParse[94]<br />ᐳ: Access[83], Access[95]<br />2: PgSelect[84], PgSelect[96]<br />3: PgSelectRows[89], PgSelectRows[99]<br />ᐳ: 88, 90, 91, 92, 93, 98, 100, 101, 102, 103"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Access81,JSONParse82,Access83,PgSelect84,First88,PgSelectRows89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,JSONParse94,Access95,PgSelect96,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression101,PgClassExpression102,PgClassExpression103 bucket7
+    class Bucket7,JSONParse82,Access83,PgSelect84,First88,PgSelectRows89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,JSONParse94,Access95,PgSelect96,First98,PgSelectRows99,PgSelectSingle100,PgClassExpression101,PgClassExpression102,PgClassExpression103 bucket7
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.mermaid
@@ -51,15 +51,15 @@ graph TD
     PgUnionAll31 --> Access35
     PgCursor36{{"PgCursor[36∈5]"}}:::plan
     PgUnionAllSingle34 & Access35 --> PgCursor36
+    Access37{{"Access[37∈5]<br />ᐸ34.1ᐳ"}}:::plan
+    PgUnionAllSingle34 --> Access37
     PgSelect40[["PgSelect[40∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access39{{"Access[39∈6]<br />ᐸ38.0ᐳ"}}:::plan
     Object13 & Access39 --> PgSelect40
     PgSelect51[["PgSelect[51∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access50{{"Access[50∈6]<br />ᐸ49.0ᐳ"}}:::plan
     Object13 & Access50 --> PgSelect51
-    Access37{{"Access[37∈6]<br />ᐸ34.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle34 --> Access37
-    JSONParse38[["JSONParse[38∈6]<br />ᐸ37ᐳ"]]:::plan
+    JSONParse38[["JSONParse[38∈6]<br />ᐸ37ᐳ<br />ᐳAwsApplication"]]:::plan
     Access37 --> JSONParse38
     JSONParse38 --> Access39
     First44{{"First[44∈6]"}}:::plan
@@ -106,10 +106,10 @@ graph TD
     class Bucket4,__Item33,PgUnionAllSingle34,Access35 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 34, 35, 13<br /><br />ROOT PgUnionAllSingle{4}[34]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor36 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 34, 13<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: Access[37]<br />2: JSONParse[38], JSONParse[49]<br />ᐳ: Access[39], Access[50]<br />3: PgSelect[40], PgSelect[51]<br />4: PgSelectRows[45], PgSelectRows[54]<br />ᐳ: 44, 46, 47, 48, 53, 55, 56, 57"):::bucket
+    class Bucket5,PgCursor36,Access37 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 37, 13, 34<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[38], JSONParse[49]<br />ᐳ: Access[39], Access[50]<br />2: PgSelect[40], PgSelect[51]<br />3: PgSelectRows[45], PgSelectRows[54]<br />ᐳ: 44, 46, 47, 48, 53, 55, 56, 57"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Access37,JSONParse38,Access39,PgSelect40,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47,PgClassExpression48,JSONParse49,Access50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,PgClassExpression57 bucket6
+    class Bucket6,JSONParse38,Access39,PgSelect40,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47,PgClassExpression48,JSONParse49,Access50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,PgClassExpression57 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.mermaid
@@ -45,15 +45,15 @@ graph TD
     PgUnionAll29 --> Access33
     PgCursor34{{"PgCursor[34∈5]"}}:::plan
     PgUnionAllSingle32 & Access33 --> PgCursor34
+    Access35{{"Access[35∈5]<br />ᐸ32.1ᐳ"}}:::plan
+    PgUnionAllSingle32 --> Access35
     PgSelect38[["PgSelect[38∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access37{{"Access[37∈6]<br />ᐸ36.0ᐳ"}}:::plan
     Object13 & Access37 --> PgSelect38
     PgSelect50[["PgSelect[50∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access49{{"Access[49∈6]<br />ᐸ48.0ᐳ"}}:::plan
     Object13 & Access49 --> PgSelect50
-    Access35{{"Access[35∈6]<br />ᐸ32.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle32 --> Access35
-    JSONParse36[["JSONParse[36∈6]<br />ᐸ35ᐳ"]]:::plan
+    JSONParse36[["JSONParse[36∈6]<br />ᐸ35ᐳ<br />ᐳAwsApplication"]]:::plan
     Access35 --> JSONParse36
     JSONParse36 --> Access37
     First42{{"First[42∈6]"}}:::plan
@@ -104,10 +104,10 @@ graph TD
     class Bucket4,__Item31,PgUnionAllSingle32,Access33 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32, 33, 13<br /><br />ROOT PgUnionAllSingle{4}[32]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor34 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 32, 13<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: Access[35]<br />2: JSONParse[36], JSONParse[48]<br />ᐳ: Access[37], Access[49]<br />3: PgSelect[38], PgSelect[50]<br />4: PgSelectRows[43], PgSelectRows[53]<br />ᐳ: 42, 44, 45, 46, 47, 52, 54, 55, 56, 57"):::bucket
+    class Bucket5,PgCursor34,Access35 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 35, 13, 32<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[36], JSONParse[48]<br />ᐳ: Access[37], Access[49]<br />2: PgSelect[38], PgSelect[50]<br />3: PgSelectRows[43], PgSelectRows[53]<br />ᐳ: 42, 44, 45, 46, 47, 52, 54, 55, 56, 57"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Access35,JSONParse36,Access37,PgSelect38,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,JSONParse48,Access49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket6
+    class Bucket6,JSONParse36,Access37,PgSelect38,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,JSONParse48,Access49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55,PgClassExpression56,PgClassExpression57 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.mermaid
@@ -50,6 +50,8 @@ graph TD
     PgUnionAll29 --> Access33
     PgCursor34{{"PgCursor[34∈5]"}}:::plan
     PgUnionAllSingle32 & Access33 --> PgCursor34
+    Access35{{"Access[35∈5]<br />ᐸ32.1ᐳ"}}:::plan
+    PgUnionAllSingle32 --> Access35
     PgUnionAll50[["PgUnionAll[50∈6]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression45{{"PgClassExpression[45∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection49{{"Connection[49∈6] ➊<br />ᐸ47ᐳ<br />ᐳAwsApplication"}}:::plan
@@ -64,9 +66,7 @@ graph TD
     PgSelect77[["PgSelect[77∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access76{{"Access[76∈6]<br />ᐸ75.0ᐳ"}}:::plan
     Object13 & Access76 --> PgSelect77
-    Access35{{"Access[35∈6]<br />ᐸ32.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle32 --> Access35
-    JSONParse36[["JSONParse[36∈6]<br />ᐸ35ᐳ"]]:::plan
+    JSONParse36[["JSONParse[36∈6]<br />ᐸ35ᐳ<br />ᐳAwsApplication"]]:::plan
     Access35 --> JSONParse36
     JSONParse36 --> Access37
     First42{{"First[42∈6]"}}:::plan
@@ -100,15 +100,15 @@ graph TD
     PgUnionAll50 --> Access54
     PgCursor55{{"PgCursor[55∈8]<br />ᐳAwsApplication"}}:::plan
     PgUnionAllSingle53 & Access54 --> PgCursor55
+    Access56{{"Access[56∈8]<br />ᐸ53.1ᐳ"}}:::plan
+    PgUnionAllSingle53 --> Access56
     PgSelect59[["PgSelect[59∈9]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access58{{"Access[58∈9]<br />ᐸ57.0ᐳ"}}:::plan
     Object13 & Access58 --> PgSelect59
     PgSelect69[["PgSelect[69∈9]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access68{{"Access[68∈9]<br />ᐸ67.0ᐳ"}}:::plan
     Object13 & Access68 --> PgSelect69
-    Access56{{"Access[56∈9]<br />ᐸ53.1ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle53 --> Access56
-    JSONParse57[["JSONParse[57∈9]<br />ᐸ56ᐳ"]]:::plan
+    JSONParse57[["JSONParse[57∈9]<br />ᐸ56ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access56 --> JSONParse57
     JSONParse57 --> Access58
     First63{{"First[63∈9]"}}:::plan
@@ -138,15 +138,15 @@ graph TD
     PgUnionAll87 --> Access91
     PgCursor92{{"PgCursor[92∈11]<br />ᐳGcpApplication"}}:::plan
     PgUnionAllSingle90 & Access91 --> PgCursor92
+    Access93{{"Access[93∈11]<br />ᐸ90.1ᐳ"}}:::plan
+    PgUnionAllSingle90 --> Access93
     PgSelect96[["PgSelect[96∈12]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access95{{"Access[95∈12]<br />ᐸ94.0ᐳ"}}:::plan
     Object13 & Access95 --> PgSelect96
     PgSelect106[["PgSelect[106∈12]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access105{{"Access[105∈12]<br />ᐸ104.0ᐳ"}}:::plan
     Object13 & Access105 --> PgSelect106
-    Access93{{"Access[93∈12]<br />ᐸ90.1ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle90 --> Access93
-    JSONParse94[["JSONParse[94∈12]<br />ᐸ93ᐳ"]]:::plan
+    JSONParse94[["JSONParse[94∈12]<br />ᐸ93ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access93 --> JSONParse94
     JSONParse94 --> Access95
     First100{{"First[100∈12]"}}:::plan
@@ -189,28 +189,28 @@ graph TD
     class Bucket4,__Item31,PgUnionAllSingle32,Access33 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 32, 33, 13, 116<br /><br />ROOT PgUnionAllSingle{4}[32]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor34 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 32, 13, 116<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 35, 49, 86<br />2: JSONParse[36], JSONParse[75]<br />ᐳ: Access[37], Access[76]<br />3: PgSelect[38], PgSelect[77]<br />4: PgSelectRows[43], PgSelectRows[80]<br />ᐳ: 42, 44, 45, 79, 81, 82<br />5: PgUnionAll[50], PgUnionAll[87]<br />ᐳ: Access[112], Access[113]"):::bucket
+    class Bucket5,PgCursor34,Access35 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 35, 13, 116, 32<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[36], JSONParse[75]<br />ᐳ: 49, 86, 37, 76<br />2: PgSelect[38], PgSelect[77]<br />3: PgSelectRows[43], PgSelectRows[80]<br />ᐳ: 42, 44, 45, 79, 81, 82<br />4: PgUnionAll[50], PgUnionAll[87]<br />ᐳ: Access[112], Access[113]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Access35,JSONParse36,Access37,PgSelect38,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,Connection49,PgUnionAll50,JSONParse75,Access76,PgSelect77,First79,PgSelectRows80,PgSelectSingle81,PgClassExpression82,Connection86,PgUnionAll87,Access112,Access113 bucket6
+    class Bucket6,JSONParse36,Access37,PgSelect38,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,Connection49,PgUnionAll50,JSONParse75,Access76,PgSelect77,First79,PgSelectRows80,PgSelectSingle81,PgClassExpression82,Connection86,PgUnionAll87,Access112,Access113 bucket6
     Bucket7("Bucket 7 (listItem)<br />Deps: 50, 13<br /><br />ROOT __Item{7}ᐸ112ᐳ[52]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7,__Item52,PgUnionAllSingle53,Access54 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 53, 54, 13<br /><br />ROOT PgUnionAllSingle{7}[53]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor55 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 53, 13<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[56]<br />2: JSONParse[57], JSONParse[67]<br />ᐳ: Access[58], Access[68]<br />3: PgSelect[59], PgSelect[69]<br />4: PgSelectRows[64], PgSelectRows[72]<br />ᐳ: 63, 65, 66, 71, 73, 74"):::bucket
+    class Bucket8,PgCursor55,Access56 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 56, 13, 53<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[57], JSONParse[67]<br />ᐳ: Access[58], Access[68]<br />2: PgSelect[59], PgSelect[69]<br />3: PgSelectRows[64], PgSelectRows[72]<br />ᐳ: 63, 65, 66, 71, 73, 74"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Access56,JSONParse57,Access58,PgSelect59,First63,PgSelectRows64,PgSelectSingle65,PgClassExpression66,JSONParse67,Access68,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74 bucket9
+    class Bucket9,JSONParse57,Access58,PgSelect59,First63,PgSelectRows64,PgSelectSingle65,PgClassExpression66,JSONParse67,Access68,PgSelect69,First71,PgSelectRows72,PgSelectSingle73,PgClassExpression74 bucket9
     Bucket10("Bucket 10 (listItem)<br />Deps: 87, 13<br /><br />ROOT __Item{10}ᐸ113ᐳ[89]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item89,PgUnionAllSingle90,Access91 bucket10
     Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 90, 91, 13<br /><br />ROOT PgUnionAllSingle{10}[90]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgCursor92 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 90, 13<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[93]<br />2: JSONParse[94], JSONParse[104]<br />ᐳ: Access[95], Access[105]<br />3: PgSelect[96], PgSelect[106]<br />4: PgSelectRows[101], PgSelectRows[109]<br />ᐳ: 100, 102, 103, 108, 110, 111"):::bucket
+    class Bucket11,PgCursor92,Access93 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 93, 13, 90<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[94], JSONParse[104]<br />ᐳ: Access[95], Access[105]<br />2: PgSelect[96], PgSelect[106]<br />3: PgSelectRows[101], PgSelectRows[109]<br />ᐳ: 100, 102, 103, 108, 110, 111"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,Access93,JSONParse94,Access95,PgSelect96,First100,PgSelectRows101,PgSelectSingle102,PgClassExpression103,JSONParse104,Access105,PgSelect106,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111 bucket12
+    class Bucket12,JSONParse94,Access95,PgSelect96,First100,PgSelectRows101,PgSelectSingle102,PgClassExpression103,JSONParse104,Access105,PgSelect106,First108,PgSelectRows109,PgSelectSingle110,PgClassExpression111 bucket12
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.mermaid
@@ -41,6 +41,8 @@ graph TD
     Access67 ==> __Item28
     PgUnionAllSingle29["PgUnionAllSingle[29∈4]"]:::plan
     __Item28 --> PgUnionAllSingle29
+    Access30{{"Access[30∈4]<br />ᐸ29.1ᐳ"}}:::plan
+    PgUnionAllSingle29 --> Access30
     PgUnionAll44[["PgUnionAll[44∈5]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression40{{"PgClassExpression[40∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
     Connection43{{"Connection[43∈5] ➊<br />ᐸ41ᐳ<br />ᐳAwsApplication"}}:::plan
@@ -55,9 +57,7 @@ graph TD
     PgSelect51[["PgSelect[51∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access50{{"Access[50∈5]<br />ᐸ49.0ᐳ"}}:::plan
     Object13 & Access50 --> PgSelect51
-    Access30{{"Access[30∈5]<br />ᐸ29.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle29 --> Access30
-    JSONParse31[["JSONParse[31∈5]<br />ᐸ30ᐳ"]]:::plan
+    JSONParse31[["JSONParse[31∈5]<br />ᐸ30ᐳ<br />ᐳAwsApplication"]]:::plan
     Access30 --> JSONParse31
     JSONParse31 --> Access32
     First37{{"First[37∈5]"}}:::plan
@@ -111,10 +111,10 @@ graph TD
     class Bucket3,PgClassExpression19,PgClassExpression20,PgUnionAll26,Access67 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 13<br /><br />ROOT __Item{4}ᐸ67ᐳ[28]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item28,PgUnionAllSingle29 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 29, 13<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 30, 43, 59<br />2: JSONParse[31], JSONParse[49]<br />ᐳ: Access[32], Access[50]<br />3: PgSelect[33], PgSelect[51]<br />4: PgSelectRows[38], PgSelectRows[54]<br />ᐳ: 37, 39, 40, 53, 55, 56<br />5: PgUnionAll[44], PgUnionAll[60]<br />ᐳ: 65, 66, 45, 61<br />6: 47, 63<br />ᐳ: 48, 64"):::bucket
+    class Bucket4,__Item28,PgUnionAllSingle29,Access30 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 30, 13, 29<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[31], JSONParse[49]<br />ᐳ: 43, 59, 32, 50<br />2: PgSelect[33], PgSelect[51]<br />3: PgSelectRows[38], PgSelectRows[54]<br />ᐳ: 37, 39, 40, 53, 55, 56<br />4: PgUnionAll[44], PgUnionAll[60]<br />ᐳ: 65, 66, 45, 61<br />5: 47, 63<br />ᐳ: 48, 64"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Access30,JSONParse31,Access32,PgSelect33,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Connection43,PgUnionAll44,First45,PgUnionAllSingle47,PgClassExpression48,JSONParse49,Access50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,Connection59,PgUnionAll60,First61,PgUnionAllSingle63,PgClassExpression64,Access65,Access66 bucket5
+    class Bucket5,JSONParse31,Access32,PgSelect33,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Connection43,PgUnionAll44,First45,PgUnionAllSingle47,PgClassExpression48,JSONParse49,Access50,PgSelect51,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression56,Connection59,PgUnionAll60,First61,PgUnionAllSingle63,PgClassExpression64,Access65,Access66 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
@@ -59,15 +59,15 @@ graph TD
     PgUnionAll31 --> Access35
     PgCursor36{{"PgCursor[36∈5]"}}:::plan
     PgUnionAllSingle34 & Access35 --> PgCursor36
+    Access37{{"Access[37∈5]<br />ᐸ34.1ᐳ"}}:::plan
+    PgUnionAllSingle34 --> Access37
     PgSelect40[["PgSelect[40∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
     Access39{{"Access[39∈6]<br />ᐸ38.0ᐳ"}}:::plan
     Object13 & Access39 --> PgSelect40
     PgSelect50[["PgSelect[50∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
     Access49{{"Access[49∈6]<br />ᐸ48.0ᐳ"}}:::plan
     Object13 & Access49 --> PgSelect50
-    Access37{{"Access[37∈6]<br />ᐸ34.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle34 --> Access37
-    JSONParse38[["JSONParse[38∈6]<br />ᐸ37ᐳ"]]:::plan
+    JSONParse38[["JSONParse[38∈6]<br />ᐸ37ᐳ<br />ᐳAwsApplication"]]:::plan
     Access37 --> JSONParse38
     JSONParse38 --> Access39
     First44{{"First[44∈6]"}}:::plan
@@ -93,6 +93,8 @@ graph TD
     Access283 ==> __Item58
     PgUnionAllSingle59["PgUnionAllSingle[59∈7]"]:::plan
     __Item58 --> PgUnionAllSingle59
+    Access60{{"Access[60∈7]<br />ᐸ59.1ᐳ"}}:::plan
+    PgUnionAllSingle59 --> Access60
     PgUnionAll75[["PgUnionAll[75∈8]<br />ᐳAwsApplication"]]:::plan
     PgClassExpression73{{"PgClassExpression[73∈8]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression74{{"PgClassExpression[74∈8]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
@@ -123,9 +125,7 @@ graph TD
     Object13 & Access169 --> PgSelect170
     PgUnionAll206[["PgUnionAll[206∈8]<br />ᐳGcpApplication"]]:::plan
     Object13 & PgClassExpression176 --> PgUnionAll206
-    Access60{{"Access[60∈8]<br />ᐸ59.1ᐳ<br />ᐳAwsApplication"}}:::plan
-    PgUnionAllSingle59 --> Access60
-    JSONParse61[["JSONParse[61∈8]<br />ᐸ60ᐳ"]]:::plan
+    JSONParse61[["JSONParse[61∈8]<br />ᐸ60ᐳ<br />ᐳAwsApplication"]]:::plan
     Access60 --> JSONParse61
     JSONParse61 --> Access62
     First67{{"First[67∈8]"}}:::plan
@@ -146,6 +146,8 @@ graph TD
     Access278 --> First77
     PgUnionAllSingle79["PgUnionAllSingle[79∈8]"]:::plan
     First77 --> PgUnionAllSingle79
+    Access80{{"Access[80∈8]<br />ᐸ79.1ᐳ"}}:::plan
+    PgUnionAllSingle79 --> Access80
     First135{{"First[135∈8]"}}:::plan
     Access276{{"Access[276∈8]<br />ᐸ134.itemsᐳ"}}:::plan
     Access276 --> First135
@@ -174,6 +176,8 @@ graph TD
     Access282 --> First182
     PgUnionAllSingle184["PgUnionAllSingle[184∈8]"]:::plan
     First182 --> PgUnionAllSingle184
+    Access185{{"Access[185∈8]<br />ᐸ184.1ᐳ"}}:::plan
+    PgUnionAllSingle184 --> Access185
     First240{{"First[240∈8]"}}:::plan
     Access280{{"Access[280∈8]<br />ᐸ239.itemsᐳ"}}:::plan
     Access280 --> First240
@@ -199,9 +203,7 @@ graph TD
     PgSelect94[["PgSelect[94∈9]<br />ᐸpeopleᐳ<br />ᐳAwsApplicationᐳPerson"]]:::plan
     Access93{{"Access[93∈9]<br />ᐸ92.0ᐳ"}}:::plan
     Object13 & Access93 --> PgSelect94
-    Access80{{"Access[80∈9]<br />ᐸ79.1ᐳ<br />ᐳAwsApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle79 --> Access80
-    JSONParse81[["JSONParse[81∈9]<br />ᐸ80ᐳ"]]:::plan
+    JSONParse81[["JSONParse[81∈9]<br />ᐸ80ᐳ<br />ᐳAwsApplicationᐳOrganization"]]:::plan
     Access80 --> JSONParse81
     JSONParse81 --> Access82
     First87{{"First[87∈9]"}}:::plan
@@ -231,15 +233,15 @@ graph TD
     Access275 ==> __Item104
     PgUnionAllSingle105["PgUnionAllSingle[105∈10]"]:::plan
     __Item104 --> PgUnionAllSingle105
+    Access106{{"Access[106∈10]<br />ᐸ105.1ᐳ"}}:::plan
+    PgUnionAllSingle105 --> Access106
     PgSelect109[["PgSelect[109∈11]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access108{{"Access[108∈11]<br />ᐸ107.0ᐳ"}}:::plan
     Object13 & Access108 --> PgSelect109
     PgSelect122[["PgSelect[122∈11]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access121{{"Access[121∈11]<br />ᐸ120.0ᐳ"}}:::plan
     Object13 & Access121 --> PgSelect122
-    Access106{{"Access[106∈11]<br />ᐸ105.1ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle105 --> Access106
-    JSONParse107[["JSONParse[107∈11]<br />ᐸ106ᐳ"]]:::plan
+    JSONParse107[["JSONParse[107∈11]<br />ᐸ106ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access106 --> JSONParse107
     JSONParse107 --> Access108
     First113{{"First[113∈11]"}}:::plan
@@ -281,15 +283,15 @@ graph TD
     PgUnionAll139 --> Access143
     PgCursor144{{"PgCursor[144∈13]<br />ᐳAwsApplication"}}:::plan
     PgUnionAllSingle142 & Access143 --> PgCursor144
+    Access145{{"Access[145∈13]<br />ᐸ142.1ᐳ"}}:::plan
+    PgUnionAllSingle142 --> Access145
     PgSelect148[["PgSelect[148∈14]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access147{{"Access[147∈14]<br />ᐸ146.0ᐳ"}}:::plan
     Object13 & Access147 --> PgSelect148
     PgSelect160[["PgSelect[160∈14]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
     Access159{{"Access[159∈14]<br />ᐸ158.0ᐳ"}}:::plan
     Object13 & Access159 --> PgSelect160
-    Access145{{"Access[145∈14]<br />ᐸ142.1ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle142 --> Access145
-    JSONParse146[["JSONParse[146∈14]<br />ᐸ145ᐳ"]]:::plan
+    JSONParse146[["JSONParse[146∈14]<br />ᐸ145ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
     Access145 --> JSONParse146
     JSONParse146 --> Access147
     First152{{"First[152∈14]"}}:::plan
@@ -325,9 +327,7 @@ graph TD
     PgSelect199[["PgSelect[199∈15]<br />ᐸpeopleᐳ<br />ᐳGcpApplicationᐳPerson"]]:::plan
     Access198{{"Access[198∈15]<br />ᐸ197.0ᐳ"}}:::plan
     Object13 & Access198 --> PgSelect199
-    Access185{{"Access[185∈15]<br />ᐸ184.1ᐳ<br />ᐳGcpApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle184 --> Access185
-    JSONParse186[["JSONParse[186∈15]<br />ᐸ185ᐳ"]]:::plan
+    JSONParse186[["JSONParse[186∈15]<br />ᐸ185ᐳ<br />ᐳGcpApplicationᐳOrganization"]]:::plan
     Access185 --> JSONParse186
     JSONParse186 --> Access187
     First192{{"First[192∈15]"}}:::plan
@@ -357,15 +357,15 @@ graph TD
     Access279 ==> __Item209
     PgUnionAllSingle210["PgUnionAllSingle[210∈16]"]:::plan
     __Item209 --> PgUnionAllSingle210
+    Access211{{"Access[211∈16]<br />ᐸ210.1ᐳ"}}:::plan
+    PgUnionAllSingle210 --> Access211
     PgSelect214[["PgSelect[214∈17]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access213{{"Access[213∈17]<br />ᐸ212.0ᐳ"}}:::plan
     Object13 & Access213 --> PgSelect214
     PgSelect227[["PgSelect[227∈17]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access226{{"Access[226∈17]<br />ᐸ225.0ᐳ"}}:::plan
     Object13 & Access226 --> PgSelect227
-    Access211{{"Access[211∈17]<br />ᐸ210.1ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle210 --> Access211
-    JSONParse212[["JSONParse[212∈17]<br />ᐸ211ᐳ"]]:::plan
+    JSONParse212[["JSONParse[212∈17]<br />ᐸ211ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access211 --> JSONParse212
     JSONParse212 --> Access213
     First218{{"First[218∈17]"}}:::plan
@@ -407,15 +407,15 @@ graph TD
     PgUnionAll244 --> Access248
     PgCursor249{{"PgCursor[249∈19]<br />ᐳGcpApplication"}}:::plan
     PgUnionAllSingle247 & Access248 --> PgCursor249
+    Access250{{"Access[250∈19]<br />ᐸ247.1ᐳ"}}:::plan
+    PgUnionAllSingle247 --> Access250
     PgSelect253[["PgSelect[253∈20]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access252{{"Access[252∈20]<br />ᐸ251.0ᐳ"}}:::plan
     Object13 & Access252 --> PgSelect253
     PgSelect265[["PgSelect[265∈20]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
     Access264{{"Access[264∈20]<br />ᐸ263.0ᐳ"}}:::plan
     Object13 & Access264 --> PgSelect265
-    Access250{{"Access[250∈20]<br />ᐸ247.1ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle247 --> Access250
-    JSONParse251[["JSONParse[251∈20]<br />ᐸ250ᐳ"]]:::plan
+    JSONParse251[["JSONParse[251∈20]<br />ᐸ250ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
     Access250 --> JSONParse251
     JSONParse251 --> Access252
     First257{{"First[257∈20]"}}:::plan
@@ -466,52 +466,52 @@ graph TD
     class Bucket4,__Item33,PgUnionAllSingle34,Access35 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 34, 35, 13<br /><br />ROOT PgUnionAllSingle{4}[34]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor36 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 34, 13<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: Access[37]<br />2: JSONParse[38], JSONParse[48]<br />ᐳ: Access[39], Access[49]<br />3: PgSelect[40], PgSelect[50]<br />4: PgSelectRows[45], PgSelectRows[53]<br />ᐳ: 44, 46, 47, 52, 54, 55"):::bucket
+    class Bucket5,PgCursor36,Access37 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 37, 13, 34<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[38], JSONParse[48]<br />ᐳ: Access[39], Access[49]<br />2: PgSelect[40], PgSelect[50]<br />3: PgSelectRows[45], PgSelectRows[53]<br />ᐳ: 44, 46, 47, 52, 54, 55"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Access37,JSONParse38,Access39,PgSelect40,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47,JSONParse48,Access49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55 bucket6
+    class Bucket6,JSONParse38,Access39,PgSelect40,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47,JSONParse48,Access49,PgSelect50,First52,PgSelectRows53,PgSelectSingle54,PgClassExpression55 bucket6
     Bucket7("Bucket 7 (listItem)<br />Deps: 13<br /><br />ROOT __Item{7}ᐸ283ᐳ[58]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,__Item58,PgUnionAllSingle59 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 59, 13<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: <br />ᐳ: 60, 133, 238<br />2: JSONParse[61], JSONParse[168]<br />ᐳ: Access[62], Access[169]<br />3: PgSelect[63], PgSelect[170]<br />4: PgSelectRows[68], PgSelectRows[173]<br />ᐳ: 67, 69, 70, 71, 72, 73, 74, 172, 174, 175, 176, 177, 178, 179<br />5: 75, 101, 134, 139, 180, 206, 239, 244<br />ᐳ: 275, 276, 277, 278, 279, 280, 281, 282, 77, 135, 182, 240<br />6: 79, 137, 184, 242<br />ᐳ: 138, 243"):::bucket
+    class Bucket7,__Item58,PgUnionAllSingle59,Access60 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 60, 13, 59<br />ᐳAwsApplication<br />ᐳGcpApplication<br /><br />1: JSONParse[61], JSONParse[168]<br />ᐳ: 133, 238, 62, 169<br />2: PgSelect[63], PgSelect[170]<br />3: PgSelectRows[68], PgSelectRows[173]<br />ᐳ: 67, 69, 70, 71, 72, 73, 74, 172, 174, 175, 176, 177, 178, 179<br />4: 75, 101, 134, 139, 180, 206, 239, 244<br />ᐳ: 275, 276, 277, 278, 279, 280, 281, 282, 77, 135, 182, 240<br />5: 79, 137, 184, 242<br />ᐳ: 80, 138, 185, 243"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,Access60,JSONParse61,Access62,PgSelect63,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression70,PgClassExpression71,PgClassExpression72,PgClassExpression73,PgClassExpression74,PgUnionAll75,First77,PgUnionAllSingle79,PgUnionAll101,Connection133,PgUnionAll134,First135,PgUnionAllSingle137,PgClassExpression138,PgUnionAll139,JSONParse168,Access169,PgSelect170,First172,PgSelectRows173,PgSelectSingle174,PgClassExpression175,PgClassExpression176,PgClassExpression177,PgClassExpression178,PgClassExpression179,PgUnionAll180,First182,PgUnionAllSingle184,PgUnionAll206,Connection238,PgUnionAll239,First240,PgUnionAllSingle242,PgClassExpression243,PgUnionAll244,Access275,Access276,Access277,Access278,Access279,Access280,Access281,Access282 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />Organization,Person<br />Deps: 79, 13<br />ᐳAwsApplicationᐳOrganization<br />ᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[80]<br />2: JSONParse[81], JSONParse[92]<br />ᐳ: Access[82], Access[93]<br />3: PgSelect[83], PgSelect[94]<br />4: PgSelectRows[88], PgSelectRows[97]<br />ᐳ: 87, 89, 90, 91, 96, 98, 99, 100"):::bucket
+    class Bucket8,JSONParse61,Access62,PgSelect63,First67,PgSelectRows68,PgSelectSingle69,PgClassExpression70,PgClassExpression71,PgClassExpression72,PgClassExpression73,PgClassExpression74,PgUnionAll75,First77,PgUnionAllSingle79,Access80,PgUnionAll101,Connection133,PgUnionAll134,First135,PgUnionAllSingle137,PgClassExpression138,PgUnionAll139,JSONParse168,Access169,PgSelect170,First172,PgSelectRows173,PgSelectSingle174,PgClassExpression175,PgClassExpression176,PgClassExpression177,PgClassExpression178,PgClassExpression179,PgUnionAll180,First182,PgUnionAllSingle184,Access185,PgUnionAll206,Connection238,PgUnionAll239,First240,PgUnionAllSingle242,PgClassExpression243,PgUnionAll244,Access275,Access276,Access277,Access278,Access279,Access280,Access281,Access282 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />Organization,Person<br />Deps: 80, 13, 79<br />ᐳAwsApplicationᐳOrganization<br />ᐳAwsApplicationᐳPerson<br /><br />1: JSONParse[81], JSONParse[92]<br />ᐳ: Access[82], Access[93]<br />2: PgSelect[83], PgSelect[94]<br />3: PgSelectRows[88], PgSelectRows[97]<br />ᐳ: 87, 89, 90, 91, 96, 98, 99, 100"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Access80,JSONParse81,Access82,PgSelect83,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression90,PgClassExpression91,JSONParse92,Access93,PgSelect94,First96,PgSelectRows97,PgSelectSingle98,PgClassExpression99,PgClassExpression100 bucket9
+    class Bucket9,JSONParse81,Access82,PgSelect83,First87,PgSelectRows88,PgSelectSingle89,PgClassExpression90,PgClassExpression91,JSONParse92,Access93,PgSelect94,First96,PgSelectRows97,PgSelectSingle98,PgClassExpression99,PgClassExpression100 bucket9
     Bucket10("Bucket 10 (listItem)<br />Deps: 13<br /><br />ROOT __Item{10}ᐸ275ᐳ[104]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,__Item104,PgUnionAllSingle105 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 105, 13<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[106]<br />2: JSONParse[107], JSONParse[120]<br />ᐳ: Access[108], Access[121]<br />3: PgSelect[109], PgSelect[122]<br />4: PgSelectRows[114], PgSelectRows[125]<br />ᐳ: 113, 115, 116, 117, 118, 119, 124, 126, 127, 128, 129, 130"):::bucket
+    class Bucket10,__Item104,PgUnionAllSingle105,Access106 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 106, 13, 105<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[107], JSONParse[120]<br />ᐳ: Access[108], Access[121]<br />2: PgSelect[109], PgSelect[122]<br />3: PgSelectRows[114], PgSelectRows[125]<br />ᐳ: 113, 115, 116, 117, 118, 119, 124, 126, 127, 128, 129, 130"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,Access106,JSONParse107,Access108,PgSelect109,First113,PgSelectRows114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119,JSONParse120,Access121,PgSelect122,First124,PgSelectRows125,PgSelectSingle126,PgClassExpression127,PgClassExpression128,PgClassExpression129,PgClassExpression130 bucket11
+    class Bucket11,JSONParse107,Access108,PgSelect109,First113,PgSelectRows114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgClassExpression119,JSONParse120,Access121,PgSelect122,First124,PgSelectRows125,PgSelectSingle126,PgClassExpression127,PgClassExpression128,PgClassExpression129,PgClassExpression130 bucket11
     Bucket12("Bucket 12 (listItem)<br />Deps: 139, 13<br /><br />ROOT __Item{12}ᐸ277ᐳ[141]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,__Item141,PgUnionAllSingle142,Access143 bucket12
     Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 142, 143, 13<br /><br />ROOT PgUnionAllSingle{12}[142]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgCursor144 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 142, 13<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[145]<br />2: JSONParse[146], JSONParse[158]<br />ᐳ: Access[147], Access[159]<br />3: PgSelect[148], PgSelect[160]<br />4: PgSelectRows[153], PgSelectRows[163]<br />ᐳ: 152, 154, 155, 156, 157, 162, 164, 165, 166, 167"):::bucket
+    class Bucket13,PgCursor144,Access145 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 145, 13, 142<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[146], JSONParse[158]<br />ᐳ: Access[147], Access[159]<br />2: PgSelect[148], PgSelect[160]<br />3: PgSelectRows[153], PgSelectRows[163]<br />ᐳ: 152, 154, 155, 156, 157, 162, 164, 165, 166, 167"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,Access145,JSONParse146,Access147,PgSelect148,First152,PgSelectRows153,PgSelectSingle154,PgClassExpression155,PgClassExpression156,PgClassExpression157,JSONParse158,Access159,PgSelect160,First162,PgSelectRows163,PgSelectSingle164,PgClassExpression165,PgClassExpression166,PgClassExpression167 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 184, 13<br />ᐳGcpApplicationᐳOrganization<br />ᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[185]<br />2: JSONParse[186], JSONParse[197]<br />ᐳ: Access[187], Access[198]<br />3: PgSelect[188], PgSelect[199]<br />4: PgSelectRows[193], PgSelectRows[202]<br />ᐳ: 192, 194, 195, 196, 201, 203, 204, 205"):::bucket
+    class Bucket14,JSONParse146,Access147,PgSelect148,First152,PgSelectRows153,PgSelectSingle154,PgClassExpression155,PgClassExpression156,PgClassExpression157,JSONParse158,Access159,PgSelect160,First162,PgSelectRows163,PgSelectSingle164,PgClassExpression165,PgClassExpression166,PgClassExpression167 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 185, 13, 184<br />ᐳGcpApplicationᐳOrganization<br />ᐳGcpApplicationᐳPerson<br /><br />1: JSONParse[186], JSONParse[197]<br />ᐳ: Access[187], Access[198]<br />2: PgSelect[188], PgSelect[199]<br />3: PgSelectRows[193], PgSelectRows[202]<br />ᐳ: 192, 194, 195, 196, 201, 203, 204, 205"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,Access185,JSONParse186,Access187,PgSelect188,First192,PgSelectRows193,PgSelectSingle194,PgClassExpression195,PgClassExpression196,JSONParse197,Access198,PgSelect199,First201,PgSelectRows202,PgSelectSingle203,PgClassExpression204,PgClassExpression205 bucket15
+    class Bucket15,JSONParse186,Access187,PgSelect188,First192,PgSelectRows193,PgSelectSingle194,PgClassExpression195,PgClassExpression196,JSONParse197,Access198,PgSelect199,First201,PgSelectRows202,PgSelectSingle203,PgClassExpression204,PgClassExpression205 bucket15
     Bucket16("Bucket 16 (listItem)<br />Deps: 13<br /><br />ROOT __Item{16}ᐸ279ᐳ[209]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,__Item209,PgUnionAllSingle210 bucket16
-    Bucket17("Bucket 17 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 210, 13<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[211]<br />2: JSONParse[212], JSONParse[225]<br />ᐳ: Access[213], Access[226]<br />3: PgSelect[214], PgSelect[227]<br />4: PgSelectRows[219], PgSelectRows[230]<br />ᐳ: 218, 220, 221, 222, 223, 224, 229, 231, 232, 233, 234, 235"):::bucket
+    class Bucket16,__Item209,PgUnionAllSingle210,Access211 bucket16
+    Bucket17("Bucket 17 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 211, 13, 210<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[212], JSONParse[225]<br />ᐳ: Access[213], Access[226]<br />2: PgSelect[214], PgSelect[227]<br />3: PgSelectRows[219], PgSelectRows[230]<br />ᐳ: 218, 220, 221, 222, 223, 224, 229, 231, 232, 233, 234, 235"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,Access211,JSONParse212,Access213,PgSelect214,First218,PgSelectRows219,PgSelectSingle220,PgClassExpression221,PgClassExpression222,PgClassExpression223,PgClassExpression224,JSONParse225,Access226,PgSelect227,First229,PgSelectRows230,PgSelectSingle231,PgClassExpression232,PgClassExpression233,PgClassExpression234,PgClassExpression235 bucket17
+    class Bucket17,JSONParse212,Access213,PgSelect214,First218,PgSelectRows219,PgSelectSingle220,PgClassExpression221,PgClassExpression222,PgClassExpression223,PgClassExpression224,JSONParse225,Access226,PgSelect227,First229,PgSelectRows230,PgSelectSingle231,PgClassExpression232,PgClassExpression233,PgClassExpression234,PgClassExpression235 bucket17
     Bucket18("Bucket 18 (listItem)<br />Deps: 244, 13<br /><br />ROOT __Item{18}ᐸ281ᐳ[246]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,__Item246,PgUnionAllSingle247,Access248 bucket18
     Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 247, 248, 13<br /><br />ROOT PgUnionAllSingle{18}[247]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgCursor249 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 247, 13<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[250]<br />2: JSONParse[251], JSONParse[263]<br />ᐳ: Access[252], Access[264]<br />3: PgSelect[253], PgSelect[265]<br />4: PgSelectRows[258], PgSelectRows[268]<br />ᐳ: 257, 259, 260, 261, 262, 267, 269, 270, 271, 272"):::bucket
+    class Bucket19,PgCursor249,Access250 bucket19
+    Bucket20("Bucket 20 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 250, 13, 247<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br /><br />1: JSONParse[251], JSONParse[263]<br />ᐳ: Access[252], Access[264]<br />2: PgSelect[253], PgSelect[265]<br />3: PgSelectRows[258], PgSelectRows[268]<br />ᐳ: 257, 259, 260, 261, 262, 267, 269, 270, 271, 272"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,Access250,JSONParse251,Access252,PgSelect253,First257,PgSelectRows258,PgSelectSingle259,PgClassExpression260,PgClassExpression261,PgClassExpression262,JSONParse263,Access264,PgSelect265,First267,PgSelectRows268,PgSelectSingle269,PgClassExpression270,PgClassExpression271,PgClassExpression272 bucket20
+    class Bucket20,JSONParse251,Access252,PgSelect253,First257,PgSelectRows258,PgSelectSingle259,PgClassExpression260,PgClassExpression261,PgClassExpression262,JSONParse263,Access264,PgSelect265,First267,PgSelectRows268,PgSelectSingle269,PgClassExpression270,PgClassExpression271,PgClassExpression272 bucket20
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.mermaid
@@ -119,11 +119,15 @@ graph TD
     PgSelectRows15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
+    PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression19
+    PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression22
+    PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression23
     List20{{"List[20∈3]<br />ᐸ18,19ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression19 --> List20
     PgSelect24[["PgSelect[24∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__single_t...parent_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object12 & PgClassExpression23 --> PgSelect24
     List49{{"List[49∈3]<br />ᐸ36,19ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression19 --> List49
@@ -133,18 +137,18 @@ graph TD
     Constant42 & PgClassExpression19 --> List99
     List124{{"List[124∈3]<br />ᐸ45,19ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression19 --> List124
-    PgSelectSingle17 --> PgClassExpression19
     Lambda21{{"Lambda[21∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List20 --> Lambda21
-    PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle17 --> PgClassExpression22
-    PgSelectSingle17 --> PgClassExpression23
     First28{{"First[28∈3]"}}:::plan
     PgSelectRows29[["PgSelectRows[29∈3]<br />ᐳSingleTableTopic"]]:::plan
     PgSelectRows29 --> First28
     PgSelect24 --> PgSelectRows29
     PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First28 --> PgSelectSingle30
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression32
+    PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression35
     Lambda50{{"Lambda[50∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List49 --> Lambda50
     First53{{"First[53∈3]"}}:::plan
@@ -153,6 +157,10 @@ graph TD
     PgSelect24 --> PgSelectRows54
     PgSelectSingle55{{"PgSelectSingle[55∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First53 --> PgSelectSingle55
+    PgClassExpression57{{"PgClassExpression[57∈3]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle55 --> PgClassExpression57
+    PgClassExpression60{{"PgClassExpression[60∈3]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle55 --> PgClassExpression60
     Lambda75{{"Lambda[75∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List74 --> Lambda75
     First78{{"First[78∈3]"}}:::plan
@@ -161,6 +169,10 @@ graph TD
     PgSelect24 --> PgSelectRows79
     PgSelectSingle80{{"PgSelectSingle[80∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First78 --> PgSelectSingle80
+    PgClassExpression82{{"PgClassExpression[82∈3]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle80 --> PgClassExpression82
+    PgClassExpression85{{"PgClassExpression[85∈3]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle80 --> PgClassExpression85
     Lambda100{{"Lambda[100∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List99 --> Lambda100
     First103{{"First[103∈3]"}}:::plan
@@ -169,6 +181,10 @@ graph TD
     PgSelect24 --> PgSelectRows104
     PgSelectSingle105{{"PgSelectSingle[105∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First103 --> PgSelectSingle105
+    PgClassExpression107{{"PgClassExpression[107∈3]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle105 --> PgClassExpression107
+    PgClassExpression110{{"PgClassExpression[110∈3]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle105 --> PgClassExpression110
     Lambda125{{"Lambda[125∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List124 --> Lambda125
     First128{{"First[128∈3]"}}:::plan
@@ -177,8 +193,11 @@ graph TD
     PgSelect24 --> PgSelectRows129
     PgSelectSingle130{{"PgSelectSingle[130∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First128 --> PgSelectSingle130
+    PgClassExpression132{{"PgClassExpression[132∈3]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle130 --> PgClassExpression132
+    PgClassExpression135{{"PgClassExpression[135∈3]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle130 --> PgClassExpression135
     List33{{"List[33∈4]<br />ᐸ18,32ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgClassExpression32{{"PgClassExpression[32∈4]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression32 --> List33
     List37{{"List[37∈4]<br />ᐸ36,32ᐳ<br />ᐳSingleTableTopicᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression32 --> List37
@@ -188,11 +207,8 @@ graph TD
     Constant42 & PgClassExpression32 --> List43
     List46{{"List[46∈4]<br />ᐸ45,32ᐳ<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression32 --> List46
-    PgSelectSingle30 --> PgClassExpression32
     Lambda34{{"Lambda[34∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List33 --> Lambda34
-    PgClassExpression35{{"PgClassExpression[35∈4]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
-    PgSelectSingle30 --> PgClassExpression35
     Lambda38{{"Lambda[38∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List37 --> Lambda38
     Lambda41{{"Lambda[41∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -202,7 +218,6 @@ graph TD
     Lambda47{{"Lambda[47∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List46 --> Lambda47
     List58{{"List[58∈5]<br />ᐸ18,57ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgClassExpression57{{"PgClassExpression[57∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression57 --> List58
     List62{{"List[62∈5]<br />ᐸ36,57ᐳ<br />ᐳSingleTablePostᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression57 --> List62
@@ -212,11 +227,8 @@ graph TD
     Constant42 & PgClassExpression57 --> List68
     List71{{"List[71∈5]<br />ᐸ45,57ᐳ<br />ᐳSingleTablePostᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression57 --> List71
-    PgSelectSingle55 --> PgClassExpression57
     Lambda59{{"Lambda[59∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List58 --> Lambda59
-    PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
-    PgSelectSingle55 --> PgClassExpression60
     Lambda63{{"Lambda[63∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List62 --> Lambda63
     Lambda66{{"Lambda[66∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -226,7 +238,6 @@ graph TD
     Lambda72{{"Lambda[72∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List71 --> Lambda72
     List83{{"List[83∈6]<br />ᐸ18,82ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgClassExpression82{{"PgClassExpression[82∈6]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression82 --> List83
     List87{{"List[87∈6]<br />ᐸ36,82ᐳ<br />ᐳSingleTableDividerᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression82 --> List87
@@ -236,11 +247,8 @@ graph TD
     Constant42 & PgClassExpression82 --> List93
     List96{{"List[96∈6]<br />ᐸ45,82ᐳ<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression82 --> List96
-    PgSelectSingle80 --> PgClassExpression82
     Lambda84{{"Lambda[84∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List83 --> Lambda84
-    PgClassExpression85{{"PgClassExpression[85∈6]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
-    PgSelectSingle80 --> PgClassExpression85
     Lambda88{{"Lambda[88∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List87 --> Lambda88
     Lambda91{{"Lambda[91∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -250,7 +258,6 @@ graph TD
     Lambda97{{"Lambda[97∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List96 --> Lambda97
     List108{{"List[108∈7]<br />ᐸ18,107ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgClassExpression107{{"PgClassExpression[107∈7]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression107 --> List108
     List112{{"List[112∈7]<br />ᐸ36,107ᐳ<br />ᐳSingleTableChecklistᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression107 --> List112
@@ -260,11 +267,8 @@ graph TD
     Constant42 & PgClassExpression107 --> List118
     List121{{"List[121∈7]<br />ᐸ45,107ᐳ<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression107 --> List121
-    PgSelectSingle105 --> PgClassExpression107
     Lambda109{{"Lambda[109∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List108 --> Lambda109
-    PgClassExpression110{{"PgClassExpression[110∈7]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
-    PgSelectSingle105 --> PgClassExpression110
     Lambda113{{"Lambda[113∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List112 --> Lambda113
     Lambda116{{"Lambda[116∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -274,7 +278,6 @@ graph TD
     Lambda122{{"Lambda[122∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List121 --> Lambda122
     List133{{"List[133∈8]<br />ᐸ18,132ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgClassExpression132{{"PgClassExpression[132∈8]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression132 --> List133
     List137{{"List[137∈8]<br />ᐸ36,132ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression132 --> List137
@@ -284,11 +287,8 @@ graph TD
     Constant42 & PgClassExpression132 --> List143
     List146{{"List[146∈8]<br />ᐸ45,132ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression132 --> List146
-    PgSelectSingle130 --> PgClassExpression132
     Lambda134{{"Lambda[134∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List133 --> Lambda134
-    PgClassExpression135{{"PgClassExpression[135∈8]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
-    PgSelectSingle130 --> PgClassExpression135
     Lambda138{{"Lambda[138∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List137 --> Lambda138
     Lambda141{{"Lambda[141∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -305,8 +305,11 @@ graph TD
     PgSelectRows154 ==> __Item155
     PgSelectSingle156{{"PgSelectSingle[156∈10]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item155 --> PgSelectSingle156
+    PgClassExpression157{{"PgClassExpression[157∈10]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle156 --> PgClassExpression157
+    PgClassExpression169{{"PgClassExpression[169∈10]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle156 --> PgClassExpression169
     PgSelect158[["PgSelect[158∈11]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression157{{"PgClassExpression[157∈11]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression157 --> PgSelect158
     List167{{"List[167∈11]<br />ᐸ165,166ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression166{{"PgClassExpression[166∈11]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -341,7 +344,6 @@ graph TD
     Constant220 & PgClassExpression419 --> List420
     PgSelect422[["PgSelect[422∈11]<br />ᐸrelational_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
     Object12 & PgClassExpression419 --> PgSelect422
-    PgSelectSingle156 --> PgClassExpression157
     First162{{"First[162∈11]"}}:::plan
     PgSelectRows163[["PgSelectRows[163∈11]"]]:::plan
     PgSelectRows163 --> First162
@@ -351,14 +353,16 @@ graph TD
     PgSelectSingle164 --> PgClassExpression166
     Lambda168{{"Lambda[168∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List167 --> Lambda168
-    PgClassExpression169{{"PgClassExpression[169∈11]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle156 --> PgClassExpression169
     First172{{"First[172∈11]"}}:::plan
     PgSelectRows173[["PgSelectRows[173∈11]"]]:::plan
     PgSelectRows173 --> First172
     PgSelect170 --> PgSelectRows173
     PgSelectSingle174{{"PgSelectSingle[174∈11]<br />ᐸrelational_itemsᐳ"}}:::plan
     First172 --> PgSelectSingle174
+    PgClassExpression175{{"PgClassExpression[175∈11]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle174 --> PgClassExpression175
+    PgClassExpression187{{"PgClassExpression[187∈11]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle174 --> PgClassExpression187
     First226{{"First[226∈11]"}}:::plan
     PgSelectRows227[["PgSelectRows[227∈11]"]]:::plan
     PgSelectRows227 --> First226
@@ -374,6 +378,10 @@ graph TD
     PgSelect233 --> PgSelectRows236
     PgSelectSingle237{{"PgSelectSingle[237∈11]<br />ᐸrelational_itemsᐳ"}}:::plan
     First235 --> PgSelectSingle237
+    PgClassExpression238{{"PgClassExpression[238∈11]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle237 --> PgClassExpression238
+    PgClassExpression250{{"PgClassExpression[250∈11]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle237 --> PgClassExpression250
     First289{{"First[289∈11]"}}:::plan
     PgSelectRows290[["PgSelectRows[290∈11]"]]:::plan
     PgSelectRows290 --> First289
@@ -389,6 +397,10 @@ graph TD
     PgSelect296 --> PgSelectRows299
     PgSelectSingle300{{"PgSelectSingle[300∈11]<br />ᐸrelational_itemsᐳ"}}:::plan
     First298 --> PgSelectSingle300
+    PgClassExpression301{{"PgClassExpression[301∈11]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression301
+    PgClassExpression313{{"PgClassExpression[313∈11]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle300 --> PgClassExpression313
     First352{{"First[352∈11]"}}:::plan
     PgSelectRows353[["PgSelectRows[353∈11]"]]:::plan
     PgSelectRows353 --> First352
@@ -404,6 +416,10 @@ graph TD
     PgSelect359 --> PgSelectRows362
     PgSelectSingle363{{"PgSelectSingle[363∈11]<br />ᐸrelational_itemsᐳ"}}:::plan
     First361 --> PgSelectSingle363
+    PgClassExpression364{{"PgClassExpression[364∈11]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle363 --> PgClassExpression364
+    PgClassExpression376{{"PgClassExpression[376∈11]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle363 --> PgClassExpression376
     First415{{"First[415∈11]"}}:::plan
     PgSelectRows416[["PgSelectRows[416∈11]"]]:::plan
     PgSelectRows416 --> First415
@@ -419,8 +435,11 @@ graph TD
     PgSelect422 --> PgSelectRows425
     PgSelectSingle426{{"PgSelectSingle[426∈11]<br />ᐸrelational_itemsᐳ"}}:::plan
     First424 --> PgSelectSingle426
+    PgClassExpression427{{"PgClassExpression[427∈11]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle426 --> PgClassExpression427
+    PgClassExpression439{{"PgClassExpression[439∈11]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle426 --> PgClassExpression439
     PgSelect176[["PgSelect[176∈12]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopicᐳRelationalTopic"]]:::plan
-    PgClassExpression175{{"PgClassExpression[175∈12]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression175 --> PgSelect176
     List185{{"List[185∈12]<br />ᐸ165,184ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
     PgClassExpression184{{"PgClassExpression[184∈12]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -445,7 +464,6 @@ graph TD
     List222{{"List[222∈12]<br />ᐸ220,221ᐳ<br />ᐳRelationalTopicᐳRelationalChecklistItem"}}:::plan
     PgClassExpression221{{"PgClassExpression[221∈12]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression221 --> List222
-    PgSelectSingle174 --> PgClassExpression175
     First180{{"First[180∈12]"}}:::plan
     PgSelectRows181[["PgSelectRows[181∈12]"]]:::plan
     PgSelectRows181 --> First180
@@ -455,8 +473,6 @@ graph TD
     PgSelectSingle182 --> PgClassExpression184
     Lambda186{{"Lambda[186∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List185 --> Lambda186
-    PgClassExpression187{{"PgClassExpression[187∈12]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopicᐳRelationalTopic"}}:::plan
-    PgSelectSingle174 --> PgClassExpression187
     First190{{"First[190∈12]"}}:::plan
     PgSelectRows191[["PgSelectRows[191∈12]"]]:::plan
     PgSelectRows191 --> First190
@@ -494,7 +510,6 @@ graph TD
     Lambda223{{"Lambda[223∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List222 --> Lambda223
     PgSelect239[["PgSelect[239∈13]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalPostᐳRelationalTopic"]]:::plan
-    PgClassExpression238{{"PgClassExpression[238∈13]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression238 --> PgSelect239
     List248{{"List[248∈13]<br />ᐸ165,247ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
     PgClassExpression247{{"PgClassExpression[247∈13]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -519,7 +534,6 @@ graph TD
     List285{{"List[285∈13]<br />ᐸ220,284ᐳ<br />ᐳRelationalPostᐳRelationalChecklistItem"}}:::plan
     PgClassExpression284{{"PgClassExpression[284∈13]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression284 --> List285
-    PgSelectSingle237 --> PgClassExpression238
     First243{{"First[243∈13]"}}:::plan
     PgSelectRows244[["PgSelectRows[244∈13]"]]:::plan
     PgSelectRows244 --> First243
@@ -529,8 +543,6 @@ graph TD
     PgSelectSingle245 --> PgClassExpression247
     Lambda249{{"Lambda[249∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List248 --> Lambda249
-    PgClassExpression250{{"PgClassExpression[250∈13]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalPostᐳRelationalTopic"}}:::plan
-    PgSelectSingle237 --> PgClassExpression250
     First253{{"First[253∈13]"}}:::plan
     PgSelectRows254[["PgSelectRows[254∈13]"]]:::plan
     PgSelectRows254 --> First253
@@ -568,7 +580,6 @@ graph TD
     Lambda286{{"Lambda[286∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List285 --> Lambda286
     PgSelect302[["PgSelect[302∈14]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalDividerᐳRelationalTopic"]]:::plan
-    PgClassExpression301{{"PgClassExpression[301∈14]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression301 --> PgSelect302
     List311{{"List[311∈14]<br />ᐸ165,310ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
     PgClassExpression310{{"PgClassExpression[310∈14]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -593,7 +604,6 @@ graph TD
     List348{{"List[348∈14]<br />ᐸ220,347ᐳ<br />ᐳRelationalDividerᐳRelationalChecklistItem"}}:::plan
     PgClassExpression347{{"PgClassExpression[347∈14]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression347 --> List348
-    PgSelectSingle300 --> PgClassExpression301
     First306{{"First[306∈14]"}}:::plan
     PgSelectRows307[["PgSelectRows[307∈14]"]]:::plan
     PgSelectRows307 --> First306
@@ -603,8 +613,6 @@ graph TD
     PgSelectSingle308 --> PgClassExpression310
     Lambda312{{"Lambda[312∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List311 --> Lambda312
-    PgClassExpression313{{"PgClassExpression[313∈14]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalDividerᐳRelationalTopic"}}:::plan
-    PgSelectSingle300 --> PgClassExpression313
     First316{{"First[316∈14]"}}:::plan
     PgSelectRows317[["PgSelectRows[317∈14]"]]:::plan
     PgSelectRows317 --> First316
@@ -642,7 +650,6 @@ graph TD
     Lambda349{{"Lambda[349∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List348 --> Lambda349
     PgSelect365[["PgSelect[365∈15]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"]]:::plan
-    PgClassExpression364{{"PgClassExpression[364∈15]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression364 --> PgSelect365
     List374{{"List[374∈15]<br />ᐸ165,373ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
     PgClassExpression373{{"PgClassExpression[373∈15]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -667,7 +674,6 @@ graph TD
     List411{{"List[411∈15]<br />ᐸ220,410ᐳ<br />ᐳRelationalChecklistᐳRelationalChecklistItem"}}:::plan
     PgClassExpression410{{"PgClassExpression[410∈15]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression410 --> List411
-    PgSelectSingle363 --> PgClassExpression364
     First369{{"First[369∈15]"}}:::plan
     PgSelectRows370[["PgSelectRows[370∈15]"]]:::plan
     PgSelectRows370 --> First369
@@ -677,8 +683,6 @@ graph TD
     PgSelectSingle371 --> PgClassExpression373
     Lambda375{{"Lambda[375∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List374 --> Lambda375
-    PgClassExpression376{{"PgClassExpression[376∈15]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistᐳRelationalTopic"}}:::plan
-    PgSelectSingle363 --> PgClassExpression376
     First379{{"First[379∈15]"}}:::plan
     PgSelectRows380[["PgSelectRows[380∈15]"]]:::plan
     PgSelectRows380 --> First379
@@ -716,7 +720,6 @@ graph TD
     Lambda412{{"Lambda[412∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List411 --> Lambda412
     PgSelect428[["PgSelect[428∈16]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"]]:::plan
-    PgClassExpression427{{"PgClassExpression[427∈16]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression427 --> PgSelect428
     List437{{"List[437∈16]<br />ᐸ165,436ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
     PgClassExpression436{{"PgClassExpression[436∈16]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -741,7 +744,6 @@ graph TD
     List474{{"List[474∈16]<br />ᐸ220,473ᐳ<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"}}:::plan
     PgClassExpression473{{"PgClassExpression[473∈16]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression473 --> List474
-    PgSelectSingle426 --> PgClassExpression427
     First432{{"First[432∈16]"}}:::plan
     PgSelectRows433[["PgSelectRows[433∈16]"]]:::plan
     PgSelectRows433 --> First432
@@ -751,8 +753,6 @@ graph TD
     PgSelectSingle434 --> PgClassExpression436
     Lambda438{{"Lambda[438∈16]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List437 --> Lambda438
-    PgClassExpression439{{"PgClassExpression[439∈16]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalChecklistItemᐳRelationalTopic"}}:::plan
-    PgSelectSingle426 --> PgClassExpression439
     First442{{"First[442∈16]"}}:::plan
     PgSelectRows443[["PgSelectRows[443∈16]"]]:::plan
     PgSelectRows443 --> First442
@@ -816,6 +816,10 @@ graph TD
     PgSelect521 --> PgSelectRows526
     PgSelectSingle527{{"PgSelectSingle[527∈19]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First525 --> PgSelectSingle527
+    PgClassExpression529{{"PgClassExpression[529∈19]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle527 --> PgClassExpression529
+    PgClassExpression532{{"PgClassExpression[532∈19]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle527 --> PgClassExpression532
     PgSelectSingle515 --> PgClassExpression545
     First548{{"First[548∈19]"}}:::plan
     PgSelectRows549[["PgSelectRows[549∈19]"]]:::plan
@@ -823,8 +827,11 @@ graph TD
     PgSelect546 --> PgSelectRows549
     PgSelectSingle550{{"PgSelectSingle[550∈19]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First548 --> PgSelectSingle550
+    PgClassExpression552{{"PgClassExpression[552∈19]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle550 --> PgClassExpression552
+    PgClassExpression555{{"PgClassExpression[555∈19]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle550 --> PgClassExpression555
     List530{{"List[530∈20]<br />ᐸ18,529ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression529{{"PgClassExpression[529∈20]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression529 --> List530
     List534{{"List[534∈20]<br />ᐸ36,529ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression529 --> List534
@@ -834,11 +841,8 @@ graph TD
     Constant42 & PgClassExpression529 --> List540
     List543{{"List[543∈20]<br />ᐸ45,529ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression529 --> List543
-    PgSelectSingle527 --> PgClassExpression529
     Lambda531{{"Lambda[531∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List530 --> Lambda531
-    PgClassExpression532{{"PgClassExpression[532∈20]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle527 --> PgClassExpression532
     Lambda535{{"Lambda[535∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List534 --> Lambda535
     Lambda538{{"Lambda[538∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -848,7 +852,6 @@ graph TD
     Lambda544{{"Lambda[544∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List543 --> Lambda544
     List553{{"List[553∈21]<br />ᐸ18,552ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression552{{"PgClassExpression[552∈21]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant18 & PgClassExpression552 --> List553
     List557{{"List[557∈21]<br />ᐸ36,552ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant36 & PgClassExpression552 --> List557
@@ -858,11 +861,8 @@ graph TD
     Constant42 & PgClassExpression552 --> List563
     List566{{"List[566∈21]<br />ᐸ45,552ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant45 & PgClassExpression552 --> List566
-    PgSelectSingle550 --> PgClassExpression552
     Lambda554{{"Lambda[554∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List553 --> Lambda554
-    PgClassExpression555{{"PgClassExpression[555∈21]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle550 --> PgClassExpression555
     Lambda558{{"Lambda[558∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List557 --> Lambda558
     Lambda561{{"Lambda[561∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
@@ -898,6 +898,10 @@ graph TD
     PgSelect613 --> PgSelectRows618
     PgSelectSingle619{{"PgSelectSingle[619∈24]<br />ᐸrelational_itemsᐳ"}}:::plan
     First617 --> PgSelectSingle619
+    PgClassExpression620{{"PgClassExpression[620∈24]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle619 --> PgClassExpression620
+    PgClassExpression632{{"PgClassExpression[632∈24]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle619 --> PgClassExpression632
     PgSelectSingle607 --> PgClassExpression669
     First672{{"First[672∈24]"}}:::plan
     PgSelectRows673[["PgSelectRows[673∈24]"]]:::plan
@@ -905,8 +909,11 @@ graph TD
     PgSelect670 --> PgSelectRows673
     PgSelectSingle674{{"PgSelectSingle[674∈24]<br />ᐸrelational_itemsᐳ"}}:::plan
     First672 --> PgSelectSingle674
+    PgClassExpression675{{"PgClassExpression[675∈24]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle674 --> PgClassExpression675
+    PgClassExpression687{{"PgClassExpression[687∈24]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle674 --> PgClassExpression687
     PgSelect621[["PgSelect[621∈25]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression620{{"PgClassExpression[620∈25]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression620 --> PgSelect621
     List630{{"List[630∈25]<br />ᐸ165,629ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression629{{"PgClassExpression[629∈25]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -931,7 +938,6 @@ graph TD
     List667{{"List[667∈25]<br />ᐸ220,666ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression666{{"PgClassExpression[666∈25]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression666 --> List667
-    PgSelectSingle619 --> PgClassExpression620
     First625{{"First[625∈25]"}}:::plan
     PgSelectRows626[["PgSelectRows[626∈25]"]]:::plan
     PgSelectRows626 --> First625
@@ -941,8 +947,6 @@ graph TD
     PgSelectSingle627 --> PgClassExpression629
     Lambda631{{"Lambda[631∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List630 --> Lambda631
-    PgClassExpression632{{"PgClassExpression[632∈25]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle619 --> PgClassExpression632
     First635{{"First[635∈25]"}}:::plan
     PgSelectRows636[["PgSelectRows[636∈25]"]]:::plan
     PgSelectRows636 --> First635
@@ -980,7 +984,6 @@ graph TD
     Lambda668{{"Lambda[668∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List667 --> Lambda668
     PgSelect676[["PgSelect[676∈26]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression675{{"PgClassExpression[675∈26]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object12 & PgClassExpression675 --> PgSelect676
     List685{{"List[685∈26]<br />ᐸ165,684ᐳ<br />ᐳRelationalTopic"}}:::plan
     PgClassExpression684{{"PgClassExpression[684∈26]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
@@ -1005,7 +1008,6 @@ graph TD
     List722{{"List[722∈26]<br />ᐸ220,721ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
     PgClassExpression721{{"PgClassExpression[721∈26]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
     Constant220 & PgClassExpression721 --> List722
-    PgSelectSingle674 --> PgClassExpression675
     First680{{"First[680∈26]"}}:::plan
     PgSelectRows681[["PgSelectRows[681∈26]"]]:::plan
     PgSelectRows681 --> First680
@@ -1015,8 +1017,6 @@ graph TD
     PgSelectSingle682 --> PgClassExpression684
     Lambda686{{"Lambda[686∈26]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List685 --> Lambda686
-    PgClassExpression687{{"PgClassExpression[687∈26]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle674 --> PgClassExpression687
     First690{{"First[690∈26]"}}:::plan
     PgSelectRows691[["PgSelectRows[691∈26]"]]:::plan
     PgSelectRows691 --> First690
@@ -1065,79 +1065,79 @@ graph TD
     class Bucket1,PgSelect14,PgSelectRows15 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 18, 12, 36, 39, 42, 45<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 17, 18, 12, 36, 39, 42, 45<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 19, 22, 23, 20, 21, 49, 50, 74, 75, 99, 100, 124, 125<br />2: PgSelect[24]<br />3: 29, 54, 79, 104, 129<br />ᐳ: 28, 30, 53, 55, 78, 80, 103, 105, 128, 130"):::bucket
+    class Bucket2,__Item16,PgSelectSingle17,PgClassExpression19,PgClassExpression22,PgClassExpression23 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 19, 12, 23, 36, 39, 42, 45, 17, 22<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[24]<br />ᐳ: 20, 49, 74, 99, 124, 21, 50, 75, 100, 125<br />2: 29, 54, 79, 104, 129<br />ᐳ: 28, 30, 32, 35, 53, 55, 57, 60, 78, 80, 82, 85, 103, 105, 107, 110, 128, 130, 132, 135"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression19,List20,Lambda21,PgClassExpression22,PgClassExpression23,PgSelect24,First28,PgSelectRows29,PgSelectSingle30,List49,Lambda50,First53,PgSelectRows54,PgSelectSingle55,List74,Lambda75,First78,PgSelectRows79,PgSelectSingle80,List99,Lambda100,First103,PgSelectRows104,PgSelectSingle105,List124,Lambda125,First128,PgSelectRows129,PgSelectSingle130 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 30, 18, 36, 39, 42, 45<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
+    class Bucket3,List20,Lambda21,PgSelect24,First28,PgSelectRows29,PgSelectSingle30,PgClassExpression32,PgClassExpression35,List49,Lambda50,First53,PgSelectRows54,PgSelectSingle55,PgClassExpression57,PgClassExpression60,List74,Lambda75,First78,PgSelectRows79,PgSelectSingle80,PgClassExpression82,PgClassExpression85,List99,Lambda100,First103,PgSelectRows104,PgSelectSingle105,PgClassExpression107,PgClassExpression110,List124,Lambda125,First128,PgSelectRows129,PgSelectSingle130,PgClassExpression132,PgClassExpression135 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 32, 36, 39, 42, 45, 30, 35<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression32,List33,Lambda34,PgClassExpression35,List37,Lambda38,List40,Lambda41,List43,Lambda44,List46,Lambda47 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 55, 18, 36, 39, 42, 45<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
+    class Bucket4,List33,Lambda34,List37,Lambda38,List40,Lambda41,List43,Lambda44,List46,Lambda47 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 57, 36, 39, 42, 45, 55, 60<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression57,List58,Lambda59,PgClassExpression60,List62,Lambda63,List65,Lambda66,List68,Lambda69,List71,Lambda72 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 80, 18, 36, 39, 42, 45<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
+    class Bucket5,List58,Lambda59,List62,Lambda63,List65,Lambda66,List68,Lambda69,List71,Lambda72 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 82, 36, 39, 42, 45, 80, 85<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgClassExpression82,List83,Lambda84,PgClassExpression85,List87,Lambda88,List90,Lambda91,List93,Lambda94,List96,Lambda97 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 105, 18, 36, 39, 42, 45<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
+    class Bucket6,List83,Lambda84,List87,Lambda88,List90,Lambda91,List93,Lambda94,List96,Lambda97 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 107, 36, 39, 42, 45, 105, 110<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression107,List108,Lambda109,PgClassExpression110,List112,Lambda113,List115,Lambda116,List118,Lambda119,List121,Lambda122 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 130, 18, 36, 39, 42, 45<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
+    class Bucket7,List108,Lambda109,List112,Lambda113,List115,Lambda116,List118,Lambda119,List121,Lambda122 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 132, 36, 39, 42, 45, 130, 135<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression132,List133,Lambda134,PgClassExpression135,List137,Lambda138,List140,Lambda141,List143,Lambda144,List146,Lambda147 bucket8
+    class Bucket8,List133,Lambda134,List137,Lambda138,List140,Lambda141,List143,Lambda144,List146,Lambda147 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 12, 152, 165, 193, 202, 211, 220<br /><br />ROOT Connectionᐸ150ᐳ[152]<br />1: PgSelect[153]<br />2: PgSelectRows[154]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgSelect153,PgSelectRows154 bucket9
     Bucket10("Bucket 10 (listItem)<br />Deps: 12, 165, 193, 202, 211, 220<br /><br />ROOT __Item{10}ᐸ154ᐳ[155]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,__Item155,PgSelectSingle156 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 156, 12, 165, 193, 202, 211, 220<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 157, 169<br />2: 158, 224, 287, 350, 413<br />3: 163, 227, 290, 353, 416<br />ᐳ: 162, 164, 166, 167, 168, 226, 228, 230, 231, 232, 289, 291, 293, 294, 295, 352, 354, 356, 357, 358, 415, 417, 419, 420, 421<br />4: 170, 233, 296, 359, 422<br />5: 173, 236, 299, 362, 425<br />ᐳ: 172, 174, 235, 237, 298, 300, 361, 363, 424, 426"):::bucket
+    class Bucket10,__Item155,PgSelectSingle156,PgClassExpression157,PgClassExpression169 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 157, 165, 193, 202, 211, 220, 156, 169<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 158, 224, 287, 350, 413<br />2: 163, 227, 290, 353, 416<br />ᐳ: 162, 164, 166, 167, 168, 226, 228, 230, 231, 232, 289, 291, 293, 294, 295, 352, 354, 356, 357, 358, 415, 417, 419, 420, 421<br />3: 170, 233, 296, 359, 422<br />4: 173, 236, 299, 362, 425<br />ᐳ: 172, 174, 175, 187, 235, 237, 238, 250, 298, 300, 301, 313, 361, 363, 364, 376, 424, 426, 427, 439"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression157,PgSelect158,First162,PgSelectRows163,PgSelectSingle164,PgClassExpression166,List167,Lambda168,PgClassExpression169,PgSelect170,First172,PgSelectRows173,PgSelectSingle174,PgSelect224,First226,PgSelectRows227,PgSelectSingle228,PgClassExpression230,List231,Lambda232,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,PgSelect287,First289,PgSelectRows290,PgSelectSingle291,PgClassExpression293,List294,Lambda295,PgSelect296,First298,PgSelectRows299,PgSelectSingle300,PgSelect350,First352,PgSelectRows353,PgSelectSingle354,PgClassExpression356,List357,Lambda358,PgSelect359,First361,PgSelectRows362,PgSelectSingle363,PgSelect413,First415,PgSelectRows416,PgSelectSingle417,PgClassExpression419,List420,Lambda421,PgSelect422,First424,PgSelectRows425,PgSelectSingle426 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 174, 12, 165, 193, 202, 211, 220<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 175, 187<br />2: 176, 188, 197, 206, 215<br />3: 181, 191, 200, 209, 218<br />ᐳ: 180, 182, 184, 185, 186, 190, 192, 194, 195, 196, 199, 201, 203, 204, 205, 208, 210, 212, 213, 214, 217, 219, 221, 222, 223"):::bucket
+    class Bucket11,PgSelect158,First162,PgSelectRows163,PgSelectSingle164,PgClassExpression166,List167,Lambda168,PgSelect170,First172,PgSelectRows173,PgSelectSingle174,PgClassExpression175,PgClassExpression187,PgSelect224,First226,PgSelectRows227,PgSelectSingle228,PgClassExpression230,List231,Lambda232,PgSelect233,First235,PgSelectRows236,PgSelectSingle237,PgClassExpression238,PgClassExpression250,PgSelect287,First289,PgSelectRows290,PgSelectSingle291,PgClassExpression293,List294,Lambda295,PgSelect296,First298,PgSelectRows299,PgSelectSingle300,PgClassExpression301,PgClassExpression313,PgSelect350,First352,PgSelectRows353,PgSelectSingle354,PgClassExpression356,List357,Lambda358,PgSelect359,First361,PgSelectRows362,PgSelectSingle363,PgClassExpression364,PgClassExpression376,PgSelect413,First415,PgSelectRows416,PgSelectSingle417,PgClassExpression419,List420,Lambda421,PgSelect422,First424,PgSelectRows425,PgSelectSingle426,PgClassExpression427,PgClassExpression439 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 175, 165, 193, 202, 211, 220, 174, 187<br />ᐳRelationalTopicᐳRelationalTopic<br />ᐳRelationalTopicᐳRelationalPost<br />ᐳRelationalTopicᐳRelationalDivider<br />ᐳRelationalTopicᐳRelationalChecklist<br />ᐳRelationalTopicᐳRelationalChecklistItem<br /><br />1: 176, 188, 197, 206, 215<br />2: 181, 191, 200, 209, 218<br />ᐳ: 180, 182, 184, 185, 186, 190, 192, 194, 195, 196, 199, 201, 203, 204, 205, 208, 210, 212, 213, 214, 217, 219, 221, 222, 223"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression175,PgSelect176,First180,PgSelectRows181,PgSelectSingle182,PgClassExpression184,List185,Lambda186,PgClassExpression187,PgSelect188,First190,PgSelectRows191,PgSelectSingle192,PgClassExpression194,List195,Lambda196,PgSelect197,First199,PgSelectRows200,PgSelectSingle201,PgClassExpression203,List204,Lambda205,PgSelect206,First208,PgSelectRows209,PgSelectSingle210,PgClassExpression212,List213,Lambda214,PgSelect215,First217,PgSelectRows218,PgSelectSingle219,PgClassExpression221,List222,Lambda223 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 237, 12, 165, 193, 202, 211, 220<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 238, 250<br />2: 239, 251, 260, 269, 278<br />3: 244, 254, 263, 272, 281<br />ᐳ: 243, 245, 247, 248, 249, 253, 255, 257, 258, 259, 262, 264, 266, 267, 268, 271, 273, 275, 276, 277, 280, 282, 284, 285, 286"):::bucket
+    class Bucket12,PgSelect176,First180,PgSelectRows181,PgSelectSingle182,PgClassExpression184,List185,Lambda186,PgSelect188,First190,PgSelectRows191,PgSelectSingle192,PgClassExpression194,List195,Lambda196,PgSelect197,First199,PgSelectRows200,PgSelectSingle201,PgClassExpression203,List204,Lambda205,PgSelect206,First208,PgSelectRows209,PgSelectSingle210,PgClassExpression212,List213,Lambda214,PgSelect215,First217,PgSelectRows218,PgSelectSingle219,PgClassExpression221,List222,Lambda223 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 238, 165, 193, 202, 211, 220, 237, 250<br />ᐳRelationalPostᐳRelationalTopic<br />ᐳRelationalPostᐳRelationalPost<br />ᐳRelationalPostᐳRelationalDivider<br />ᐳRelationalPostᐳRelationalChecklist<br />ᐳRelationalPostᐳRelationalChecklistItem<br /><br />1: 239, 251, 260, 269, 278<br />2: 244, 254, 263, 272, 281<br />ᐳ: 243, 245, 247, 248, 249, 253, 255, 257, 258, 259, 262, 264, 266, 267, 268, 271, 273, 275, 276, 277, 280, 282, 284, 285, 286"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression238,PgSelect239,First243,PgSelectRows244,PgSelectSingle245,PgClassExpression247,List248,Lambda249,PgClassExpression250,PgSelect251,First253,PgSelectRows254,PgSelectSingle255,PgClassExpression257,List258,Lambda259,PgSelect260,First262,PgSelectRows263,PgSelectSingle264,PgClassExpression266,List267,Lambda268,PgSelect269,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression275,List276,Lambda277,PgSelect278,First280,PgSelectRows281,PgSelectSingle282,PgClassExpression284,List285,Lambda286 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 300, 12, 165, 193, 202, 211, 220<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 301, 313<br />2: 302, 314, 323, 332, 341<br />3: 307, 317, 326, 335, 344<br />ᐳ: 306, 308, 310, 311, 312, 316, 318, 320, 321, 322, 325, 327, 329, 330, 331, 334, 336, 338, 339, 340, 343, 345, 347, 348, 349"):::bucket
+    class Bucket13,PgSelect239,First243,PgSelectRows244,PgSelectSingle245,PgClassExpression247,List248,Lambda249,PgSelect251,First253,PgSelectRows254,PgSelectSingle255,PgClassExpression257,List258,Lambda259,PgSelect260,First262,PgSelectRows263,PgSelectSingle264,PgClassExpression266,List267,Lambda268,PgSelect269,First271,PgSelectRows272,PgSelectSingle273,PgClassExpression275,List276,Lambda277,PgSelect278,First280,PgSelectRows281,PgSelectSingle282,PgClassExpression284,List285,Lambda286 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 301, 165, 193, 202, 211, 220, 300, 313<br />ᐳRelationalDividerᐳRelationalTopic<br />ᐳRelationalDividerᐳRelationalPost<br />ᐳRelationalDividerᐳRelationalDivider<br />ᐳRelationalDividerᐳRelationalChecklist<br />ᐳRelationalDividerᐳRelationalChecklistItem<br /><br />1: 302, 314, 323, 332, 341<br />2: 307, 317, 326, 335, 344<br />ᐳ: 306, 308, 310, 311, 312, 316, 318, 320, 321, 322, 325, 327, 329, 330, 331, 334, 336, 338, 339, 340, 343, 345, 347, 348, 349"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression301,PgSelect302,First306,PgSelectRows307,PgSelectSingle308,PgClassExpression310,List311,Lambda312,PgClassExpression313,PgSelect314,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,List321,Lambda322,PgSelect323,First325,PgSelectRows326,PgSelectSingle327,PgClassExpression329,List330,Lambda331,PgSelect332,First334,PgSelectRows335,PgSelectSingle336,PgClassExpression338,List339,Lambda340,PgSelect341,First343,PgSelectRows344,PgSelectSingle345,PgClassExpression347,List348,Lambda349 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 363, 12, 165, 193, 202, 211, 220<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 364, 376<br />2: 365, 377, 386, 395, 404<br />3: 370, 380, 389, 398, 407<br />ᐳ: 369, 371, 373, 374, 375, 379, 381, 383, 384, 385, 388, 390, 392, 393, 394, 397, 399, 401, 402, 403, 406, 408, 410, 411, 412"):::bucket
+    class Bucket14,PgSelect302,First306,PgSelectRows307,PgSelectSingle308,PgClassExpression310,List311,Lambda312,PgSelect314,First316,PgSelectRows317,PgSelectSingle318,PgClassExpression320,List321,Lambda322,PgSelect323,First325,PgSelectRows326,PgSelectSingle327,PgClassExpression329,List330,Lambda331,PgSelect332,First334,PgSelectRows335,PgSelectSingle336,PgClassExpression338,List339,Lambda340,PgSelect341,First343,PgSelectRows344,PgSelectSingle345,PgClassExpression347,List348,Lambda349 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 364, 165, 193, 202, 211, 220, 363, 376<br />ᐳRelationalChecklistᐳRelationalTopic<br />ᐳRelationalChecklistᐳRelationalPost<br />ᐳRelationalChecklistᐳRelationalDivider<br />ᐳRelationalChecklistᐳRelationalChecklist<br />ᐳRelationalChecklistᐳRelationalChecklistItem<br /><br />1: 365, 377, 386, 395, 404<br />2: 370, 380, 389, 398, 407<br />ᐳ: 369, 371, 373, 374, 375, 379, 381, 383, 384, 385, 388, 390, 392, 393, 394, 397, 399, 401, 402, 403, 406, 408, 410, 411, 412"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression364,PgSelect365,First369,PgSelectRows370,PgSelectSingle371,PgClassExpression373,List374,Lambda375,PgClassExpression376,PgSelect377,First379,PgSelectRows380,PgSelectSingle381,PgClassExpression383,List384,Lambda385,PgSelect386,First388,PgSelectRows389,PgSelectSingle390,PgClassExpression392,List393,Lambda394,PgSelect395,First397,PgSelectRows398,PgSelectSingle399,PgClassExpression401,List402,Lambda403,PgSelect404,First406,PgSelectRows407,PgSelectSingle408,PgClassExpression410,List411,Lambda412 bucket15
-    Bucket16("Bucket 16 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 426, 12, 165, 193, 202, 211, 220<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 427, 439<br />2: 428, 440, 449, 458, 467<br />3: 433, 443, 452, 461, 470<br />ᐳ: 432, 434, 436, 437, 438, 442, 444, 446, 447, 448, 451, 453, 455, 456, 457, 460, 462, 464, 465, 466, 469, 471, 473, 474, 475"):::bucket
+    class Bucket15,PgSelect365,First369,PgSelectRows370,PgSelectSingle371,PgClassExpression373,List374,Lambda375,PgSelect377,First379,PgSelectRows380,PgSelectSingle381,PgClassExpression383,List384,Lambda385,PgSelect386,First388,PgSelectRows389,PgSelectSingle390,PgClassExpression392,List393,Lambda394,PgSelect395,First397,PgSelectRows398,PgSelectSingle399,PgClassExpression401,List402,Lambda403,PgSelect404,First406,PgSelectRows407,PgSelectSingle408,PgClassExpression410,List411,Lambda412 bucket15
+    Bucket16("Bucket 16 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 427, 165, 193, 202, 211, 220, 426, 439<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem<br /><br />1: 428, 440, 449, 458, 467<br />2: 433, 443, 452, 461, 470<br />ᐳ: 432, 434, 436, 437, 438, 442, 444, 446, 447, 448, 451, 453, 455, 456, 457, 460, 462, 464, 465, 466, 469, 471, 473, 474, 475"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgClassExpression427,PgSelect428,First432,PgSelectRows433,PgSelectSingle434,PgClassExpression436,List437,Lambda438,PgClassExpression439,PgSelect440,First442,PgSelectRows443,PgSelectSingle444,PgClassExpression446,List447,Lambda448,PgSelect449,First451,PgSelectRows452,PgSelectSingle453,PgClassExpression455,List456,Lambda457,PgSelect458,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,List465,Lambda466,PgSelect467,First469,PgSelectRows470,PgSelectSingle471,PgClassExpression473,List474,Lambda475 bucket16
+    class Bucket16,PgSelect428,First432,PgSelectRows433,PgSelectSingle434,PgClassExpression436,List437,Lambda438,PgSelect440,First442,PgSelectRows443,PgSelectSingle444,PgClassExpression446,List447,Lambda448,PgSelect449,First451,PgSelectRows452,PgSelectSingle453,PgClassExpression455,List456,Lambda457,PgSelect458,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,List465,Lambda466,PgSelect467,First469,PgSelectRows470,PgSelectSingle471,PgClassExpression473,List474,Lambda475 bucket16
     Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 12, 511, 482, 516, 18, 36, 39, 42, 45<br /><br />ROOT Connectionᐸ480ᐳ[482]<br />1: PgSelect[512]<br />2: PgSelectRows[513]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,PgSelect512,PgSelectRows513 bucket17
     Bucket18("Bucket 18 (listItem)<br />Deps: 516, 12, 18, 36, 39, 42, 45<br /><br />ROOT __Item{18}ᐸ513ᐳ[514]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18,__Item514,PgSelectSingle515 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 515, 516, 12, 18, 36, 39, 42, 45<br /><br />ROOT PgSelectSingle{18}ᐸsingle_table_item_relationsᐳ[515]<br />1: <br />ᐳ: 517, 520, 545, 518, 519<br />2: PgSelect[521], PgSelect[546]<br />3: PgSelectRows[526], PgSelectRows[549]<br />ᐳ: 525, 527, 548, 550"):::bucket
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 515, 516, 12, 18, 36, 39, 42, 45<br /><br />ROOT PgSelectSingle{18}ᐸsingle_table_item_relationsᐳ[515]<br />1: <br />ᐳ: 517, 520, 545, 518, 519<br />2: PgSelect[521], PgSelect[546]<br />3: PgSelectRows[526], PgSelectRows[549]<br />ᐳ: 525, 527, 529, 532, 548, 550, 552, 555"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgClassExpression517,List518,Lambda519,PgClassExpression520,PgSelect521,First525,PgSelectRows526,PgSelectSingle527,PgClassExpression545,PgSelect546,First548,PgSelectRows549,PgSelectSingle550 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 527, 18, 36, 39, 42, 45<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket19,PgClassExpression517,List518,Lambda519,PgClassExpression520,PgSelect521,First525,PgSelectRows526,PgSelectSingle527,PgClassExpression529,PgClassExpression532,PgClassExpression545,PgSelect546,First548,PgSelectRows549,PgSelectSingle550,PgClassExpression552,PgClassExpression555 bucket19
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 529, 36, 39, 42, 45, 527, 532<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression529,List530,Lambda531,PgClassExpression532,List534,Lambda535,List537,Lambda538,List540,Lambda541,List543,Lambda544 bucket20
-    Bucket21("Bucket 21 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 550, 18, 36, 39, 42, 45<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket20,List530,Lambda531,List534,Lambda535,List537,Lambda538,List540,Lambda541,List543,Lambda544 bucket20
+    Bucket21("Bucket 21 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 552, 36, 39, 42, 45, 550, 555<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PgClassExpression552,List553,Lambda554,PgClassExpression555,List557,Lambda558,List560,Lambda561,List563,Lambda564,List566,Lambda567 bucket21
+    class Bucket21,List553,Lambda554,List557,Lambda558,List560,Lambda561,List563,Lambda564,List566,Lambda567 bucket21
     Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 12, 603, 574, 608, 165, 193, 202, 211, 220<br /><br />ROOT Connectionᐸ572ᐳ[574]<br />1: PgSelect[604]<br />2: PgSelectRows[605]"):::bucket
     classDef bucket22 stroke:#7fff00
     class Bucket22,PgSelect604,PgSelectRows605 bucket22
     Bucket23("Bucket 23 (listItem)<br />Deps: 608, 12, 165, 193, 202, 211, 220<br /><br />ROOT __Item{23}ᐸ605ᐳ[606]"):::bucket
     classDef bucket23 stroke:#ff1493
     class Bucket23,__Item606,PgSelectSingle607 bucket23
-    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 607, 608, 12, 165, 193, 202, 211, 220<br /><br />ROOT PgSelectSingle{23}ᐸrelational_item_relationsᐳ[607]<br />1: <br />ᐳ: 609, 612, 669, 610, 611<br />2: PgSelect[613], PgSelect[670]<br />3: PgSelectRows[618], PgSelectRows[673]<br />ᐳ: 617, 619, 672, 674"):::bucket
+    Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 607, 608, 12, 165, 193, 202, 211, 220<br /><br />ROOT PgSelectSingle{23}ᐸrelational_item_relationsᐳ[607]<br />1: <br />ᐳ: 609, 612, 669, 610, 611<br />2: PgSelect[613], PgSelect[670]<br />3: PgSelectRows[618], PgSelectRows[673]<br />ᐳ: 617, 619, 620, 632, 672, 674, 675, 687"):::bucket
     classDef bucket24 stroke:#808000
-    class Bucket24,PgClassExpression609,List610,Lambda611,PgClassExpression612,PgSelect613,First617,PgSelectRows618,PgSelectSingle619,PgClassExpression669,PgSelect670,First672,PgSelectRows673,PgSelectSingle674 bucket24
-    Bucket25("Bucket 25 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 619, 12, 165, 193, 202, 211, 220<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 620, 632<br />2: 621, 633, 642, 651, 660<br />3: 626, 636, 645, 654, 663<br />ᐳ: 625, 627, 629, 630, 631, 635, 637, 639, 640, 641, 644, 646, 648, 649, 650, 653, 655, 657, 658, 659, 662, 664, 666, 667, 668"):::bucket
+    class Bucket24,PgClassExpression609,List610,Lambda611,PgClassExpression612,PgSelect613,First617,PgSelectRows618,PgSelectSingle619,PgClassExpression620,PgClassExpression632,PgClassExpression669,PgSelect670,First672,PgSelectRows673,PgSelectSingle674,PgClassExpression675,PgClassExpression687 bucket24
+    Bucket25("Bucket 25 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 620, 165, 193, 202, 211, 220, 619, 632<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 621, 633, 642, 651, 660<br />2: 626, 636, 645, 654, 663<br />ᐳ: 625, 627, 629, 630, 631, 635, 637, 639, 640, 641, 644, 646, 648, 649, 650, 653, 655, 657, 658, 659, 662, 664, 666, 667, 668"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,PgClassExpression620,PgSelect621,First625,PgSelectRows626,PgSelectSingle627,PgClassExpression629,List630,Lambda631,PgClassExpression632,PgSelect633,First635,PgSelectRows636,PgSelectSingle637,PgClassExpression639,List640,Lambda641,PgSelect642,First644,PgSelectRows645,PgSelectSingle646,PgClassExpression648,List649,Lambda650,PgSelect651,First653,PgSelectRows654,PgSelectSingle655,PgClassExpression657,List658,Lambda659,PgSelect660,First662,PgSelectRows663,PgSelectSingle664,PgClassExpression666,List667,Lambda668 bucket25
-    Bucket26("Bucket 26 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 674, 12, 165, 193, 202, 211, 220<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: <br />ᐳ: 675, 687<br />2: 676, 688, 697, 706, 715<br />3: 681, 691, 700, 709, 718<br />ᐳ: 680, 682, 684, 685, 686, 690, 692, 694, 695, 696, 699, 701, 703, 704, 705, 708, 710, 712, 713, 714, 717, 719, 721, 722, 723"):::bucket
+    class Bucket25,PgSelect621,First625,PgSelectRows626,PgSelectSingle627,PgClassExpression629,List630,Lambda631,PgSelect633,First635,PgSelectRows636,PgSelectSingle637,PgClassExpression639,List640,Lambda641,PgSelect642,First644,PgSelectRows645,PgSelectSingle646,PgClassExpression648,List649,Lambda650,PgSelect651,First653,PgSelectRows654,PgSelectSingle655,PgClassExpression657,List658,Lambda659,PgSelect660,First662,PgSelectRows663,PgSelectSingle664,PgClassExpression666,List667,Lambda668 bucket25
+    Bucket26("Bucket 26 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 12, 675, 165, 193, 202, 211, 220, 674, 687<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br /><br />1: 676, 688, 697, 706, 715<br />2: 681, 691, 700, 709, 718<br />ᐳ: 680, 682, 684, 685, 686, 690, 692, 694, 695, 696, 699, 701, 703, 704, 705, 708, 710, 712, 713, 714, 717, 719, 721, 722, 723"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,PgClassExpression675,PgSelect676,First680,PgSelectRows681,PgSelectSingle682,PgClassExpression684,List685,Lambda686,PgClassExpression687,PgSelect688,First690,PgSelectRows691,PgSelectSingle692,PgClassExpression694,List695,Lambda696,PgSelect697,First699,PgSelectRows700,PgSelectSingle701,PgClassExpression703,List704,Lambda705,PgSelect706,First708,PgSelectRows709,PgSelectSingle710,PgClassExpression712,List713,Lambda714,PgSelect715,First717,PgSelectRows718,PgSelectSingle719,PgClassExpression721,List722,Lambda723 bucket26
+    class Bucket26,PgSelect676,First680,PgSelectRows681,PgSelectSingle682,PgClassExpression684,List685,Lambda686,PgSelect688,First690,PgSelectRows691,PgSelectSingle692,PgClassExpression694,List695,Lambda696,PgSelect697,First699,PgSelectRows700,PgSelectSingle701,PgClassExpression703,List704,Lambda705,PgSelect706,First708,PgSelectRows709,PgSelectSingle710,PgClassExpression712,List713,Lambda714,PgSelect715,First717,PgSelectRows718,PgSelectSingle719,PgClassExpression721,List722,Lambda723 bucket26
     Bucket0 --> Bucket1 & Bucket9 & Bucket17 & Bucket22
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-log-entries.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-log-entries.mermaid
@@ -39,6 +39,8 @@ graph TD
     Access47 --> First25
     PgUnionAllSingle27["PgUnionAllSingle[27∈3]"]:::plan
     First25 --> PgUnionAllSingle27
+    Access28{{"Access[28∈3]<br />ᐸ27.1ᐳ"}}:::plan
+    PgUnionAllSingle27 --> Access28
     PgUnionAll21 --> Access47
     PgSelect31[["PgSelect[31∈4]<br />ᐸorganizationsᐳ<br />ᐳOrganization"]]:::plan
     Access30{{"Access[30∈4]<br />ᐸ29.0ᐳ"}}:::plan
@@ -46,9 +48,7 @@ graph TD
     PgSelect41[["PgSelect[41∈4]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
     Access40{{"Access[40∈4]<br />ᐸ39.0ᐳ"}}:::plan
     Object12 & Access40 --> PgSelect41
-    Access28{{"Access[28∈4]<br />ᐸ27.1ᐳ<br />ᐳOrganization"}}:::plan
-    PgUnionAllSingle27 --> Access28
-    JSONParse29[["JSONParse[29∈4]<br />ᐸ28ᐳ"]]:::plan
+    JSONParse29[["JSONParse[29∈4]<br />ᐸ28ᐳ<br />ᐳOrganization"]]:::plan
     Access28 --> JSONParse29
     JSONParse29 --> Access30
     First35{{"First[35∈4]"}}:::plan
@@ -83,12 +83,12 @@ graph TD
     Bucket2("Bucket 2 (listItem)<br />Deps: 12<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 12<br /><br />ROOT PgSelectSingle{2}ᐸlog_entriesᐳ[17]<br />1: <br />ᐳ: 18, 19, 20<br />2: PgUnionAll[21]<br />ᐳ: Access[47], First[25]<br />3: PgUnionAllSingle[27]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 12<br /><br />ROOT PgSelectSingle{2}ᐸlog_entriesᐳ[17]<br />1: <br />ᐳ: 18, 19, 20<br />2: PgUnionAll[21]<br />ᐳ: Access[47], First[25]<br />3: PgUnionAllSingle[27]<br />ᐳ: Access[28]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgUnionAll21,First25,PgUnionAllSingle27,Access47 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />Organization,Person<br />Deps: 27, 12<br />ᐳOrganization<br />ᐳPerson<br /><br />1: <br />ᐳ: Access[28]<br />2: JSONParse[29], JSONParse[39]<br />ᐳ: Access[30], Access[40]<br />3: PgSelect[31], PgSelect[41]<br />4: PgSelectRows[36], PgSelectRows[44]<br />ᐳ: 35, 37, 38, 43, 45, 46"):::bucket
+    class Bucket3,PgClassExpression18,PgClassExpression19,PgClassExpression20,PgUnionAll21,First25,PgUnionAllSingle27,Access28,Access47 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />Organization,Person<br />Deps: 28, 12, 27<br />ᐳOrganization<br />ᐳPerson<br /><br />1: JSONParse[29], JSONParse[39]<br />ᐳ: Access[30], Access[40]<br />2: PgSelect[31], PgSelect[41]<br />3: PgSelectRows[36], PgSelectRows[44]<br />ᐳ: 35, 37, 38, 43, 45, 46"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access28,JSONParse29,Access30,PgSelect31,First35,PgSelectRows36,PgSelectSingle37,PgClassExpression38,JSONParse39,Access40,PgSelect41,First43,PgSelectRows44,PgSelectSingle45,PgClassExpression46 bucket4
+    class Bucket4,JSONParse29,Access30,PgSelect31,First35,PgSelectRows36,PgSelectSingle37,PgClassExpression38,JSONParse39,Access40,PgSelect41,First43,PgSelectRows44,PgSelectSingle45,PgClassExpression46 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
@@ -49,11 +49,15 @@ graph TD
     PgSelectRows15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
+    PgClassExpression18{{"PgClassExpression[18∈2]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression18
+    PgClassExpression22{{"PgClassExpression[22∈2]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression22
+    PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__single_t..._topic_id”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression23
     List20{{"List[20∈3]<br />ᐸ19,18ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant19 & PgClassExpression18 --> List20
     PgSelect24[["PgSelect[24∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__single_t..._topic_id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Object12 & PgClassExpression23 --> PgSelect24
     List34{{"List[34∈3]<br />ᐸ33,18ᐳ<br />ᐳSingleTablePost"}}:::plan
     Constant33 & PgClassExpression18 --> List34
@@ -63,12 +67,8 @@ graph TD
     Constant53 & PgClassExpression18 --> List54
     List64{{"List[64∈3]<br />ᐸ63,18ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
     Constant63 & PgClassExpression18 --> List64
-    PgSelectSingle17 --> PgClassExpression18
     Lambda21{{"Lambda[21∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List20 --> Lambda21
-    PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    PgSelectSingle17 --> PgClassExpression22
-    PgSelectSingle17 --> PgClassExpression23
     First28{{"First[28∈3]"}}:::plan
     PgSelectRows29[["PgSelectRows[29∈3]<br />ᐳSingleTableTopic"]]:::plan
     PgSelectRows29 --> First28
@@ -150,8 +150,8 @@ graph TD
     PgClassExpression96{{"PgClassExpression[96∈10] ➊<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
     PgSelectSingle94 --> PgClassExpression96
     PgSelect149[["PgSelect[149∈11] ➊<br />ᐸrelational_item_relation_composite_pksᐳ<br />ᐳRelationalItemRelationCompositePk"]]:::plan
-    Access254{{"Access[254∈11] ➊<br />ᐸ99.base64JSON.1ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Access255{{"Access[255∈11] ➊<br />ᐸ99.base64JSON.2ᐳ<br />ᐳRelationalItemRelationCompositePk"}}:::plan
+    Access254{{"Access[254∈11] ➊<br />ᐸ99.base64JSON.1ᐳ<br />ᐳSingleTableTopic<br />ᐳPerson<br />ᐳLogEntry<br />ᐳOrganization<br />ᐳAwsApplication<br />ᐳGcpApplication<br />ᐳRelationalItemRelation<br />ᐳRelationalItemRelationCompositePk<br />ᐳSingleTableItemRelation<br />ᐳSingleTableItemRelationCompositePk<br />ᐳSingleTablePost<br />ᐳPriority<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability"}}:::plan
+    Access255{{"Access[255∈11] ➊<br />ᐸ99.base64JSON.2ᐳ<br />ᐳRelationalItemRelationCompositePk<br />ᐳSingleTableItemRelationCompositePk"}}:::plan
     Object12 -->|rejectNull| PgSelect149
     Access254 -->|rejectNull| PgSelect149
     Access255 --> PgSelect149
@@ -375,10 +375,10 @@ graph TD
     class Bucket1,PgSelect14,PgSelectRows15 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 19, 12, 33, 43, 53, 63<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 17, 19, 12, 33, 43, 53, 63<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 18, 22, 23, 20, 21, 34, 35, 44, 45, 54, 55, 64, 65<br />2: PgSelect[24]<br />3: 29, 39, 49, 59, 69<br />ᐳ: 28, 30, 38, 40, 48, 50, 58, 60, 68, 70"):::bucket
+    class Bucket2,__Item16,PgSelectSingle17,PgClassExpression18,PgClassExpression22,PgClassExpression23 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 19, 18, 12, 23, 33, 43, 53, 63, 17, 22<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[24]<br />ᐳ: 20, 34, 44, 54, 64, 21, 35, 45, 55, 65<br />2: 29, 39, 49, 59, 69<br />ᐳ: 28, 30, 38, 40, 48, 50, 58, 60, 68, 70"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression18,List20,Lambda21,PgClassExpression22,PgClassExpression23,PgSelect24,First28,PgSelectRows29,PgSelectSingle30,List34,Lambda35,First38,PgSelectRows39,PgSelectSingle40,List44,Lambda45,First48,PgSelectRows49,PgSelectSingle50,List54,Lambda55,First58,PgSelectRows59,PgSelectSingle60,List64,Lambda65,First68,PgSelectRows69,PgSelectSingle70 bucket3
+    class Bucket3,List20,Lambda21,PgSelect24,First28,PgSelectRows29,PgSelectSingle30,List34,Lambda35,First38,PgSelectRows39,PgSelectSingle40,List44,Lambda45,First48,PgSelectRows49,PgSelectSingle50,List54,Lambda55,First58,PgSelectRows59,PgSelectSingle60,List64,Lambda65,First68,PgSelectRows69,PgSelectSingle70 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 30<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[30]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression31,PgClassExpression32 bucket4

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/single-table-items-and-children.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/single-table-items-and-children.mermaid
@@ -26,12 +26,12 @@ graph TD
     PgSelectRows15 ==> __Item16
     PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item16 --> PgSelectSingle17
-    PgSelect20[["PgSelect[20∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Object12 & PgClassExpression18 --> PgSelect20
+    PgClassExpression18{{"PgClassExpression[18∈2]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression18
-    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    PgClassExpression19{{"PgClassExpression[19∈2]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
     PgSelectSingle17 --> PgClassExpression19
+    PgSelect20[["PgSelect[20∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
+    Object12 & PgClassExpression18 --> PgSelect20
     PgSelectRows24[["PgSelectRows[24∈3]<br />ᐳSingleTableTopic"]]:::plan
     PgSelect20 --> PgSelectRows24
     PgSelectRows31[["PgSelectRows[31∈3]<br />ᐳSingleTablePost"]]:::plan
@@ -46,41 +46,41 @@ graph TD
     PgSelectRows24 ==> __Item25
     PgSelectSingle26{{"PgSelectSingle[26∈4]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item25 --> PgSelectSingle26
-    PgClassExpression27{{"PgClassExpression[27∈5]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression27
-    PgClassExpression28{{"PgClassExpression[28∈5]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableTopicᐳSingleTableTopic"}}:::plan
+    PgClassExpression28{{"PgClassExpression[28∈4]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle26 --> PgClassExpression28
     __Item32[/"__Item[32∈6]<br />ᐸ31ᐳ"\]:::itemplan
     PgSelectRows31 ==> __Item32
     PgSelectSingle33{{"PgSelectSingle[33∈6]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item32 --> PgSelectSingle33
-    PgClassExpression34{{"PgClassExpression[34∈7]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈6]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression34
-    PgClassExpression35{{"PgClassExpression[35∈7]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTablePostᐳSingleTableTopic"}}:::plan
+    PgClassExpression35{{"PgClassExpression[35∈6]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle33 --> PgClassExpression35
     __Item39[/"__Item[39∈8]<br />ᐸ38ᐳ"\]:::itemplan
     PgSelectRows38 ==> __Item39
     PgSelectSingle40{{"PgSelectSingle[40∈8]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item39 --> PgSelectSingle40
-    PgClassExpression41{{"PgClassExpression[41∈9]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
+    PgClassExpression41{{"PgClassExpression[41∈8]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression41
-    PgClassExpression42{{"PgClassExpression[42∈9]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableDividerᐳSingleTableTopic"}}:::plan
+    PgClassExpression42{{"PgClassExpression[42∈8]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression42
     __Item46[/"__Item[46∈10]<br />ᐸ45ᐳ"\]:::itemplan
     PgSelectRows45 ==> __Item46
     PgSelectSingle47{{"PgSelectSingle[47∈10]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item46 --> PgSelectSingle47
-    PgClassExpression48{{"PgClassExpression[48∈11]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
+    PgClassExpression48{{"PgClassExpression[48∈10]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle47 --> PgClassExpression48
-    PgClassExpression49{{"PgClassExpression[49∈11]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistᐳSingleTableTopic"}}:::plan
+    PgClassExpression49{{"PgClassExpression[49∈10]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle47 --> PgClassExpression49
     __Item53[/"__Item[53∈12]<br />ᐸ52ᐳ"\]:::itemplan
     PgSelectRows52 ==> __Item53
     PgSelectSingle54{{"PgSelectSingle[54∈12]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     __Item53 --> PgSelectSingle54
-    PgClassExpression55{{"PgClassExpression[55∈13]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
+    PgClassExpression55{{"PgClassExpression[55∈12]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle54 --> PgClassExpression55
-    PgClassExpression56{{"PgClassExpression[56∈13]<br />ᐸ__single_t...”position”ᐳ<br />ᐳSingleTableChecklistItemᐳSingleTableTopic"}}:::plan
+    PgClassExpression56{{"PgClassExpression[56∈12]<br />ᐸ__single_t...”position”ᐳ"}}:::plan
     PgSelectSingle54 --> PgClassExpression56
 
     %% define steps
@@ -94,40 +94,40 @@ graph TD
     class Bucket1,PgSelect14,PgSelectRows15 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 12<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item16,PgSelectSingle17 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 17, 12<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: <br />ᐳ: 18, 19<br />2: PgSelect[20]<br />3: 24, 31, 38, 45, 52"):::bucket
+    class Bucket2,__Item16,PgSelectSingle17,PgClassExpression18,PgClassExpression19 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 12, 18, 17, 19<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br /><br />1: PgSelect[20]<br />2: 24, 31, 38, 45, 52"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression18,PgClassExpression19,PgSelect20,PgSelectRows24,PgSelectRows31,PgSelectRows38,PgSelectRows45,PgSelectRows52 bucket3
+    class Bucket3,PgSelect20,PgSelectRows24,PgSelectRows31,PgSelectRows38,PgSelectRows45,PgSelectRows52 bucket3
     Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ24ᐳ[25]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item25,PgSelectSingle26 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 26<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
+    class Bucket4,__Item25,PgSelectSingle26,PgClassExpression27,PgClassExpression28 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 26, 27, 28<br />ᐳSingleTableTopicᐳSingleTableTopic<br />ᐳSingleTableTopicᐳSingleTablePost<br />ᐳSingleTableTopicᐳSingleTableDivider<br />ᐳSingleTableTopicᐳSingleTableChecklist<br />ᐳSingleTableTopicᐳSingleTableChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression27,PgClassExpression28 bucket5
+    class Bucket5 bucket5
     Bucket6("Bucket 6 (listItem)<br /><br />ROOT __Item{6}ᐸ31ᐳ[32]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,__Item32,PgSelectSingle33 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 33<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
+    class Bucket6,__Item32,PgSelectSingle33,PgClassExpression34,PgClassExpression35 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 33, 34, 35<br />ᐳSingleTablePostᐳSingleTableTopic<br />ᐳSingleTablePostᐳSingleTablePost<br />ᐳSingleTablePostᐳSingleTableDivider<br />ᐳSingleTablePostᐳSingleTableChecklist<br />ᐳSingleTablePostᐳSingleTableChecklistItem"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression34,PgClassExpression35 bucket7
+    class Bucket7 bucket7
     Bucket8("Bucket 8 (listItem)<br /><br />ROOT __Item{8}ᐸ38ᐳ[39]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,__Item39,PgSelectSingle40 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 40<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
+    class Bucket8,__Item39,PgSelectSingle40,PgClassExpression41,PgClassExpression42 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 40, 41, 42<br />ᐳSingleTableDividerᐳSingleTableTopic<br />ᐳSingleTableDividerᐳSingleTablePost<br />ᐳSingleTableDividerᐳSingleTableDivider<br />ᐳSingleTableDividerᐳSingleTableChecklist<br />ᐳSingleTableDividerᐳSingleTableChecklistItem"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression41,PgClassExpression42 bucket9
+    class Bucket9 bucket9
     Bucket10("Bucket 10 (listItem)<br /><br />ROOT __Item{10}ᐸ45ᐳ[46]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,__Item46,PgSelectSingle47 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 47<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
+    class Bucket10,__Item46,PgSelectSingle47,PgClassExpression48,PgClassExpression49 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 47, 48, 49<br />ᐳSingleTableChecklistᐳSingleTableTopic<br />ᐳSingleTableChecklistᐳSingleTablePost<br />ᐳSingleTableChecklistᐳSingleTableDivider<br />ᐳSingleTableChecklistᐳSingleTableChecklist<br />ᐳSingleTableChecklistᐳSingleTableChecklistItem"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression48,PgClassExpression49 bucket11
+    class Bucket11 bucket11
     Bucket12("Bucket 12 (listItem)<br /><br />ROOT __Item{12}ᐸ52ᐳ[53]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,__Item53,PgSelectSingle54 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 54<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
+    class Bucket12,__Item53,PgSelectSingle54,PgClassExpression55,PgClassExpression56 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 54, 55, 56<br />ᐳSingleTableChecklistItemᐳSingleTableTopic<br />ᐳSingleTableChecklistItemᐳSingleTablePost<br />ᐳSingleTableChecklistItemᐳSingleTableDivider<br />ᐳSingleTableChecklistItemᐳSingleTableChecklist<br />ᐳSingleTableChecklistItemᐳSingleTableChecklistItem"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression55,PgClassExpression56 bucket13
+    class Bucket13 bucket13
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
@@ -93,15 +93,15 @@ graph TD
     __Item19 --> PgUnionAllSingle20
     PgCursor22{{"PgCursor[22∈3]"}}:::plan
     PgUnionAllSingle20 & Access21 --> PgCursor22
+    Access23{{"Access[23∈3]<br />ᐸ20.1ᐳ"}}:::plan
+    PgUnionAllSingle20 --> Access23
     PgSelect26[["PgSelect[26∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access25{{"Access[25∈4]<br />ᐸ24.0ᐳ"}}:::plan
     Object14 & Access25 --> PgSelect26
     PgSelect38[["PgSelect[38∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access37{{"Access[37∈4]<br />ᐸ36.0ᐳ"}}:::plan
     Object14 & Access37 --> PgSelect38
-    Access23{{"Access[23∈4]<br />ᐸ20.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle20 --> Access23
-    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ"]]:::plan
+    JSONParse24[["JSONParse[24∈4]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access23 --> JSONParse24
     JSONParse24 --> Access25
     First30{{"First[30∈4]"}}:::plan
@@ -137,15 +137,15 @@ graph TD
     Access112 ==> __Item82
     PgUnionAllSingle83["PgUnionAllSingle[83∈5]"]:::plan
     __Item82 --> PgUnionAllSingle83
+    Access84{{"Access[84∈5]<br />ᐸ83.1ᐳ"}}:::plan
+    PgUnionAllSingle83 --> Access84
     PgSelect87[["PgSelect[87∈6]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access86{{"Access[86∈6]<br />ᐸ85.0ᐳ"}}:::plan
     Object14 & Access86 --> PgSelect87
     PgSelect99[["PgSelect[99∈6]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
     Access98{{"Access[98∈6]<br />ᐸ97.0ᐳ"}}:::plan
     Object14 & Access98 --> PgSelect99
-    Access84{{"Access[84∈6]<br />ᐸ83.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle83 --> Access84
-    JSONParse85[["JSONParse[85∈6]<br />ᐸ84ᐳ"]]:::plan
+    JSONParse85[["JSONParse[85∈6]<br />ᐸ84ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access84 --> JSONParse85
     JSONParse85 --> Access86
     First91{{"First[91∈6]"}}:::plan
@@ -192,16 +192,16 @@ graph TD
     class Bucket2,__Item19,PgUnionAllSingle20 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20, 21, 14<br /><br />ROOT PgUnionAllSingle{2}[20]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor22 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 20, 14<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[23]<br />2: JSONParse[24], JSONParse[36]<br />ᐳ: Access[25], Access[37]<br />3: PgSelect[26], PgSelect[38]<br />4: PgSelectRows[31], PgSelectRows[41]<br />ᐳ: 30, 32, 33, 34, 35, 40, 42, 43, 44, 45, 46"):::bucket
+    class Bucket3,PgCursor22,Access23 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 14, 20<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[24], JSONParse[36]<br />ᐳ: Access[25], Access[37]<br />2: PgSelect[26], PgSelect[38]<br />3: PgSelectRows[31], PgSelectRows[41]<br />ᐳ: 30, 32, 33, 34, 35, 40, 42, 43, 44, 45, 46"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,Access23,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,JSONParse36,Access37,PgSelect38,First40,PgSelectRows41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgClassExpression45,PgClassExpression46 bucket4
+    class Bucket4,JSONParse24,Access25,PgSelect26,First30,PgSelectRows31,PgSelectSingle32,PgClassExpression33,PgClassExpression34,PgClassExpression35,JSONParse36,Access37,PgSelect38,First40,PgSelectRows41,PgSelectSingle42,PgClassExpression43,PgClassExpression44,PgClassExpression45,PgClassExpression46 bucket4
     Bucket5("Bucket 5 (listItem)<br />Deps: 14<br /><br />ROOT __Item{5}ᐸ112ᐳ[82]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,__Item82,PgUnionAllSingle83 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 83, 14<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: Access[84]<br />2: JSONParse[85], JSONParse[97]<br />ᐳ: Access[86], Access[98]<br />3: PgSelect[87], PgSelect[99]<br />4: PgSelectRows[92], PgSelectRows[102]<br />ᐳ: 91, 93, 94, 95, 96, 101, 103, 104, 105, 106, 107"):::bucket
+    class Bucket5,__Item82,PgUnionAllSingle83,Access84 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 84, 14, 83<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[85], JSONParse[97]<br />ᐳ: Access[86], Access[98]<br />2: PgSelect[87], PgSelect[99]<br />3: PgSelectRows[92], PgSelectRows[102]<br />ᐳ: 91, 93, 94, 95, 96, 101, 103, 104, 105, 106, 107"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Access84,JSONParse85,Access86,PgSelect87,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,PgClassExpression106,PgClassExpression107 bucket6
+    class Bucket6,JSONParse85,Access86,PgSelect87,First91,PgSelectRows92,PgSelectSingle93,PgClassExpression94,PgClassExpression95,PgClassExpression96,JSONParse97,Access98,PgSelect99,First101,PgSelectRows102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,PgClassExpression106,PgClassExpression107 bucket6
     Bucket0 --> Bucket1 & Bucket5
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
@@ -34,6 +34,8 @@ graph TD
     Access596 ==> __Item15
     PgUnionAllSingle16["PgUnionAllSingle[16∈2]"]:::plan
     __Item15 --> PgUnionAllSingle16
+    Access17{{"Access[17∈2]<br />ᐸ16.1ᐳ"}}:::plan
+    PgUnionAllSingle16 --> Access17
     PgUnionAll35[["PgUnionAll[35∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
     PgClassExpression28{{"PgClassExpression[28∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
     Connection34{{"Connection[34∈3] ➊<br />ᐸ32ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
@@ -66,9 +68,7 @@ graph TD
     Object11 & PgClassExpression308 --> PgUnionAll414
     PgUnionAll548[["PgUnionAll[548∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
     Object11 & PgClassExpression308 --> PgUnionAll548
-    Access17{{"Access[17∈3]<br />ᐸ16.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle16 --> Access17
-    JSONParse18[["JSONParse[18∈3]<br />ᐸ17ᐳ"]]:::plan
+    JSONParse18[["JSONParse[18∈3]<br />ᐸ17ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access17 --> JSONParse18
     JSONParse18 --> Access19
     First24{{"First[24∈3]"}}:::plan
@@ -116,6 +116,8 @@ graph TD
     Access582 ==> __Item37
     PgUnionAllSingle38["PgUnionAllSingle[38∈4]"]:::plan
     __Item37 --> PgUnionAllSingle38
+    Access39{{"Access[39∈4]<br />ᐸ38.1ᐳ"}}:::plan
+    PgUnionAllSingle38 --> Access39
     PgUnionAll56[["PgUnionAll[56∈5]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression54{{"PgClassExpression[54∈5]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression55{{"PgClassExpression[55∈5]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
@@ -136,9 +138,7 @@ graph TD
     List97{{"List[97∈5]<br />ᐸ95,96ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
     PgClassExpression96{{"PgClassExpression[96∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Constant95 & PgClassExpression96 --> List97
-    Access39{{"Access[39∈5]<br />ᐸ38.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgUnionAllSingle38 --> Access39
-    JSONParse40[["JSONParse[40∈5]<br />ᐸ39ᐳ"]]:::plan
+    JSONParse40[["JSONParse[40∈5]<br />ᐸ39ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access39 --> JSONParse40
     JSONParse40 --> Access41
     First46{{"First[46∈5]"}}:::plan
@@ -159,6 +159,8 @@ graph TD
     Access580 --> First58
     PgUnionAllSingle60["PgUnionAllSingle[60∈5]"]:::plan
     First58 --> PgUnionAllSingle60
+    Access61{{"Access[61∈5]<br />ᐸ60.1ᐳ"}}:::plan
+    PgUnionAllSingle60 --> Access61
     JSONParse88[["JSONParse[88∈5]<br />ᐸ39ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
     Access39 --> JSONParse88
     JSONParse88 --> Access89
@@ -180,6 +182,8 @@ graph TD
     Access581 --> First104
     PgUnionAllSingle106["PgUnionAllSingle[106∈5]"]:::plan
     First104 --> PgUnionAllSingle106
+    Access107{{"Access[107∈5]<br />ᐸ106.1ᐳ"}}:::plan
+    PgUnionAllSingle106 --> Access107
     PgUnionAll56 --> Access580
     PgUnionAll102 --> Access581
     PgSelect64[["PgSelect[64∈6]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
@@ -194,9 +198,7 @@ graph TD
     List85{{"List[85∈6]<br />ᐸ83,84ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
     PgClassExpression84{{"PgClassExpression[84∈6]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression84 --> List85
-    Access61{{"Access[61∈6]<br />ᐸ60.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle60 --> Access61
-    JSONParse62[["JSONParse[62∈6]<br />ᐸ61ᐳ"]]:::plan
+    JSONParse62[["JSONParse[62∈6]<br />ᐸ61ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access61 --> JSONParse62
     JSONParse62 --> Access63
     First68{{"First[68∈6]"}}:::plan
@@ -236,9 +238,7 @@ graph TD
     List131{{"List[131∈7]<br />ᐸ83,130ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
     PgClassExpression130{{"PgClassExpression[130∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression130 --> List131
-    Access107{{"Access[107∈7]<br />ᐸ106.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle106 --> Access107
-    JSONParse108[["JSONParse[108∈7]<br />ᐸ107ᐳ"]]:::plan
+    JSONParse108[["JSONParse[108∈7]<br />ᐸ107ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access107 --> JSONParse108
     JSONParse108 --> Access109
     First114{{"First[114∈7]"}}:::plan
@@ -270,6 +270,8 @@ graph TD
     Access585 ==> __Item137
     PgUnionAllSingle138["PgUnionAllSingle[138∈8]"]:::plan
     __Item137 --> PgUnionAllSingle138
+    Access139{{"Access[139∈8]<br />ᐸ138.1ᐳ"}}:::plan
+    PgUnionAllSingle138 --> Access139
     PgUnionAll156[["PgUnionAll[156∈9]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression154{{"PgClassExpression[154∈9]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression155{{"PgClassExpression[155∈9]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
@@ -290,9 +292,7 @@ graph TD
     List197{{"List[197∈9]<br />ᐸ95,196ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
     PgClassExpression196{{"PgClassExpression[196∈9]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Constant95 & PgClassExpression196 --> List197
-    Access139{{"Access[139∈9]<br />ᐸ138.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgUnionAllSingle138 --> Access139
-    JSONParse140[["JSONParse[140∈9]<br />ᐸ139ᐳ"]]:::plan
+    JSONParse140[["JSONParse[140∈9]<br />ᐸ139ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access139 --> JSONParse140
     JSONParse140 --> Access141
     First146{{"First[146∈9]"}}:::plan
@@ -313,6 +313,8 @@ graph TD
     Access583 --> First158
     PgUnionAllSingle160["PgUnionAllSingle[160∈9]"]:::plan
     First158 --> PgUnionAllSingle160
+    Access161{{"Access[161∈9]<br />ᐸ160.1ᐳ"}}:::plan
+    PgUnionAllSingle160 --> Access161
     JSONParse188[["JSONParse[188∈9]<br />ᐸ139ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
     Access139 --> JSONParse188
     JSONParse188 --> Access189
@@ -334,6 +336,8 @@ graph TD
     Access584 --> First204
     PgUnionAllSingle206["PgUnionAllSingle[206∈9]"]:::plan
     First204 --> PgUnionAllSingle206
+    Access207{{"Access[207∈9]<br />ᐸ206.1ᐳ"}}:::plan
+    PgUnionAllSingle206 --> Access207
     PgUnionAll156 --> Access583
     PgUnionAll202 --> Access584
     PgSelect164[["PgSelect[164∈10]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
@@ -348,9 +352,7 @@ graph TD
     List185{{"List[185∈10]<br />ᐸ83,184ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
     PgClassExpression184{{"PgClassExpression[184∈10]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression184 --> List185
-    Access161{{"Access[161∈10]<br />ᐸ160.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle160 --> Access161
-    JSONParse162[["JSONParse[162∈10]<br />ᐸ161ᐳ"]]:::plan
+    JSONParse162[["JSONParse[162∈10]<br />ᐸ161ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access161 --> JSONParse162
     JSONParse162 --> Access163
     First168{{"First[168∈10]"}}:::plan
@@ -390,9 +392,7 @@ graph TD
     List231{{"List[231∈11]<br />ᐸ83,230ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
     PgClassExpression230{{"PgClassExpression[230∈11]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression230 --> List231
-    Access207{{"Access[207∈11]<br />ᐸ206.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle206 --> Access207
-    JSONParse208[["JSONParse[208∈11]<br />ᐸ207ᐳ"]]:::plan
+    JSONParse208[["JSONParse[208∈11]<br />ᐸ207ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access207 --> JSONParse208
     JSONParse208 --> Access209
     First214{{"First[214∈11]"}}:::plan
@@ -424,6 +424,8 @@ graph TD
     Access586 ==> __Item239
     PgUnionAllSingle240["PgUnionAllSingle[240∈12]"]:::plan
     __Item239 --> PgUnionAllSingle240
+    Access241{{"Access[241∈12]<br />ᐸ240.1ᐳ"}}:::plan
+    PgUnionAllSingle240 --> Access241
     PgSelect244[["PgSelect[244∈13]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access243{{"Access[243∈13]<br />ᐸ242.0ᐳ"}}:::plan
     Object11 & Access243 --> PgSelect244
@@ -436,9 +438,7 @@ graph TD
     List265{{"List[265∈13]<br />ᐸ83,264ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
     PgClassExpression264{{"PgClassExpression[264∈13]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression264 --> List265
-    Access241{{"Access[241∈13]<br />ᐸ240.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    PgUnionAllSingle240 --> Access241
-    JSONParse242[["JSONParse[242∈13]<br />ᐸ241ᐳ"]]:::plan
+    JSONParse242[["JSONParse[242∈13]<br />ᐸ241ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access241 --> JSONParse242
     JSONParse242 --> Access243
     First248{{"First[248∈13]"}}:::plan
@@ -470,6 +470,8 @@ graph TD
     Access587 ==> __Item271
     PgUnionAllSingle272["PgUnionAllSingle[272∈14]"]:::plan
     __Item271 --> PgUnionAllSingle272
+    Access273{{"Access[273∈14]<br />ᐸ272.1ᐳ"}}:::plan
+    PgUnionAllSingle272 --> Access273
     PgSelect276[["PgSelect[276∈15]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access275{{"Access[275∈15]<br />ᐸ274.0ᐳ"}}:::plan
     Object11 & Access275 --> PgSelect276
@@ -482,9 +484,7 @@ graph TD
     List297{{"List[297∈15]<br />ᐸ83,296ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
     PgClassExpression296{{"PgClassExpression[296∈15]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression296 --> List297
-    Access273{{"Access[273∈15]<br />ᐸ272.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    PgUnionAllSingle272 --> Access273
-    JSONParse274[["JSONParse[274∈15]<br />ᐸ273ᐳ"]]:::plan
+    JSONParse274[["JSONParse[274∈15]<br />ᐸ273ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access273 --> JSONParse274
     JSONParse274 --> Access275
     First280{{"First[280∈15]"}}:::plan
@@ -516,6 +516,8 @@ graph TD
     Access590 ==> __Item317
     PgUnionAllSingle318["PgUnionAllSingle[318∈16]"]:::plan
     __Item317 --> PgUnionAllSingle318
+    Access319{{"Access[319∈16]<br />ᐸ318.1ᐳ"}}:::plan
+    PgUnionAllSingle318 --> Access319
     PgUnionAll336[["PgUnionAll[336∈17]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression334{{"PgClassExpression[334∈17]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression335{{"PgClassExpression[335∈17]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
@@ -536,9 +538,7 @@ graph TD
     List377{{"List[377∈17]<br />ᐸ95,376ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
     PgClassExpression376{{"PgClassExpression[376∈17]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Constant95 & PgClassExpression376 --> List377
-    Access319{{"Access[319∈17]<br />ᐸ318.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgUnionAllSingle318 --> Access319
-    JSONParse320[["JSONParse[320∈17]<br />ᐸ319ᐳ"]]:::plan
+    JSONParse320[["JSONParse[320∈17]<br />ᐸ319ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access319 --> JSONParse320
     JSONParse320 --> Access321
     First326{{"First[326∈17]"}}:::plan
@@ -559,6 +559,8 @@ graph TD
     Access588 --> First338
     PgUnionAllSingle340["PgUnionAllSingle[340∈17]"]:::plan
     First338 --> PgUnionAllSingle340
+    Access341{{"Access[341∈17]<br />ᐸ340.1ᐳ"}}:::plan
+    PgUnionAllSingle340 --> Access341
     JSONParse368[["JSONParse[368∈17]<br />ᐸ319ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
     Access319 --> JSONParse368
     JSONParse368 --> Access369
@@ -580,6 +582,8 @@ graph TD
     Access589 --> First384
     PgUnionAllSingle386["PgUnionAllSingle[386∈17]"]:::plan
     First384 --> PgUnionAllSingle386
+    Access387{{"Access[387∈17]<br />ᐸ386.1ᐳ"}}:::plan
+    PgUnionAllSingle386 --> Access387
     PgUnionAll336 --> Access588
     PgUnionAll382 --> Access589
     PgSelect344[["PgSelect[344∈18]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
@@ -594,9 +598,7 @@ graph TD
     List365{{"List[365∈18]<br />ᐸ83,364ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
     PgClassExpression364{{"PgClassExpression[364∈18]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression364 --> List365
-    Access341{{"Access[341∈18]<br />ᐸ340.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle340 --> Access341
-    JSONParse342[["JSONParse[342∈18]<br />ᐸ341ᐳ"]]:::plan
+    JSONParse342[["JSONParse[342∈18]<br />ᐸ341ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access341 --> JSONParse342
     JSONParse342 --> Access343
     First348{{"First[348∈18]"}}:::plan
@@ -636,9 +638,7 @@ graph TD
     List411{{"List[411∈19]<br />ᐸ83,410ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
     PgClassExpression410{{"PgClassExpression[410∈19]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression410 --> List411
-    Access387{{"Access[387∈19]<br />ᐸ386.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle386 --> Access387
-    JSONParse388[["JSONParse[388∈19]<br />ᐸ387ᐳ"]]:::plan
+    JSONParse388[["JSONParse[388∈19]<br />ᐸ387ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access387 --> JSONParse388
     JSONParse388 --> Access389
     First394{{"First[394∈19]"}}:::plan
@@ -670,6 +670,8 @@ graph TD
     Access593 ==> __Item417
     PgUnionAllSingle418["PgUnionAllSingle[418∈20]"]:::plan
     __Item417 --> PgUnionAllSingle418
+    Access419{{"Access[419∈20]<br />ᐸ418.1ᐳ"}}:::plan
+    PgUnionAllSingle418 --> Access419
     PgUnionAll436[["PgUnionAll[436∈21]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     PgClassExpression434{{"PgClassExpression[434∈21]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
     PgClassExpression435{{"PgClassExpression[435∈21]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
@@ -690,9 +692,7 @@ graph TD
     List477{{"List[477∈21]<br />ᐸ95,476ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
     PgClassExpression476{{"PgClassExpression[476∈21]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
     Constant95 & PgClassExpression476 --> List477
-    Access419{{"Access[419∈21]<br />ᐸ418.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgUnionAllSingle418 --> Access419
-    JSONParse420[["JSONParse[420∈21]<br />ᐸ419ᐳ"]]:::plan
+    JSONParse420[["JSONParse[420∈21]<br />ᐸ419ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
     Access419 --> JSONParse420
     JSONParse420 --> Access421
     First426{{"First[426∈21]"}}:::plan
@@ -713,6 +713,8 @@ graph TD
     Access591 --> First438
     PgUnionAllSingle440["PgUnionAllSingle[440∈21]"]:::plan
     First438 --> PgUnionAllSingle440
+    Access441{{"Access[441∈21]<br />ᐸ440.1ᐳ"}}:::plan
+    PgUnionAllSingle440 --> Access441
     JSONParse468[["JSONParse[468∈21]<br />ᐸ419ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
     Access419 --> JSONParse468
     JSONParse468 --> Access469
@@ -734,6 +736,8 @@ graph TD
     Access592 --> First484
     PgUnionAllSingle486["PgUnionAllSingle[486∈21]"]:::plan
     First484 --> PgUnionAllSingle486
+    Access487{{"Access[487∈21]<br />ᐸ486.1ᐳ"}}:::plan
+    PgUnionAllSingle486 --> Access487
     PgUnionAll436 --> Access591
     PgUnionAll482 --> Access592
     PgSelect444[["PgSelect[444∈22]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
@@ -748,9 +752,7 @@ graph TD
     List465{{"List[465∈22]<br />ᐸ83,464ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
     PgClassExpression464{{"PgClassExpression[464∈22]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression464 --> List465
-    Access441{{"Access[441∈22]<br />ᐸ440.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle440 --> Access441
-    JSONParse442[["JSONParse[442∈22]<br />ᐸ441ᐳ"]]:::plan
+    JSONParse442[["JSONParse[442∈22]<br />ᐸ441ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
     Access441 --> JSONParse442
     JSONParse442 --> Access443
     First448{{"First[448∈22]"}}:::plan
@@ -790,9 +792,7 @@ graph TD
     List511{{"List[511∈23]<br />ᐸ83,510ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
     PgClassExpression510{{"PgClassExpression[510∈23]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression510 --> List511
-    Access487{{"Access[487∈23]<br />ᐸ486.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgUnionAllSingle486 --> Access487
-    JSONParse488[["JSONParse[488∈23]<br />ᐸ487ᐳ"]]:::plan
+    JSONParse488[["JSONParse[488∈23]<br />ᐸ487ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
     Access487 --> JSONParse488
     JSONParse488 --> Access489
     First494{{"First[494∈23]"}}:::plan
@@ -824,6 +824,8 @@ graph TD
     Access594 ==> __Item519
     PgUnionAllSingle520["PgUnionAllSingle[520∈24]"]:::plan
     __Item519 --> PgUnionAllSingle520
+    Access521{{"Access[521∈24]<br />ᐸ520.1ᐳ"}}:::plan
+    PgUnionAllSingle520 --> Access521
     PgSelect524[["PgSelect[524∈25]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access523{{"Access[523∈25]<br />ᐸ522.0ᐳ"}}:::plan
     Object11 & Access523 --> PgSelect524
@@ -836,9 +838,7 @@ graph TD
     List545{{"List[545∈25]<br />ᐸ83,544ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
     PgClassExpression544{{"PgClassExpression[544∈25]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression544 --> List545
-    Access521{{"Access[521∈25]<br />ᐸ520.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    PgUnionAllSingle520 --> Access521
-    JSONParse522[["JSONParse[522∈25]<br />ᐸ521ᐳ"]]:::plan
+    JSONParse522[["JSONParse[522∈25]<br />ᐸ521ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access521 --> JSONParse522
     JSONParse522 --> Access523
     First528{{"First[528∈25]"}}:::plan
@@ -870,6 +870,8 @@ graph TD
     Access595 ==> __Item551
     PgUnionAllSingle552["PgUnionAllSingle[552∈26]"]:::plan
     __Item551 --> PgUnionAllSingle552
+    Access553{{"Access[553∈26]<br />ᐸ552.1ᐳ"}}:::plan
+    PgUnionAllSingle552 --> Access553
     PgSelect556[["PgSelect[556∈27]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access555{{"Access[555∈27]<br />ᐸ554.0ᐳ"}}:::plan
     Object11 & Access555 --> PgSelect556
@@ -882,9 +884,7 @@ graph TD
     List577{{"List[577∈27]<br />ᐸ83,576ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
     PgClassExpression576{{"PgClassExpression[576∈27]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant83 & PgClassExpression576 --> List577
-    Access553{{"Access[553∈27]<br />ᐸ552.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    PgUnionAllSingle552 --> Access553
-    JSONParse554[["JSONParse[554∈27]<br />ᐸ553ᐳ"]]:::plan
+    JSONParse554[["JSONParse[554∈27]<br />ᐸ553ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access553 --> JSONParse554
     JSONParse554 --> Access555
     First560{{"First[560∈27]"}}:::plan
@@ -924,82 +924,82 @@ graph TD
     class Bucket1,PgUnionAll13,Access596 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 11, 27, 307, 49, 95, 71, 83<br /><br />ROOT __Item{2}ᐸ596ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item15,PgUnionAllSingle16 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 16, 11, 27, 307, 49, 95, 71, 83<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: 17, 34, 236, 314, 516<br />2: JSONParse[18], JSONParse[300]<br />ᐳ: Access[19], Access[301]<br />3: PgSelect[20], PgSelect[302]<br />4: PgSelectRows[25], PgSelectRows[305]<br />ᐳ: 24, 26, 28, 29, 30, 31, 304, 306, 308, 309, 310, 311<br />5: 35, 134, 237, 268, 315, 414, 517, 548<br />ᐳ: 582, 585, 586, 587, 590, 593, 594, 595"):::bucket
+    class Bucket2,__Item15,PgUnionAllSingle16,Access17 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 17, 11, 27, 307, 16, 49, 95, 71, 83<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[18], JSONParse[300]<br />ᐳ: 34, 236, 314, 516, 19, 301<br />2: PgSelect[20], PgSelect[302]<br />3: PgSelectRows[25], PgSelectRows[305]<br />ᐳ: 24, 26, 28, 29, 30, 31, 304, 306, 308, 309, 310, 311<br />4: 35, 134, 237, 268, 315, 414, 517, 548<br />ᐳ: 582, 585, 586, 587, 590, 593, 594, 595"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Access17,JSONParse18,Access19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression28,List29,Lambda30,PgClassExpression31,Connection34,PgUnionAll35,PgUnionAll134,Connection236,PgUnionAll237,PgUnionAll268,JSONParse300,Access301,PgSelect302,First304,PgSelectRows305,PgSelectSingle306,PgClassExpression308,List309,Lambda310,PgClassExpression311,Connection314,PgUnionAll315,PgUnionAll414,Connection516,PgUnionAll517,PgUnionAll548,Access582,Access585,Access586,Access587,Access590,Access593,Access594,Access595 bucket3
+    class Bucket3,JSONParse18,Access19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression28,List29,Lambda30,PgClassExpression31,Connection34,PgUnionAll35,PgUnionAll134,Connection236,PgUnionAll237,PgUnionAll268,JSONParse300,Access301,PgSelect302,First304,PgSelectRows305,PgSelectSingle306,PgClassExpression308,List309,Lambda310,PgClassExpression311,Connection314,PgUnionAll315,PgUnionAll414,Connection516,PgUnionAll517,PgUnionAll548,Access582,Access585,Access586,Access587,Access590,Access593,Access594,Access595 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 11, 49, 95, 71, 83<br /><br />ROOT __Item{4}ᐸ582ᐳ[37]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item37,PgUnionAllSingle38 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 38, 11, 49, 95, 71, 83<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[39]<br />2: JSONParse[40], JSONParse[88]<br />ᐳ: Access[41], Access[89]<br />3: PgSelect[42], PgSelect[90]<br />4: PgSelectRows[47], PgSelectRows[93]<br />ᐳ: 46, 48, 50, 51, 52, 53, 54, 55, 92, 94, 96, 97, 98, 99, 100, 101<br />5: PgUnionAll[56], PgUnionAll[102]<br />ᐳ: 580, 581, 58, 104<br />6: 60, 106"):::bucket
+    class Bucket4,__Item37,PgUnionAllSingle38,Access39 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 39, 11, 49, 95, 38, 71, 83<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: JSONParse[40], JSONParse[88]<br />ᐳ: Access[41], Access[89]<br />2: PgSelect[42], PgSelect[90]<br />3: PgSelectRows[47], PgSelectRows[93]<br />ᐳ: 46, 48, 50, 51, 52, 53, 54, 55, 92, 94, 96, 97, 98, 99, 100, 101<br />4: PgUnionAll[56], PgUnionAll[102]<br />ᐳ: 580, 581, 58, 104<br />5: 60, 106<br />ᐳ: Access[61], Access[107]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Access39,JSONParse40,Access41,PgSelect42,First46,PgSelectRows47,PgSelectSingle48,PgClassExpression50,List51,Lambda52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgUnionAll56,First58,PgUnionAllSingle60,JSONParse88,Access89,PgSelect90,First92,PgSelectRows93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgClassExpression99,PgClassExpression100,PgClassExpression101,PgUnionAll102,First104,PgUnionAllSingle106,Access580,Access581 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 60, 11, 71, 83<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[61]<br />2: JSONParse[62], JSONParse[76]<br />ᐳ: Access[63], Access[77]<br />3: PgSelect[64], PgSelect[78]<br />4: PgSelectRows[69], PgSelectRows[81]<br />ᐳ: 68, 70, 72, 73, 74, 75, 80, 82, 84, 85, 86, 87"):::bucket
+    class Bucket5,JSONParse40,Access41,PgSelect42,First46,PgSelectRows47,PgSelectSingle48,PgClassExpression50,List51,Lambda52,PgClassExpression53,PgClassExpression54,PgClassExpression55,PgUnionAll56,First58,PgUnionAllSingle60,Access61,JSONParse88,Access89,PgSelect90,First92,PgSelectRows93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgClassExpression99,PgClassExpression100,PgClassExpression101,PgUnionAll102,First104,PgUnionAllSingle106,Access107,Access580,Access581 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 61, 11, 71, 83, 60<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: JSONParse[62], JSONParse[76]<br />ᐳ: Access[63], Access[77]<br />2: PgSelect[64], PgSelect[78]<br />3: PgSelectRows[69], PgSelectRows[81]<br />ᐳ: 68, 70, 72, 73, 74, 75, 80, 82, 84, 85, 86, 87"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,Access61,JSONParse62,Access63,PgSelect64,First68,PgSelectRows69,PgSelectSingle70,PgClassExpression72,List73,Lambda74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression84,List85,Lambda86,PgClassExpression87 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 106, 11, 71, 83<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[107]<br />2: JSONParse[108], JSONParse[122]<br />ᐳ: Access[109], Access[123]<br />3: PgSelect[110], PgSelect[124]<br />4: PgSelectRows[115], PgSelectRows[127]<br />ᐳ: 114, 116, 118, 119, 120, 121, 126, 128, 130, 131, 132, 133"):::bucket
+    class Bucket6,JSONParse62,Access63,PgSelect64,First68,PgSelectRows69,PgSelectSingle70,PgClassExpression72,List73,Lambda74,PgClassExpression75,JSONParse76,Access77,PgSelect78,First80,PgSelectRows81,PgSelectSingle82,PgClassExpression84,List85,Lambda86,PgClassExpression87 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 107, 11, 71, 83, 106<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: JSONParse[108], JSONParse[122]<br />ᐳ: Access[109], Access[123]<br />2: PgSelect[110], PgSelect[124]<br />3: PgSelectRows[115], PgSelectRows[127]<br />ᐳ: 114, 116, 118, 119, 120, 121, 126, 128, 130, 131, 132, 133"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Access107,JSONParse108,Access109,PgSelect110,First114,PgSelectRows115,PgSelectSingle116,PgClassExpression118,List119,Lambda120,PgClassExpression121,JSONParse122,Access123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128,PgClassExpression130,List131,Lambda132,PgClassExpression133 bucket7
+    class Bucket7,JSONParse108,Access109,PgSelect110,First114,PgSelectRows115,PgSelectSingle116,PgClassExpression118,List119,Lambda120,PgClassExpression121,JSONParse122,Access123,PgSelect124,First126,PgSelectRows127,PgSelectSingle128,PgClassExpression130,List131,Lambda132,PgClassExpression133 bucket7
     Bucket8("Bucket 8 (listItem)<br />Deps: 11, 49, 95, 71, 83<br /><br />ROOT __Item{8}ᐸ585ᐳ[137]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,__Item137,PgUnionAllSingle138 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 138, 11, 49, 95, 71, 83<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[139]<br />2: JSONParse[140], JSONParse[188]<br />ᐳ: Access[141], Access[189]<br />3: PgSelect[142], PgSelect[190]<br />4: PgSelectRows[147], PgSelectRows[193]<br />ᐳ: 146, 148, 150, 151, 152, 153, 154, 155, 192, 194, 196, 197, 198, 199, 200, 201<br />5: PgUnionAll[156], PgUnionAll[202]<br />ᐳ: 583, 584, 158, 204<br />6: 160, 206"):::bucket
+    class Bucket8,__Item137,PgUnionAllSingle138,Access139 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 139, 11, 49, 95, 138, 71, 83<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br /><br />1: JSONParse[140], JSONParse[188]<br />ᐳ: Access[141], Access[189]<br />2: PgSelect[142], PgSelect[190]<br />3: PgSelectRows[147], PgSelectRows[193]<br />ᐳ: 146, 148, 150, 151, 152, 153, 154, 155, 192, 194, 196, 197, 198, 199, 200, 201<br />4: PgUnionAll[156], PgUnionAll[202]<br />ᐳ: 583, 584, 158, 204<br />5: 160, 206<br />ᐳ: Access[161], Access[207]"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Access139,JSONParse140,Access141,PgSelect142,First146,PgSelectRows147,PgSelectSingle148,PgClassExpression150,List151,Lambda152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgUnionAll156,First158,PgUnionAllSingle160,JSONParse188,Access189,PgSelect190,First192,PgSelectRows193,PgSelectSingle194,PgClassExpression196,List197,Lambda198,PgClassExpression199,PgClassExpression200,PgClassExpression201,PgUnionAll202,First204,PgUnionAllSingle206,Access583,Access584 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 160, 11, 71, 83<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[161]<br />2: JSONParse[162], JSONParse[176]<br />ᐳ: Access[163], Access[177]<br />3: PgSelect[164], PgSelect[178]<br />4: PgSelectRows[169], PgSelectRows[181]<br />ᐳ: 168, 170, 172, 173, 174, 175, 180, 182, 184, 185, 186, 187"):::bucket
+    class Bucket9,JSONParse140,Access141,PgSelect142,First146,PgSelectRows147,PgSelectSingle148,PgClassExpression150,List151,Lambda152,PgClassExpression153,PgClassExpression154,PgClassExpression155,PgUnionAll156,First158,PgUnionAllSingle160,Access161,JSONParse188,Access189,PgSelect190,First192,PgSelectRows193,PgSelectSingle194,PgClassExpression196,List197,Lambda198,PgClassExpression199,PgClassExpression200,PgClassExpression201,PgUnionAll202,First204,PgUnionAllSingle206,Access207,Access583,Access584 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 161, 11, 71, 83, 160<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: JSONParse[162], JSONParse[176]<br />ᐳ: Access[163], Access[177]<br />2: PgSelect[164], PgSelect[178]<br />3: PgSelectRows[169], PgSelectRows[181]<br />ᐳ: 168, 170, 172, 173, 174, 175, 180, 182, 184, 185, 186, 187"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,Access161,JSONParse162,Access163,PgSelect164,First168,PgSelectRows169,PgSelectSingle170,PgClassExpression172,List173,Lambda174,PgClassExpression175,JSONParse176,Access177,PgSelect178,First180,PgSelectRows181,PgSelectSingle182,PgClassExpression184,List185,Lambda186,PgClassExpression187 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 206, 11, 71, 83<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[207]<br />2: JSONParse[208], JSONParse[222]<br />ᐳ: Access[209], Access[223]<br />3: PgSelect[210], PgSelect[224]<br />4: PgSelectRows[215], PgSelectRows[227]<br />ᐳ: 214, 216, 218, 219, 220, 221, 226, 228, 230, 231, 232, 233"):::bucket
+    class Bucket10,JSONParse162,Access163,PgSelect164,First168,PgSelectRows169,PgSelectSingle170,PgClassExpression172,List173,Lambda174,PgClassExpression175,JSONParse176,Access177,PgSelect178,First180,PgSelectRows181,PgSelectSingle182,PgClassExpression184,List185,Lambda186,PgClassExpression187 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 207, 11, 71, 83, 206<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: JSONParse[208], JSONParse[222]<br />ᐳ: Access[209], Access[223]<br />2: PgSelect[210], PgSelect[224]<br />3: PgSelectRows[215], PgSelectRows[227]<br />ᐳ: 214, 216, 218, 219, 220, 221, 226, 228, 230, 231, 232, 233"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,Access207,JSONParse208,Access209,PgSelect210,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression218,List219,Lambda220,PgClassExpression221,JSONParse222,Access223,PgSelect224,First226,PgSelectRows227,PgSelectSingle228,PgClassExpression230,List231,Lambda232,PgClassExpression233 bucket11
+    class Bucket11,JSONParse208,Access209,PgSelect210,First214,PgSelectRows215,PgSelectSingle216,PgClassExpression218,List219,Lambda220,PgClassExpression221,JSONParse222,Access223,PgSelect224,First226,PgSelectRows227,PgSelectSingle228,PgClassExpression230,List231,Lambda232,PgClassExpression233 bucket11
     Bucket12("Bucket 12 (listItem)<br />Deps: 11, 71, 83<br /><br />ROOT __Item{12}ᐸ586ᐳ[239]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,__Item239,PgUnionAllSingle240 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 240, 11, 71, 83<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[241]<br />2: JSONParse[242], JSONParse[256]<br />ᐳ: Access[243], Access[257]<br />3: PgSelect[244], PgSelect[258]<br />4: PgSelectRows[249], PgSelectRows[261]<br />ᐳ: 248, 250, 252, 253, 254, 255, 260, 262, 264, 265, 266, 267"):::bucket
+    class Bucket12,__Item239,PgUnionAllSingle240,Access241 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 241, 11, 71, 83, 240<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: JSONParse[242], JSONParse[256]<br />ᐳ: Access[243], Access[257]<br />2: PgSelect[244], PgSelect[258]<br />3: PgSelectRows[249], PgSelectRows[261]<br />ᐳ: 248, 250, 252, 253, 254, 255, 260, 262, 264, 265, 266, 267"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,Access241,JSONParse242,Access243,PgSelect244,First248,PgSelectRows249,PgSelectSingle250,PgClassExpression252,List253,Lambda254,PgClassExpression255,JSONParse256,Access257,PgSelect258,First260,PgSelectRows261,PgSelectSingle262,PgClassExpression264,List265,Lambda266,PgClassExpression267 bucket13
+    class Bucket13,JSONParse242,Access243,PgSelect244,First248,PgSelectRows249,PgSelectSingle250,PgClassExpression252,List253,Lambda254,PgClassExpression255,JSONParse256,Access257,PgSelect258,First260,PgSelectRows261,PgSelectSingle262,PgClassExpression264,List265,Lambda266,PgClassExpression267 bucket13
     Bucket14("Bucket 14 (listItem)<br />Deps: 11, 71, 83<br /><br />ROOT __Item{14}ᐸ587ᐳ[271]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,__Item271,PgUnionAllSingle272 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 272, 11, 71, 83<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[273]<br />2: JSONParse[274], JSONParse[288]<br />ᐳ: Access[275], Access[289]<br />3: PgSelect[276], PgSelect[290]<br />4: PgSelectRows[281], PgSelectRows[293]<br />ᐳ: 280, 282, 284, 285, 286, 287, 292, 294, 296, 297, 298, 299"):::bucket
+    class Bucket14,__Item271,PgUnionAllSingle272,Access273 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 273, 11, 71, 83, 272<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: JSONParse[274], JSONParse[288]<br />ᐳ: Access[275], Access[289]<br />2: PgSelect[276], PgSelect[290]<br />3: PgSelectRows[281], PgSelectRows[293]<br />ᐳ: 280, 282, 284, 285, 286, 287, 292, 294, 296, 297, 298, 299"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,Access273,JSONParse274,Access275,PgSelect276,First280,PgSelectRows281,PgSelectSingle282,PgClassExpression284,List285,Lambda286,PgClassExpression287,JSONParse288,Access289,PgSelect290,First292,PgSelectRows293,PgSelectSingle294,PgClassExpression296,List297,Lambda298,PgClassExpression299 bucket15
+    class Bucket15,JSONParse274,Access275,PgSelect276,First280,PgSelectRows281,PgSelectSingle282,PgClassExpression284,List285,Lambda286,PgClassExpression287,JSONParse288,Access289,PgSelect290,First292,PgSelectRows293,PgSelectSingle294,PgClassExpression296,List297,Lambda298,PgClassExpression299 bucket15
     Bucket16("Bucket 16 (listItem)<br />Deps: 11, 49, 95, 71, 83<br /><br />ROOT __Item{16}ᐸ590ᐳ[317]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,__Item317,PgUnionAllSingle318 bucket16
-    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 318, 11, 49, 95, 71, 83<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[319]<br />2: JSONParse[320], JSONParse[368]<br />ᐳ: Access[321], Access[369]<br />3: PgSelect[322], PgSelect[370]<br />4: PgSelectRows[327], PgSelectRows[373]<br />ᐳ: 326, 328, 330, 331, 332, 333, 334, 335, 372, 374, 376, 377, 378, 379, 380, 381<br />5: PgUnionAll[336], PgUnionAll[382]<br />ᐳ: 588, 589, 338, 384<br />6: 340, 386"):::bucket
+    class Bucket16,__Item317,PgUnionAllSingle318,Access319 bucket16
+    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 319, 11, 49, 95, 318, 71, 83<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: JSONParse[320], JSONParse[368]<br />ᐳ: Access[321], Access[369]<br />2: PgSelect[322], PgSelect[370]<br />3: PgSelectRows[327], PgSelectRows[373]<br />ᐳ: 326, 328, 330, 331, 332, 333, 334, 335, 372, 374, 376, 377, 378, 379, 380, 381<br />4: PgUnionAll[336], PgUnionAll[382]<br />ᐳ: 588, 589, 338, 384<br />5: 340, 386<br />ᐳ: Access[341], Access[387]"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,Access319,JSONParse320,Access321,PgSelect322,First326,PgSelectRows327,PgSelectSingle328,PgClassExpression330,List331,Lambda332,PgClassExpression333,PgClassExpression334,PgClassExpression335,PgUnionAll336,First338,PgUnionAllSingle340,JSONParse368,Access369,PgSelect370,First372,PgSelectRows373,PgSelectSingle374,PgClassExpression376,List377,Lambda378,PgClassExpression379,PgClassExpression380,PgClassExpression381,PgUnionAll382,First384,PgUnionAllSingle386,Access588,Access589 bucket17
-    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 340, 11, 71, 83<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[341]<br />2: JSONParse[342], JSONParse[356]<br />ᐳ: Access[343], Access[357]<br />3: PgSelect[344], PgSelect[358]<br />4: PgSelectRows[349], PgSelectRows[361]<br />ᐳ: 348, 350, 352, 353, 354, 355, 360, 362, 364, 365, 366, 367"):::bucket
+    class Bucket17,JSONParse320,Access321,PgSelect322,First326,PgSelectRows327,PgSelectSingle328,PgClassExpression330,List331,Lambda332,PgClassExpression333,PgClassExpression334,PgClassExpression335,PgUnionAll336,First338,PgUnionAllSingle340,Access341,JSONParse368,Access369,PgSelect370,First372,PgSelectRows373,PgSelectSingle374,PgClassExpression376,List377,Lambda378,PgClassExpression379,PgClassExpression380,PgClassExpression381,PgUnionAll382,First384,PgUnionAllSingle386,Access387,Access588,Access589 bucket17
+    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 341, 11, 71, 83, 340<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: JSONParse[342], JSONParse[356]<br />ᐳ: Access[343], Access[357]<br />2: PgSelect[344], PgSelect[358]<br />3: PgSelectRows[349], PgSelectRows[361]<br />ᐳ: 348, 350, 352, 353, 354, 355, 360, 362, 364, 365, 366, 367"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,Access341,JSONParse342,Access343,PgSelect344,First348,PgSelectRows349,PgSelectSingle350,PgClassExpression352,List353,Lambda354,PgClassExpression355,JSONParse356,Access357,PgSelect358,First360,PgSelectRows361,PgSelectSingle362,PgClassExpression364,List365,Lambda366,PgClassExpression367 bucket18
-    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 386, 11, 71, 83<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[387]<br />2: JSONParse[388], JSONParse[402]<br />ᐳ: Access[389], Access[403]<br />3: PgSelect[390], PgSelect[404]<br />4: PgSelectRows[395], PgSelectRows[407]<br />ᐳ: 394, 396, 398, 399, 400, 401, 406, 408, 410, 411, 412, 413"):::bucket
+    class Bucket18,JSONParse342,Access343,PgSelect344,First348,PgSelectRows349,PgSelectSingle350,PgClassExpression352,List353,Lambda354,PgClassExpression355,JSONParse356,Access357,PgSelect358,First360,PgSelectRows361,PgSelectSingle362,PgClassExpression364,List365,Lambda366,PgClassExpression367 bucket18
+    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 387, 11, 71, 83, 386<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: JSONParse[388], JSONParse[402]<br />ᐳ: Access[389], Access[403]<br />2: PgSelect[390], PgSelect[404]<br />3: PgSelectRows[395], PgSelectRows[407]<br />ᐳ: 394, 396, 398, 399, 400, 401, 406, 408, 410, 411, 412, 413"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,Access387,JSONParse388,Access389,PgSelect390,First394,PgSelectRows395,PgSelectSingle396,PgClassExpression398,List399,Lambda400,PgClassExpression401,JSONParse402,Access403,PgSelect404,First406,PgSelectRows407,PgSelectSingle408,PgClassExpression410,List411,Lambda412,PgClassExpression413 bucket19
+    class Bucket19,JSONParse388,Access389,PgSelect390,First394,PgSelectRows395,PgSelectSingle396,PgClassExpression398,List399,Lambda400,PgClassExpression401,JSONParse402,Access403,PgSelect404,First406,PgSelectRows407,PgSelectSingle408,PgClassExpression410,List411,Lambda412,PgClassExpression413 bucket19
     Bucket20("Bucket 20 (listItem)<br />Deps: 11, 49, 95, 71, 83<br /><br />ROOT __Item{20}ᐸ593ᐳ[417]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,__Item417,PgUnionAllSingle418 bucket20
-    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 418, 11, 49, 95, 71, 83<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: <br />ᐳ: Access[419]<br />2: JSONParse[420], JSONParse[468]<br />ᐳ: Access[421], Access[469]<br />3: PgSelect[422], PgSelect[470]<br />4: PgSelectRows[427], PgSelectRows[473]<br />ᐳ: 426, 428, 430, 431, 432, 433, 434, 435, 472, 474, 476, 477, 478, 479, 480, 481<br />5: PgUnionAll[436], PgUnionAll[482]<br />ᐳ: 591, 592, 438, 484<br />6: 440, 486"):::bucket
+    class Bucket20,__Item417,PgUnionAllSingle418,Access419 bucket20
+    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 419, 11, 49, 95, 418, 71, 83<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br /><br />1: JSONParse[420], JSONParse[468]<br />ᐳ: Access[421], Access[469]<br />2: PgSelect[422], PgSelect[470]<br />3: PgSelectRows[427], PgSelectRows[473]<br />ᐳ: 426, 428, 430, 431, 432, 433, 434, 435, 472, 474, 476, 477, 478, 479, 480, 481<br />4: PgUnionAll[436], PgUnionAll[482]<br />ᐳ: 591, 592, 438, 484<br />5: 440, 486<br />ᐳ: Access[441], Access[487]"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,Access419,JSONParse420,Access421,PgSelect422,First426,PgSelectRows427,PgSelectSingle428,PgClassExpression430,List431,Lambda432,PgClassExpression433,PgClassExpression434,PgClassExpression435,PgUnionAll436,First438,PgUnionAllSingle440,JSONParse468,Access469,PgSelect470,First472,PgSelectRows473,PgSelectSingle474,PgClassExpression476,List477,Lambda478,PgClassExpression479,PgClassExpression480,PgClassExpression481,PgUnionAll482,First484,PgUnionAllSingle486,Access591,Access592 bucket21
-    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 440, 11, 71, 83<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[441]<br />2: JSONParse[442], JSONParse[456]<br />ᐳ: Access[443], Access[457]<br />3: PgSelect[444], PgSelect[458]<br />4: PgSelectRows[449], PgSelectRows[461]<br />ᐳ: 448, 450, 452, 453, 454, 455, 460, 462, 464, 465, 466, 467"):::bucket
+    class Bucket21,JSONParse420,Access421,PgSelect422,First426,PgSelectRows427,PgSelectSingle428,PgClassExpression430,List431,Lambda432,PgClassExpression433,PgClassExpression434,PgClassExpression435,PgUnionAll436,First438,PgUnionAllSingle440,Access441,JSONParse468,Access469,PgSelect470,First472,PgSelectRows473,PgSelectSingle474,PgClassExpression476,List477,Lambda478,PgClassExpression479,PgClassExpression480,PgClassExpression481,PgUnionAll482,First484,PgUnionAllSingle486,Access487,Access591,Access592 bucket21
+    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 441, 11, 71, 83, 440<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br /><br />1: JSONParse[442], JSONParse[456]<br />ᐳ: Access[443], Access[457]<br />2: PgSelect[444], PgSelect[458]<br />3: PgSelectRows[449], PgSelectRows[461]<br />ᐳ: 448, 450, 452, 453, 454, 455, 460, 462, 464, 465, 466, 467"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,Access441,JSONParse442,Access443,PgSelect444,First448,PgSelectRows449,PgSelectSingle450,PgClassExpression452,List453,Lambda454,PgClassExpression455,JSONParse456,Access457,PgSelect458,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,List465,Lambda466,PgClassExpression467 bucket22
-    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 486, 11, 71, 83<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: <br />ᐳ: Access[487]<br />2: JSONParse[488], JSONParse[502]<br />ᐳ: Access[489], Access[503]<br />3: PgSelect[490], PgSelect[504]<br />4: PgSelectRows[495], PgSelectRows[507]<br />ᐳ: 494, 496, 498, 499, 500, 501, 506, 508, 510, 511, 512, 513"):::bucket
+    class Bucket22,JSONParse442,Access443,PgSelect444,First448,PgSelectRows449,PgSelectSingle450,PgClassExpression452,List453,Lambda454,PgClassExpression455,JSONParse456,Access457,PgSelect458,First460,PgSelectRows461,PgSelectSingle462,PgClassExpression464,List465,Lambda466,PgClassExpression467 bucket22
+    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 487, 11, 71, 83, 486<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br /><br />1: JSONParse[488], JSONParse[502]<br />ᐳ: Access[489], Access[503]<br />2: PgSelect[490], PgSelect[504]<br />3: PgSelectRows[495], PgSelectRows[507]<br />ᐳ: 494, 496, 498, 499, 500, 501, 506, 508, 510, 511, 512, 513"):::bucket
     classDef bucket23 stroke:#ff1493
-    class Bucket23,Access487,JSONParse488,Access489,PgSelect490,First494,PgSelectRows495,PgSelectSingle496,PgClassExpression498,List499,Lambda500,PgClassExpression501,JSONParse502,Access503,PgSelect504,First506,PgSelectRows507,PgSelectSingle508,PgClassExpression510,List511,Lambda512,PgClassExpression513 bucket23
+    class Bucket23,JSONParse488,Access489,PgSelect490,First494,PgSelectRows495,PgSelectSingle496,PgClassExpression498,List499,Lambda500,PgClassExpression501,JSONParse502,Access503,PgSelect504,First506,PgSelectRows507,PgSelectSingle508,PgClassExpression510,List511,Lambda512,PgClassExpression513 bucket23
     Bucket24("Bucket 24 (listItem)<br />Deps: 11, 71, 83<br /><br />ROOT __Item{24}ᐸ594ᐳ[519]"):::bucket
     classDef bucket24 stroke:#808000
-    class Bucket24,__Item519,PgUnionAllSingle520 bucket24
-    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 520, 11, 71, 83<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[521]<br />2: JSONParse[522], JSONParse[536]<br />ᐳ: Access[523], Access[537]<br />3: PgSelect[524], PgSelect[538]<br />4: PgSelectRows[529], PgSelectRows[541]<br />ᐳ: 528, 530, 532, 533, 534, 535, 540, 542, 544, 545, 546, 547"):::bucket
+    class Bucket24,__Item519,PgUnionAllSingle520,Access521 bucket24
+    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 521, 11, 71, 83, 520<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: JSONParse[522], JSONParse[536]<br />ᐳ: Access[523], Access[537]<br />2: PgSelect[524], PgSelect[538]<br />3: PgSelectRows[529], PgSelectRows[541]<br />ᐳ: 528, 530, 532, 533, 534, 535, 540, 542, 544, 545, 546, 547"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,Access521,JSONParse522,Access523,PgSelect524,First528,PgSelectRows529,PgSelectSingle530,PgClassExpression532,List533,Lambda534,PgClassExpression535,JSONParse536,Access537,PgSelect538,First540,PgSelectRows541,PgSelectSingle542,PgClassExpression544,List545,Lambda546,PgClassExpression547 bucket25
+    class Bucket25,JSONParse522,Access523,PgSelect524,First528,PgSelectRows529,PgSelectSingle530,PgClassExpression532,List533,Lambda534,PgClassExpression535,JSONParse536,Access537,PgSelect538,First540,PgSelectRows541,PgSelectSingle542,PgClassExpression544,List545,Lambda546,PgClassExpression547 bucket25
     Bucket26("Bucket 26 (listItem)<br />Deps: 11, 71, 83<br /><br />ROOT __Item{26}ᐸ595ᐳ[551]"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,__Item551,PgUnionAllSingle552 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 552, 11, 71, 83<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[553]<br />2: JSONParse[554], JSONParse[568]<br />ᐳ: Access[555], Access[569]<br />3: PgSelect[556], PgSelect[570]<br />4: PgSelectRows[561], PgSelectRows[573]<br />ᐳ: 560, 562, 564, 565, 566, 567, 572, 574, 576, 577, 578, 579"):::bucket
+    class Bucket26,__Item551,PgUnionAllSingle552,Access553 bucket26
+    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 553, 11, 71, 83, 552<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: JSONParse[554], JSONParse[568]<br />ᐳ: Access[555], Access[569]<br />2: PgSelect[556], PgSelect[570]<br />3: PgSelectRows[561], PgSelectRows[573]<br />ᐳ: 560, 562, 564, 565, 566, 567, 572, 574, 576, 577, 578, 579"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,Access553,JSONParse554,Access555,PgSelect556,First560,PgSelectRows561,PgSelectSingle562,PgClassExpression564,List565,Lambda566,PgClassExpression567,JSONParse568,Access569,PgSelect570,First572,PgSelectRows573,PgSelectSingle574,PgClassExpression576,List577,Lambda578,PgClassExpression579 bucket27
+    class Bucket27,JSONParse554,Access555,PgSelect556,First560,PgSelectRows561,PgSelectSingle562,PgClassExpression564,List565,Lambda566,PgClassExpression567,JSONParse568,Access569,PgSelect570,First572,PgSelectRows573,PgSelectSingle574,PgClassExpression576,List577,Lambda578,PgClassExpression579 bucket27
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
@@ -32,6 +32,8 @@ graph TD
     Access114 ==> __Item15
     PgUnionAllSingle16["PgUnionAllSingle[16∈2]"]:::plan
     __Item15 --> PgUnionAllSingle16
+    Access17{{"Access[17∈2]<br />ᐸ16.1ᐳ"}}:::plan
+    PgUnionAllSingle16 --> Access17
     PgUnionAll35[["PgUnionAll[35∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
     PgClassExpression28{{"PgClassExpression[28∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
     Connection34{{"Connection[34∈3] ➊<br />ᐸ32ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
@@ -50,9 +52,7 @@ graph TD
     Object11 & Access67 --> PgSelect68
     List75{{"List[75∈3]<br />ᐸ73,74ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
     Constant73 & PgClassExpression74 --> List75
-    Access17{{"Access[17∈3]<br />ᐸ16.1ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    PgUnionAllSingle16 --> Access17
-    JSONParse18[["JSONParse[18∈3]<br />ᐸ17ᐳ"]]:::plan
+    JSONParse18[["JSONParse[18∈3]<br />ᐸ17ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
     Access17 --> JSONParse18
     JSONParse18 --> Access19
     First24{{"First[24∈3]"}}:::plan
@@ -88,6 +88,8 @@ graph TD
     Access112 ==> __Item37
     PgUnionAllSingle38["PgUnionAllSingle[38∈4]"]:::plan
     __Item37 --> PgUnionAllSingle38
+    Access39{{"Access[39∈4]<br />ᐸ38.1ᐳ"}}:::plan
+    PgUnionAllSingle38 --> Access39
     PgSelect42[["PgSelect[42∈5]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access41{{"Access[41∈5]<br />ᐸ40.0ᐳ"}}:::plan
     Object11 & Access41 --> PgSelect42
@@ -100,9 +102,7 @@ graph TD
     List63{{"List[63∈5]<br />ᐸ61,62ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
     PgClassExpression62{{"PgClassExpression[62∈5]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant61 & PgClassExpression62 --> List63
-    Access39{{"Access[39∈5]<br />ᐸ38.1ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    PgUnionAllSingle38 --> Access39
-    JSONParse40[["JSONParse[40∈5]<br />ᐸ39ᐳ"]]:::plan
+    JSONParse40[["JSONParse[40∈5]<br />ᐸ39ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
     Access39 --> JSONParse40
     JSONParse40 --> Access41
     First46{{"First[46∈5]"}}:::plan
@@ -134,6 +134,8 @@ graph TD
     Access113 ==> __Item83
     PgUnionAllSingle84["PgUnionAllSingle[84∈6]"]:::plan
     __Item83 --> PgUnionAllSingle84
+    Access85{{"Access[85∈6]<br />ᐸ84.1ᐳ"}}:::plan
+    PgUnionAllSingle84 --> Access85
     PgSelect88[["PgSelect[88∈7]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access87{{"Access[87∈7]<br />ᐸ86.0ᐳ"}}:::plan
     Object11 & Access87 --> PgSelect88
@@ -146,9 +148,7 @@ graph TD
     List109{{"List[109∈7]<br />ᐸ61,108ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
     PgClassExpression108{{"PgClassExpression[108∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Constant61 & PgClassExpression108 --> List109
-    Access85{{"Access[85∈7]<br />ᐸ84.1ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    PgUnionAllSingle84 --> Access85
-    JSONParse86[["JSONParse[86∈7]<br />ᐸ85ᐳ"]]:::plan
+    JSONParse86[["JSONParse[86∈7]<br />ᐸ85ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
     Access85 --> JSONParse86
     JSONParse86 --> Access87
     First92{{"First[92∈7]"}}:::plan
@@ -188,22 +188,22 @@ graph TD
     class Bucket1,PgUnionAll13,Access114 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 11, 27, 73, 49, 61<br /><br />ROOT __Item{2}ᐸ114ᐳ[15]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item15,PgUnionAllSingle16 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 16, 11, 27, 73, 49, 61<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: <br />ᐳ: 17, 34, 80<br />2: JSONParse[18], JSONParse[66]<br />ᐳ: Access[19], Access[67]<br />3: PgSelect[20], PgSelect[68]<br />4: PgSelectRows[25], PgSelectRows[71]<br />ᐳ: 24, 26, 28, 29, 30, 31, 70, 72, 74, 75, 76, 77<br />5: PgUnionAll[35], PgUnionAll[81]<br />ᐳ: Access[112], Access[113]"):::bucket
+    class Bucket2,__Item15,PgUnionAllSingle16,Access17 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 17, 11, 27, 73, 16, 49, 61<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br /><br />1: JSONParse[18], JSONParse[66]<br />ᐳ: 34, 80, 19, 67<br />2: PgSelect[20], PgSelect[68]<br />3: PgSelectRows[25], PgSelectRows[71]<br />ᐳ: 24, 26, 28, 29, 30, 31, 70, 72, 74, 75, 76, 77<br />4: PgUnionAll[35], PgUnionAll[81]<br />ᐳ: Access[112], Access[113]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Access17,JSONParse18,Access19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression28,List29,Lambda30,PgClassExpression31,Connection34,PgUnionAll35,JSONParse66,Access67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72,PgClassExpression74,List75,Lambda76,PgClassExpression77,Connection80,PgUnionAll81,Access112,Access113 bucket3
+    class Bucket3,JSONParse18,Access19,PgSelect20,First24,PgSelectRows25,PgSelectSingle26,PgClassExpression28,List29,Lambda30,PgClassExpression31,Connection34,PgUnionAll35,JSONParse66,Access67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72,PgClassExpression74,List75,Lambda76,PgClassExpression77,Connection80,PgUnionAll81,Access112,Access113 bucket3
     Bucket4("Bucket 4 (listItem)<br />Deps: 11, 49, 61<br /><br />ROOT __Item{4}ᐸ112ᐳ[37]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item37,PgUnionAllSingle38 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 38, 11, 49, 61<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[39]<br />2: JSONParse[40], JSONParse[54]<br />ᐳ: Access[41], Access[55]<br />3: PgSelect[42], PgSelect[56]<br />4: PgSelectRows[47], PgSelectRows[59]<br />ᐳ: 46, 48, 50, 51, 52, 53, 58, 60, 62, 63, 64, 65"):::bucket
+    class Bucket4,__Item37,PgUnionAllSingle38,Access39 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 39, 11, 49, 61, 38<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br /><br />1: JSONParse[40], JSONParse[54]<br />ᐳ: Access[41], Access[55]<br />2: PgSelect[42], PgSelect[56]<br />3: PgSelectRows[47], PgSelectRows[59]<br />ᐳ: 46, 48, 50, 51, 52, 53, 58, 60, 62, 63, 64, 65"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Access39,JSONParse40,Access41,PgSelect42,First46,PgSelectRows47,PgSelectSingle48,PgClassExpression50,List51,Lambda52,PgClassExpression53,JSONParse54,Access55,PgSelect56,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression62,List63,Lambda64,PgClassExpression65 bucket5
+    class Bucket5,JSONParse40,Access41,PgSelect42,First46,PgSelectRows47,PgSelectSingle48,PgClassExpression50,List51,Lambda52,PgClassExpression53,JSONParse54,Access55,PgSelect56,First58,PgSelectRows59,PgSelectSingle60,PgClassExpression62,List63,Lambda64,PgClassExpression65 bucket5
     Bucket6("Bucket 6 (listItem)<br />Deps: 11, 49, 61<br /><br />ROOT __Item{6}ᐸ113ᐳ[83]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,__Item83,PgUnionAllSingle84 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 84, 11, 49, 61<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: <br />ᐳ: Access[85]<br />2: JSONParse[86], JSONParse[100]<br />ᐳ: Access[87], Access[101]<br />3: PgSelect[88], PgSelect[102]<br />4: PgSelectRows[93], PgSelectRows[105]<br />ᐳ: 92, 94, 96, 97, 98, 99, 104, 106, 108, 109, 110, 111"):::bucket
+    class Bucket6,__Item83,PgUnionAllSingle84,Access85 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 85, 11, 49, 61, 84<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br /><br />1: JSONParse[86], JSONParse[100]<br />ᐳ: Access[87], Access[101]<br />2: PgSelect[88], PgSelect[102]<br />3: PgSelectRows[93], PgSelectRows[105]<br />ᐳ: 92, 94, 96, 97, 98, 99, 104, 106, 108, 109, 110, 111"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,Access85,JSONParse86,Access87,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgClassExpression99,JSONParse100,Access101,PgSelect102,First104,PgSelectRows105,PgSelectSingle106,PgClassExpression108,List109,Lambda110,PgClassExpression111 bucket7
+    class Bucket7,JSONParse86,Access87,PgSelect88,First92,PgSelectRows93,PgSelectSingle94,PgClassExpression96,List97,Lambda98,PgClassExpression99,JSONParse100,Access101,PgSelect102,First104,PgSelectRows105,PgSelectSingle106,PgClassExpression108,List109,Lambda110,PgClassExpression111 bucket7
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/js-reserved-keywords.mermaid
@@ -79,22 +79,22 @@ graph TD
     PgSelectRows54 ==> __Item55
     PgSelectSingle56{{"PgSelectSingle[56∈7]<br />ᐸrelational_itemsᐳ"}}:::plan
     __Item55 --> PgSelectSingle56
+    PgClassExpression57{{"PgClassExpression[57∈7]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression57
+    PgClassExpression65{{"PgClassExpression[65∈7]<br />ᐸ__relation...nstructor”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression65
+    PgClassExpression66{{"PgClassExpression[66∈7]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression66
     PgSelect58[["PgSelect[58∈8]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    PgClassExpression57{{"PgClassExpression[57∈8]<br />ᐸ__relation...ems__.”id”ᐳ<br />ᐳRelationalTopic"}}:::plan
     Object10 & PgClassExpression57 --> PgSelect58
     PgSelect68[["PgSelect[68∈8]<br />ᐸrelational_statusᐳ<br />ᐳRelationalStatus"]]:::plan
     Object10 & PgClassExpression57 --> PgSelect68
-    PgSelectSingle56 --> PgClassExpression57
     First62{{"First[62∈8]"}}:::plan
     PgSelectRows63[["PgSelectRows[63∈8]"]]:::plan
     PgSelectRows63 --> First62
     PgSelect58 --> PgSelectRows63
     PgSelectSingle64{{"PgSelectSingle[64∈8]<br />ᐸrelational_topicsᐳ"}}:::plan
     First62 --> PgSelectSingle64
-    PgClassExpression65{{"PgClassExpression[65∈8]<br />ᐸ__relation...nstructor”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle56 --> PgClassExpression65
-    PgClassExpression66{{"PgClassExpression[66∈8]<br />ᐸ__relation...s__.”type”ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgSelectSingle56 --> PgClassExpression66
     PgClassExpression67{{"PgClassExpression[67∈8]<br />ᐸ__relation...__.”title”ᐳ"}}:::plan
     PgSelectSingle64 --> PgClassExpression67
     First70{{"First[70∈8]"}}:::plan
@@ -132,10 +132,10 @@ graph TD
     class Bucket6,PgSelect53,PgSelectRows54 bucket6
     Bucket7("Bucket 7 (listItem)<br />Deps: 10<br /><br />ROOT __Item{7}ᐸ54ᐳ[55]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,__Item55,PgSelectSingle56 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalStatus<br />Deps: 56, 10<br />ᐳRelationalTopic<br />ᐳRelationalStatus<br /><br />1: <br />ᐳ: 57, 65, 66<br />2: PgSelect[58], PgSelect[68]<br />3: PgSelectRows[63], PgSelectRows[71]<br />ᐳ: 62, 64, 67, 70, 72, 73"):::bucket
+    class Bucket7,__Item55,PgSelectSingle56,PgClassExpression57,PgClassExpression65,PgClassExpression66 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />RelationalTopic,RelationalStatus<br />Deps: 10, 57, 56, 65, 66<br />ᐳRelationalTopic<br />ᐳRelationalStatus<br /><br />1: PgSelect[58], PgSelect[68]<br />2: PgSelectRows[63], PgSelectRows[71]<br />ᐳ: 62, 64, 67, 70, 72, 73"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression57,PgSelect58,First62,PgSelectRows63,PgSelectSingle64,PgClassExpression65,PgClassExpression66,PgClassExpression67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72,PgClassExpression73 bucket8
+    class Bucket8,PgSelect58,First62,PgSelectRows63,PgSelectSingle64,PgClassExpression67,PgSelect68,First70,PgSelectRows71,PgSelectSingle72,PgClassExpression73 bucket8
     Bucket0 --> Bucket1 & Bucket3 & Bucket6
     Bucket1 --> Bucket2
     Bucket3 --> Bucket4

--- a/postgraphile/postgraphile/__tests__/queries/v4/node.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/node.mermaid
@@ -225,7 +225,7 @@ graph TD
     Lambda36{{"Lambda[36∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List35 --> Lambda36
     PgSelect110[["PgSelect[110∈7] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1839{{"Access[1839∈7] ➊<br />ᐸ39.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1839{{"Access[1839∈7] ➊<br />ᐸ39.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1840{{"Access[1840∈7] ➊<br />ᐸ39.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect110
     Access1839 -->|rejectNull| PgSelect110
@@ -533,7 +533,7 @@ graph TD
     Lambda39 --> Access1839
     Lambda39 --> Access1840
     PgSelect320[["PgSelect[320∈8] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1842{{"Access[1842∈8] ➊<br />ᐸ249.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1842{{"Access[1842∈8] ➊<br />ᐸ249.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1843{{"Access[1843∈8] ➊<br />ᐸ249.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect320
     Access1842 -->|rejectNull| PgSelect320
@@ -841,7 +841,7 @@ graph TD
     Lambda249 --> Access1842
     Lambda249 --> Access1843
     PgSelect530[["PgSelect[530∈9] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1845{{"Access[1845∈9] ➊<br />ᐸ459.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1845{{"Access[1845∈9] ➊<br />ᐸ459.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1846{{"Access[1846∈9] ➊<br />ᐸ459.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect530
     Access1845 -->|rejectNull| PgSelect530
@@ -1149,7 +1149,7 @@ graph TD
     Lambda459 --> Access1845
     Lambda459 --> Access1846
     PgSelect740[["PgSelect[740∈10] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1848{{"Access[1848∈10] ➊<br />ᐸ669.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1848{{"Access[1848∈10] ➊<br />ᐸ669.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1849{{"Access[1849∈10] ➊<br />ᐸ669.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect740
     Access1848 -->|rejectNull| PgSelect740
@@ -1457,7 +1457,7 @@ graph TD
     Lambda669 --> Access1848
     Lambda669 --> Access1849
     PgSelect950[["PgSelect[950∈11] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1851{{"Access[1851∈11] ➊<br />ᐸ879.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1851{{"Access[1851∈11] ➊<br />ᐸ879.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1852{{"Access[1852∈11] ➊<br />ᐸ879.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect950
     Access1851 -->|rejectNull| PgSelect950
@@ -1765,7 +1765,7 @@ graph TD
     Lambda879 --> Access1851
     Lambda879 --> Access1852
     PgSelect1160[["PgSelect[1160∈12] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1854{{"Access[1854∈12] ➊<br />ᐸ1089.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1854{{"Access[1854∈12] ➊<br />ᐸ1089.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1855{{"Access[1855∈12] ➊<br />ᐸ1089.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1160
     Access1854 -->|rejectNull| PgSelect1160
@@ -2121,7 +2121,7 @@ graph TD
     Lambda1386{{"Lambda[1386∈18] ➊<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List1385 --> Lambda1386
     PgSelect1460[["PgSelect[1460∈19] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1857{{"Access[1857∈19] ➊<br />ᐸ1389.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1857{{"Access[1857∈19] ➊<br />ᐸ1389.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1858{{"Access[1858∈19] ➊<br />ᐸ1389.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1460
     Access1857 -->|rejectNull| PgSelect1460
@@ -2429,7 +2429,7 @@ graph TD
     Lambda1389 --> Access1857
     Lambda1389 --> Access1858
     PgSelect1670[["PgSelect[1670∈20] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access1860{{"Access[1860∈20] ➊<br />ᐸ1599.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access1860{{"Access[1860∈20] ➊<br />ᐸ1599.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1861{{"Access[1861∈20] ➊<br />ᐸ1599.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1670
     Access1860 -->|rejectNull| PgSelect1670

--- a/postgraphile/postgraphile/__tests__/queries/v4/query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/query.mermaid
@@ -68,7 +68,7 @@ graph TD
     Constant213{{"Constant[213∈0] ➊<br />ᐸ'lists'ᐳ"}}:::plan
     PgSelect487[["PgSelect[487∈1] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object426{{"Object[426∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2447{{"Access[2447∈1] ➊<br />ᐸ10.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2447{{"Access[2447∈1] ➊<br />ᐸ10.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2448{{"Access[2448∈1] ➊<br />ᐸ10.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object426 -->|rejectNull| PgSelect487
     Access2447 -->|rejectNull| PgSelect487
@@ -80,8 +80,8 @@ graph TD
     PgSelect423[["PgSelect[423∈1] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object426 -->|rejectNull| PgSelect423
     Access2447 --> PgSelect423
-    Access424{{"Access[424∈1] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access425{{"Access[425∈1] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access424{{"Access[424∈1] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access425{{"Access[425∈1] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access424 & Access425 --> Object426
     List432{{"List[432∈1] ➊<br />ᐸ30,431ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression431{{"PgClassExpression[431∈1] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -373,7 +373,7 @@ graph TD
     Lambda10 --> Access2447
     Lambda10 --> Access2448
     PgSelect87[["PgSelect[87∈2] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access2450{{"Access[2450∈2] ➊<br />ᐸ16.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access2450{{"Access[2450∈2] ➊<br />ᐸ16.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList"}}:::plan
     Access2451{{"Access[2451∈2] ➊<br />ᐸ16.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object426 -->|rejectNull| PgSelect87
     Access2450 -->|rejectNull| PgSelect87
@@ -665,7 +665,7 @@ graph TD
     Lambda16 --> Access2450
     Lambda16 --> Access2451
     PgSelect290[["PgSelect[290∈3] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access2452{{"Access[2452∈3] ➊<br />ᐸ219.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access2452{{"Access[2452∈3] ➊<br />ᐸ219.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList"}}:::plan
     Access2453{{"Access[2453∈3] ➊<br />ᐸ219.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object426 -->|rejectNull| PgSelect290
     Access2452 -->|rejectNull| PgSelect290
@@ -958,7 +958,7 @@ graph TD
     Lambda219 --> Access2453
     PgSelect1096[["PgSelect[1096∈4] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1035{{"Object[1035∈4] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2455{{"Access[2455∈4] ➊<br />ᐸ619.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2455{{"Access[2455∈4] ➊<br />ᐸ619.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2456{{"Access[2456∈4] ➊<br />ᐸ619.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1035 -->|rejectNull| PgSelect1096
     Access2455 -->|rejectNull| PgSelect1096
@@ -970,8 +970,8 @@ graph TD
     PgSelect1032[["PgSelect[1032∈4] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1035 -->|rejectNull| PgSelect1032
     Access2455 --> PgSelect1032
-    Access1033{{"Access[1033∈4] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access1034{{"Access[1034∈4] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access1033{{"Access[1033∈4] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access1034{{"Access[1034∈4] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1033 & Access1034 --> Object1035
     List1041{{"List[1041∈4] ➊<br />ᐸ30,1040ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1040{{"PgClassExpression[1040∈4] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -1263,7 +1263,7 @@ graph TD
     Lambda619 --> Access2455
     Lambda619 --> Access2456
     PgSelect696[["PgSelect[696∈5] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access2457{{"Access[2457∈5] ➊<br />ᐸ625.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access2457{{"Access[2457∈5] ➊<br />ᐸ625.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList"}}:::plan
     Access2458{{"Access[2458∈5] ➊<br />ᐸ625.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object1035 -->|rejectNull| PgSelect696
     Access2457 -->|rejectNull| PgSelect696
@@ -1555,7 +1555,7 @@ graph TD
     Lambda625 --> Access2457
     Lambda625 --> Access2458
     PgSelect899[["PgSelect[899∈6] ➊<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
-    Access2459{{"Access[2459∈6] ➊<br />ᐸ828.base64JSON.1ᐳ<br />ᐳQueryᐳInput"}}:::plan
+    Access2459{{"Access[2459∈6] ➊<br />ᐸ828.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756<br />ᐳQueryᐳList"}}:::plan
     Access2460{{"Access[2460∈6] ➊<br />ᐸ828.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Object1035 -->|rejectNull| PgSelect899
     Access2459 -->|rejectNull| PgSelect899
@@ -1848,7 +1848,7 @@ graph TD
     Lambda828 --> Access2460
     PgSelect1300[["PgSelect[1300∈7] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1239{{"Object[1239∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2461{{"Access[2461∈7] ➊<br />ᐸ1229.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2461{{"Access[2461∈7] ➊<br />ᐸ1229.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2462{{"Access[2462∈7] ➊<br />ᐸ1229.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1239 -->|rejectNull| PgSelect1300
     Access2461 -->|rejectNull| PgSelect1300
@@ -1860,8 +1860,8 @@ graph TD
     PgSelect1236[["PgSelect[1236∈7] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1239 -->|rejectNull| PgSelect1236
     Access2461 --> PgSelect1236
-    Access1237{{"Access[1237∈7] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access1238{{"Access[1238∈7] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access1237{{"Access[1237∈7] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access1238{{"Access[1238∈7] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1237 & Access1238 --> Object1239
     List1245{{"List[1245∈7] ➊<br />ᐸ30,1244ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1244{{"PgClassExpression[1244∈7] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -2146,7 +2146,7 @@ graph TD
     Lambda1229 --> Access2462
     PgSelect1503[["PgSelect[1503∈8] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1442{{"Object[1442∈8] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2463{{"Access[2463∈8] ➊<br />ᐸ1432.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2463{{"Access[2463∈8] ➊<br />ᐸ1432.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2464{{"Access[2464∈8] ➊<br />ᐸ1432.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1442 -->|rejectNull| PgSelect1503
     Access2463 -->|rejectNull| PgSelect1503
@@ -2158,8 +2158,8 @@ graph TD
     PgSelect1439[["PgSelect[1439∈8] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1442 -->|rejectNull| PgSelect1439
     Access2463 --> PgSelect1439
-    Access1440{{"Access[1440∈8] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access1441{{"Access[1441∈8] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access1440{{"Access[1440∈8] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access1441{{"Access[1441∈8] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1440 & Access1441 --> Object1442
     List1448{{"List[1448∈8] ➊<br />ᐸ30,1447ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1447{{"PgClassExpression[1447∈8] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -2444,7 +2444,7 @@ graph TD
     Lambda1432 --> Access2464
     PgSelect1707[["PgSelect[1707∈9] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1646{{"Object[1646∈9] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2465{{"Access[2465∈9] ➊<br />ᐸ1636.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2465{{"Access[2465∈9] ➊<br />ᐸ1636.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2466{{"Access[2466∈9] ➊<br />ᐸ1636.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1646 -->|rejectNull| PgSelect1707
     Access2465 -->|rejectNull| PgSelect1707
@@ -2456,8 +2456,8 @@ graph TD
     PgSelect1643[["PgSelect[1643∈9] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1646 -->|rejectNull| PgSelect1643
     Access2465 --> PgSelect1643
-    Access1644{{"Access[1644∈9] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access1645{{"Access[1645∈9] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access1644{{"Access[1644∈9] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access1645{{"Access[1645∈9] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1644 & Access1645 --> Object1646
     List1652{{"List[1652∈9] ➊<br />ᐸ30,1651ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1651{{"PgClassExpression[1651∈9] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -2742,7 +2742,7 @@ graph TD
     Lambda1636 --> Access2466
     PgSelect1910[["PgSelect[1910∈10] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object1849{{"Object[1849∈10] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2467{{"Access[2467∈10] ➊<br />ᐸ1839.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2467{{"Access[2467∈10] ➊<br />ᐸ1839.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2468{{"Access[2468∈10] ➊<br />ᐸ1839.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object1849 -->|rejectNull| PgSelect1910
     Access2467 -->|rejectNull| PgSelect1910
@@ -2754,8 +2754,8 @@ graph TD
     PgSelect1846[["PgSelect[1846∈10] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object1849 -->|rejectNull| PgSelect1846
     Access2467 --> PgSelect1846
-    Access1847{{"Access[1847∈10] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access1848{{"Access[1848∈10] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access1847{{"Access[1847∈10] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access1848{{"Access[1848∈10] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access1847 & Access1848 --> Object1849
     List1855{{"List[1855∈10] ➊<br />ᐸ30,1854ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1854{{"PgClassExpression[1854∈10] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -3040,7 +3040,7 @@ graph TD
     Lambda1839 --> Access2468
     PgSelect2114[["PgSelect[2114∈11] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object2053{{"Object[2053∈11] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2469{{"Access[2469∈11] ➊<br />ᐸ2043.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2469{{"Access[2469∈11] ➊<br />ᐸ2043.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2470{{"Access[2470∈11] ➊<br />ᐸ2043.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object2053 -->|rejectNull| PgSelect2114
     Access2469 -->|rejectNull| PgSelect2114
@@ -3052,8 +3052,8 @@ graph TD
     PgSelect2050[["PgSelect[2050∈11] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object2053 -->|rejectNull| PgSelect2050
     Access2469 --> PgSelect2050
-    Access2051{{"Access[2051∈11] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access2052{{"Access[2052∈11] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access2051{{"Access[2051∈11] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access2052{{"Access[2052∈11] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2051 & Access2052 --> Object2053
     List2059{{"List[2059∈11] ➊<br />ᐸ30,2058ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression2058{{"PgClassExpression[2058∈11] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
@@ -3338,7 +3338,7 @@ graph TD
     Lambda2043 --> Access2470
     PgSelect2317[["PgSelect[2317∈12] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object2256{{"Object[2256∈12] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access2471{{"Access[2471∈12] ➊<br />ᐸ2246.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access2471{{"Access[2471∈12] ➊<br />ᐸ2246.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2472{{"Access[2472∈12] ➊<br />ᐸ2246.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object2256 -->|rejectNull| PgSelect2317
     Access2471 -->|rejectNull| PgSelect2317
@@ -3350,8 +3350,8 @@ graph TD
     PgSelect2253[["PgSelect[2253∈12] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object2256 -->|rejectNull| PgSelect2253
     Access2471 --> PgSelect2253
-    Access2254{{"Access[2254∈12] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access2255{{"Access[2255∈12] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access2254{{"Access[2254∈12] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access2255{{"Access[2255∈12] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access2254 & Access2255 --> Object2256
     List2262{{"List[2262∈12] ➊<br />ᐸ30,2261ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression2261{{"PgClassExpression[2261∈12] ➊<br />ᐸ__inputs__.”id”ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/types-single-node.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types-single-node.mermaid
@@ -18,7 +18,7 @@ graph TD
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect53[["PgSelect[53∈1] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Object16{{"Object[16∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
-    Access131{{"Access[131∈1] ➊<br />ᐸ8.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access131{{"Access[131∈1] ➊<br />ᐸ8.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access132{{"Access[132∈1] ➊<br />ᐸ8.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object16 -->|rejectNull| PgSelect53
     Access131 -->|rejectNull| PgSelect53
@@ -26,8 +26,8 @@ graph TD
     PgSelect13[["PgSelect[13∈1] ➊<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
     Object16 -->|rejectNull| PgSelect13
     Access131 --> PgSelect13
-    Access14{{"Access[14∈1] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput"}}:::plan
-    Access15{{"Access[15∈1] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput"}}:::plan
+    Access14{{"Access[14∈1] ➊<br />ᐸ2.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
+    Access15{{"Access[15∈1] ➊<br />ᐸ2.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access14 & Access15 --> Object16
     PgSelect21[["PgSelect[21∈1] ➊<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
     Object16 -->|rejectNull| PgSelect21

--- a/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
@@ -1705,7 +1705,7 @@ graph TD
     __Item1079[/"__Item[1079∈138]<br />ᐸ1078ᐳ"\]:::itemplan
     PgClassExpression1078 ==> __Item1079
     PgSelect1127[["PgSelect[1127∈139] ➊<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
-    Access3809{{"Access[3809∈139] ➊<br />ᐸ1082.base64JSON.1ᐳ<br />ᐳInput"}}:::plan
+    Access3809{{"Access[3809∈139] ➊<br />ᐸ1082.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756<br />ᐳList"}}:::plan
     Access3810{{"Access[3810∈139] ➊<br />ᐸ1082.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
     Object12 -->|rejectNull| PgSelect1127
     Access3809 -->|rejectNull| PgSelect1127


### PR DESCRIPTION
## Description

If you cache a step we now apply it to all relevant polymorphic paths in which the cache is used.

## Performance impact

Marginal planning cost, but necessary.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
