### PR TITLE
Uncomplicate trackedArguments

### DIFF
--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -217,7 +217,7 @@ const OUTPUT_PLAN_TYPE_ARRAY = Object.freeze({ mode: "array" });
 const newValueStepCallback = (isImmutable: boolean) =>
   new __ValueStep(isImmutable);
 
-const NO_ARGS: TrackedArguments = {};
+const NO_ARGS: TrackedArguments = Object.create(null);
 
 export class OperationPlan {
   /* This only exists to make establishOperationPlan easier for TypeScript */

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -217,11 +217,7 @@ const OUTPUT_PLAN_TYPE_ARRAY = Object.freeze({ mode: "array" });
 const newValueStepCallback = (isImmutable: boolean) =>
   new __ValueStep(isImmutable);
 
-const NO_ARGS: TrackedArguments = {
-  get() {
-    throw new Error(`This field doesn't have any arguments`);
-  },
-};
+const NO_ARGS: TrackedArguments = {};
 
 export class OperationPlan {
   /* This only exists to make establishOperationPlan easier for TypeScript */
@@ -922,12 +918,7 @@ export class OperationPlan {
         POLYMORPHIC_ROOT_PATHS,
         planningPath,
         () => {
-          const $args = object(
-            field.arguments?.reduce((memo, arg) => {
-              memo[arg.name.value] = trackedArguments.get(arg.name.value);
-              return memo;
-            }, Object.create(null)) ?? Object.create(null),
-          );
+          const $args = object(trackedArguments);
           const rawResolver = fieldSpec.resolve;
           const rawSubscriber = fieldSpec.subscribe;
           return graphqlResolver(
@@ -1375,11 +1366,7 @@ export class OperationPlan {
             polymorphicPaths,
             fieldPlanningPath,
             () => {
-              const spec = Object.create(null);
-              for (const arg of field.arguments ?? EMPTY_ARRAY) {
-                spec[arg.name.value] = trackedArguments.get(arg.name.value);
-              }
-              const $args = object(spec);
+              const $args = object(trackedArguments);
               return graphqlResolver(resolver, subscriber, step, $args, {
                 ...this.resolveInfoOperationBase,
                 fieldName,
@@ -2717,11 +2704,7 @@ export class OperationPlan {
       );
       trackedArgumentValues[argumentName] = argumentPlan;
     }
-    return {
-      get(name) {
-        return trackedArgumentValues[name];
-      },
-    };
+    return trackedArgumentValues;
   }
 
   /**

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -441,7 +441,7 @@ export type GrafastInputFieldConfig<
 export type TrackedArguments<
   TArgs extends BaseGraphQLArguments = BaseGraphQLArguments,
 > = {
-  get<TKey extends keyof TArgs>(key: TKey): AnyInputStep;
+  [TKey in keyof TArgs & string]: AnyInputStep;
 };
 
 /**

--- a/grafast/grafast/src/operationPlan-input.ts
+++ b/grafast/grafast/src/operationPlan-input.ts
@@ -39,7 +39,7 @@ function assertNotRuntime(operationPlan: OperationPlan, description: string) {
 
 export function withFieldArgsForArguments<T extends Step>(
   operationPlan: OperationPlan,
-  $all: TrackedArguments,
+  trackedArguments: TrackedArguments,
   field: GraphQLField<any, any, any>,
   $parent: Step,
   applyAfterMode: ApplyAfterModeArg,
@@ -115,19 +115,15 @@ export function withFieldArgsForArguments<T extends Step>(
     getRaw(path) {
       assertNotRuntime(operationPlan, `fieldArgs.getRaw()`);
       if (path === undefined) {
-        return object(
-          Object.fromEntries(
-            Object.keys(args).map((argName) => [argName, $all[argName]]),
-          ),
-        );
+        return object(trackedArguments);
       } else if (typeof path === "string") {
-        return $all[path];
+        return trackedArguments[path];
       } else if (Array.isArray(path)) {
         const [first, ...rest] = path;
         if (!first) {
           throw new Error(`getRaw() must be called with a non-empty path`);
         }
-        let $entry = $all[first];
+        let $entry = trackedArguments[first];
         for (const pathSegment of rest) {
           if (typeof pathSegment === "number" && "at" in $entry) {
             $entry = $entry.at(pathSegment);

--- a/grafast/grafast/src/operationPlan-input.ts
+++ b/grafast/grafast/src/operationPlan-input.ts
@@ -117,17 +117,17 @@ export function withFieldArgsForArguments<T extends Step>(
       if (path === undefined) {
         return object(
           Object.fromEntries(
-            Object.keys(args).map((argName) => [argName, $all.get(argName)]),
+            Object.keys(args).map((argName) => [argName, $all[argName]]),
           ),
         );
       } else if (typeof path === "string") {
-        return $all.get(path);
+        return $all[path];
       } else if (Array.isArray(path)) {
         const [first, ...rest] = path;
         if (!first) {
           throw new Error(`getRaw() must be called with a non-empty path`);
         }
-        let $entry = $all.get(first);
+        let $entry = $all[first];
         for (const pathSegment of rest) {
           if (typeof pathSegment === "number" && "at" in $entry) {
             $entry = $entry.at(pathSegment);

--- a/grafast/grafast/src/steps/graphqlResolver.ts
+++ b/grafast/grafast/src/steps/graphqlResolver.ts
@@ -8,7 +8,11 @@ import * as graphql from "graphql";
 
 import type { __ItemStep, ExecutionDetails, ObjectStep } from "../index.js";
 import { context, flagError } from "../index.js";
-import type { PlanTypeInfo, UnbatchedExecutionExtra } from "../interfaces.js";
+import type {
+  PlanTypeInfo,
+  TrackedArguments,
+  UnbatchedExecutionExtra,
+} from "../interfaces.js";
 import { Step, UnbatchedStep } from "../step.js";
 import { isPromiseLike } from "../utils.js";
 
@@ -45,7 +49,7 @@ export class GraphQLResolverStep extends UnbatchedStep {
       | null
       | undefined,
     $plan: Step,
-    $args: ObjectStep,
+    $args: ObjectStep<TrackedArguments>,
     private resolveInfoBase: ResolveInfoBase,
   ) {
     super();
@@ -219,7 +223,7 @@ export function graphqlResolver(
   resolver: GraphQLFieldResolver<any, any> | null | undefined,
   subscriber: GraphQLFieldResolver<any, any> | null | undefined,
   $step: Step,
-  $args: ObjectStep,
+  $args: ObjectStep<TrackedArguments>,
   resolveInfoBase: ResolveInfoBase,
 ): Step {
   return new GraphQLResolverStep(


### PR DESCRIPTION
For some reason trackedArguments used to to be an indirect object with get function, but going forward we don't need this complexity; let's remove it.