### PR TITLE
Mark all eval methods as internal

### DIFF
--- a/.changeset/mean-ads-develop.md
+++ b/.changeset/mean-ads-develop.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Mark `$step.eval*()` methods as internal in preparation for removing them.

--- a/grafast/grafast/src/steps/__inputDynamicScalar.ts
+++ b/grafast/grafast/src/steps/__inputDynamicScalar.ts
@@ -129,6 +129,7 @@ export class __InputDynamicScalarStep<
     return converted;
   };
 
+  /** @internal */
   eval(): TLeaf {
     const variableValues = this.variableNames.map((variableName, i) =>
       this.getDep<__TrackedValueStep>(i).eval(),
@@ -136,6 +137,7 @@ export class __InputDynamicScalarStep<
     return this.valueFromValues(variableValues);
   }
 
+  /** @internal */
   evalIs(expectedValue: undefined | null | 0): boolean {
     if (
       expectedValue === undefined ||

--- a/grafast/grafast/src/steps/__inputList.ts
+++ b/grafast/grafast/src/steps/__inputList.ts
@@ -95,6 +95,7 @@ export class __InputListStep<
     return itemPlan;
   }
 
+  /** @internal */
   eval(): any[] | null {
     if (this.inputValues?.kind === "NullValue") {
       return null;
@@ -113,6 +114,7 @@ export class __InputListStep<
     return list;
   }
 
+  /** @internal */
   evalIs(value: null | undefined | 0): boolean {
     if (value === undefined) {
       return this.inputValues === value;
@@ -125,6 +127,7 @@ export class __InputListStep<
     }
   }
 
+  /** @internal */
   evalLength(): number | null {
     if (this.inputValues === undefined) {
       return null;

--- a/grafast/grafast/src/steps/__inputObject.ts
+++ b/grafast/grafast/src/steps/__inputObject.ts
@@ -128,6 +128,7 @@ export class __InputObjectStep<
     return step;
   }
 
+  /** @internal */
   eval(): any {
     if (this.inputValues?.kind === "NullValue") {
       return null;
@@ -140,6 +141,7 @@ export class __InputObjectStep<
     return resultValues;
   }
 
+  /** @internal */
   evalIs(value: null | undefined | 0): boolean {
     if (value === undefined) {
       return this.inputValues === value;
@@ -156,6 +158,7 @@ export class __InputObjectStep<
     }
   }
 
+  /** @internal */
   evalIsEmpty(): boolean {
     return (
       this.inputValues?.kind === "ObjectValue" &&
@@ -164,6 +167,7 @@ export class __InputObjectStep<
   }
 
   // Written without consulting spec.
+  /** @internal */
   evalHas(attrName: string): boolean {
     if (!this.inputValues) {
       return false;
@@ -177,6 +181,7 @@ export class __InputObjectStep<
     return !this.inputFields[attrName].step.evalIs(undefined);
   }
 
+  /** @internal */
   evalKeys(): ReadonlyArray<keyof TInputType & string> | null {
     if (this.inputValues === undefined) {
       return null;

--- a/grafast/grafast/src/steps/__inputStaticLeaf.ts
+++ b/grafast/grafast/src/steps/__inputStaticLeaf.ts
@@ -55,10 +55,12 @@ export class __InputStaticLeafStep<TLeaf = any> extends UnbatchedStep<TLeaf> {
     return constant(this.coercedValue, false);
   }
 
+  /** @internal */
   eval(): TLeaf {
     return this.coercedValue;
   }
 
+  /** @internal */
   evalIs(expectedValue: unknown): boolean {
     return this.coercedValue === expectedValue;
   }

--- a/grafast/grafast/src/steps/__trackedValue.ts
+++ b/grafast/grafast/src/steps/__trackedValue.ts
@@ -292,6 +292,8 @@ export class __TrackedValueStep<
    * **WARNING**: avoid using this where possible, it causes OpPlans to split.
    *
    * **WARNING**: this is the most expensive eval, if you need to eval, prefer evalIs, evalHas, etc instead.
+   *
+   * @internal
    */
   eval(): TData | undefined {
     const { path, value } = this;
@@ -311,6 +313,8 @@ export class __TrackedValueStep<
    * Should only be used on scalars.
    *
    * **WARNING**: avoid using this where possible, it causes OpPlans to split.
+   *
+   * @internal
    */
   evalIs(expectedValue: unknown): boolean {
     const { value, path } = this;
@@ -324,6 +328,7 @@ export class __TrackedValueStep<
     return pass;
   }
 
+  /** @internal */
   evalIsEmpty() {
     const { value, path } = this;
     const isEmpty =
@@ -344,6 +349,8 @@ export class __TrackedValueStep<
    * check will always return the same (boolean) result.
    *
    * **WARNING**: avoid using this where possible, it causes OpPlans to split.
+   *
+   * @internal
    */
   evalHas(key: string): boolean {
     const { value, path } = this;
@@ -372,6 +379,8 @@ export class __TrackedValueStep<
    * check will always return the same result.
    *
    * **WARNING**: avoid using this where possible, it causes OpPlans to split.
+   *
+   * @internal
    */
   evalKeys(): ReadonlyArray<keyof TData & string> | null {
     const { value, path } = this;
@@ -417,6 +426,8 @@ export class __TrackedValueStep<
    * the same length.
    *
    * **WARNING**: avoid using this where possible, it causes OpPlans to split.
+   *
+   * @internal
    */
   evalLength(): number | null {
     const { value, path } = this;

--- a/grafast/grafast/src/steps/constant.ts
+++ b/grafast/grafast/src/steps/constant.ts
@@ -71,14 +71,17 @@ export class ConstantStep<TData> extends UnbatchedStep<TData> {
     return arrayOfLength(count, this.data);
   }
 
+  /** @internal */
   eval() {
     return this.data;
   }
 
+  /** @internal */
   evalIs(value: any) {
     return this.data === value;
   }
 
+  /** @internal */
   evalIsEmpty() {
     return (
       typeof this.data === "object" &&
@@ -87,10 +90,12 @@ export class ConstantStep<TData> extends UnbatchedStep<TData> {
     );
   }
 
+  /** @internal */
   evalLength() {
     return Array.isArray(this.data) ? this.data.length : null;
   }
 
+  /** @internal */
   evalKeys(): ReadonlyArray<keyof TData & string> | null {
     if (this.data == null || typeof this.data !== "object") {
       return null;


### PR DESCRIPTION
## Description

Long term aim is to completely remove eval. For now, we'll settle for just using it for `@skip`, `@include`, `@defer` and `@stream` `if:` evaluation

## Performance impact

None.

## Security impact

Helps guide people away from using `$input.eval*()`, which avoids plan branching, helping to avoid DOS through plan explosion.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
