### PR TITLE
Update export schema linter to use ES2022

### DIFF
--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -2110,7 +2110,7 @@ async function lint(code: string, rawFilePath: string | URL) {
     overrideConfig: {
       reportUnusedDisableDirectives: false,
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: "module",
       },
       rules: {


### PR DESCRIPTION
## Description

Fixes an issue tracked in https://github.com/graphile/crystal/issues/2445

See related discord thread on April 14th 2025 (sadly [can't link to discord threads right now](https://www.reddit.com/r/discordapp/comments/1jzibkb/copy_message_link_not_working/)!)

## Performance impact

None -- this is a linting issue.

## Security impact

None -- this is a linting issue.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~I've added tests for the new feature, and `yarn test` passes.~
- [ ] ~I have detailed the new feature in the relevant documentation.~
- [ ] ~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~
- [ ] ~If this is a breaking change I've explained why.~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
