### PR TITLE
Be stricter about types and usage of getDep/getDepOptions

### DIFF
--- a/.changeset/silent-jars-greet.md
+++ b/.changeset/silent-jars-greet.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+"grafast": patch
+---
+
+Be stricter about usage of `this.getDep(depId)` vs `this.getDepOptions(depId)`.

--- a/grafast/dataplan-pg/src/steps/pgPolymorphic.ts
+++ b/grafast/dataplan-pg/src/steps/pgPolymorphic.ts
@@ -82,12 +82,13 @@ export class PgPolymorphicStep<
     }) as any;
   }
 
-  itemPlan(): TItemStep {
-    return this.getDep<any>(this.itemStepId);
+  private itemPlan(): TItemStep {
+    return this.getDepOptions<TItemStep>(this.itemStepId).step;
   }
 
-  typeSpecifierPlan(): TTypeSpecifierStep {
-    return this.getDep<TTypeSpecifierStep>(this.typeSpecifierStepId);
+  private typeSpecifierPlan(): TTypeSpecifierStep {
+    return this.getDepOptions<TTypeSpecifierStep>(this.typeSpecifierStepId)
+      .step;
   }
 
   planForType(type: GraphQLObjectType): ExecutableStep {
@@ -101,7 +102,9 @@ export class PgPolymorphicStep<
         ).join("', '")}'`,
       );
     }
