### PR TITLE
add docs for making context type-safe

### DIFF
--- a/grafast/website/grafast/step-library/standard-steps/context.md
+++ b/grafast/website/grafast/step-library/standard-steps/context.md
@@ -26,7 +26,7 @@ declare global {
   namespace Grafast {
     interface Context {
       currentUserId?: number;
-    };
+    }
   }
 }
 ```

--- a/grafast/website/grafast/step-library/standard-steps/context.md
+++ b/grafast/website/grafast/step-library/standard-steps/context.md
@@ -15,18 +15,22 @@ The returned step has the following methods:
 - `.at(index)` - gets the value at index `index` assuming the parsed JSON value
   was an array
 
-## Typescript
+## TypeScript
 
-Typescript declaration merging should be used to extend the default grafast context and make the usage of this step type safe in the plan resolvers. Here's an example:
+TypeScript declaration merging should be used to detail the properties you are
+making available on GraphQL context such that usage of this step is type safe in
+plan resolvers. For example:
 
 ```ts
 declare global {
   namespace Grafast {
     interface Context {
-      postgresClient: PostgresClient;
+      currentUserId?: number;
     };
   }
 }
 ```
 
-The code above would make accessing `context().get("postgresClient")` and its return value type-safe in the plan resolvers.
+The code above would mean that `context().get("currentUserId")` returns
+`Step<number | undefined>`, thereby making its usage in plan resolvers type
+safe.

--- a/grafast/website/grafast/step-library/standard-steps/context.md
+++ b/grafast/website/grafast/step-library/standard-steps/context.md
@@ -14,3 +14,19 @@ The returned step has the following methods:
   was an object
 - `.at(index)` - gets the value at index `index` assuming the parsed JSON value
   was an array
+
+## Typescript
+
+Typescript declaration merging should be used to extend the default grafast context and make the usage of this step type safe in the plan resolvers. Here's an example:
+
+```ts
+declare global {
+  namespace Grafast {
+    interface Context {
+      postgresClient: PostgresClient;
+    };
+  }
+}
+```
+
+The code above would make accessing `context().get("postgresClient")` and its return value type-safe in the plan resolvers.


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

Adds documentation for extending the default grafast context for having type safety in the access patterns of the `context` step.

Discussed on discord, [link](https://discord.com/channels/489127045289476126/498852330754801666/1349800186272153712)

## Performance impact

None

## Security impact

None

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
