### PR TITLE
Fix default plan resolvers

### DIFF
--- a/.changeset/sweet-bulldogs-share.md
+++ b/.changeset/sweet-bulldogs-share.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Export `defaultPlanResolver` and add `fieldName` to `FieldInfo`.

--- a/.changeset/swift-elephants-destroy.md
+++ b/.changeset/swift-elephants-destroy.md
@@ -1,0 +1,7 @@
+---
+"graphile-utils": patch
+---
+
+Fix bug in makeWrapPlansPlugin where the default plan resolver used was
+incorrect; use the new `defaultPlanResolver` export from `grafast` instead of
+building our own.

--- a/grafast/grafast/src/engine/lib/defaultPlanResolver.ts
+++ b/grafast/grafast/src/engine/lib/defaultPlanResolver.ts
@@ -1,0 +1,13 @@
+import type { FieldPlanResolver } from "../../interfaces.js";
+import type { ExecutableStep } from "../../step.js";
+import { access } from "../../steps/access.js";
+
+export const defaultPlanResolver: FieldPlanResolver<
+  any,
+  ExecutableStep & { get?: (field: string) => ExecutableStep },
+  any
+> = ($step, _, { fieldName }) => {
+  return typeof $step.get === "function"
+    ? $step.get(fieldName)
+    : access($step, [fieldName]);
+};

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -33,6 +33,7 @@ debugFactory.formatters.c = grafastPrint;
 import { defer, Deferred } from "./deferred.js";
 // Handy for debugging
 import { isDev, noop } from "./dev.js";
+import { defaultPlanResolver } from "./engine/lib/defaultPlanResolver.js";
 import { isUnaryStep } from "./engine/lib/withGlobalLayerPlan.js";
 import { OperationPlan } from "./engine/OperationPlan.js";
 import { $$inhibit, flagError, isSafeError, SafeError } from "./error.js";
@@ -307,6 +308,7 @@ export {
   DataFromObjectSteps,
   DataFromStep,
   debugPlans,
+  defaultPlanResolver,
   defer,
   Deferred,
   each,
@@ -608,6 +610,7 @@ exportAsMany("grafast", {
   flagError,
   SafeError,
   isUnaryStep,
+  defaultPlanResolver,
   multistep,
 });
 

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -298,6 +298,7 @@ export type AnyInputStepDollars = {
 };
 
 export interface FieldInfo {
+  fieldName: string;
   field: GraphQLField<any, any, any>;
   schema: GraphQLSchema;
 }
@@ -322,12 +323,8 @@ export interface FieldInfo {
 export type FieldPlanResolver<
   _TArgs extends BaseGraphQLArguments,
   TParentStep extends ExecutableStep | null,
-  TResultStep extends ExecutableStep,
-> = (
-  $parentPlan: TParentStep,
-  args: FieldArgs,
-  info: FieldInfo,
-) => TResultStep | null;
+  TResultStep extends ExecutableStep | null,
+> = ($parentPlan: TParentStep, args: FieldArgs, info: FieldInfo) => TResultStep;
 
 // TYPES: review _TContext
 /**

--- a/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
@@ -98,7 +98,7 @@ export function makeWrapPlansPlugin<T>(
           const rules = (build as any)[symbol].rules as PlanWrapperRules | null;
           const {
             EXPORTABLE,
-            grafast: { access, ExecutableStep, isExecutableStep },
+            grafast: { ExecutableStep, isExecutableStep, defaultPlanResolver },
           } = build;
           const filter = (build as any)[symbol]
             .filter as PlanWrapperFilter<T> | null;
@@ -141,15 +141,7 @@ export function makeWrapPlansPlugin<T>(
           if (!planWrapper) {
             return field;
           }
-          const {
-            plan: oldPlan = EXPORTABLE(
-              (access, fieldName) =>
-                // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-                ($obj: import("grafast").ExecutableStep) =>
-                  access($obj, fieldName),
-              [access, fieldName],
-            ),
-          } = field;
+          const { plan: oldPlan = defaultPlanResolver } = field;
           const typeName = Self.name;
           return {
             ...field,


### PR DESCRIPTION
## Description

This changes us to using a static default plan resolver (rather than generating a new one per field) by adding the `fieldName` to the plan info. We also update `graphile-utils` to use this new default plan resolver rather than using its own (inconsistent!) default.

Fixes #2306

## Performance impact

Maybe better? Less memory allocation, I expect?

## Security impact

Unlikely.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