-    return spec.plan(this.typeSpecifierPlan(), this.itemPlan());
+    const $typeSpecifier = this.typeSpecifierPlan();
+    const $item = this.itemPlan();
+    return spec.plan($typeSpecifier, $item);
   }
 
   private getTypeNameFromSpecifier(specifier: TTypeSpecifier) {

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -1644,7 +1644,7 @@ export class PgSelectRowsStep<
   }
 
   public getClassStep(): PgSelectStep<TResource> {
-    return this.getDep<PgSelectStep<TResource>>(0);
+    return this.getDepOptions<PgSelectStep<TResource>>(0).step;
   }
 
   listItem(itemPlan: Step) {

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -1096,7 +1096,7 @@ export class PgUnionAllRowsStep<
     this.addDependency($pgUnionAll);
   }
   public getClassStep(): PgUnionAllStep<TAttributes, TTypeNames> {
-    return this.getDep<PgUnionAllStep<TAttributes, TTypeNames>>(0);
+    return this.getDepOptions<PgUnionAllStep<TAttributes, TTypeNames>>(0).step;
   }
 
   listItem(itemPlan: Step) {

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -466,7 +466,7 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
         | undefined = ($root.unbatchedExecute! as any)[expressionSymbol];
       if (expressionDetails !== undefined) {
         // @ts-ignore
-        const $parent: Step = $root.getDep(0);
+        const { step: $parent } = $root.getDepOptions(0);
         this.layerPlan.operationPlan.stepTracker.setOutputPlanRootStep(
           this,
           $parent,

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -788,7 +788,7 @@ export interface LocationDetails {
 }
 
 export type UnwrapPlanTuple</* const */ TIn extends readonly Step[]> = {
-  [Index in keyof TIn]: TIn[Index] extends Step<infer U> ? U : never;
+  [Index in keyof TIn]: DataFromStep<TIn[Index]>;
 };
 
 export type NotVariableValueNode = Exclude<ValueNode, VariableNode>;
@@ -809,14 +809,21 @@ export type Maybe<T> = T | null | undefined;
 
 export * from "./planJSONInterfaces.js";
 
-export interface AddDependencyOptions {
-  step: Step;
+export interface AddDependencyOptions<TStep extends Step = Step> {
+  step: TStep;
   skipDeduplication?: boolean;
   /** @defaultValue `FLAG_NULL` */
   acceptFlags?: ExecutionEntryFlags;
-  onReject?: null | Error | undefined;
+  onReject?: Maybe<Error>;
   nonUnaryMessage?: ($dependent: Step, $dependency: Step) => string;
 }
+
+export interface DependencyOptions<TStep extends Step = Step> {
+  step: TStep;
+  acceptFlags: ExecutionEntryFlags;
+  onReject: Maybe<Error>;
+}
+
 /**
  * @internal
  */

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -3,6 +3,7 @@ import { $$inhibit, flagError, SafeError } from "../error.js";
 import { inspect } from "../inspect.js";
 import type {
   AddDependencyOptions,
+  DataFromStep,
   ExecutionDetails,
   ExecutionEntryFlags,
   GrafastResultsList,
@@ -89,7 +90,7 @@ function resolveTrapValue(tv: TrapValue): ResolvedTrapValue {
   }
 }
 
-export class __FlagStep<TData> extends Step<TData> {
+export class __FlagStep<TStep extends Step> extends Step<DataFromStep<TStep>> {
   static $$export = {
     moduleName: "grafast",
     exportName: "__FlagStep",
@@ -102,7 +103,7 @@ export class __FlagStep<TData> extends Step<TData> {
   private valueForInhibited: ResolvedTrapValue;
   private valueForError: ResolvedTrapValue;
   private canBeInlined: boolean;
-  constructor(step: Step, options: FlagStepOptions) {
+  constructor(step: TStep, options: FlagStepOptions) {
     super();
     const {
       acceptFlags = DEFAULT_ACCEPT_FLAGS,
@@ -207,8 +208,8 @@ export class __FlagStep<TData> extends Step<TData> {
   }
 
   public execute(
-    _details: ExecutionDetails<[data: TData, cond?: boolean]>,
-  ): GrafastResultsList<TData> {
+    _details: ExecutionDetails<[data: DataFromStep<TStep>, cond?: boolean]>,
+  ): GrafastResultsList<DataFromStep<TStep>> {
     throw new Error(`${this} not finalized?`);
   }
 
@@ -222,7 +223,7 @@ export class __FlagStep<TData> extends Step<TData> {
   }
 
   private fancyExecute(
-    details: ExecutionDetails<[data: TData, cond?: boolean]>,
+    details: ExecutionDetails<[data: DataFromStep<TStep>, cond?: boolean]>,
   ): any {
     const dataEv = details.values[0]!;
     const condEv =
@@ -268,7 +269,7 @@ export class __FlagStep<TData> extends Step<TData> {
 
   // Checks already performed via addDependency, just pass everything through. Should have been inlined!
   private passThroughExecute(
-    details: ExecutionDetails<[data: TData, cond?: boolean]>,
+    details: ExecutionDetails<[data: DataFromStep<TStep>, cond?: boolean]>,
   ): any {
     const ev = details.values[0];
     if (ev.isBatch) {
@@ -284,11 +285,11 @@ export class __FlagStep<TData> extends Step<TData> {
  * Example use case: get user by id, but id is null: no need to fetch the user
  * since we know they won't exist.
  */
-export function inhibitOnNull<T>(
-  $step: Step<T>,
+export function inhibitOnNull<TStep extends Step>(
+  $step: TStep,
   options?: { if?: FlagStepOptions["if"] },
 ) {
-  return new __FlagStep<T>($step, {
+  return new __FlagStep<TStep>($step, {
     ...options,
     acceptFlags: DEFAULT_ACCEPT_FLAGS & ~FLAG_NULL,
   });
@@ -299,20 +300,20 @@ export function inhibitOnNull<T>(
  * that represents a Post instead: throw error to tell user they've sent invalid
  * data.
  */
-export function assertNotNull<T>(
-  $step: Step<T>,
+export function assertNotNull<TStep extends Step>(
+  $step: TStep,
   message: string,
   options?: { if?: FlagStepOptions["if"] },
 ) {
-  return new __FlagStep<T>($step, {
+  return new __FlagStep<TStep>($step, {
     ...options,
     acceptFlags: DEFAULT_ACCEPT_FLAGS & ~FLAG_NULL,
     onReject: new SafeError(message),
   });
 }
 
-export function trap<T>(
-  $step: Step<T>,
+export function trap<TStep extends Step>(
+  $step: TStep,
   acceptFlags: ExecutionEntryFlags,
   options?: {
     valueForInhibited?: FlagStepOptions["valueForInhibited"];
@@ -320,18 +321,31 @@ export function trap<T>(
     if?: FlagStepOptions["if"];
   },
 ) {
-  return new __FlagStep<T>($step, {
+  return new __FlagStep<TStep>($step, {
     ...options,
     acceptFlags: (acceptFlags & TRAPPABLE_FLAGS) | FLAG_NULL,
   });
 }
 
 // Have to overwrite the getDep method due to circular dependency
-(Step.prototype as any).getDep = function (this: Step, depId: number) {
+(Step.prototype as any).getDep = function (
+  this: Step,
+  depId: number,
+  throwOnFlagged = false,
+) {
   const { step, acceptFlags, onReject } = this.getDepOptions(depId);
   if (acceptFlags === DEFAULT_ACCEPT_FLAGS && onReject == null) {
     return step;
   } else {
+    if (throwOnFlagged) {
+      throw new Error(
+        `When retrieving dependency ${step} of ${this}, the dependency is flagged as ${digestAcceptFlags(
+          acceptFlags,
+        )}/onReject=${String(
+          onReject,
+        )}. Please use \`this.getDepOptions(depId)\` instead, and handle the flags`,
+      );
+    }
     // Return a __FlagStep around options.step so that all the options are preserved.
     return new __FlagStep(step, { acceptFlags, onReject });
   }

--- a/grafast/grafast/src/steps/__inputDynamicScalar.ts
+++ b/grafast/grafast/src/steps/__inputDynamicScalar.ts
@@ -132,7 +132,7 @@ export class __InputDynamicScalarStep<
   /** @internal */
   eval(): TLeaf {
     const variableValues = this.variableNames.map((variableName, i) =>
-      this.getDep<__TrackedValueStep>(i).eval(),
+      this.getDep<__TrackedValueStep>(i, true).eval(),
     );
     return this.valueFromValues(variableValues);
   }

--- a/grafast/grafast/src/steps/__trackedValue.ts
+++ b/grafast/grafast/src/steps/__trackedValue.ts
@@ -166,7 +166,7 @@ export class __TrackedValueStep<
   }
 
   private getValuePlan() {
-    return this.getDep<__ValueStep<TData> | AccessStep<TData>>(0);
+    return this.getDep<__ValueStep<TData> | AccessStep<TData>>(0, true);
   }
 
   /**

--- a/grafast/grafast/src/steps/access.ts
+++ b/grafast/grafast/src/steps/access.ts
@@ -160,12 +160,12 @@ export class AccessStep<TData> extends UnbatchedStep<TData> {
   }
 
   toStringMeta(): string {
-    return `${chalk.bold.yellow(String(this.getDep(0).id))}.${this.path
-      .map((p) => String(p))
-      .join(".")}`;
+    return `${chalk.bold.yellow(
+      String(this.getDepOptions(0).step.id),
+    )}.${this.path.map((p) => String(p)).join(".")}`;
   }
 
-  getParentStep(): Step {
+  getParentStep() {
     return this.getDep(0);
   }
 

--- a/grafast/grafast/src/steps/connection.ts
+++ b/grafast/grafast/src/steps/connection.ts
@@ -186,7 +186,7 @@ export class ConnectionStep<
     });
   }
   public getBefore(): TCursorStep | null {
-    return this.maybeGetDep<TCursorStep>(this._beforeDepId);
+    return this.maybeGetDep<TCursorStep>(this._beforeDepId, true);
   }
   public setBefore($beforePlan: Step<string | null | undefined>) {
     if ($beforePlan instanceof ConstantStep && $beforePlan.data == null) {
@@ -203,7 +203,7 @@ export class ConnectionStep<
     });
   }
   public getAfter(): TCursorStep | null {
-    return this.maybeGetDep<TCursorStep>(this._afterDepId);
+    return this.maybeGetDep<TCursorStep>(this._afterDepId, true);
   }
   public setAfter($afterPlan: Step<string | null | undefined>) {
     if ($afterPlan instanceof ConstantStep && $afterPlan.data == null) {

--- a/grafast/grafast/src/steps/listTransform.ts
+++ b/grafast/grafast/src/steps/listTransform.ts
@@ -10,7 +10,11 @@ import {
 import type { LayerPlanReasonSubroutine } from "../engine/LayerPlan.js";
 import { LayerPlan } from "../engine/LayerPlan.js";
 import { withGlobalLayerPlan } from "../engine/lib/withGlobalLayerPlan.js";
-import type { ConnectionCapableStep, ExecutionDetails } from "../index.js";
+import type {
+  __FlagStep,
+  ConnectionCapableStep,
+  ExecutionDetails,
+} from "../index.js";
 import type { GrafastResultsList } from "../interfaces.js";
 import { $$deepDepSkip } from "../interfaces.js";
 import type { ListCapableStep } from "../step.js";
@@ -186,7 +190,7 @@ export class __ListTransformStep<
   }
 
   getListStep(): TListStep {
-    return this.getDep<TListStep>(this.rawListStepDepId);
+    return this.getDepOptions<TListStep>(this.rawListStepDepId).step;
   }
 
   [$$deepDepSkip]() {

--- a/grafast/grafast/src/steps/object.ts
+++ b/grafast/grafast/src/steps/object.ts
@@ -97,10 +97,15 @@ export class ObjectStep<
     this.addDependency({ step: plan, skipDeduplication: true });
   }
 
+  getStepForKey<TKey extends keyof TPlans>(key: TKey): TPlans[TKey];
+  getStepForKey<TKey extends keyof TPlans>(
+    key: TKey,
+    allowMissing: true,
+  ): TPlans[TKey] | null;
   getStepForKey<TKey extends keyof TPlans>(
     key: TKey,
     allowMissing = false,
-  ): TKey extends keyof TPlans ? TPlans[TKey] : null {
+  ): TPlans[TKey] | null {
     const idx = this.keys.indexOf(key as string);
     if (idx < 0) {
       if (!allowMissing) {
@@ -110,9 +115,9 @@ export class ObjectStep<
           )}' - we have no such key`,
         );
       }
-      return null as any;
+      return null;
     }
-    return this.getDep(idx) as any;
+    return this.getDepOptions<TPlans[TKey]>(idx).step;
   }
 
   toStringMeta(): string {
@@ -316,7 +321,7 @@ ${inner}
         )}'; supported keys: '${this.keys.join("', '")}'`,
       );
     }
-    return this.getDep<TPlans[TKey]>(index);
+    return this.getDepOptions<TPlans[TKey]>(index).step;
   }
 }
 

--- a/grafast/grafast/src/steps/polymorphicBranch.ts
+++ b/grafast/grafast/src/steps/polymorphicBranch.ts
@@ -54,7 +54,7 @@ export class PolymorphicBranchStep<TStep extends Step>
 
   planForType(objectType: GraphQLObjectType): Step {
     const matcher = this.matchers[objectType.name];
-    const $step = this.getDep<TStep>(0);
+    const $step = this.getDep<TStep>(0, true);
     if (matcher) {
       if (typeof matcher.plan === "function") {
         return matcher.plan($step);


### PR DESCRIPTION
## Description

When we introduced step flagging, we had it so that a step could be added as a dependency along with flags, for example "inhibit on null". But this left us with a bit of a predicament... what if you `.getDep(0)` to get this dependency, and then try and add it to a copy of yourself? Now the "inhibit on null" has gone missing!

To solve this, we had `.getDep(0)` return the step _wrapped_ in a `__FlagStep` (if necessary) to ensure that anything else that added this dependency would have the flags maintained.

This was great, except it meant that sometimes you would get a `__FlagStep` when you're expecting, for example, a PgSelectSingleStep, and your code would go wrong. So we also gave you a new method `.getDepOptions(0)` which would let you fetch this dependency along with its flags. It's then on you to ensure that flags are maintained when you e.g. move the dependency to a new step.

In this PR we fix the types of `getDep` so that it's clear it _might_ return a __FlagStep. We also use getDepOptions in the relevant places. Further getDepOptions can now be passed a generic to indicate the type of class that you want it cast to (we trust you on this) to simplify the coding.

## Performance impact

Negligible.

## Security impact

Types are more correct, so fewer places for bugs to hide?

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
