### PR TITLE
Fix mutation functions accepting lists of composite types

### DIFF
--- a/.changeset/spicy-zoos-drive.md
+++ b/.changeset/spicy-zoos-drive.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Ensure all variable/argument-related input plans remain in the root layer plan.

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -177,7 +177,8 @@ export interface MetaByMetaKey {
 const REASON_ROOT = Object.freeze({ type: "root" });
 const OUTPUT_PLAN_TYPE_NULL = Object.freeze({ mode: "null" });
 const OUTPUT_PLAN_TYPE_ARRAY = Object.freeze({ mode: "array" });
-const newValueStepCallback = () => new __ValueStep();
+const newValueStepCallback = (isImmutable: boolean) =>
+  new __ValueStep(isImmutable);
 
 const NO_ARGS: TrackedArguments = {
   get() {
@@ -2109,6 +2110,8 @@ export class OperationPlan {
       this.rootLayerPlan,
       POLYMORPHIC_ROOT_PATHS,
       newValueStepCallback,
+      null,
+      variableDefinitions != null,
     );
     const trackedObjectStep = withGlobalLayerPlan(
       this.rootLayerPlan,
@@ -2119,6 +2122,7 @@ export class OperationPlan {
           valueStep,
           constraints,
           [],
+          variableDefinitions != null,
           variableDefinitions,
         ),
     );

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -117,6 +117,12 @@ export /* abstract */ class Step<TData = any> {
   public _isUnary: boolean;
   /** @internal */
   public _isUnaryLocked: boolean;
+  /**
+   * For input values, set {true} if it comes from variables/arguments since
+   * they cannot be modified (even by mutations), set false otherwise.
+   * @internal
+   */
+  public _isImmutable = false;
   public debug: boolean;
 
   // Explicitly we do not add $$export here because we want children to set it

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -118,8 +118,9 @@ export /* abstract */ class Step<TData = any> {
   /** @internal */
   public _isUnaryLocked: boolean;
   /**
-   * For input values, set {true} if it comes from variables/arguments since
-   * they cannot be modified (even by mutations), set false otherwise.
+   * For input values, set `true` if it comes from variables/arguments since
+   * they cannot be modified (even by mutations), set `false` otherwise.
+   *
    * @internal
    */
   public _isImmutable = false;

--- a/grafast/grafast/src/steps/__trackedValue.ts
+++ b/grafast/grafast/src/steps/__trackedValue.ts
@@ -14,7 +14,7 @@ import {
 } from "graphql";
 
 import type { Constraint } from "../constraints.js";
-import { __ListTransformStep, arrayOfLength } from "../index.js";
+import { __ListTransformStep, arrayOfLength, operationPlan } from "../index.js";
 import type {
   ExecutionDetails,
   GrafastResultsList,
@@ -83,12 +83,16 @@ export class __TrackedValueStep<
     path: Array<string | number> = [],
     graphqlType: TInputType,
   ) {
-    return new __TrackedValueStep<TData, TInputType>(
-      value,
-      valuePlan,
-      constraints,
-      path,
-      graphqlType,
+    return operationPlan().withRootLayerPlan(
+      () =>
+        new __TrackedValueStep<TData, TInputType>(
+          value,
+          valuePlan,
+          constraints,
+          path,
+          true,
+          graphqlType,
+        ),
     ) as __TrackedValueStepWithDollars<TData, TInputType>;
   }
 
@@ -96,6 +100,7 @@ export class __TrackedValueStep<
   private variableDefinitions:
     | ReadonlyArray<VariableDefinitionNode>
     | undefined;
+
   /**
    * @internal
    */
@@ -104,9 +109,11 @@ export class __TrackedValueStep<
     valuePlan: __ValueStep<TData> | AccessStep<TData>,
     constraints: Constraint[],
     path: Array<string | number> = [],
+    isImmutable: boolean,
     graphqlTypeOrVariableDefinitions?: TInputType,
   ) {
     super();
+    this._isImmutable = isImmutable;
     this.addDependency(valuePlan);
     this.value = value;
     this.constraints = constraints;
@@ -233,12 +240,24 @@ export class __TrackedValueStep<
         newPath,
         type,
       ) as any;
+    } else if (this._isImmutable) {
+      return this.operationPlan.withRootLayerPlan(
+        () =>
+          new __TrackedValueStep(
+            newValue,
+            newValuePlan,
+            constraints,
+            newPath,
+            this._isImmutable,
+          ),
+      ) as any;
     } else {
       return new __TrackedValueStep(
         newValue,
         newValuePlan,
         constraints,
         newPath,
+        this._isImmutable,
       ) as any;
     }
   }
@@ -274,12 +293,24 @@ export class __TrackedValueStep<
           `'${this.nullableGraphQLType}' is not a list type, cannot access array index '${index}' on it`,
         );
       }
+    } else if (this._isImmutable) {
+      return this.operationPlan.withRootLayerPlan(
+        () =>
+          new __TrackedValueStep(
+            newValue,
+            newValuePlan,
+            constraints,
+            newPath,
+            this._isImmutable,
+          ),
+      ) as any;
     } else {
       return new __TrackedValueStep(
         newValue,
         newValuePlan,
         constraints,
         newPath,
+        this._isImmutable,
       ) as any;
     }
   }

