### PR TITLE
Add normalizedConnectionParams

### DIFF
--- a/.changeset/early-worms-eat.md
+++ b/.changeset/early-worms-eat.md
@@ -1,0 +1,6 @@
+---
+"grafserv": patch
+---
+
+Add `ctx.ws?.normalizedConnectionParams` which can be treated as headers (i.e.
+has lower-cased keys).

--- a/.changeset/early-worms-eat.md
+++ b/.changeset/early-worms-eat.md
@@ -1,4 +1,5 @@
 ---
+"grafast": patch
 "grafserv": patch
 ---
 

--- a/grafast/grafast/src/envelop.ts
+++ b/grafast/grafast/src/envelop.ts
@@ -27,7 +27,7 @@ function processExplain(
   const explainHeader = Array.isArray(explainHeaders)
     ? explainHeaders.join(",")
     : explainHeaders;
-  if (!explainHeader) {
+  if (typeof explainHeader !== "string") {
     return undefined;
   }
   const explainParts = explainHeader.split(",");
@@ -63,9 +63,25 @@ export const useGrafast = (options: UseGrafastOptions = {}): EnvelopPlugin => {
     },
     async onSubscribe(opts) {
       const ctx = opts.args.contextValue as any;
-      const explainHeaders = (ctx?.req?.headers ||
+
+      const headersObj =
+        ctx?.req?.headers ||
         ctx?.request?.headers ||
-        ctx?.normalizedConnectionParams)?.["x-graphql-explain"];
+        ctx?.normalizedConnectionParams ||
+        ctx?.connectionParams;
+      let explainHeaders: string | string[] | undefined;
+      if (headersObj) {
+        explainHeaders = headersObj["x-graphql-explain"];
+        if (explainHeaders == null) {
+          const key = Object.keys(headersObj).find(
+            (k) => k.toLowerCase() === "x-graphql-explain",
+          );
+          if (key != null) {
+            explainHeaders = headersObj[key];
+          }
+        }
+      }
+
       const explain = processExplain(explainAllowed, explainHeaders);
       opts.setSubscribeFn(async (args) =>
         grafastSubscribe(

--- a/grafast/grafast/src/envelop.ts
+++ b/grafast/grafast/src/envelop.ts
@@ -65,7 +65,7 @@ export const useGrafast = (options: UseGrafastOptions = {}): EnvelopPlugin => {
       const ctx = opts.args.contextValue as any;
       const explainHeaders = (ctx?.req?.headers ||
         ctx?.request?.headers ||
-        ctx?.connectionParams)?.["x-graphql-explain"];
+        ctx?.normalizedConnectionParams)?.["x-graphql-explain"];
       const explain = processExplain(explainAllowed, explainHeaders);
       opts.setSubscribeFn(async (args) =>
         grafastSubscribe(

--- a/grafast/grafserv/src/index.ts
+++ b/grafast/grafserv/src/index.ts
@@ -58,6 +58,7 @@ export {
   httpError,
   makeGraphQLWSConfig,
   memo,
+  normalizeConnectionParams,
   normalizeRequest,
   parseGraphQLJSONBody,
   processHeaders,

--- a/grafast/grafserv/src/servers/node/index.ts
+++ b/grafast/grafserv/src/servers/node/index.ts
@@ -1,4 +1,5 @@
 import type {
+  IncomingHttpHeaders,
   IncomingMessage,
   Server as HTTPServer,
   ServerResponse,
@@ -41,6 +42,19 @@ declare global {
 
         /** The parameters passed during the connection initialisation. */
         readonly connectionParams: Record<string, unknown> | undefined;
+
+        /**
+         * As `connectionParams`, but with lower case keys to avoid case sensitivity issues. The actual transforms are:
+         *
+         * - Non-string keys are ignored
+         * - Keys are lowercased
+         * - Array values are confirmed to be string[], otherwise they're ignored
+         * - Other values are coerced to string if appropriate, otherwise ignored
+         * - Ignored values are not added to headers
+         * - If duplicate keys are found, the resulting value will be string[]
+         *   by concatenating existing and new values
+         */
+        readonly normalizedConnectionParams: IncomingHttpHeaders | undefined;
       };
     }
   }

--- a/graphile-build/graphile-build-pg/package.json
+++ b/graphile-build/graphile-build-pg/package.json
@@ -88,6 +88,7 @@
     "express-graphql": "^0.12.0",
     "fastify": "^4.22.1",
     "fastify-static": "^4.7.0",
+    "grafserv": "workspace:^",
     "graphile-export": "workspace:^",
     "graphql": "16.1.0-experimental-stream-defer.6",
     "graphql-helix": "^1.13.0",

--- a/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
+++ b/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
@@ -21,6 +21,7 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 import fastify from "fastify";
 import { useGrafast, useMoreDetailedErrors } from "grafast/envelop";
 import { graphql } from "grafast/graphql";
+import { normalizeConnectionParams } from "grafserv";
 import {
   buildInflection,
   buildSchema,
@@ -306,6 +307,9 @@ pool.on("error", (e) => {
             subscribe,
           } = getEnveloped({
             connectionParams: ctx.connectionParams,
+            normalizedConnectionParams: normalizeConnectionParams(
+              ctx.connectionParams,
+            ),
             socket: ctx.extra.socket,
             request: ctx.extra.request,
           });

--- a/graphile-build/graphile-build-pg/tsconfig.json
+++ b/graphile-build/graphile-build-pg/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../../grafast/dataplan-pg" },
     { "path": "../graphile-build" },
     { "path": "../../grafast/grafast" },
+    { "path": "../../grafast/grafserv" },
     { "path": "../../utils/graphile-export" },
     { "path": "../../grafast/ruru/tsconfig.build.json" },
     { "path": "../../utils/graphile-config" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13033,6 +13033,7 @@ __metadata:
     express-graphql: "npm:^0.12.0"
     fastify: "npm:^4.22.1"
     fastify-static: "npm:^4.7.0"
+    grafserv: "workspace:^"
     graphile-config: "workspace:^"
     graphile-export: "workspace:^"
     graphql: "npm:16.1.0-experimental-stream-defer.6"


### PR DESCRIPTION
## Description

In V4 we had `normalizedConnectionParams` which could be used to read connectionParams (an arbitrary JSON object) as if they were headers (i.e. with lowercase keys). This PR adds that.

## Performance impact

Small processing overhead for websocket requests.

## Security impact

Enables users to easily read the normalized params, thus a benefit.

It _does_ combine values if there is mixed case, so potentially risky but I can't think of a situation in which this would be problematic.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
