### PR TITLE
Allow mutations to complete synchronously

### DIFF
--- a/.changeset/mean-pugs-sell.md
+++ b/.changeset/mean-pugs-sell.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Allow `mutation` operations to complete synchronously (via `grafastSync`) if
+possible.

--- a/grafast/grafast/__tests__/grafastSync.test.ts
+++ b/grafast/grafast/__tests__/grafastSync.test.ts
@@ -1,0 +1,83 @@
+/* eslint-disable graphile-export/exhaustive-deps, graphile-export/export-methods, graphile-export/export-instances, graphile-export/export-subclasses, graphile-export/no-nested */
+import { expect } from "chai";
+import { resolvePreset } from "graphile-config";
+import type { ExecutionResult } from "graphql";
+import { it } from "mocha";
+
+import { grafastSync, lambda, makeGrafastSchema } from "../dist/index.js";
+
+const resolvedPreset = resolvePreset({});
+const requestContext = {};
+
+const makeSchema = () => {
+  return makeGrafastSchema({
+    typeDefs: /* GraphQL */ `
+      type Mutation {
+        addTwoNumbers(a: Int!, b: Int!): Int
+      }
+
+      type Query {
+        addTwoNumbers(a: Int!, b: Int!): Int
+      }
+    `,
+    plans: {
+      Mutation: {
+        addTwoNumbers(parentStep, fieldArgs) {
+          return lambda(
+            [fieldArgs.get("a"), fieldArgs.get("b")],
+            ([a, b]) => a + b,
+          );
+        },
+      },
+      Query: {
+        addTwoNumbers(parentStep, fieldArgs) {
+          return lambda(
+            [fieldArgs.get("a"), fieldArgs.get("b")],
+            ([a, b]) => a + b,
+          );
+        },
+      },
+    },
+    enableDeferStream: false,
+  });
+};
+
+it("query works sync", async () => {
+  const schema = makeSchema();
+  const source = /* GraphQL */ `
+    query AddTwoNumbers($a: Int!, $b: Int!) {
+      addTwoNumbers(a: $a, b: $b)
+    }
+  `;
+  const variableValues = { a: 7, b: 13 };
+  const result = grafastSync({
+    schema,
+    source,
+    variableValues,
+    contextValue: {},
+    resolvedPreset,
+    requestContext,
+  }) as ExecutionResult;
+  expect(result.errors).not.to.exist;
+  expect(result.data).to.deep.equal({ addTwoNumbers: 20 });
+});
+
+it("mutation works sync", async () => {
+  const schema = makeSchema();
+  const source = /* GraphQL */ `
+    mutation AddTwoNumbers($a: Int!, $b: Int!) {
+      addTwoNumbers(a: $a, b: $b)
+    }
+  `;
+  const variableValues = { a: 9, b: 12 };
+  const result = grafastSync({
+    schema,
+    source,
+    variableValues,
+    contextValue: {},
+    resolvedPreset,
+    requestContext,
+  }) as ExecutionResult;
+  expect(result.errors).not.to.exist;
+  expect(result.data).to.deep.equal({ addTwoNumbers: 21 });
+});


### PR DESCRIPTION
## Description

`grafastSync` should be able to execute mutation operations if those operations only use synchronous steps.

## Performance impact

Negligible

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
