### PR TITLE
Add 'ref' system for Grafast shortcut references

### DIFF
--- a/.changeset/pretty-guests-eat.md
+++ b/.changeset/pretty-guests-eat.md
@@ -1,0 +1,6 @@
+---
+"postgraphile": patch
+"@dataplan/pg": patch
+---
+
+Use new .addRef and .getRef methods from grafast.

--- a/.changeset/puny-eels-act.md
+++ b/.changeset/puny-eels-act.md
@@ -1,0 +1,7 @@
+---
+"grafast": patch
+---
+
+Add `const refId = this.addRef($other);` and
+`const $other = this.getRef(refId);` APIs to steps, to allow referencing
+ancestor steps at plan-time only. Useful for optimization.

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.deopt.mermaid
@@ -32,10 +32,10 @@ graph TD
     PgSelect18[["PgSelect[18∈2]<br />ᐸforums_messages_list_setᐳ"]]:::plan
     PgClassExpression17{{"PgClassExpression[17∈2]<br />ᐸ__forums__ᐳ"}}:::plan
     Object11 & PgClassExpression17 & PgFromExpression22 --> PgSelect18
+    PgSelectSingle16 --> PgClassExpression17
     __ListTransform23[["__ListTransform[23∈2]<br />ᐸpartitionByIndex1:18ᐳ"]]:::plan
     PgSelectRows24[["PgSelectRows[24∈2]"]]:::plan
-    PgSelectRows24 & PgSelect18 --> __ListTransform23
-    PgSelectSingle16 --> PgClassExpression17
+    PgSelectRows24 --> __ListTransform23
     PgSelect18 --> PgSelectRows24
     __Item25[/"__Item[25∈3]<br />ᐸ24ᐳ"\]:::itemplan
     PgSelectRows24 -.-> __Item25

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-list-set.mermaid
@@ -32,12 +32,12 @@ graph TD
     PgSelectRows14 ==> __Item15
     PgSelectSingle16{{"PgSelectSingle[16∈1]<br />ᐸforumsᐳ"}}:::plan
     __Item15 --> PgSelectSingle16
