### PR TITLE
codecs: Add explicit array check

### DIFF
--- a/grafast/dataplan-pg/src/codecs.ts
+++ b/grafast/dataplan-pg/src/codecs.ts
@@ -656,6 +656,11 @@ export function listOfCodec<
         .flat(100)
         .map((v) => (v == null ? null : innerCodec.fromPg(v))) as any,
     toPg: (value) => {
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `Do not know how to encode ${inspect(value)} to an array`,
+        );
+      }
       let result = "{";
       for (let i = 0, l = value.length; i < l; i++) {
         if (i > 0) {


### PR DESCRIPTION

## Description

Replaces an obscure error message such as "Cannot read properties of null (reading 'length')" with an explicit one.

## Performance impact

Should be negligible.

## Security impact

Should be none.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [X] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
