### PR TITLE
Naked GraphQLErrors are safe

### DIFF
--- a/.changeset/icy-views-care.md
+++ b/.changeset/icy-views-care.md
@@ -1,0 +1,6 @@
+---
+"grafserv": patch
+---
+
+Naked GraphQL errors (such as those you'd see from coercion) are now treated as
+safe to output.

--- a/grafast/grafserv/src/options.ts
+++ b/grafast/grafserv/src/options.ts
@@ -28,7 +28,10 @@ const randomString = (length = 10) => {
 export function defaultMaskError(
   error: graphql.GraphQLError,
 ): graphql.GraphQLError {
-  if (error.originalError instanceof GraphQLError) {
+  if (!error.originalError && error instanceof GraphQLError) {
+    // Things like 'Cannot return null for non-nullable field'
+    return error;
+  } else if (error.originalError instanceof GraphQLError) {
     return error;
   } else if (error.originalError != null && isSafeError(error.originalError)) {
     return new GraphQLError(


### PR DESCRIPTION
## Description

Naked GraphQL errors, such as those generated by coercion, are now treated as safe.

## Performance impact

Negligible.

## Security impact

Potentially quite high depending on what values fail to coerce and how GraphQL presents them in the error message; however this will always be the fault of the schema developer and isn't an inherent flaw in Grafast.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