-    __ListTransform23[["__ListTransform[23∈2]<br />ᐸpartitionByIndex1:18ᐳ"]]:::plan
-    PgSelectRows24[["PgSelectRows[24∈2]"]]:::plan
-    Lambda38{{"Lambda[38∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows24 & Lambda38 --> __ListTransform23
     List37{{"List[37∈2]<br />ᐸ36,15ᐳ"}}:::plan
     Access36 & __Item15 --> List37
+    __ListTransform23[["__ListTransform[23∈2]<br />ᐸpartitionByIndex1:18ᐳ"]]:::plan
+    PgSelectRows24[["PgSelectRows[24∈2]"]]:::plan
+    PgSelectRows24 --> __ListTransform23
+    Lambda38{{"Lambda[38∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda38 --> PgSelectRows24
     List37 --> Lambda38
     __Item25[/"__Item[25∈3]<br />ᐸ24ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.deopt.mermaid
@@ -34,8 +34,8 @@ graph TD
     PgSelectSingle16 --> PgClassExpression27
     __ListTransform22[["__ListTransform[22∈3]<br />ᐸfilter:18ᐳ"]]:::plan
     PgSelectRows23[["PgSelectRows[23∈3] ➊"]]:::plan
+    PgSelectRows23 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
     PgSelect18[["PgSelect[18∈3] ➊<br />ᐸmessagesᐳ"]]:::plan
-    PgSelectRows23 & PgSelect18 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
     Object11 --> PgSelect18
     PgSelect18 --> PgSelectRows23
     __ListTransform30[["__ListTransform[30∈3]<br />ᐸgroupBy:22ᐳ"]]:::plan

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.defer.mermaid
@@ -34,8 +34,8 @@ graph TD
     PgSelectSingle16 --> PgClassExpression27
     __ListTransform22[["__ListTransform[22∈3]<br />ᐸfilter:18ᐳ"]]:::plan
     PgSelectRows23[["PgSelectRows[23∈3] ➊"]]:::plan
+    PgSelectRows23 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
     PgSelect18[["PgSelect[18∈3] ➊<br />ᐸmessagesᐳ"]]:::plan
-    PgSelectRows23 & PgSelect18 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
     Object11 --> PgSelect18
     PgSelect18 --> PgSelectRows23
     __ListTransform30[["__ListTransform[30∈3]<br />ᐸgroupBy:22ᐳ"]]:::plan

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.deopt.mermaid
@@ -34,7 +34,7 @@ graph TD
     __Item15 --> PgSelectSingle16
     __ListTransform22[["__ListTransform[22∈2]<br />ᐸfilter:18ᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    PgSelectRows23 & PgSelect18 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
+    PgSelectRows23 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
     PgClassExpression17{{"PgClassExpression[17∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
     PgSelectSingle16 --> PgClassExpression27
@@ -75,10 +75,10 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 44, 11, 13<br />2: PgSelect[8], PgSelect[18]<br />3: PgSelectRows[14], PgSelectRows[23]"):::bucket
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda13,PgSelectRows14,PgSelect18,PgSelectRows23,Constant44 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 18<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
+    Bucket1("Bucket 1 (listItem)<br />Deps: 23<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item15,PgSelectSingle16 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 23, 18<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 27<br />2: __ListTransform[22]<br />3: __ListTransform[30]<br />ᐳ: Lambda[34]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 23<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 27<br />2: __ListTransform[22]<br />3: __ListTransform[30]<br />ᐳ: Lambda[34]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,__ListTransform22,PgClassExpression27,__ListTransform30,Lambda34 bucket2
     Bucket3("Bucket 3 (subroutine)<br />Deps: 27<br /><br />ROOT Lambda{3}[29]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/computed-column-forums-messages-with-many-transforms.mermaid
@@ -34,7 +34,7 @@ graph TD
     __Item15 --> PgSelectSingle16
     __ListTransform22[["__ListTransform[22∈2]<br />ᐸfilter:18ᐳ"]]:::plan
     PgClassExpression27{{"PgClassExpression[27∈2]<br />ᐸ__forums__.”id”ᐳ"}}:::plan
-    PgSelectRows23 & PgSelect18 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
+    PgSelectRows23 & PgSelectSingle16 & PgClassExpression27 --> __ListTransform22
     PgClassExpression17{{"PgClassExpression[17∈2]<br />ᐸ__forums__.”name”ᐳ"}}:::plan
     PgSelectSingle16 --> PgClassExpression17
     PgSelectSingle16 --> PgClassExpression27
@@ -75,10 +75,10 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 44, 11, 13<br />2: PgSelect[8], PgSelect[18]<br />3: PgSelectRows[14], PgSelectRows[23]"):::bucket
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,__Value4,PgSelect8,Access9,Access10,Object11,Lambda13,PgSelectRows14,PgSelect18,PgSelectRows23,Constant44 bucket0
-    Bucket1("Bucket 1 (listItem)<br />Deps: 23, 18<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
+    Bucket1("Bucket 1 (listItem)<br />Deps: 23<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,__Item15,PgSelectSingle16 bucket1
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 23, 18<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 27<br />2: __ListTransform[22]<br />3: __ListTransform[30]<br />ᐳ: Lambda[34]"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 23<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 27<br />2: __ListTransform[22]<br />3: __ListTransform[30]<br />ᐳ: Lambda[34]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,__ListTransform22,PgClassExpression27,__ListTransform30,Lambda34 bucket2
     Bucket3("Bucket 3 (subroutine)<br />Deps: 27<br /><br />ROOT Lambda{3}[29]"):::bucket

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.deopt.mermaid
@@ -13,14 +13,14 @@ graph TD
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
-    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸeach:6ᐳ"]]:::plan
-    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_namesᐳ"]]:::plan
-    PgSelectRows11 & PgSelect6 --> __ListTransform10
     Object9 --> PgSelect6
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
+    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸeach:6ᐳ"]]:::plan
+    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
+    PgSelectRows11 --> __ListTransform10
     PgSelect6 --> PgSelectRows11
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ11ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-forum-names-upper.mermaid
@@ -13,14 +13,14 @@ graph TD
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
-    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸeach:6ᐳ"]]:::plan
-    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸforum_namesᐳ"]]:::plan
-    PgSelectRows11 & PgSelect6 --> __ListTransform10
     Object9 --> PgSelect6
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
+    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸeach:6ᐳ"]]:::plan
+    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
+    PgSelectRows11 --> __ListTransform10
     PgSelect6 --> PgSelectRows11
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ11ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.deopt.mermaid
@@ -13,14 +13,14 @@ graph TD
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
-    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸpartitionByIndex1:6ᐳ"]]:::plan
-    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_user_array_setᐳ"]]:::plan
-    PgSelectRows11 & PgSelect6 --> __ListTransform10
     Object9 --> PgSelect6
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
+    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸpartitionByIndex1:6ᐳ"]]:::plan
+    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
+    PgSelectRows11 --> __ListTransform10
     PgSelect6 --> PgSelectRows11
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ11ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/functions/custom-query-random-user-array-set.mermaid
@@ -13,14 +13,14 @@ graph TD
     Access7{{"Access[7∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access7 & Access8 --> Object9
-    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸpartitionByIndex1:6ᐳ"]]:::plan
-    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
     PgSelect6[["PgSelect[6∈0] ➊<br />ᐸrandom_user_array_setᐳ"]]:::plan
-    PgSelectRows11 & PgSelect6 --> __ListTransform10
     Object9 --> PgSelect6
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access7
     __Value2 --> Access8
+    __ListTransform10[["__ListTransform[10∈0] ➊<br />ᐸpartitionByIndex1:6ᐳ"]]:::plan
+    PgSelectRows11[["PgSelectRows[11∈0] ➊"]]:::plan
+    PgSelectRows11 --> __ListTransform10
     PgSelect6 --> PgSelectRows11
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item12[/"__Item[12∈1]<br />ᐸ11ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics-with-fragments.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda74{{"Lambda[74∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda74 --> __ListTransform19
     List73{{"List[73∈2]<br />ᐸ72,11ᐳ"}}:::plan
     Access72 & __Item11 --> List73
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda74{{"Lambda[74∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda74 --> PgSelectRows20
     List73 --> Lambda74
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/basics.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda65{{"Lambda[65∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda65 --> __ListTransform19
     List64{{"List[64∈2]<br />ᐸ63,11ᐳ"}}:::plan
     Access63 & __Item11 --> List64
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda65{{"Lambda[65∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda65 --> PgSelectRows20
     List64 --> Lambda65
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.deopt.mermaid
@@ -16,12 +16,12 @@ graph TD
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
-    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
-    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
-    PgSelectRows12 & PgSelect7 --> __ListTransform11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
+    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
+    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
+    PgSelectRows12 --> __ListTransform11
     PgSelect7 --> PgSelectRows12
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ12ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables-simple.mermaid
@@ -16,12 +16,12 @@ graph TD
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
-    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
-    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
-    PgSelectRows12 & PgSelect7 --> __ListTransform11
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
+    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
+    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
+    PgSelectRows12 --> __ListTransform11
     PgSelect7 --> PgSelectRows12
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ12ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.deopt.mermaid
@@ -13,14 +13,14 @@ graph TD
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
-    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
-    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_commentablesᐳ"]]:::plan
-    PgSelectRows12 & PgSelect7 --> __ListTransform11
     Object10 --> PgSelect7
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
+    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
+    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
+    PgSelectRows12 --> __ListTransform11
     PgSelect7 --> PgSelectRows12
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ12ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/commentables.mermaid
@@ -13,14 +13,14 @@ graph TD
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
-    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
-    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸrelational_commentablesᐳ"]]:::plan
-    PgSelectRows12 & PgSelect7 --> __ListTransform11
     Object10 --> PgSelect7
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
+    __ListTransform11[["__ListTransform[11∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
+    PgSelectRows12[["PgSelectRows[12∈0] ➊"]]:::plan
+    PgSelectRows12 --> __ListTransform11
     PgSelect7 --> PgSelectRows12
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item13[/"__Item[13∈1]<br />ᐸ12ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more-fragments.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda408{{"Lambda[408∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda408 --> __ListTransform19
     List407{{"List[407∈2]<br />ᐸ406,11ᐳ"}}:::plan
     Access406 & __Item11 --> List407
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda408{{"Lambda[408∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda408 --> PgSelectRows20
     List407 --> Lambda408
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested-more.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda390{{"Lambda[390∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda390 --> __ListTransform19
     List389{{"List[389∈2]<br />ᐸ388,11ᐳ"}}:::plan
     Access388 & __Item11 --> List389
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda390{{"Lambda[390∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda390 --> PgSelectRows20
     List389 --> Lambda390
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸrelational_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-relational/nested.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda226{{"Lambda[226∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda226 --> __ListTransform19
     List225{{"List[225∈2]<br />ᐸ224,11ᐳ"}}:::plan
     Access224 & __Item11 --> List225
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda226{{"Lambda[226∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda226 --> PgSelectRows20
     List225 --> Lambda226
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics-with-fragments.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda43{{"Lambda[43∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda43 --> __ListTransform19
     List42{{"List[42∈2]<br />ᐸ41,11ᐳ"}}:::plan
     Access41 & __Item11 --> List42
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda43{{"Lambda[43∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda43 --> PgSelectRows20
     List42 --> Lambda43
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/basics.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda39{{"Lambda[39∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda39 --> __ListTransform19
     List38{{"List[38∈2]<br />ᐸ37,11ᐳ"}}:::plan
     Access37 & __Item11 --> List38
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda39{{"Lambda[39∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda39 --> PgSelectRows20
     List38 --> Lambda39
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more-fragments.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda254{{"Lambda[254∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda254 --> __ListTransform19
     List253{{"List[253∈2]<br />ᐸ252,11ᐳ"}}:::plan
     Access252 & __Item11 --> List253
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda254{{"Lambda[254∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda254 --> PgSelectRows20
     List253 --> Lambda254
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested-more.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda246{{"Lambda[246∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda246 --> __ListTransform19
     List245{{"List[245∈2]<br />ᐸ244,11ᐳ"}}:::plan
     Access244 & __Item11 --> List245
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda246{{"Lambda[246∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda246 --> PgSelectRows20
     List245 --> Lambda246
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.deopt.mermaid
@@ -28,12 +28,12 @@ graph TD
     PgSelect15[["PgSelect[15∈2]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     PgClassExpression14{{"PgClassExpression[14∈2]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
     Object9 & PgClassExpression14 --> PgSelect15
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    PgSelectRows20 & PgSelect15 --> __ListTransform19
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
     PgSelectSingle12 --> PgClassExpression14
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
     PgSelect15 --> PgSelectRows20
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelectRows20 -.-> __Item21

--- a/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/interfaces-single-table/nested.mermaid
@@ -28,14 +28,14 @@ graph TD
     PgSelectRows10 ==> __Item11
     PgSelectSingle12{{"PgSelectSingle[12∈1]<br />ᐸpeopleᐳ"}}:::plan
     __Item11 --> PgSelectSingle12
-    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
-    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
-    Lambda80{{"Lambda[80∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
-    PgSelectRows20 & Lambda80 --> __ListTransform19
     List79{{"List[79∈2]<br />ᐸ78,11ᐳ"}}:::plan
     Access78 & __Item11 --> List79
     PgClassExpression13{{"PgClassExpression[13∈2]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression13
+    __ListTransform19[["__ListTransform[19∈2]<br />ᐸeach:15ᐳ"]]:::plan
+    PgSelectRows20[["PgSelectRows[20∈2]"]]:::plan
+    PgSelectRows20 --> __ListTransform19
+    Lambda80{{"Lambda[80∈2]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     Lambda80 --> PgSelectRows20
     List79 --> Lambda80
     __Item21[/"__Item[21∈3]<br />ᐸ20ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.deopt.mermaid
@@ -16,14 +16,14 @@ graph TD
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
-    __ListTransform12[["__ListTransform[12∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
-    PgSelectRows13[["PgSelectRows[13∈0] ➊"]]:::plan
-    PgSelectRows13 & PgSelect7 --> __ListTransform12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
     Constant68{{"Constant[68∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
     Constant68 --> PgFromExpression11
+    __ListTransform12[["__ListTransform[12∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
+    PgSelectRows13[["PgSelectRows[13∈0] ➊"]]:::plan
+    PgSelectRows13 --> __ListTransform12
     PgSelect7 --> PgSelectRows13
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item14[/"__Item[14∈1]<br />ᐸ13ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-search-entities/search.mermaid
@@ -16,14 +16,14 @@ graph TD
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
-    __ListTransform12[["__ListTransform[12∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
-    PgSelectRows13[["PgSelectRows[13∈0] ➊"]]:::plan
-    PgSelectRows13 & PgSelect7 --> __ListTransform12
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
     Constant80{{"Constant[80∈0] ➊<br />ᐸ'Dave'ᐳ"}}:::plan
     Constant80 --> PgFromExpression11
+    __ListTransform12[["__ListTransform[12∈0] ➊<br />ᐸeach:7ᐳ"]]:::plan
+    PgSelectRows13[["PgSelectRows[13∈0] ➊"]]:::plan
+    PgSelectRows13 --> __ListTransform12
     PgSelect7 --> PgSelectRows13
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     __Item14[/"__Item[14∈1]<br />ᐸ13ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
@@ -90,7 +90,8 @@ export class PgSelectSingleStep<
   public readonly resource: TResource;
   private _coalesceToEmptyObject = false;
   private typeStepIndexList: number[] | null = null;
-  private fromRelation: { refId: number; relationName: string } | null = null;
+  private fromRelation: { refId: number | null; relationName: string } | null =
+    null;
 
   constructor(
     $class: PgSelectStep<TResource>,
@@ -99,18 +100,21 @@ export class PgSelectSingleStep<
   ) {
     super();
     this.itemStepId = this.addDependency($item);
-    if (options.fromRelation) {
-      const [$pgSelectSingle, relationName] = options.fromRelation;
-      this.fromRelation = {
-        refId: this.addRef($pgSelectSingle),
-        relationName,
-      };
-    }
     this.resource = $class.resource;
     this.pgCodec = this.resource.codec as GetPgResourceCodec<TResource>;
     this.mode = $class.mode;
     this.classStepId = $class.id;
     this.peerKey = this.resource.name;
+    if (options.fromRelation) {
+      const [$pgSelectSingle, relationName] = options.fromRelation;
+      this.fromRelation = {
+        refId: this.addRef(
+          $pgSelectSingle,
+          "Indirect reference allowed due to relational field potentially pulling from a parent relation",
+        ),
+        relationName,
+      };
+    }
   }
 
   public coalesceToEmptyObject(): void {

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -476,6 +476,24 @@ export /* abstract */ class Step<TData = any> {
     return undefined;
   }
 
+  /** @internal */
+  private _refs = new Set<number>();
+
+  /**
+   * **IF IN DOUBT, USE `.addDependency()` INSTEAD!
+   *
+   * This **DANGEROUS** method allows you to create a reference to another
+   * step. A reference is like a dependency except it has no runtime impact -
+   * the data is not passed into execute. In general you should only add
+   * references to steps that you directly or indirectly depend on (e.g. an
+   * ancestor step) so that you may communicate with said step during
+   * `optimize` (for example). Sometimes it's acceptable to reference steps
+   * that you don't transitively depend on; in those cases you're permitted to
+   * pass an `allowIndirectReason` to explain to yourself and others why you
+   * are breaking these rules.
+   *
+   * @experimental
+   */
   protected addRef(
     rawStep: Step,
     allowIndirectReason: string | null = null,
@@ -516,12 +534,33 @@ ${printDeps(step, 1)}
         `${this}.addRef(${step}) forbidden: invalid plan heirarchy`,
       );
     }
+    this._refs.add(-step.id);
     return -step.id;
   }
 
-  protected getRef<TStep extends Step = Step>(id: number | null): TStep | null {
+  /**
+   * Allows you to dereference a reference made via `addRef`. Will resolve to
+   * whatever that step is now (or null if not found). Note that referenced
+   * referenced steps may change to a new step instance due to lifecycle
+   * methods (e.g. deduplicate) or even to an entirely separate class
+   * altogether (e.g. due to optimize). References are not guaranteed to be
+   * honoured.
+   *
+   * @experimental
+   */
+  protected getRef(id: number | null): Step | null {
+    if (!["plan", "validate", "optimize"].includes(this.operationPlan.phase)) {
+      throw new Error(
+        `Cannot call ${this}.getRef() when the operation plan phase is ${this.operationPlan.phase}; getRef may only be called during planning.`,
+      );
+    }
     if (id == null) return null;
-    return (this.operationPlan.stepTracker.getStepById(-id) as TStep) ?? null;
+    if (!this._refs.has(id)) {
+      throw new Error(
+        `Attempted to get a ref from ${this}, but no matching ref was made. Use .addRef() to add a reference.`,
+      );
+    }
+    return this.operationPlan.stepTracker.getStepById(-id) ?? null;
   }
 
   protected canAddDependency(step: Step): boolean {

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -511,6 +511,10 @@ Reference:
 ${printDeps(step, 1)}
   `,
       );
+    } else if (!stepAMayDependOnStepB(this, step)) {
+      throw new Error(
+        `${this}.addRef(${step}) forbidden: invalid plan heirarchy`,
+      );
     }
     return -step.id;
   }

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -476,6 +476,19 @@ export /* abstract */ class Step<TData = any> {
     return undefined;
   }
 
+  protected addRef(step: Step): number {
+    if (!stepADependsOnStepB(this, step)) {
+      throw new Error(
+        `${this} may only reference steps that it depends on (directly or indirectly); it does not depend on ${step}`,
+      );
+    }
+    return -step.id;
+  }
+
+  protected getRef(id: number) {
+    return this.operationPlan.stepTracker.getStepById(-id);
+  }
+
   protected canAddDependency(step: Step): boolean {
     return stepAMayDependOnStepB(this, step);
   }

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -519,9 +519,9 @@ ${printDeps(step, 1)}
     return -step.id;
   }
 
-  protected getRef(id: number | null): Step | null {
+  protected getRef<TStep extends Step = Step>(id: number | null): TStep | null {
     if (id == null) return null;
-    return this.operationPlan.stepTracker.getStepById(-id) ?? null;
+    return (this.operationPlan.stepTracker.getStepById(-id) as TStep) ?? null;
   }
 
   protected canAddDependency(step: Step): boolean {

--- a/grafast/grafast/src/steps/listTransform.ts
+++ b/grafast/grafast/src/steps/listTransform.ts
@@ -186,7 +186,7 @@ export class __ListTransformStep<
   }
 
   getListStep(): TListStep {
-    return this.getRef<TListStep>(this.rawListStepRefId)!;
+    return this.getRef(this.rawListStepRefId) as TListStep;
   }
 
   [$$deepDepSkip]() {
@@ -194,7 +194,7 @@ export class __ListTransformStep<
   }
 
   dangerouslyGetListPlan(): TListStep {
-    return this.getRef<TListStep>(this.rawListStepRefId)!;
+    return this.getRef(this.rawListStepRefId) as TListStep;
   }
 
   deduplicate(

--- a/grafast/grafast/src/steps/listTransform.ts
+++ b/grafast/grafast/src/steps/listTransform.ts
@@ -90,7 +90,7 @@ export class __ListTransformStep<
   isSyncAndSafe = false;
 
   private listStepDepId: number;
-  private rawListStepDepId: number;
+  private rawListStepRefId: number | null;
   public itemPlanCallback: ListTransformItemPlanCallback<
     ItemsStep<TListStep>,
     TDepsStep
@@ -134,11 +134,7 @@ export class __ListTransformStep<
     const listStep = itemsOrStep(rawListStep);
     this.listStepDepId = this.addDependency(listStep);
 
-    // PERF: This is just so we can populate getListStep() correctly... Ideally we could mark this as a "plan-time-only" dependency.
-    this.rawListStepDepId =
-      rawListStep === listStep
-        ? this.listStepDepId
-        : this.addDependency(rawListStep);
+    this.rawListStepRefId = this.addRef(rawListStep);
 
     this.itemPlanCallback = itemPlanCallback;
     this.initialState = initialState;
@@ -190,7 +186,7 @@ export class __ListTransformStep<
   }
 
   getListStep(): TListStep {
-    return this.getDepOptions<TListStep>(this.rawListStepDepId).step;
+    return this.getRef<TListStep>(this.rawListStepRefId)!;
   }
 
   [$$deepDepSkip]() {
@@ -198,7 +194,7 @@ export class __ListTransformStep<
   }
 
   dangerouslyGetListPlan(): TListStep {
-    return this.dependencies[this.rawListStepDepId] as TListStep;
+    return this.getRef<TListStep>(this.rawListStepRefId)!;
   }
 
   deduplicate(

--- a/postgraphile/postgraphile/__tests__/queries/v4/badlyBehavedFunction.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/badlyBehavedFunction.mermaid
@@ -21,10 +21,10 @@ graph TD
     Constant16{{"Constant[16∈0] ➊<br />ᐸ'people'ᐳ"}}:::plan
     PgSelect12[["PgSelect[12∈1] ➊<br />ᐸbadly_behaved_functionᐳ"]]:::plan
     Object10 & Connection11 --> PgSelect12
-    __ListTransform23[["__ListTransform[23∈1] ➊<br />ᐸeach:22ᐳ"]]:::plan
     PgSelectRows13[["PgSelectRows[13∈1] ➊"]]:::plan
-    PgSelectRows13 & PgSelect12 --> __ListTransform23
     PgSelect12 --> PgSelectRows13
+    __ListTransform23[["__ListTransform[23∈1] ➊<br />ᐸeach:22ᐳ"]]:::plan
+    PgSelectRows13 --> __ListTransform23
     Access30{{"Access[30∈1] ➊<br />ᐸ12.cursorDetailsᐳ"}}:::plan
     PgSelect12 --> Access30
     __Item14[/"__Item[14∈2]<br />ᐸ13ᐳ"\]:::itemplan

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
@@ -264,9 +264,6 @@ graph TD
     __Item109 --> PgSelectSingle110
     Lambda357{{"Lambda[357∈11]<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     List356 --> Lambda357
-    __ListTransform204[["__ListTransform[204∈12]<br />ᐸeach:203ᐳ"]]:::plan
-    PgSelectRows193[["PgSelectRows[193∈12]"]]:::plan
-    PgSelectRows193 & Lambda357 --> __ListTransform204
     List352{{"List[352∈12]<br />ᐸ351,109ᐳ"}}:::plan
     Access351 & __Item109 --> List352
     PgClassExpression111{{"PgClassExpression[111∈12]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -294,7 +291,10 @@ graph TD
     PgSelectSingle110 --> PgClassExpression176
     PgClassExpression179{{"PgClassExpression[179∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle110 --> PgClassExpression179
+    PgSelectRows193[["PgSelectRows[193∈12]"]]:::plan
     Lambda357 --> PgSelectRows193
+    __ListTransform204[["__ListTransform[204∈12]<br />ᐸeach:203ᐳ"]]:::plan
+    PgSelectRows193 --> __ListTransform204
     List352 --> Lambda353
     __Item162[/"__Item[162∈13]<br />ᐸ161ᐳ"\]:::itemplan
     PgSelectRows161 ==> __Item162

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
@@ -403,9 +403,6 @@ graph TD
     Object10 & Connection197 & Constant1054 --> PgSelect198
     Object236{{"Object[236∈3] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1054 & Access235 --> Object236
-    __ListTransform199[["__ListTransform[199∈3] ➊<br />ᐸeach:198ᐳ"]]:::plan
-    PgSelectRows200[["PgSelectRows[200∈3] ➊"]]:::plan
-    PgSelectRows200 & PgSelect198 --> __ListTransform199
     PgCursor226{{"PgCursor[226∈3] ➊"}}:::plan
     PgSelectSingle224{{"PgSelectSingle[224∈3] ➊<br />ᐸcompound_type_set_queryᐳ"}}:::plan
     Access206{{"Access[206∈3] ➊<br />ᐸ198.cursorDetailsᐳ"}}:::plan
@@ -413,6 +410,9 @@ graph TD
     PgCursor232{{"PgCursor[232∈3] ➊"}}:::plan
     PgSelectSingle230{{"PgSelectSingle[230∈3] ➊<br />ᐸcompound_type_set_queryᐳ"}}:::plan
     PgSelectSingle230 & Access206 --> PgCursor232
+    __ListTransform199[["__ListTransform[199∈3] ➊<br />ᐸeach:198ᐳ"]]:::plan
+    PgSelectRows200[["PgSelectRows[200∈3] ➊"]]:::plan
+    PgSelectRows200 --> __ListTransform199
     PgSelect198 --> PgSelectRows200
     PgSelect198 --> Access206
     PgPageInfo220{{"PgPageInfo[220∈3] ➊"}}:::plan
@@ -493,9 +493,6 @@ graph TD
     Access314 --> Object315
     PgSelect287[["PgSelect[287∈13] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
     Object10 & Connection286 --> PgSelect287
-    __ListTransform288[["__ListTransform[288∈13] ➊<br />ᐸeach:287ᐳ"]]:::plan
-    PgSelectRows289[["PgSelectRows[289∈13] ➊"]]:::plan
-    PgSelectRows289 & PgSelect287 --> __ListTransform288
     PgCursor305{{"PgCursor[305∈13] ➊"}}:::plan
     PgSelectSingle303{{"PgSelectSingle[303∈13] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access295{{"Access[295∈13] ➊<br />ᐸ287.cursorDetailsᐳ"}}:::plan
@@ -503,6 +500,9 @@ graph TD
     PgCursor311{{"PgCursor[311∈13] ➊"}}:::plan
     PgSelectSingle309{{"PgSelectSingle[309∈13] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle309 & Access295 --> PgCursor311
+    __ListTransform288[["__ListTransform[288∈13] ➊<br />ᐸeach:287ᐳ"]]:::plan
+    PgSelectRows289[["PgSelectRows[289∈13] ➊"]]:::plan
+    PgSelectRows289 --> __ListTransform288
     PgSelect287 --> PgSelectRows289
     PgSelect287 --> Access295
     PgPageInfo299{{"PgPageInfo[299∈13] ➊"}}:::plan
@@ -539,9 +539,6 @@ graph TD
     Access353 --> Object354
     PgSelect326[["PgSelect[326∈18] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
     Object10 & Connection324 --> PgSelect326
-    __ListTransform327[["__ListTransform[327∈18] ➊<br />ᐸeach:326ᐳ"]]:::plan
-    PgSelectRows328[["PgSelectRows[328∈18] ➊"]]:::plan
-    PgSelectRows328 & PgSelect326 --> __ListTransform327
     PgCursor344{{"PgCursor[344∈18] ➊"}}:::plan
     PgSelectSingle342{{"PgSelectSingle[342∈18] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access334{{"Access[334∈18] ➊<br />ᐸ326.cursorDetailsᐳ"}}:::plan
@@ -549,6 +546,9 @@ graph TD
     PgCursor350{{"PgCursor[350∈18] ➊"}}:::plan
     PgSelectSingle348{{"PgSelectSingle[348∈18] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle348 & Access334 --> PgCursor350
+    __ListTransform327[["__ListTransform[327∈18] ➊<br />ᐸeach:326ᐳ"]]:::plan
+    PgSelectRows328[["PgSelectRows[328∈18] ➊"]]:::plan
+    PgSelectRows328 --> __ListTransform327
     PgSelect326 --> PgSelectRows328
     PgSelect326 --> Access334
     PgPageInfo338{{"PgPageInfo[338∈18] ➊"}}:::plan
@@ -585,9 +585,6 @@ graph TD
     Object10 & ApplyInput365 & Connection364 --> PgSelect366
     Object394{{"Object[394∈23] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access393 --> Object394
-    __ListTransform367[["__ListTransform[367∈23] ➊<br />ᐸeach:366ᐳ"]]:::plan
-    PgSelectRows368[["PgSelectRows[368∈23] ➊"]]:::plan
-    PgSelectRows368 & PgSelect366 --> __ListTransform367
     PgCursor384{{"PgCursor[384∈23] ➊"}}:::plan
     PgSelectSingle382{{"PgSelectSingle[382∈23] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access374{{"Access[374∈23] ➊<br />ᐸ366.cursorDetailsᐳ"}}:::plan
@@ -595,6 +592,9 @@ graph TD
     PgCursor390{{"PgCursor[390∈23] ➊"}}:::plan
     PgSelectSingle388{{"PgSelectSingle[388∈23] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle388 & Access374 --> PgCursor390
+    __ListTransform367[["__ListTransform[367∈23] ➊<br />ᐸeach:366ᐳ"]]:::plan
+    PgSelectRows368[["PgSelectRows[368∈23] ➊"]]:::plan
+    PgSelectRows368 --> __ListTransform367
     PgSelect366 --> PgSelectRows368
     PgSelect366 --> Access374
     PgPageInfo378{{"PgPageInfo[378∈23] ➊"}}:::plan
@@ -631,9 +631,6 @@ graph TD
     Access434 --> Object439
     Object435{{"Object[435∈28] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access434 --> Object435
-    __ListTransform408[["__ListTransform[408∈28] ➊<br />ᐸeach:407ᐳ"]]:::plan
-    PgSelectRows409[["PgSelectRows[409∈28] ➊"]]:::plan
-    PgSelectRows409 & PgSelect407 --> __ListTransform408
     PgCursor425{{"PgCursor[425∈28] ➊"}}:::plan
     PgSelectSingle423{{"PgSelectSingle[423∈28] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access415{{"Access[415∈28] ➊<br />ᐸ407.cursorDetailsᐳ"}}:::plan
@@ -641,6 +638,9 @@ graph TD
     PgCursor431{{"PgCursor[431∈28] ➊"}}:::plan
     PgSelectSingle429{{"PgSelectSingle[429∈28] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle429 & Access415 --> PgCursor431
+    __ListTransform408[["__ListTransform[408∈28] ➊<br />ᐸeach:407ᐳ"]]:::plan
+    PgSelectRows409[["PgSelectRows[409∈28] ➊"]]:::plan
+    PgSelectRows409 --> __ListTransform408
     PgSelect407 --> PgSelectRows409
     PgSelect407 --> Access415
     PgPageInfo419{{"PgPageInfo[419∈28] ➊"}}:::plan
@@ -677,9 +677,6 @@ graph TD
     Access475 --> Object480
     Object476{{"Object[476∈33] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access475 --> Object476
-    __ListTransform449[["__ListTransform[449∈33] ➊<br />ᐸeach:448ᐳ"]]:::plan
-    PgSelectRows450[["PgSelectRows[450∈33] ➊"]]:::plan
-    PgSelectRows450 & PgSelect448 --> __ListTransform449
     PgCursor466{{"PgCursor[466∈33] ➊"}}:::plan
     PgSelectSingle464{{"PgSelectSingle[464∈33] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access456{{"Access[456∈33] ➊<br />ᐸ448.cursorDetailsᐳ"}}:::plan
@@ -687,6 +684,9 @@ graph TD
     PgCursor472{{"PgCursor[472∈33] ➊"}}:::plan
     PgSelectSingle470{{"PgSelectSingle[470∈33] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle470 & Access456 --> PgCursor472
+    __ListTransform449[["__ListTransform[449∈33] ➊<br />ᐸeach:448ᐳ"]]:::plan
+    PgSelectRows450[["PgSelectRows[450∈33] ➊"]]:::plan
+    PgSelectRows450 --> __ListTransform449
     PgSelect448 --> PgSelectRows450
     PgSelect448 --> Access456
     PgPageInfo460{{"PgPageInfo[460∈33] ➊"}}:::plan
@@ -723,9 +723,6 @@ graph TD
     Constant1053 & Access515 --> Object520
     Object516{{"Object[516∈38] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access515 --> Object516
-    __ListTransform489[["__ListTransform[489∈38] ➊<br />ᐸeach:488ᐳ"]]:::plan
-    PgSelectRows490[["PgSelectRows[490∈38] ➊"]]:::plan
-    PgSelectRows490 & PgSelect488 --> __ListTransform489
     PgCursor506{{"PgCursor[506∈38] ➊"}}:::plan
     PgSelectSingle504{{"PgSelectSingle[504∈38] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access496{{"Access[496∈38] ➊<br />ᐸ488.cursorDetailsᐳ"}}:::plan
@@ -733,6 +730,9 @@ graph TD
     PgCursor512{{"PgCursor[512∈38] ➊"}}:::plan
     PgSelectSingle510{{"PgSelectSingle[510∈38] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle510 & Access496 --> PgCursor512
+    __ListTransform489[["__ListTransform[489∈38] ➊<br />ᐸeach:488ᐳ"]]:::plan
+    PgSelectRows490[["PgSelectRows[490∈38] ➊"]]:::plan
+    PgSelectRows490 --> __ListTransform489
     PgSelect488 --> PgSelectRows490
     PgSelect488 --> Access496
     PgPageInfo500{{"PgPageInfo[500∈38] ➊"}}:::plan
@@ -769,9 +769,6 @@ graph TD
     Constant1053 & Access555 --> Object560
     Object556{{"Object[556∈43] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access555 --> Object556
-    __ListTransform529[["__ListTransform[529∈43] ➊<br />ᐸeach:528ᐳ"]]:::plan
-    PgSelectRows530[["PgSelectRows[530∈43] ➊"]]:::plan
-    PgSelectRows530 & PgSelect528 --> __ListTransform529
     PgCursor546{{"PgCursor[546∈43] ➊"}}:::plan
     PgSelectSingle544{{"PgSelectSingle[544∈43] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access536{{"Access[536∈43] ➊<br />ᐸ528.cursorDetailsᐳ"}}:::plan
@@ -779,6 +776,9 @@ graph TD
     PgCursor552{{"PgCursor[552∈43] ➊"}}:::plan
     PgSelectSingle550{{"PgSelectSingle[550∈43] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle550 & Access536 --> PgCursor552
+    __ListTransform529[["__ListTransform[529∈43] ➊<br />ᐸeach:528ᐳ"]]:::plan
+    PgSelectRows530[["PgSelectRows[530∈43] ➊"]]:::plan
+    PgSelectRows530 --> __ListTransform529
     PgSelect528 --> PgSelectRows530
     PgSelect528 --> Access536
     PgPageInfo540{{"PgPageInfo[540∈43] ➊"}}:::plan
@@ -815,9 +815,6 @@ graph TD
     Constant1053 & Access595 --> Object600
     Object596{{"Object[596∈48] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access595 --> Object596
-    __ListTransform569[["__ListTransform[569∈48] ➊<br />ᐸeach:568ᐳ"]]:::plan
-    PgSelectRows570[["PgSelectRows[570∈48] ➊"]]:::plan
-    PgSelectRows570 & PgSelect568 --> __ListTransform569
     PgCursor586{{"PgCursor[586∈48] ➊"}}:::plan
     PgSelectSingle584{{"PgSelectSingle[584∈48] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access576{{"Access[576∈48] ➊<br />ᐸ568.cursorDetailsᐳ"}}:::plan
@@ -825,6 +822,9 @@ graph TD
     PgCursor592{{"PgCursor[592∈48] ➊"}}:::plan
     PgSelectSingle590{{"PgSelectSingle[590∈48] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle590 & Access576 --> PgCursor592
+    __ListTransform569[["__ListTransform[569∈48] ➊<br />ᐸeach:568ᐳ"]]:::plan
+    PgSelectRows570[["PgSelectRows[570∈48] ➊"]]:::plan
+    PgSelectRows570 --> __ListTransform569
     PgSelect568 --> PgSelectRows570
     PgSelect568 --> Access576
     PgPageInfo580{{"PgPageInfo[580∈48] ➊"}}:::plan
@@ -863,9 +863,6 @@ graph TD
     Constant1053 -- 2 --> Object639
     Object635{{"Object[635∈53] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access634 --> Object635
-    __ListTransform608[["__ListTransform[608∈53] ➊<br />ᐸeach:607ᐳ"]]:::plan
-    PgSelectRows609[["PgSelectRows[609∈53] ➊"]]:::plan
-    PgSelectRows609 & PgSelect607 --> __ListTransform608
     PgCursor625{{"PgCursor[625∈53] ➊"}}:::plan
     PgSelectSingle623{{"PgSelectSingle[623∈53] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access615{{"Access[615∈53] ➊<br />ᐸ607.cursorDetailsᐳ"}}:::plan
@@ -873,6 +870,9 @@ graph TD
     PgCursor631{{"PgCursor[631∈53] ➊"}}:::plan
     PgSelectSingle629{{"PgSelectSingle[629∈53] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle629 & Access615 --> PgCursor631
+    __ListTransform608[["__ListTransform[608∈53] ➊<br />ᐸeach:607ᐳ"]]:::plan
+    PgSelectRows609[["PgSelectRows[609∈53] ➊"]]:::plan
+    PgSelectRows609 --> __ListTransform608
     PgSelect607 --> PgSelectRows609
     PgSelect607 --> Access615
     PgPageInfo619{{"PgPageInfo[619∈53] ➊"}}:::plan
@@ -909,9 +909,6 @@ graph TD
     Constant1053 & Constant1072 & Access673 --> Object678
     Object674{{"Object[674∈58] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access673 --> Object674
-    __ListTransform647[["__ListTransform[647∈58] ➊<br />ᐸeach:646ᐳ"]]:::plan
-    PgSelectRows648[["PgSelectRows[648∈58] ➊"]]:::plan
-    PgSelectRows648 & PgSelect646 --> __ListTransform647
     PgCursor664{{"PgCursor[664∈58] ➊"}}:::plan
     PgSelectSingle662{{"PgSelectSingle[662∈58] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access654{{"Access[654∈58] ➊<br />ᐸ646.cursorDetailsᐳ"}}:::plan
@@ -919,6 +916,9 @@ graph TD
     PgCursor670{{"PgCursor[670∈58] ➊"}}:::plan
     PgSelectSingle668{{"PgSelectSingle[668∈58] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle668 & Access654 --> PgCursor670
+    __ListTransform647[["__ListTransform[647∈58] ➊<br />ᐸeach:646ᐳ"]]:::plan
+    PgSelectRows648[["PgSelectRows[648∈58] ➊"]]:::plan
+    PgSelectRows648 --> __ListTransform647
     PgSelect646 --> PgSelectRows648
     PgSelect646 --> Access654
     PgPageInfo658{{"PgPageInfo[658∈58] ➊"}}:::plan
@@ -955,9 +955,6 @@ graph TD
     Constant1053 & Constant1073 & Access712 --> Object717
     Object713{{"Object[713∈63] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access712 --> Object713
-    __ListTransform686[["__ListTransform[686∈63] ➊<br />ᐸeach:685ᐳ"]]:::plan
-    PgSelectRows687[["PgSelectRows[687∈63] ➊"]]:::plan
-    PgSelectRows687 & PgSelect685 --> __ListTransform686
     PgCursor703{{"PgCursor[703∈63] ➊"}}:::plan
     PgSelectSingle701{{"PgSelectSingle[701∈63] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access693{{"Access[693∈63] ➊<br />ᐸ685.cursorDetailsᐳ"}}:::plan
@@ -965,6 +962,9 @@ graph TD
     PgCursor709{{"PgCursor[709∈63] ➊"}}:::plan
     PgSelectSingle707{{"PgSelectSingle[707∈63] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle707 & Access693 --> PgCursor709
+    __ListTransform686[["__ListTransform[686∈63] ➊<br />ᐸeach:685ᐳ"]]:::plan
+    PgSelectRows687[["PgSelectRows[687∈63] ➊"]]:::plan
+    PgSelectRows687 --> __ListTransform686
     PgSelect685 --> PgSelectRows687
     PgSelect685 --> Access693
     PgPageInfo697{{"PgPageInfo[697∈63] ➊"}}:::plan
@@ -1001,9 +1001,6 @@ graph TD
     Constant1074 & Constant1073 & Access751 --> Object756
     Object752{{"Object[752∈68] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1074 & Access751 --> Object752
-    __ListTransform725[["__ListTransform[725∈68] ➊<br />ᐸeach:724ᐳ"]]:::plan
-    PgSelectRows726[["PgSelectRows[726∈68] ➊"]]:::plan
-    PgSelectRows726 & PgSelect724 --> __ListTransform725
     PgCursor742{{"PgCursor[742∈68] ➊"}}:::plan
     PgSelectSingle740{{"PgSelectSingle[740∈68] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access732{{"Access[732∈68] ➊<br />ᐸ724.cursorDetailsᐳ"}}:::plan
@@ -1011,6 +1008,9 @@ graph TD
     PgCursor748{{"PgCursor[748∈68] ➊"}}:::plan
     PgSelectSingle746{{"PgSelectSingle[746∈68] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle746 & Access732 --> PgCursor748
+    __ListTransform725[["__ListTransform[725∈68] ➊<br />ᐸeach:724ᐳ"]]:::plan
+    PgSelectRows726[["PgSelectRows[726∈68] ➊"]]:::plan
+    PgSelectRows726 --> __ListTransform725
     PgSelect724 --> PgSelectRows726
     PgSelect724 --> Access732
     PgPageInfo736{{"PgPageInfo[736∈68] ➊"}}:::plan
@@ -1047,9 +1047,6 @@ graph TD
     Constant1053 & Access791 --> Object796
     Object792{{"Object[792∈73] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access791 --> Object792
-    __ListTransform765[["__ListTransform[765∈73] ➊<br />ᐸeach:764ᐳ"]]:::plan
-    PgSelectRows766[["PgSelectRows[766∈73] ➊"]]:::plan
-    PgSelectRows766 & PgSelect764 --> __ListTransform765
     PgCursor782{{"PgCursor[782∈73] ➊"}}:::plan
     PgSelectSingle780{{"PgSelectSingle[780∈73] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access772{{"Access[772∈73] ➊<br />ᐸ764.cursorDetailsᐳ"}}:::plan
@@ -1057,6 +1054,9 @@ graph TD
     PgCursor788{{"PgCursor[788∈73] ➊"}}:::plan
     PgSelectSingle786{{"PgSelectSingle[786∈73] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle786 & Access772 --> PgCursor788
+    __ListTransform765[["__ListTransform[765∈73] ➊<br />ᐸeach:764ᐳ"]]:::plan
+    PgSelectRows766[["PgSelectRows[766∈73] ➊"]]:::plan
+    PgSelectRows766 --> __ListTransform765
     PgSelect764 --> PgSelectRows766
     PgSelect764 --> Access772
     PgPageInfo776{{"PgPageInfo[776∈73] ➊"}}:::plan
@@ -1093,9 +1093,6 @@ graph TD
     Constant1053 & Constant1052 & Access832 --> Object837
     Object833{{"Object[833∈78] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access832 --> Object833
-    __ListTransform806[["__ListTransform[806∈78] ➊<br />ᐸeach:805ᐳ"]]:::plan
-    PgSelectRows807[["PgSelectRows[807∈78] ➊"]]:::plan
-    PgSelectRows807 & PgSelect805 --> __ListTransform806
     PgCursor823{{"PgCursor[823∈78] ➊"}}:::plan
     PgSelectSingle821{{"PgSelectSingle[821∈78] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     Access813{{"Access[813∈78] ➊<br />ᐸ805.cursorDetailsᐳ"}}:::plan
@@ -1103,6 +1100,9 @@ graph TD
     PgCursor829{{"PgCursor[829∈78] ➊"}}:::plan
     PgSelectSingle827{{"PgSelectSingle[827∈78] ➊<br />ᐸtable_set_queryᐳ"}}:::plan
     PgSelectSingle827 & Access813 --> PgCursor829
+    __ListTransform806[["__ListTransform[806∈78] ➊<br />ᐸeach:805ᐳ"]]:::plan
+    PgSelectRows807[["PgSelectRows[807∈78] ➊"]]:::plan
+    PgSelectRows807 --> __ListTransform806
     PgSelect805 --> PgSelectRows807
     PgSelect805 --> Access813
     PgPageInfo817{{"PgPageInfo[817∈78] ➊"}}:::plan
@@ -1139,9 +1139,6 @@ graph TD
     Object10 & Connection842 & Constant1053 --> PgSelect843
     Object871{{"Object[871∈83] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access870 --> Object871
-    __ListTransform844[["__ListTransform[844∈83] ➊<br />ᐸeach:843ᐳ"]]:::plan
-    PgSelectRows845[["PgSelectRows[845∈83] ➊"]]:::plan
-    PgSelectRows845 & PgSelect843 --> __ListTransform844
     PgCursor861{{"PgCursor[861∈83] ➊"}}:::plan
     PgSelectSingle859{{"PgSelectSingle[859∈83] ➊<br />ᐸtable_set_query_plpgsqlᐳ"}}:::plan
     Access851{{"Access[851∈83] ➊<br />ᐸ843.cursorDetailsᐳ"}}:::plan
@@ -1149,6 +1146,9 @@ graph TD
     PgCursor867{{"PgCursor[867∈83] ➊"}}:::plan
     PgSelectSingle865{{"PgSelectSingle[865∈83] ➊<br />ᐸtable_set_query_plpgsqlᐳ"}}:::plan
     PgSelectSingle865 & Access851 --> PgCursor867
+    __ListTransform844[["__ListTransform[844∈83] ➊<br />ᐸeach:843ᐳ"]]:::plan
+    PgSelectRows845[["PgSelectRows[845∈83] ➊"]]:::plan
+    PgSelectRows845 --> __ListTransform844
     PgSelect843 --> PgSelectRows845
     PgSelect843 --> Access851
     PgPageInfo855{{"PgPageInfo[855∈83] ➊"}}:::plan
@@ -1185,9 +1185,6 @@ graph TD
     Constant1053 & Access910 --> Object915
     Object911{{"Object[911∈88] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Constant1053 & Access910 --> Object911
-    __ListTransform884[["__ListTransform[884∈88] ➊<br />ᐸeach:883ᐳ"]]:::plan
-    PgSelectRows885[["PgSelectRows[885∈88] ➊"]]:::plan
-    PgSelectRows885 & PgSelect883 --> __ListTransform884
     PgCursor901{{"PgCursor[901∈88] ➊"}}:::plan
     PgSelectSingle899{{"PgSelectSingle[899∈88] ➊<br />ᐸtable_set_query_plpgsqlᐳ"}}:::plan
     Access891{{"Access[891∈88] ➊<br />ᐸ883.cursorDetailsᐳ"}}:::plan
@@ -1195,6 +1192,9 @@ graph TD
     PgCursor907{{"PgCursor[907∈88] ➊"}}:::plan
     PgSelectSingle905{{"PgSelectSingle[905∈88] ➊<br />ᐸtable_set_query_plpgsqlᐳ"}}:::plan
     PgSelectSingle905 & Access891 --> PgCursor907
+    __ListTransform884[["__ListTransform[884∈88] ➊<br />ᐸeach:883ᐳ"]]:::plan
+    PgSelectRows885[["PgSelectRows[885∈88] ➊"]]:::plan
+    PgSelectRows885 --> __ListTransform884
     PgSelect883 --> PgSelectRows885
     PgSelect883 --> Access891
     PgPageInfo895{{"PgPageInfo[895∈88] ➊"}}:::plan
@@ -1230,7 +1230,7 @@ graph TD
     Object10 & PgFromExpression921 & Connection922 --> PgSelect935
     __ListTransform924[["__ListTransform[924∈93] ➊<br />ᐸeach:923ᐳ"]]:::plan
     PgSelectRows925[["PgSelectRows[925∈93] ➊"]]:::plan
-    PgSelectRows925 & PgSelect923 --> __ListTransform924
+    PgSelectRows925 --> __ListTransform924
     PgSelect923 --> PgSelectRows925
     Access933{{"Access[933∈93] ➊<br />ᐸ923.cursorDetailsᐳ"}}:::plan
     PgSelect923 --> Access933
@@ -1260,11 +1260,11 @@ graph TD
     PgSelectSingle930 --> PgClassExpression931
     PgSelect949[["PgSelect[949∈97] ➊<br />ᐸstatic_big_integerᐳ"]]:::plan
     Object10 & Connection948 --> PgSelect949
-    __ListTransform950[["__ListTransform[950∈97] ➊<br />ᐸeach:949ᐳ"]]:::plan
-    PgSelectRows951[["PgSelectRows[951∈97] ➊"]]:::plan
-    PgSelectRows951 & PgSelect949 --> __ListTransform950
     PgSelect961[["PgSelect[961∈97] ➊<br />ᐸstatic_big_integer(aggregate)ᐳ"]]:::plan
     Object10 & Connection948 --> PgSelect961
+    __ListTransform950[["__ListTransform[950∈97] ➊<br />ᐸeach:949ᐳ"]]:::plan
+    PgSelectRows951[["PgSelectRows[951∈97] ➊"]]:::plan
+    PgSelectRows951 --> __ListTransform950
     PgSelect949 --> PgSelectRows951
     First962{{"First[962∈97] ➊"}}:::plan
     PgSelectRows963[["PgSelectRows[963∈97] ➊"]]:::plan
@@ -1314,12 +1314,12 @@ graph TD
     PgClassExpression1005 ==> __Item1006
     PgSelect1016[["PgSelect[1016∈107] ➊<br />ᐸquery_interval_setᐳ"]]:::plan
     Object10 & Connection1015 --> PgSelect1016
-    __ListTransform1028[["__ListTransform[1028∈107] ➊<br />ᐸeach:1027ᐳ"]]:::plan
-    PgSelectRows1017[["PgSelectRows[1017∈107] ➊"]]:::plan
-    PgSelectRows1017 & PgSelect1016 --> __ListTransform1028
     PgSelect1042[["PgSelect[1042∈107] ➊<br />ᐸquery_interval_set(aggregate)ᐳ"]]:::plan
     Object10 & Connection1015 --> PgSelect1042
+    PgSelectRows1017[["PgSelectRows[1017∈107] ➊"]]:::plan
     PgSelect1016 --> PgSelectRows1017
+    __ListTransform1028[["__ListTransform[1028∈107] ➊<br />ᐸeach:1027ᐳ"]]:::plan
+    PgSelectRows1017 --> __ListTransform1028
     Access1037{{"Access[1037∈107] ➊<br />ᐸ1016.cursorDetailsᐳ"}}:::plan
     PgSelect1016 --> Access1037
     First1043{{"First[1043∈107] ➊"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
@@ -3237,9 +3237,6 @@ graph TD
     Access2226 --> Object2231
     Object2227{{"Object[2227∈199] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access2226 --> Object2227
-    __ListTransform1998[["__ListTransform[1998∈199] ➊<br />ᐸeach:1997ᐳ"]]:::plan
-    PgSelectRows1784[["PgSelectRows[1784∈199] ➊"]]:::plan
-    PgSelectRows1784 & PgSelect1783 --> __ListTransform1998
     PgSelect2217[["PgSelect[2217∈199] ➊<br />ᐸtype_function_connection(aggregate)ᐳ"]]:::plan
     Object11 & Connection1782 --> PgSelect2217
     PgCursor2238{{"PgCursor[2238∈199] ➊"}}:::plan
@@ -3249,7 +3246,10 @@ graph TD
     PgCursor2244{{"PgCursor[2244∈199] ➊"}}:::plan
     PgSelectSingle2242{{"PgSelectSingle[2242∈199] ➊<br />ᐸtype_function_connectionᐳ"}}:::plan
     PgSelectSingle2242 & Access2005 --> PgCursor2244
+    PgSelectRows1784[["PgSelectRows[1784∈199] ➊"]]:::plan
     PgSelect1783 --> PgSelectRows1784
+    __ListTransform1998[["__ListTransform[1998∈199] ➊<br />ᐸeach:1997ᐳ"]]:::plan
+    PgSelectRows1784 --> __ListTransform1998
     PgSelect1783 --> Access2005
     First2218{{"First[2218∈199] ➊"}}:::plan
     PgSelectRows2219[["PgSelectRows[2219∈199] ➊"]]:::plan
@@ -3947,9 +3947,6 @@ graph TD
     Access3136 --> Object3141
     Object3137{{"Object[3137∈258] ➊<br />ᐸ{first,last,hasMore}ᐳ"}}:::plan
     Access3136 --> Object3137
-    __ListTransform2908[["__ListTransform[2908∈258] ➊<br />ᐸeach:2907ᐳ"]]:::plan
-    PgSelectRows2694[["PgSelectRows[2694∈258] ➊"]]:::plan
-    PgSelectRows2694 & Lambda4313 --> __ListTransform2908
     PgCursor3148{{"PgCursor[3148∈258] ➊"}}:::plan
     PgSelectSingle3146{{"PgSelectSingle[3146∈258] ➊<br />ᐸperson_type_function_connectionᐳ"}}:::plan
     Access2915{{"Access[2915∈258] ➊<br />ᐸ4313.cursorDetailsᐳ"}}:::plan
@@ -3968,7 +3965,10 @@ graph TD
     First2258 --> PgSelectSingle2260
     PgSelectRows2475[["PgSelectRows[2475∈258] ➊"]]:::plan
     Lambda4243 --> PgSelectRows2475
+    PgSelectRows2694[["PgSelectRows[2694∈258] ➊"]]:::plan
     Lambda4313 --> PgSelectRows2694
+    __ListTransform2908[["__ListTransform[2908∈258] ➊<br />ᐸeach:2907ᐳ"]]:::plan
+    PgSelectRows2694 --> __ListTransform2908
     Lambda4313 --> Access2915
     First3128{{"First[3128∈258] ➊"}}:::plan
     PgSelectRows3129[["PgSelectRows[3129∈258] ➊"]]:::plan


### PR DESCRIPTION
## Description

Sometimes you need to reference an ancestor step during query planning, but you don't need its data at runtime. We forbid directly storing steps because we know those steps might well be replaced due to `.deduplicate()` or `.optimize()` or other lifecycle methods. Until now your only options were to add an explicit dependency (which has runtime overhead) or to do sketchy things.

This PR adds `const refId = this.addRef(step)` and `const step = this.getRef(refId)` APIs to allow you to create a reference. This saves the need for deep traversal of your dependency tree if you can declare up front a relation. (For example: if a PgSelectSingleStep (B) is related directly to an extant PgSelectSingleStep (A) due to a relationship traversal, A can inform B that it's the relevant ancestor, and then access to B's properties may, if they overlap with A, request said properties from A instead for efficiency.)

## Performance impact

Reduces runtime cost.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
