### PR TITLE
Ensure undefined values are flagged correctl

### DIFF
--- a/.changeset/two-ears-pull.md
+++ b/.changeset/two-ears-pull.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Fixes bug where undefined values might not be flagged with FLAG_NULL

--- a/grafast/grafast/__tests__/dcc/queries/floor-minimal.json5
+++ b/grafast/grafast/__tests__/dcc/queries/floor-minimal.json5
@@ -1,0 +1,18 @@
+{
+  floor: {
+    number: 3,
+    locations: [
+      {},
+      {
+        manager: {
+          __typename: 'Staff',
+        },
+      },
+      {
+        manager: null,
+      },
+      {},
+      {},
+    ],
+  },
+}

--- a/grafast/grafast/__tests__/dcc/queries/floor-minimal.test.graphql
+++ b/grafast/grafast/__tests__/dcc/queries/floor-minimal.test.graphql
@@ -1,0 +1,13 @@
+# This test reproduced a bug where 'undefined' was not correctly marked with FLAG_NULL
+{
+  floor(number: 3) {
+    number
+    locations {
+      ... on Club {
+        manager {
+          __typename
+        }
+      }
+    }
+  }
+}

--- a/grafast/grafast/src/engine/executeBucket.ts
+++ b/grafast/grafast/src/engine/executeBucket.ts
@@ -289,14 +289,14 @@ export function executeBucket(
         flags: ExecutionEntryFlags,
       ) => {
         // Fast lanes
-        if (typeof value !== "object") {
+        if (value == null) {
+          // null / undefined
+          const finalFlags = flags | FLAG_NULL;
+          bucket.setResult(finishedStep, resultIndex, value, finalFlags);
+          return;
+        } else if (typeof value !== "object") {
           // non-objects
           bucket.setResult(finishedStep, resultIndex, value, flags);
-          return;
-        } else if (value === null) {
-          // nulls
-          const finalFlags = flags | FLAG_NULL;
-          bucket.setResult(finishedStep, resultIndex, null, finalFlags);
           return;
         } else if (isFlaggedValue(value)) {
           // flagged values


### PR DESCRIPTION
`undefined` values should get `FLAG_NULL`, but this wasn't always the case. The result is that `inhibitOnNull` wouldn't always inhibit when undefined. This fixes that.