--- a/grafast/grafast/src/steps/__value.ts
+++ b/grafast/grafast/src/steps/__value.ts
@@ -16,8 +16,9 @@ export class __ValueStep<TData> extends Step<TData> {
   isSyncAndSafe = true;
   [$$noExec] = true;
 
-  constructor() {
+  constructor(isImmutable: boolean) {
     super();
+    this._isImmutable = isImmutable;
   }
 
   toStringMeta(): string | null {

--- a/grafast/grafast/src/steps/access.ts
+++ b/grafast/grafast/src/steps/access.ts
@@ -150,6 +150,7 @@ export class AccessStep<TData> extends UnbatchedStep<TData> {
     public readonly fallback?: any,
   ) {
     super();
+    this._isImmutable = parentPlan._isImmutable;
     this.path = path;
     this.hasSymbols = this.path.some((k) => typeof k === "symbol");
     this.peerKey =
@@ -258,12 +259,23 @@ export function access<TData>(
     !path.some((k) => typeof k === "symbol")
   ) {
     const pathKey = digestKeys(path);
-    return parentPlan.operationPlan.cacheStep(
-      parentPlan,
-      "GrafastInternal:access()",
-      pathKey,
-      () => new AccessStep<TData>(parentPlan, path),
-    );
+    if (parentPlan._isImmutable) {
+      return parentPlan.operationPlan.withRootLayerPlan(() =>
+        parentPlan.operationPlan.cacheStep(
+          parentPlan,
+          "GrafastInternal:access()",
+          pathKey,
+          () => new AccessStep<TData>(parentPlan, path),
+        ),
+      );
+    } else {
+      return parentPlan.operationPlan.cacheStep(
+        parentPlan,
+        "GrafastInternal:access()",
+        pathKey,
+        () => new AccessStep<TData>(parentPlan, path),
+      );
+    }
   }
   return new AccessStep<TData>(parentPlan, path, fallback);
 }

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -412,6 +412,10 @@ begin
   return ARRAY[]::uuid[];
 end;
 $$ language plpgsql volatile;
+create function c.list_of_compound_types_mutation(records c.compound_type[]) returns setof c.compound_type as $$
+  select r.*
+  from unnest(list_of_compound_types_mutation.records) as r;
+$$ language sql volatile;
 
 create function c.person_first_name(person c.person) returns text as $$ select split_part(person.person_full_name, ' ', 1) $$ language sql stable;
 comment on function c.person_first_name(c.person) is E'@sortable\nThe first name of the person.';

--- a/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.json5
@@ -1,0 +1,20 @@
+{
+  listOfCompoundTypesMutation: {
+    compoundTypes: [
+      {
+        a: 1,
+        b: "B",
+        c: "RED",
+        d: "00000000-0000-0000-0000-000000000000",
+        e: "BAZ_QUX",
+        f: "_EMPTY_",
+        g: {
+          seconds: 21,
+          minutes: 0,
+          hours: 0,
+        },
+        fooBar: 42,
+      },
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.mermaid
@@ -1,0 +1,84 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access12 & Access13 --> Object14
+    Access6{{"Access[6∈0] ➊<br />ᐸ0.inputᐳ"}}:::plan
+    __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
+    __Value0 --> Access6
+    Access8{{"Access[8∈0] ➊<br />ᐸ0.input.recordsᐳ"}}:::plan
+    __Value0 --> Access8
+    BakedInput10{{"BakedInput[10∈0] ➊"}}:::plan
+    Access8 --> BakedInput10
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access12
+    __Value2 --> Access13
+    PgFromExpression15{{"PgFromExpression[15∈0] ➊"}}:::plan
+    BakedInput10 --> PgFromExpression15
+    ApplyInput17{{"ApplyInput[17∈0] ➊"}}:::plan
+    Access6 --> ApplyInput17
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    PgSelect11[["PgSelect[11∈1] ➊<br />ᐸlist_of_compound_types_mutation(mutation)ᐳ"]]:::sideeffectplan
+    Object14 & PgFromExpression15 & ApplyInput17 --> PgSelect11
+    Object16{{"Object[16∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
+    PgSelect11 --> Object16
+    PgSelectRows18[["PgSelectRows[18∈2] ➊"]]:::plan
+    PgSelect11 --> PgSelectRows18
+    __Item19[/"__Item[19∈3]<br />ᐸ18ᐳ"\]:::itemplan
+    PgSelectRows18 ==> __Item19
+    PgSelectSingle20{{"PgSelectSingle[20∈3]<br />ᐸlist_of_compound_types_mutationᐳ"}}:::plan
+    __Item19 --> PgSelectSingle20
+    PgClassExpression21{{"PgClassExpression[21∈4]<br />ᐸ__list_of_...tion__.”a”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression21
+    PgClassExpression22{{"PgClassExpression[22∈4]<br />ᐸ__list_of_...tion__.”b”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression22
+    PgClassExpression23{{"PgClassExpression[23∈4]<br />ᐸ__list_of_...tion__.”c”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression23
+    PgClassExpression24{{"PgClassExpression[24∈4]<br />ᐸ__list_of_...tion__.”d”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression24
+    PgClassExpression25{{"PgClassExpression[25∈4]<br />ᐸ__list_of_...tion__.”e”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression25
+    PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__list_of_...tion__.”f”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression26
+    PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__list_of_...tion__.”g”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression27
+    PgClassExpression31{{"PgClassExpression[31∈4]<br />ᐸ__list_of_....”foo_bar”ᐳ"}}:::plan
+    PgSelectSingle20 --> PgClassExpression31
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/c.list_of_compound_types_mutation"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value2,__Value4,Access6,Access8,BakedInput10,Access12,Access13,Object14,PgFromExpression15,ApplyInput17 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 14, 15, 17<br /><br />1: PgSelect[11]<br />2: <br />ᐳ: Object[16]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgSelect11,Object16 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 11, 16<br /><br />ROOT Object{1}ᐸ{result}ᐳ[16]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,PgSelectRows18 bucket2
+    Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ18ᐳ[19]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,__Item19,PgSelectSingle20 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgSelectSingle{3}ᐸlist_of_compound_types_mutationᐳ[20]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgClassExpression27,PgClassExpression31 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 27<br /><br />ROOT PgClassExpression{4}ᐸ__list_of_...tion__.”g”ᐳ[27]"):::bucket
+    classDef bucket5 stroke:#7fff00
+    class Bucket5 bucket5
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    Bucket4 --> Bucket5
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.sql
@@ -1,0 +1,11 @@
+select
+  __list_of_compound_types_mutation__."a"::text as "0",
+  __list_of_compound_types_mutation__."b" as "1",
+  __list_of_compound_types_mutation__."c"::text as "2",
+  __list_of_compound_types_mutation__."d" as "3",
+  __list_of_compound_types_mutation__."e"::text as "4",
+  __list_of_compound_types_mutation__."f"::text as "5",
+  to_char(__list_of_compound_types_mutation__."g", 'YYYY_MM_DD_HH24_MI_SS.US'::text) as "6",
+  __list_of_compound_types_mutation__."foo_bar"::text as "7",
+  (not (__list_of_compound_types_mutation__ is null))::text as "8"
+from "c"."list_of_compound_types_mutation"($1::"c"."compound_type"[]) as __list_of_compound_types_mutation__;

--- a/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/c.list_of_compound_types_mutation.test.graphql
@@ -1,0 +1,20 @@
+## expect(errors).toBeFalsy()
+#> variableValues: {"input": {"records": [{"a":1,"b":"B","c":"RED","d":"00000000-0000-0000-0000-000000000000","e":"BAZ_QUX","f":"_EMPTY_","g":{"seconds":21},"fooBar":42}]}}
+mutation M($input: ListOfCompoundTypesMutationInput!) {
+  listOfCompoundTypesMutation(input: $input) {
+    compoundTypes {
+      a
+      b
+      c
+      d
+      e
+      f
+      g {
+        seconds
+        minutes
+        hours
+      }
+      fooBar
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -3842,6 +3842,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7428,6 +7429,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11204,6 +11231,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -15986,6 +16022,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18088,6 +18130,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -37433,6 +37500,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -41050,6 +41146,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
@@ -3630,6 +3630,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4453,6 +4478,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -3842,6 +3842,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7428,6 +7429,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11204,6 +11231,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -15986,6 +16022,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18088,6 +18130,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -37433,6 +37500,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -41050,6 +41146,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
@@ -3630,6 +3630,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4453,6 +4478,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -2409,6 +2409,21 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     }
   }
 });
+const compoundTypeArrayCodec = listOfCodec(compoundTypeCodec, {
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_compound_type"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  typeDelim: ",",
+  description: undefined,
+  name: "compoundTypeArray"
+});
 const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
 const func_outFunctionIdentifer = sql.identifier("c", "func_out");
 const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
@@ -2615,8 +2630,31 @@ const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_ou
 const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
 const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const resourceConfig_compound_type = {
+  executor: executor,
+  name: "compound_type",
+  identifier: "main.c.compound_type",
+  from: compoundTypeIdentifier,
+  codec: compoundTypeCodec,
+  uniques: [],
+  isVirtual: true,
+  description: "Awesome feature!",
+  extensions: {
+    description: "Awesome feature!",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    isInsertable: false,
+    isUpdatable: false,
+    isDeletable: false,
+    tags: {}
+  }
+};
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
 const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
 const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
@@ -2815,6 +2853,7 @@ const registry = makeRegistry({
     }),
     int4Array: int4ArrayCodec,
     floatrange: floatrangeCodec,
+    compoundTypeArray: compoundTypeArrayCodec,
     int8Array: int8ArrayCodec
   },
   pgResources: {
@@ -4187,28 +4226,7 @@ const registry = makeRegistry({
       },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor,
-      name: "compound_type",
-      identifier: "main.c.compound_type",
-      from: compoundTypeIdentifier,
-      codec: compoundTypeCodec,
-      uniques: [],
-      isVirtual: true,
-      description: "Awesome feature!",
-      extensions: {
-        description: "Awesome feature!",
-        pg: {
-          serviceName: "main",
-          schemaName: "c",
-          name: "compound_type"
-        },
-        isInsertable: false,
-        isUpdatable: false,
-        isDeletable: false,
-        tags: {}
-      }
-    }, {
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
@@ -4282,6 +4300,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "table_query"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -6506,6 +6550,15 @@ const argDetailsSimple_table_mutation = [{
 }];
 const makeArgs_table_mutation = (args, path = []) => argDetailsSimple_table_mutation.map(details => makeArg(path, args, details));
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_mutation_out_complex = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -8737,6 +8790,12 @@ type Mutation {
     """
     input: TableMutationInput!
   ): TableMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationOutComplex(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -9720,6 +9779,70 @@ input TableMutationInput {
   """
   clientMutationId: String
   id: Int
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""An input for mutations affecting \`CompoundType\`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  g: IntervalInput
+  fooBar: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """A quantity of years."""
+  years: Int
 }
 
 """The output of our \`mutationOutComplex\` mutation."""
@@ -17793,6 +17916,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     mutationOutComplex: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_mutation_out_complex(args, ["input"]);
@@ -19376,6 +19528,102 @@ export const plans = {
       }
     },
     id: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
+  },
+  CompoundTypeInput: {
+    "__baked": createObjectAndApplyChildren,
+    a: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("a", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    b: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("b", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    c: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("c", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    d: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("d", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    e: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("e", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    f: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("f", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    g: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("g", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    fooBar: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("foo_bar", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  IntervalInput: {
+    seconds: undefined,
+    minutes: undefined,
+    hours: undefined,
+    days: undefined,
+    months: undefined,
+    years: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
@@ -185,6 +185,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1277,6 +1289,33 @@ type Interval {
   years: Int
 }
 
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
 type Issue756 implements Node {
   id: Int!
 
@@ -1655,6 +1694,31 @@ enum LeftArmsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -1898,6 +1962,12 @@ type Mutation {
     """
     input: LeftArmIdentityInput!
   ): LeftArmIdentityPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
@@ -185,6 +185,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1288,6 +1300,33 @@ type Interval {
   years: Int
 }
 
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
 type Issue756 implements Node {
   id: Int!
 
@@ -1666,6 +1705,31 @@ enum LeftArmsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -1917,6 +1981,12 @@ type Mutation {
     """
     input: LeftArmIdentityInput!
   ): LeftArmIdentityPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -3848,6 +3848,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const create_postFunctionIdentifer = sql.identifier("a", "create_post");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
@@ -7435,6 +7436,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11237,6 +11264,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_create_post = [{
   graphqlArgName: "t",
   postgresArgName: "t",
@@ -16028,6 +16064,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   createPost(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18128,6 +18170,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`createPost\` mutation."""
@@ -37469,6 +37536,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     createPost: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_create_post(args, ["input"]);
@@ -41095,6 +41191,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   CreatePostPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
@@ -3626,6 +3626,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4447,6 +4472,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -3842,6 +3842,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const create_postFunctionIdentifer = sql.identifier("a", "create_post");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
@@ -7429,6 +7430,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11231,6 +11258,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -16013,6 +16049,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18115,6 +18157,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -37460,6 +37527,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -41077,6 +41173,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
@@ -3630,6 +3630,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4453,6 +4478,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -3973,6 +3973,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7571,6 +7572,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11350,6 +11377,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -15435,6 +15471,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -17537,6 +17579,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -31408,6 +31475,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -35025,6 +35121,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
@@ -3499,6 +3499,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4322,6 +4347,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -3842,6 +3842,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7428,6 +7429,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11204,6 +11231,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -15991,6 +16027,12 @@ type M {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18093,6 +18135,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Q
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -37438,6 +37505,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -41055,6 +41151,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
@@ -3635,6 +3635,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Q
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4350,6 +4375,12 @@ type M {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -2408,6 +2408,21 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     }
   }
 });
+const compoundTypeArrayCodec = listOfCodec(compoundTypeCodec, {
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_compound_type"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  typeDelim: ",",
+  description: undefined,
+  name: "compoundTypeArray"
+});
 const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
 const func_outFunctionIdentifer = sql.identifier("c", "func_out");
 const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
@@ -2613,8 +2628,31 @@ const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_ou
 const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
 const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const resourceConfig_compound_type = {
+  executor: executor,
+  name: "compound_type",
+  identifier: "main.c.compound_type",
+  from: compoundTypeIdentifier,
+  codec: compoundTypeCodec,
+  uniques: [],
+  isVirtual: true,
+  description: "Awesome feature!",
+  extensions: {
+    description: "Awesome feature!",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    isInsertable: false,
+    isUpdatable: false,
+    isDeletable: false,
+    tags: {}
+  }
+};
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
 const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
 const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
@@ -2803,6 +2841,7 @@ const registry = makeRegistry({
     }),
     int4Array: int4ArrayCodec,
     floatrange: floatrangeCodec,
+    compoundTypeArray: compoundTypeArrayCodec,
     int8Array: int8ArrayCodec
   },
   pgResources: {
@@ -4175,28 +4214,7 @@ const registry = makeRegistry({
       },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor,
-      name: "compound_type",
-      identifier: "main.c.compound_type",
-      from: compoundTypeIdentifier,
-      codec: compoundTypeCodec,
-      uniques: [],
-      isVirtual: true,
-      description: "Awesome feature!",
-      extensions: {
-        description: "Awesome feature!",
-        pg: {
-          serviceName: "main",
-          schemaName: "c",
-          name: "compound_type"
-        },
-        isInsertable: false,
-        isUpdatable: false,
-        isDeletable: false,
-        tags: {}
-      }
-    }, {
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
@@ -4270,6 +4288,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "table_query"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -6464,6 +6508,15 @@ const argDetailsSimple_table_mutation = [{
 }];
 const makeArgs_table_mutation = (args, path = []) => argDetailsSimple_table_mutation.map(details => makeArg(path, args, details));
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_mutation_out_complex = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -8607,6 +8660,12 @@ type Mutation {
     """
     input: TableMutationInput!
   ): TableMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationOutComplex(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -9264,6 +9323,70 @@ input TableMutationInput {
   """
   clientMutationId: String
   id: Int
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""An input for mutations affecting \`CompoundType\`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  g: IntervalInput
+  fooBar: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """A quantity of years."""
+  years: Int
 }
 
 """The output of our \`mutationOutComplex\` mutation."""
@@ -16011,6 +16134,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     mutationOutComplex: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_mutation_out_complex(args, ["input"]);
@@ -16788,6 +16940,102 @@ export const plans = {
       }
     },
     id: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
+  },
+  CompoundTypeInput: {
+    "__baked": createObjectAndApplyChildren,
+    a: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("a", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    b: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("b", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    c: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("c", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    d: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("d", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    e: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("e", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    f: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("f", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    g: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("g", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    fooBar: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("foo_bar", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  IntervalInput: {
+    seconds: undefined,
+    minutes: undefined,
+    hours: undefined,
+    days: undefined,
+    months: undefined,
+    years: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
@@ -169,6 +169,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -591,6 +603,33 @@ type Interval {
   years: Int
 }
 
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
 type Issue756 implements Node {
   id: Int!
 
@@ -937,6 +976,31 @@ enum LeftArmsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -989,6 +1053,12 @@ type Mutation {
     """
     input: LeftArmIdentityInput!
   ): LeftArmIdentityPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/pgStrictFunctions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pgStrictFunctions.1.graphql
@@ -3630,6 +3630,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]!
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4453,6 +4478,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -4124,6 +4124,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const mutation_compound_type_arrayFunctionIdentifer = sql.identifier("a", "mutation_compound_type_array");
 const query_compound_type_arrayFunctionIdentifer = sql.identifier("a", "query_compound_type_array");
 const compound_type_array_mutationFunctionIdentifer = sql.identifier("b", "compound_type_array_mutation");
@@ -7999,6 +8000,33 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {},
+        canExecute: false
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {},
         canExecute: false

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -3842,6 +3842,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7428,6 +7429,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11204,6 +11231,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -15986,6 +16022,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18088,6 +18130,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -37433,6 +37500,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -41050,6 +41146,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
@@ -3630,6 +3630,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -4453,6 +4478,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -2408,6 +2408,21 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     }
   }
 });
+const compoundTypeArrayCodec = listOfCodec(compoundTypeCodec, {
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_compound_type"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  typeDelim: ",",
+  description: undefined,
+  name: "compoundTypeArray"
+});
 const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
 const func_outFunctionIdentifer = sql.identifier("c", "func_out");
 const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
@@ -2613,8 +2628,31 @@ const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_ou
 const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
 const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const resourceConfig_compound_type = {
+  executor: executor,
+  name: "compound_type",
+  identifier: "main.c.compound_type",
+  from: compoundTypeIdentifier,
+  codec: compoundTypeCodec,
+  uniques: [],
+  isVirtual: true,
+  description: "Awesome feature!",
+  extensions: {
+    description: "Awesome feature!",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    isInsertable: false,
+    isUpdatable: false,
+    isDeletable: false,
+    tags: {}
+  }
+};
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
 const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
 const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
@@ -2803,6 +2841,7 @@ const registry = makeRegistry({
     }),
     int4Array: int4ArrayCodec,
     floatrange: floatrangeCodec,
+    compoundTypeArray: compoundTypeArrayCodec,
     int8Array: int8ArrayCodec
   },
   pgResources: {
@@ -4175,28 +4214,7 @@ const registry = makeRegistry({
       },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor,
-      name: "compound_type",
-      identifier: "main.c.compound_type",
-      from: compoundTypeIdentifier,
-      codec: compoundTypeCodec,
-      uniques: [],
-      isVirtual: true,
-      description: "Awesome feature!",
-      extensions: {
-        description: "Awesome feature!",
-        pg: {
-          serviceName: "main",
-          schemaName: "c",
-          name: "compound_type"
-        },
-        isInsertable: false,
-        isUpdatable: false,
-        isDeletable: false,
-        tags: {}
-      }
-    }, {
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
@@ -4270,6 +4288,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "table_query"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -6464,6 +6508,15 @@ const argDetailsSimple_table_mutation = [{
 }];
 const makeArgs_table_mutation = (args, path = []) => argDetailsSimple_table_mutation.map(details => makeArg(path, args, details));
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_mutation_out_complex = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -8663,6 +8716,12 @@ type Mutation {
     """
     input: TableMutationInput!
   ): TableMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationOutComplex(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -9646,6 +9705,70 @@ input TableMutationInput {
   """
   clientMutationId: String
   id: Int
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""An input for mutations affecting \`CompoundType\`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  g: IntervalInput
+  fooBar: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """A quantity of years."""
+  years: Int
 }
 
 """The output of our \`mutationOutComplex\` mutation."""
@@ -17637,6 +17760,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     mutationOutComplex: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_mutation_out_complex(args, ["input"]);
@@ -19220,6 +19372,102 @@ export const plans = {
       }
     },
     id: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
+  },
+  CompoundTypeInput: {
+    "__baked": createObjectAndApplyChildren,
+    a: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("a", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    b: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("b", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    c: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("c", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    d: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("d", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    e: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("e", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    f: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("f", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    g: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("g", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    fooBar: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("foo_bar", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  IntervalInput: {
+    seconds: undefined,
+    minutes: undefined,
+    hours: undefined,
+    days: undefined,
+    months: undefined,
+    years: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
@@ -185,6 +185,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1271,6 +1283,33 @@ type Interval {
   years: Int
 }
 
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
 type Issue756 implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
@@ -1647,6 +1686,31 @@ enum LeftArmsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -1890,6 +1954,12 @@ type Mutation {
     """
     input: LeftArmIdentityInput!
   ): LeftArmIdentityPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -2408,6 +2408,21 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     }
   }
 });
+const compoundTypeArrayCodec = listOfCodec(compoundTypeCodec, {
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_compound_type"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  typeDelim: ",",
+  description: undefined,
+  name: "compoundTypeArray"
+});
 const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
 const func_outFunctionIdentifer = sql.identifier("c", "func_out");
 const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
@@ -2613,8 +2628,31 @@ const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_ou
 const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
 const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const resourceConfig_compound_type = {
+  executor: executor,
+  name: "compound_type",
+  identifier: "main.c.compound_type",
+  from: compoundTypeIdentifier,
+  codec: compoundTypeCodec,
+  uniques: [],
+  isVirtual: true,
+  description: "Awesome feature!",
+  extensions: {
+    description: "Awesome feature!",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    isInsertable: false,
+    isUpdatable: false,
+    isDeletable: false,
+    tags: {}
+  }
+};
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
 const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
 const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
@@ -2803,6 +2841,7 @@ const registry = makeRegistry({
     }),
     int4Array: int4ArrayCodec,
     floatrange: floatrangeCodec,
+    compoundTypeArray: compoundTypeArrayCodec,
     int8Array: int8ArrayCodec
   },
   pgResources: {
@@ -4175,28 +4214,7 @@ const registry = makeRegistry({
       },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor,
-      name: "compound_type",
-      identifier: "main.c.compound_type",
-      from: compoundTypeIdentifier,
-      codec: compoundTypeCodec,
-      uniques: [],
-      isVirtual: true,
-      description: "Awesome feature!",
-      extensions: {
-        description: "Awesome feature!",
-        pg: {
-          serviceName: "main",
-          schemaName: "c",
-          name: "compound_type"
-        },
-        isInsertable: false,
-        isUpdatable: false,
-        isDeletable: false,
-        tags: {}
-      }
-    }, {
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
@@ -4270,6 +4288,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "table_query"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -6464,6 +6508,15 @@ const argDetailsSimple_table_mutation = [{
 }];
 const makeArgs_table_mutation = (args, path = []) => argDetailsSimple_table_mutation.map(details => makeArg(path, args, details));
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_mutation_out_complex = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -8948,6 +9001,12 @@ type Mutation {
     """
     input: TableMutationInput!
   ): TableMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationOutComplex(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -9931,6 +9990,70 @@ input TableMutationInput {
   """
   clientMutationId: String
   id: Int
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""An input for mutations affecting \`CompoundType\`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  g: IntervalInput
+  fooBar: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """A quantity of years."""
+  years: Int
 }
 
 """The output of our \`mutationOutComplex\` mutation."""
@@ -18613,6 +18736,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     mutationOutComplex: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_mutation_out_complex(args, ["input"]);
@@ -20196,6 +20348,102 @@ export const plans = {
       }
     },
     id: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
+  },
+  CompoundTypeInput: {
+    "__baked": createObjectAndApplyChildren,
+    a: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("a", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    b: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("b", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    c: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("c", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    d: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("d", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    e: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("e", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    f: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("f", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    g: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("g", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    fooBar: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("foo_bar", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  IntervalInput: {
+    seconds: undefined,
+    minutes: undefined,
+    hours: undefined,
+    days: undefined,
+    months: undefined,
+    years: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
@@ -185,6 +185,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1271,6 +1283,33 @@ type Interval {
   years: Int
 }
 
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
 type Issue756 implements Node {
   id: Int!
 
@@ -1649,6 +1688,31 @@ enum LeftArmsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -1892,6 +1956,12 @@ type Mutation {
     """
     input: LeftArmIdentityInput!
   ): LeftArmIdentityPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -2408,6 +2408,21 @@ const floatrangeCodec = rangeOfCodec(TYPES.float, "floatrange", sql.identifier("
     }
   }
 });
+const compoundTypeArrayCodec = listOfCodec(compoundTypeCodec, {
+  extensions: {
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "_compound_type"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  typeDelim: ",",
+  description: undefined,
+  name: "compoundTypeArray"
+});
 const current_user_idFunctionIdentifer = sql.identifier("c", "current_user_id");
 const func_outFunctionIdentifer = sql.identifier("c", "func_out");
 const func_out_setofFunctionIdentifer = sql.identifier("c", "func_out_setof");
@@ -2613,8 +2628,31 @@ const func_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "func_ou
 const mutation_out_out_compound_typeFunctionIdentifer = sql.identifier("c", "mutation_out_out_compound_type");
 const query_output_two_rowsFunctionIdentifer = sql.identifier("c", "query_output_two_rows");
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
+const resourceConfig_compound_type = {
+  executor: executor,
+  name: "compound_type",
+  identifier: "main.c.compound_type",
+  from: compoundTypeIdentifier,
+  codec: compoundTypeCodec,
+  uniques: [],
+  isVirtual: true,
+  description: "Awesome feature!",
+  extensions: {
+    description: "Awesome feature!",
+    pg: {
+      serviceName: "main",
+      schemaName: "c",
+      name: "compound_type"
+    },
+    isInsertable: false,
+    isUpdatable: false,
+    isDeletable: false,
+    tags: {}
+  }
+};
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const person_computed_outFunctionIdentifer = sql.identifier("c", "person_computed_out");
 const person_first_nameFunctionIdentifer = sql.identifier("c", "person_first_name");
 const person_computed_out_outFunctionIdentifer = sql.identifier("c", "person_computed_out_out");
@@ -2803,6 +2841,7 @@ const registry = makeRegistry({
     }),
     int4Array: int4ArrayCodec,
     floatrange: floatrangeCodec,
+    compoundTypeArray: compoundTypeArrayCodec,
     int8Array: int8ArrayCodec
   },
   pgResources: {
@@ -4175,28 +4214,7 @@ const registry = makeRegistry({
       },
       description: undefined
     },
-    compound_type_set_query: PgResource.functionResourceOptions({
-      executor: executor,
-      name: "compound_type",
-      identifier: "main.c.compound_type",
-      from: compoundTypeIdentifier,
-      codec: compoundTypeCodec,
-      uniques: [],
-      isVirtual: true,
-      description: "Awesome feature!",
-      extensions: {
-        description: "Awesome feature!",
-        pg: {
-          serviceName: "main",
-          schemaName: "c",
-          name: "compound_type"
-        },
-        isInsertable: false,
-        isUpdatable: false,
-        isDeletable: false,
-        tags: {}
-      }
-    }, {
+    compound_type_set_query: PgResource.functionResourceOptions(resourceConfig_compound_type, {
       name: "compound_type_set_query",
       identifier: "main.c.compound_type_set_query()",
       from(...args) {
@@ -4270,6 +4288,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "table_query"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -6344,6 +6388,15 @@ const argDetailsSimple_table_mutation = [{
 }];
 const makeArgs_table_mutation = (args, path = []) => argDetailsSimple_table_mutation.map(details => makeArg(path, args, details));
 const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_mutation_out_complex = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -7797,6 +7850,12 @@ type Mutation {
     """
     input: TableMutationInput!
   ): TableMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationOutComplex(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -8768,6 +8827,70 @@ input TableMutationInput {
   """
   clientMutationId: String
   id: Int
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""An input for mutations affecting \`CompoundType\`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  g: IntervalInput
+  fooBar: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """A quantity of years."""
+  years: Int
 }
 
 """The output of our \`mutationOutComplex\` mutation."""
@@ -15628,6 +15751,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     mutationOutComplex: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_mutation_out_complex(args, ["input"]);
@@ -17163,6 +17315,102 @@ export const plans = {
       }
     },
     id: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
+  },
+  CompoundTypeInput: {
+    "__baked": createObjectAndApplyChildren,
+    a: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("a", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    b: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("b", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    c: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("c", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    d: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("d", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    e: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("e", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    f: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("f", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    g: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("g", bakedInputRuntime(schema, field.type, val));
+      }
+    },
+    fooBar: {
+      apply(obj, val, {
+        field,
+        schema
+      }) {
+        obj.set("foo_bar", bakedInputRuntime(schema, field.type, val));
+      }
+    }
+  },
+  IntervalInput: {
+    seconds: undefined,
+    minutes: undefined,
+    hours: undefined,
+    days: undefined,
+    months: undefined,
+    years: undefined
   },
   MutationOutComplexPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
@@ -159,6 +159,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 type Comptype {
   isOptimised: Boolean
   schedule: Datetime
@@ -944,6 +956,33 @@ type Interval {
   years: Int
 }
 
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
 type Issue756 implements Node {
   id: Int!
 
@@ -1258,6 +1297,31 @@ enum LeftArmsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType!]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """
 The root mutation type which contains root level fields which mutate data.
 """
@@ -1501,6 +1565,12 @@ type Mutation {
     """
     input: LeftArmIdentityInput!
   ): LeftArmIdentityPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -3842,6 +3842,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7428,6 +7429,32 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "b",
           name: "compound_type_set_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
         },
         tags: {}
       },
@@ -11204,6 +11231,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -15986,6 +16022,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -18088,6 +18130,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -37433,6 +37500,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -41050,6 +41146,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
@@ -4522,6 +4522,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -6624,6 +6630,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our `tableMutation` mutation."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -3776,6 +3776,7 @@ const resourceConfig_compound_type = {
 const compound_type_mutationFunctionIdentifer = sql.identifier("b", "compound_type_mutation");
 const compound_type_queryFunctionIdentifer = sql.identifier("b", "compound_type_query");
 const compound_type_set_mutationFunctionIdentifer = sql.identifier("b", "compound_type_set_mutation");
+const list_of_compound_types_mutationFunctionIdentifer = sql.identifier("c", "list_of_compound_types_mutation");
 const table_mutationFunctionIdentifer = sql.identifier("c", "table_mutation");
 const table_queryFunctionIdentifer = sql.identifier("c", "table_query");
 const post_with_suffixFunctionIdentifer = sql.identifier("a", "post_with_suffix");
@@ -7367,6 +7368,32 @@ const registry = makeRegistry({
       },
       description: undefined
     }),
+    list_of_compound_types_mutation: PgResource.functionResourceOptions(resourceConfig_compound_type, {
+      name: "list_of_compound_types_mutation",
+      identifier: "main.c.list_of_compound_types_mutation(c._compound_type)",
+      from(...args) {
+        return sql`${list_of_compound_types_mutationFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "records",
+        required: true,
+        notNull: false,
+        codec: compoundTypeArrayCodec
+      }],
+      returnsArray: false,
+      returnsSetof: true,
+      isMutation: true,
+      hasImplicitOrder: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "list_of_compound_types_mutation"
+        },
+        tags: {}
+      },
+      description: undefined
+    }),
     table_mutation: PgResource.functionResourceOptions(registryConfig_pgResources_post_post, {
       name: "table_mutation",
       identifier: "main.c.table_mutation(int4)",
@@ -10544,6 +10571,15 @@ const argDetailsSimple_compound_type_set_mutation = [{
 }];
 const makeArgs_compound_type_set_mutation = (args, path = []) => argDetailsSimple_compound_type_set_mutation.map(details => makeArg(path, args, details));
 const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const argDetailsSimple_list_of_compound_types_mutation = [{
+  graphqlArgName: "records",
+  postgresArgName: "records",
+  pgCodec: compoundTypeArrayCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs_list_of_compound_types_mutation = (args, path = []) => argDetailsSimple_list_of_compound_types_mutation.map(details => makeArg(path, args, details));
+const resource_list_of_compound_types_mutationPgResource = registry.pgResources["list_of_compound_types_mutation"];
 const argDetailsSimple_table_mutation = [{
   graphqlArgName: "id",
   postgresArgName: "id",
@@ -14948,6 +14984,12 @@ type Mutation {
     """
     input: CompoundTypeSetMutationInput!
   ): CompoundTypeSetMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   tableMutation(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -16730,6 +16772,31 @@ input CompoundTypeSetMutationInput {
   """
   clientMutationId: String
   object: CompoundTypeInput
+}
+
+"""The output of our \`listOfCompoundTypesMutation\` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the \`listOfCompoundTypesMutation\` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
 }
 
 """The output of our \`tableMutation\` mutation."""
@@ -35270,6 +35337,35 @@ export const plans = {
         }
       }
     },
+    listOfCompoundTypesMutation: {
+      plan($root, args, _info) {
+        const selectArgs = makeArgs_list_of_compound_types_mutation(args, ["input"]);
+        const $result = resource_list_of_compound_types_mutationPgResource.execute(selectArgs, "mutation");
+        return object({
+          result: $result
+        });
+      },
+      args: {
+        input: {
+          __proto__: null,
+          grafast: {
+            applyPlan(_, $object, arg) {
+              // We might have any number of step types here; we need
+              // to get back to the underlying pgSelect.
+              const $result = $object.getStepForKey("result");
+              const $parent = "getParentStep" in $result ? $result.getParentStep() : $result;
+              const $pgSelect = "getClassStep" in $parent ? $parent.getClassStep() : $parent;
+              if ($pgSelect instanceof PgSelectStep) {
+                // Mostly so `clientMutationId` works!
+                arg.apply($pgSelect);
+              } else {
+                throw new Error(`Could not determine PgSelectStep for ${$result}`);
+              }
+            }
+          }
+        }
+      }
+    },
     tableMutation: {
       plan($root, args, _info) {
         const selectArgs = makeArgs_table_mutation(args, ["input"]);
@@ -38165,6 +38261,27 @@ export const plans = {
       }
     },
     object: undefined
+  },
+  ListOfCompoundTypesMutationPayload: {
+    __assertStep: ObjectStep,
+    clientMutationId($object) {
+      const $result = $object.getStepForKey("result");
+      return $result.getMeta("clientMutationId");
+    },
+    compoundTypes($object) {
+      return $object.get("result");
+    },
+    query() {
+      return rootValue();
+    }
+  },
+  ListOfCompoundTypesMutationInput: {
+    clientMutationId: {
+      apply(qb, val) {
+        qb.setMeta("clientMutationId", val);
+      }
+    },
+    records: undefined
   },
   TableMutationPayload: {
     __assertStep: ObjectStep,

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
@@ -3315,6 +3315,31 @@ input ListInput {
   timestamptzArrayNn: [Datetime]!
 }
 
+"""All input for the `listOfCompoundTypesMutation` mutation."""
+input ListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CompoundTypeInput]
+}
+
+"""The output of our `listOfCompoundTypesMutation` mutation."""
+type ListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  compoundTypes: [CompoundType]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
 """Represents an update to a `List`. Fields that are set will be updated."""
 input ListPatch {
   byteaArray: [Base64EncodedBinary]
@@ -3986,6 +4011,12 @@ type Mutation {
     """
     input: ListBdeMutationInput!
   ): ListBdeMutationPayload
+  listOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ListOfCompoundTypesMutationInput!
+  ): ListOfCompoundTypesMutationPayload
   mult1(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
@@ -2097,6 +2097,31 @@ input CLeftArmPatch {
   rowId: Int
 }
 
+"""All input for the `cListOfCompoundTypesMutation` mutation."""
+input CListOfCompoundTypesMutationInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  records: [CCompoundTypeInput]
+}
+
+"""The output of our `cListOfCompoundTypesMutation` mutation."""
+type CListOfCompoundTypesMutationPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+  result: [CCompoundType]
+}
+
 """All input for the `cMutationInInout` mutation."""
 input CMutationInInoutInput {
   """
@@ -5355,6 +5380,12 @@ type Mutation {
     """
     input: CLeftArmIdentityInput!
   ): CLeftArmIdentityPayload
+  cListOfCompoundTypesMutation(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CListOfCompoundTypesMutationInput!
+  ): CListOfCompoundTypesMutationPayload
   cMutationInInout(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.


### PR DESCRIPTION
Inadvertently broken as part of #2060; discovered whilst doing a performance test. Fixed by introducing "isImmutable" on variable/argument-related steps; not sure that we'll keep this for long, it's hidden internally, but the test will prevent the issue coming back.