### PR TITLE
Fix issue with multi-path refs to non-polymorphic types

### DIFF
--- a/.changeset/wise-pigs-slide.md
+++ b/.changeset/wise-pigs-slide.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Fix bug with `@ref ... plural` smart tag where multiple `@refVia` are present
+but the target type is not abstract.

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -1046,16 +1046,6 @@ function addRelations(
         }
       }
 
-      if (
-        refSpec.graphqlType &&
-        sharedFinalResource &&
-        refSpec.graphqlType !==
-          build.inflection.tableType(sharedFinalResource.codec)
-      ) {
-        // The might have been referencing a polymorphic thing
-        sharedFinalResource = null;
-      }
-
       if (refSpec.graphqlType) {
         // If this is a union/interface, can we find the associated codec?
 
@@ -1076,6 +1066,17 @@ function addRelations(
 
       if (hasExactlyOneSource) {
         sharedSource = firstSource;
+      }
+
+      if (
+        sharedCodec?.polymorphism?.mode === "union" &&
+        refSpec.graphqlType &&
+        sharedFinalResource &&
+        refSpec.graphqlType !==
+          build.inflection.tableType(sharedFinalResource.codec)
+      ) {
+        // The might have been referencing a polymorphic thing
+        sharedFinalResource = null;
       }
 
       // TEST: previously `sharedCodec?.polymorphism?.mode === "union" || paths.length > 1`

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -1289,7 +1289,26 @@ function addRelations(
                     te`from \${${te.ref(path.layers[penultimateIndex].resource, path.layers[penultimateIndex].resource.name)}.from} as ${lyr(penultimateIndex)}`,
                   );
 
-                  // TODO: inner joins
+                  for (
+                    let layerIdx = penultimateIndex - 1;
+                    layerIdx >= 0;
+                    layerIdx--
+                  ) {
+                    const { localAttributes, remoteAttributes } =
+                      path.layers[layerIdx + 1];
+                    lines.push(
+                      te`inner join \${${te.ref(path.layers[layerIdx].resource, path.layers[layerIdx].resource.name)}.from} as ${lyr(layerIdx)}`,
+                    );
+                    lines.push(
+                      te`on (${te.join(
+                        localAttributes.map(
+                          (attr, attrIdx) =>
+                            te`${lyr(layerIdx)}.\${${ref_sql}.identifier(${te.literal(attr)})} = ${lyr(layerIdx + 1)}.\${${ref_sql}.identifier(${te.literal(remoteAttributes[attrIdx])})}`,
+                        ),
+                        " and ",
+                      )})`,
+                    );
+                  }
 
                   lines.push(
                     te`where ${te.join(

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
@@ -80,6 +80,12 @@ delete from d.person cascade;
 delete from issue_2210.test_message cascade;
 delete from issue_2210.test_user cascade;
 
+delete from refs.posts cascade;
+delete from refs.people cascade;
+delete from refs.book_editors cascade;
+delete from refs.book_authors cascade;
+delete from refs.books cascade;
+
 alter table b.types enable trigger user;
 
 alter sequence inheritence.file_id_seq restart with 1;
@@ -1051,3 +1057,29 @@ values (1, 1, null, 0.2)
 alter sequence relay.users_id_seq restart with 100;
 alter sequence relay.spectacles_id_seq restart with 100;
 alter sequence relay.distances_id_seq restart with 100;
+
+--------------------------------------------------------------------------------
+
+insert into refs.people (id, name) values
+  (1, 'Alice Smith'),
+  (2, 'Bob Jones'),
+  (3, 'Carol Wilson');
+
+insert into refs.posts (id, user_id) values
+  (1, 1), -- Alice's post
+  (2, 2), -- Bob's post
+  (3, 1), -- Another post by Alice
+  (4, 3); -- Carol's post
+
+insert into refs.books (id, title, isbn) values
+  (1, 'Dungeon Crawler Carl', '978-0593820247'),
+  (2, 'The Shining', '978-0385121675');
+
+insert into refs.book_authors (book_id, person_id) values
+  (1, 1),
+  (2, 2);
+
+insert into refs.book_editors (book_id, person_id) values
+  (1, 3), 
+  (1, 2),
+  (2, 3);

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
@@ -1083,3 +1083,7 @@ insert into refs.book_editors (book_id, person_id) values
   (1, 3), 
   (1, 2),
   (2, 3);
+
+alter sequence refs.people_id_seq restart with 100;
+alter sequence refs.posts_id_seq restart with 100;
+alter sequence refs.books_id_seq restart with 100;

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
@@ -84,6 +84,7 @@ delete from refs.posts cascade;
 delete from refs.people cascade;
 delete from refs.book_editors cascade;
 delete from refs.book_authors cascade;
+delete from refs.pen_names cascade;
 delete from refs.books cascade;
 
 alter table b.types enable trigger user;
@@ -1065,6 +1066,15 @@ insert into refs.people (id, name) values
   (2, 'Bob Jones'),
   (3, 'Carol Wilson');
 
+insert into refs.pen_names (id, person_id, pen_name) values
+  (1, 1, 'Smalice Ith'),
+  (2, 1, 'Sally Aces'),
+  (3, 1, 'Albert Smithe'),
+  (4, 2, 'Robert A.B.C. Dee'),
+  (5, 2, 'Jonesy McAdams'),
+  (6, 3, 'Carol Wilson');
+
+
 insert into refs.posts (id, user_id) values
   (1, 1), -- Alice's post
   (2, 2), -- Bob's post
@@ -1075,15 +1085,16 @@ insert into refs.books (id, title, isbn) values
   (1, 'Dungeon Crawler Carl', '978-0593820247'),
   (2, 'The Shining', '978-0385121675');
 
-insert into refs.book_authors (book_id, person_id) values
-  (1, 1),
-  (2, 2);
+insert into refs.book_authors (book_id, pen_name_id) values
+  (1, 3),
+  (2, 4);
 
 insert into refs.book_editors (book_id, person_id) values
-  (1, 3), 
+  (1, 3),
   (1, 2),
   (2, 3);
 
 alter sequence refs.people_id_seq restart with 100;
 alter sequence refs.posts_id_seq restart with 100;
 alter sequence refs.books_id_seq restart with 100;
+alter sequence refs.pen_names_id_seq restart with 100;

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1980,10 +1980,16 @@ CREATE TABLE refs.books (
   isbn TEXT UNIQUE
 );
 
+CREATE TABLE refs.pen_names (
+  id serial primary key,
+  pen_name text not null,
+  person_id INTEGER REFERENCES refs.people(id) ON DELETE CASCADE
+);
+
 CREATE TABLE refs.book_authors (
   book_id INTEGER REFERENCES refs.books(id) ON DELETE CASCADE,
-  person_id INTEGER REFERENCES refs.people(id) ON DELETE CASCADE,
-  PRIMARY KEY (book_id, person_id)
+  pen_name_id INTEGER REFERENCES refs.pen_names(id) ON DELETE CASCADE,
+  PRIMARY KEY (book_id, pen_name_id)
 );
 
 CREATE TABLE refs.book_editors (
@@ -1994,7 +2000,7 @@ CREATE TABLE refs.book_editors (
 
 COMMENT ON TABLE refs.books IS $$
   @ref relatedPeople to:Person plural
-  @refVia relatedPeople via:(id)->book_authors(book_id);(person_id)->people(id)
+  @refVia relatedPeople via:(id)->book_authors(book_id);(pen_name_id)->pen_names(id);(person_id)->people(id)
   @refVia relatedPeople via:(id)->book_editors(book_id);(person_id)->people(id)
   @ref editors to:Person plural
   @refVia editors via:(id)->book_editors(book_id);(person_id)->people(id)

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1974,6 +1974,32 @@ comment on table refs.posts is $$
 @ref author via:(user_id)->people(id) singular
 $$;
 
+CREATE TABLE refs.books (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  isbn TEXT UNIQUE
+);
+
+CREATE TABLE refs.book_authors (
+  book_id INTEGER REFERENCES refs.books(id) ON DELETE CASCADE,
+  person_id INTEGER REFERENCES refs.people(id) ON DELETE CASCADE,
+  PRIMARY KEY (book_id, person_id)
+);
+
+CREATE TABLE refs.book_editors (
+  book_id INTEGER REFERENCES refs.books(id) ON DELETE CASCADE,
+  person_id INTEGER REFERENCES refs.people(id) ON DELETE CASCADE,
+  PRIMARY KEY (book_id, person_id)
+);
+
+COMMENT ON TABLE refs.books IS $$
+  @ref relatedPeople to:Person plural
+  @refVia relatedPeople via:(id)->book_authors(book_id);(person_id)->people(id)
+  @refVia relatedPeople via:(id)->book_editors(book_id);(person_id)->people(id)
+  @ref editors to:Person plural
+  @refVia editors via:(id)->book_editors(book_id);(person_id)->people(id)
+$$;
+
 --------------------------------------------------------------------------------
 
 -- From https://github.com/graphile/crystal/issues/1987

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.json5
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.json5
@@ -1,0 +1,27 @@
+{
+  allBooks: {
+    nodes: [
+      {
+        editors: {
+          nodes: [
+            {
+              name: "Bob Jones",
+            },
+            {
+              name: "Carol Wilson",
+            },
+          ],
+        },
+      },
+      {
+        editors: {
+          nodes: [
+            {
+              name: "Carol Wilson",
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.mermaid
@@ -1,0 +1,68 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+    subgraph "Buckets for queries/refs/books-editors-plural-ref"
+    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 24<br /><br />ROOT Connectionᐸ8ᐳ[12]<br />1: PgSelect[14]<br />2: PgSelectRows[15]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 24<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 11, 24<br /><br />ROOT PgSelectSingle{2}ᐸbooksᐳ[17]<br />1: <br />ᐳ: PgClassExpression[23]<br />2: PgSelect[26]<br />3: PgSelectRows[27]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ27ᐳ[28]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 29<br /><br />ROOT PgSelectSingle{4}ᐸpeopleᐳ[29]"):::bucket
+    end
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    Bucket4 --> Bucket5
+
+    %% plan dependencies
+    Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 2"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access9 & Access10 --> Object11
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access9
+    __Value2 --> Access10
+    Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Connection24{{"Connection[24∈0] ➊<br />ᐸ19ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸbooksᐳ<br />More deps:<br />- Object[11]"]]:::plan
+    Connection12 --> PgSelect14
+    PgSelectRows15[["PgSelectRows[15∈1] ➊"]]:::plan
+    PgSelect14 --> PgSelectRows15
+    __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
+    PgSelectRows15 ==> __Item16
+    PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸbooksᐳ"}}:::plan
+    __Item16 --> PgSelectSingle17
+    PgSelect26[["PgSelect[26∈3]<br />ᐸpeopleᐳ<br />More deps:<br />- Object[11]"]]:::plan
+    PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__books__.”id”ᐳ"}}:::plan
+    PgClassExpression23 & Connection24 --> PgSelect26
+    PgSelectSingle17 --> PgClassExpression23
+    PgSelectRows27[["PgSelectRows[27∈3]"]]:::plan
+    PgSelect26 --> PgSelectRows27
+    __Item28[/"__Item[28∈4]<br />ᐸ27ᐳ"\]:::itemplan
+    PgSelectRows27 ==> __Item28
+    PgSelectSingle29{{"PgSelectSingle[29∈4]<br />ᐸpeopleᐳ"}}:::plan
+    __Item28 --> PgSelectSingle29
+    PgClassExpression30{{"PgClassExpression[30∈5]<br />ᐸ__people__.”name”ᐳ"}}:::plan
+    PgSelectSingle29 --> PgClassExpression30
+
+    %% define steps
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value2,Access9,Access10,Object11,Connection12,Connection24 bucket0
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgSelect14,PgSelectRows15 bucket1
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item16,PgSelectSingle17 bucket2
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,PgClassExpression23,PgSelect26,PgSelectRows27 bucket3
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,__Item28,PgSelectSingle29 bucket4
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,PgClassExpression30 bucket5
+

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.sql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.sql
@@ -1,0 +1,19 @@
+select
+  __books__."id"::text as "0"
+from "refs"."books" as __books__
+order by __books__."id" asc;
+
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."name" as "0",
+    __people_identifiers__.idx as "1"
+  from "refs"."people" as __people__
+  inner join "refs"."book_editors" as __book_editors__
+  on (__people__."id" = __book_editors__."person_id")
+  where (
+    __book_editors__."book_id" = __people_identifiers__."id0"
+  )
+  order by __people__."id" asc
+) as __people_result__;

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-editors-plural-ref.test.graphql
@@ -1,0 +1,21 @@
+## expect(errors).toBeFalsy()
+#> schema: ["refs"]
+#> simpleCollections: "both"
+## expect(data.allBooks.nodes.length).toEqual(2)
+## expect(data.allBooks.nodes[0].editors.nodes.length).toEqual(2)
+## expect(data.allBooks.nodes[0].editors.nodes[0].name).toEqual("Bob Jones")
+## expect(data.allBooks.nodes[0].editors.nodes[1].name).toEqual("Carol Wilson")
+## expect(data.allBooks.nodes[1].editors.nodes.length).toEqual(1)
+## expect(data.allBooks.nodes[1].editors.nodes[0].name).toEqual("Carol Wilson")
+
+{
+  allBooks {
+    nodes {
+      editors {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.json5
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.json5
@@ -1,0 +1,35 @@
+{
+  data: {
+    allBooks: {
+      nodes: [
+        {
+          relatedPeople: {
+            nodes: [
+              {
+                name: "Alice Smith",
+              },
+              {
+                name: "Carol Wilson",
+              },
+              {
+                name: "Bob Jones",
+              },
+            ],
+          },
+        },
+        {
+          relatedPeople: {
+            nodes: [
+              {
+                name: "Bob Jones",
+              },
+              {
+                name: "Carol Wilson",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.json5
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.json5
@@ -1,35 +1,35 @@
 {
-  data: {
-    allBooks: {
-      nodes: [
-        {
-          relatedPeople: {
-            nodes: [
-              {
-                name: "Alice Smith",
-              },
-              {
-                name: "Carol Wilson",
-              },
-              {
-                name: "Bob Jones",
-              },
-            ],
-          },
+  allBooks: {
+    nodes: [
+      {
+        title: "Dungeon Crawler Carl",
+        relatedPeople: {
+          nodes: [
+            {
+              name: "Alice Smith",
+            },
+            {
+              name: "Bob Jones",
+            },
+            {
+              name: "Carol Wilson",
+            },
+          ],
         },
-        {
-          relatedPeople: {
-            nodes: [
-              {
-                name: "Bob Jones",
-              },
-              {
-                name: "Carol Wilson",
-              },
-            ],
-          },
+      },
+      {
+        title: "The Shining",
+        relatedPeople: {
+          nodes: [
+            {
+              name: "Bob Jones",
+            },
+            {
+              name: "Carol Wilson",
+            },
+          ],
         },
-      ],
-    },
+      },
+    ],
   },
 }

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.mermaid
@@ -1,0 +1,70 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+    subgraph "Buckets for queries/refs/books-related-people-plural-ref"
+    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 25<br /><br />ROOT Connectionᐸ8ᐳ[12]<br />1: PgSelect[14]<br />2: PgSelectRows[15]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 11, 25<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 11, 25<br /><br />ROOT PgSelectSingle{2}ᐸbooksᐳ[17]<br />1: <br />ᐳ: 18, 24<br />2: PgSelect[27]<br />3: PgSelectRows[28]"):::bucket
+    Bucket4("Bucket 4 (listItem)<br /><br />ROOT __Item{4}ᐸ28ᐳ[29]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 30<br /><br />ROOT PgSelectSingle{4}ᐸpeopleᐳ[30]"):::bucket
+    end
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    Bucket4 --> Bucket5
+
+    %% plan dependencies
+    Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 2"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access9 & Access10 --> Object11
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access9
+    __Value2 --> Access10
+    Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Connection25{{"Connection[25∈0] ➊<br />ᐸ20ᐳ"}}:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸbooksᐳ<br />More deps:<br />- Object[11]"]]:::plan
+    Connection12 --> PgSelect14
+    PgSelectRows15[["PgSelectRows[15∈1] ➊"]]:::plan
+    PgSelect14 --> PgSelectRows15
+    __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
+    PgSelectRows15 ==> __Item16
+    PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸbooksᐳ"}}:::plan
+    __Item16 --> PgSelectSingle17
+    PgSelect27[["PgSelect[27∈3]<br />ᐸpeopleᐳ<br />More deps:<br />- Object[11]"]]:::plan
+    PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__books__.”id”ᐳ"}}:::plan
+    PgClassExpression24 & Connection25 --> PgSelect27
+    PgClassExpression18{{"PgClassExpression[18∈3]<br />ᐸ__books__.”title”ᐳ"}}:::plan
+    PgSelectSingle17 --> PgClassExpression18
+    PgSelectSingle17 --> PgClassExpression24
+    PgSelectRows28[["PgSelectRows[28∈3]"]]:::plan
+    PgSelect27 --> PgSelectRows28
+    __Item29[/"__Item[29∈4]<br />ᐸ28ᐳ"\]:::itemplan
+    PgSelectRows28 ==> __Item29
+    PgSelectSingle30{{"PgSelectSingle[30∈4]<br />ᐸpeopleᐳ"}}:::plan
+    __Item29 --> PgSelectSingle30
+    PgClassExpression31{{"PgClassExpression[31∈5]<br />ᐸ__people__.”name”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression31
+
+    %% define steps
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value2,Access9,Access10,Object11,Connection12,Connection25 bucket0
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgSelect14,PgSelectRows15 bucket1
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item16,PgSelectSingle17 bucket2
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,PgClassExpression18,PgClassExpression24,PgSelect27,PgSelectRows28 bucket3
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,__Item29,PgSelectSingle30 bucket4
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,PgClassExpression31 bucket5
+

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.sql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.sql
@@ -1,0 +1,27 @@
+select
+  __books__."title" as "0",
+  __books__."id"::text as "1"
+from "refs"."books" as __books__
+order by __books__."id" asc;
+
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."name" as "0",
+    __people_identifiers__.idx as "1"
+  from "refs"."people" as __people__
+  inner join (
+      select __l1__."person_id" as "0"
+      from "refs"."pen_names" as __l1__
+      inner join "refs"."book_authors" as __l0__
+      on (__l0__."pen_name_id" = __l1__."id")
+      where __l0__."book_id" = __people_identifiers__."id0"
+    union all
+      select __l0__."person_id" as "0"
+      from "refs"."book_editors" as __l0__
+      where __l0__."book_id" = __people_identifiers__."id0"
+  ) as __subquery__
+  on (__people__."id" = __subquery__."0")
+  order by __people__."id" asc
+) as __people_result__;

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.test.graphql
@@ -3,17 +3,17 @@
 #> simpleCollections: "both"
 ## expect(data.allBooks.nodes.length).toEqual(2)
 ## expect(data.allBooks.nodes[0].relatedPeople.nodes[0].name).toEqual("Alice Smith")
-## expect(data.allBooks.nodes[0].relatedPeople.nodes[1].name).toEqual("Carol Wilson")
-## expect(data.allBooks.nodes[0].relatedPeople.nodes[2].name).toEqual("Bob Jones")
-## expect(data.allBooks.nodes[0].relatedPeople.length).toEqual(3)
+## expect(data.allBooks.nodes[0].relatedPeople.nodes[1].name).toEqual("Bob Jones")
+## expect(data.allBooks.nodes[0].relatedPeople.nodes[2].name).toEqual("Carol Wilson")
+## expect(data.allBooks.nodes[0].relatedPeople.nodes.length).toEqual(3)
 ## expect(data.allBooks.nodes[1].relatedPeople.nodes[0].name).toEqual("Bob Jones")
 ## expect(data.allBooks.nodes[1].relatedPeople.nodes[1].name).toEqual("Carol Wilson")
-## expect(data.allBooks.nodes[1].relatedPeople.length).toEqual(2)
-
+## expect(data.allBooks.nodes[1].relatedPeople.nodes.length).toEqual(2)
 
 {
   allBooks {
     nodes {
+      title
       relatedPeople {
         nodes {
           name

--- a/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/books-related-people-plural-ref.test.graphql
@@ -1,0 +1,24 @@
+## expect(errors).toBeFalsy()
+#> schema: ["refs"]
+#> simpleCollections: "both"
+## expect(data.allBooks.nodes.length).toEqual(2)
+## expect(data.allBooks.nodes[0].relatedPeople.nodes[0].name).toEqual("Alice Smith")
+## expect(data.allBooks.nodes[0].relatedPeople.nodes[1].name).toEqual("Carol Wilson")
+## expect(data.allBooks.nodes[0].relatedPeople.nodes[2].name).toEqual("Bob Jones")
+## expect(data.allBooks.nodes[0].relatedPeople.length).toEqual(3)
+## expect(data.allBooks.nodes[1].relatedPeople.nodes[0].name).toEqual("Bob Jones")
+## expect(data.allBooks.nodes[1].relatedPeople.nodes[1].name).toEqual("Carol Wilson")
+## expect(data.allBooks.nodes[1].relatedPeople.length).toEqual(2)
+
+
+{
+  allBooks {
+    nodes {
+      relatedPeople {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.json5
+++ b/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.json5
@@ -1,0 +1,26 @@
+{
+  allPosts: {
+    nodes: [
+      {
+        author: {
+          name: "Alice Smith",
+        },
+      },
+      {
+        author: {
+          name: "Bob Jones",
+        },
+      },
+      {
+        author: {
+          name: "Alice Smith",
+        },
+      },
+      {
+        author: {
+          name: "Carol Wilson",
+        },
+      },
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.mermaid
@@ -1,0 +1,66 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+    subgraph "Buckets for queries/refs/posts-author-singular-ref"
+    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 11, 12, 27<br /><br />ROOT Connectionᐸ8ᐳ[12]<br />1: PgSelect[14]<br />ᐳ: Access[28]<br />2: PgSelectRows[15]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 28<br /><br />ROOT __Item{2}ᐸ15ᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 28, 17<br /><br />ROOT PgSelectSingle{2}ᐸpostsᐳ[17]<br />1: <br />ᐳ: List[29], Lambda[30]<br />2: PgSelectRows[24]<br />ᐳ: First[23], PgSelectSingle[25]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 25<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[25]"):::bucket
+    end
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+
+    %% plan dependencies
+    Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access10{{"Access[10∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access9 & Access10 --> Object11
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access9
+    __Value2 --> Access10
+    Connection12{{"Connection[12∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    PgSelectInlineApply27["PgSelectInlineApply[27∈0] ➊"]:::plan
+    PgSelect14[["PgSelect[14∈1] ➊<br />ᐸpostsᐳ"]]:::plan
+    Object11 & Connection12 & PgSelectInlineApply27 --> PgSelect14
+    PgSelectRows15[["PgSelectRows[15∈1] ➊"]]:::plan
+    PgSelect14 --> PgSelectRows15
+    Access28{{"Access[28∈1] ➊<br />ᐸ14.m.joinDetailsFor19ᐳ"}}:::plan
+    PgSelect14 --> Access28
+    __Item16[/"__Item[16∈2]<br />ᐸ15ᐳ"\]:::itemplan
+    PgSelectRows15 ==> __Item16
+    PgSelectSingle17{{"PgSelectSingle[17∈2]<br />ᐸpostsᐳ"}}:::plan
+    __Item16 --> PgSelectSingle17
+    List29{{"List[29∈3]<br />ᐸ28,17ᐳ"}}:::plan
+    Access28 & PgSelectSingle17 --> List29
+    First23{{"First[23∈3]"}}:::plan
+    PgSelectRows24[["PgSelectRows[24∈3]"]]:::plan
+    PgSelectRows24 --> First23
+    Lambda30{{"Lambda[30∈3]<br />ᐸpgInlineViaJoinTransformᐳ"}}:::plan
+    Lambda30 --> PgSelectRows24
+    PgSelectSingle25{{"PgSelectSingle[25∈3]<br />ᐸpeopleᐳ"}}:::plan
+    First23 --> PgSelectSingle25
+    List29 --> Lambda30
+    PgClassExpression26{{"PgClassExpression[26∈4]<br />ᐸ__people__.”name”ᐳ"}}:::plan
+    PgSelectSingle25 --> PgClassExpression26
+
+    %% define steps
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value2,Access9,Access10,Object11,Connection12,PgSelectInlineApply27 bucket0
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgSelect14,PgSelectRows15,Access28 bucket1
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item16,PgSelectSingle17 bucket2
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,First23,PgSelectRows24,PgSelectSingle25,List29,Lambda30 bucket3
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression26 bucket4
+

--- a/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.sql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.sql
@@ -1,0 +1,10 @@
+select
+  __posts__."user_id"::text as "0",
+  __people__."name" as "1"
+from "refs"."posts" as __posts__
+left outer join "refs"."people" as __people__
+on (
+/* WHERE becoming ON */ (
+  __people__."id" = __posts__."user_id"
+))
+order by __posts__."id" asc;

--- a/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/refs/posts-author-singular-ref.test.graphql
@@ -1,0 +1,19 @@
+## expect(errors).toBeFalsy()
+#> schema: ["refs"]
+#> simpleCollections: "both"
+## expect(data.allPosts.nodes.length).toEqual(4)
+## expect(data.allPosts.nodes[0].author.name).toEqual("Alice Smith")
+## expect(data.allPosts.nodes[1].author.name).toEqual("Bob Jones")
+## expect(data.allPosts.nodes[2].author.name).toEqual("Alice Smith")
+## expect(data.allPosts.nodes[3].author.name).toEqual("Carol Wilson")
+
+
+{
+  allPosts {
+    nodes {
+      author {
+        name
+      }
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
@@ -78,6 +78,208 @@ const executor = new PgExecutor({
     });
   }
 });
+const bookAuthorsIdentifier = sql.identifier("refs", "book_authors");
+const bookAuthorsCodec = recordCodec({
+  name: "bookAuthors",
+  identifier: bookAuthorsIdentifier,
+  attributes: {
+    __proto__: null,
+    book_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    pen_name_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "book_authors"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const bookEditorsIdentifier = sql.identifier("refs", "book_editors");
+const bookEditorsCodec = recordCodec({
+  name: "bookEditors",
+  identifier: bookEditorsIdentifier,
+  attributes: {
+    __proto__: null,
+    book_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "book_editors"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
+const booksIdentifier = sql.identifier("refs", "books");
+const spec_books = {
+  name: "books",
+  identifier: booksIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    isbn: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "books"
+    },
+    tags: {
+      __proto__: null,
+      ref: ["relatedPeople to:Person plural", "editors to:Person plural"],
+      refVia: ["relatedPeople via:(id)->book_authors(book_id);(pen_name_id)->pen_names(id);(person_id)->people(id)", "relatedPeople via:(id)->book_editors(book_id);(person_id)->people(id)", "editors via:(id)->book_editors(book_id);(person_id)->people(id)"]
+    },
+    refDefinitions: {
+      __proto__: null,
+      relatedPeople: {
+        singular: false,
+        graphqlType: "Person",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      editors: {
+        singular: false,
+        graphqlType: "Person",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    }
+  },
+  executor: executor
+};
+const booksCodec = recordCodec(spec_books);
+const penNamesIdentifier = sql.identifier("refs", "pen_names");
+const penNamesCodec = recordCodec({
+  name: "penNames",
+  identifier: penNamesIdentifier,
+  attributes: {
+    __proto__: null,
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    pen_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  },
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "pen_names"
+    },
+    tags: {
+      __proto__: null
+    }
+  },
+  executor: executor
+});
 const peopleIdentifier = sql.identifier("refs", "people");
 const peopleCodec = recordCodec({
   name: "people",
@@ -174,6 +376,70 @@ const postsCodec = recordCodec({
   },
   executor: executor
 });
+const book_authorsUniques = [{
+  isPrimary: true,
+  attributes: ["book_id", "pen_name_id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_book_authors_book_authors = {
+  executor: executor,
+  name: "book_authors",
+  identifier: "main.refs.book_authors",
+  from: bookAuthorsIdentifier,
+  codec: bookAuthorsCodec,
+  uniques: book_authorsUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "book_authors"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {}
+  }
+};
+const book_editorsUniques = [{
+  isPrimary: true,
+  attributes: ["book_id", "person_id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_book_editors_book_editors = {
+  executor: executor,
+  name: "book_editors",
+  identifier: "main.refs.book_editors",
+  from: bookEditorsIdentifier,
+  codec: bookEditorsCodec,
+  uniques: book_editorsUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "book_editors"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {}
+  }
+};
 const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -240,6 +506,82 @@ const registryConfig_pgResources_posts_posts = {
     }
   }
 };
+const booksUniques = [{
+  isPrimary: true,
+  attributes: ["id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}, {
+  isPrimary: false,
+  attributes: ["isbn"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_books_books = {
+  executor: executor,
+  name: "books",
+  identifier: "main.refs.books",
+  from: booksIdentifier,
+  codec: booksCodec,
+  uniques: booksUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "books"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {
+      ref: spec_books.extensions.tags.ref,
+      refVia: spec_books.extensions.tags.refVia
+    }
+  }
+};
+const pen_namesUniques = [{
+  isPrimary: true,
+  attributes: ["id"],
+  description: undefined,
+  extensions: {
+    tags: {
+      __proto__: null
+    }
+  }
+}];
+const registryConfig_pgResources_pen_names_pen_names = {
+  executor: executor,
+  name: "pen_names",
+  identifier: "main.refs.pen_names",
+  from: penNamesIdentifier,
+  codec: penNamesCodec,
+  uniques: pen_namesUniques,
+  isVirtual: false,
+  description: undefined,
+  extensions: {
+    description: undefined,
+    pg: {
+      serviceName: "main",
+      schemaName: "refs",
+      name: "pen_names"
+    },
+    isInsertable: true,
+    isUpdatable: true,
+    isDeletable: true,
+    tags: {}
+  }
+};
 const registry = makeRegistry({
   pgExecutors: {
     __proto__: null,
@@ -251,16 +593,156 @@ const registry = makeRegistry({
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
     int4: TYPES.int,
+    bookAuthors: bookAuthorsCodec,
+    bookEditors: bookEditorsCodec,
+    books: booksCodec,
+    penNames: penNamesCodec,
     people: peopleCodec,
     posts: postsCodec
   },
   pgResources: {
     __proto__: null,
+    book_authors: registryConfig_pgResources_book_authors_book_authors,
+    book_editors: registryConfig_pgResources_book_editors_book_editors,
     people: registryConfig_pgResources_people_people,
-    posts: registryConfig_pgResources_posts_posts
+    posts: registryConfig_pgResources_posts_posts,
+    books: registryConfig_pgResources_books_books,
+    pen_names: registryConfig_pgResources_pen_names_pen_names
   },
   pgRelations: {
     __proto__: null,
+    bookAuthors: {
+      __proto__: null,
+      booksByMyBookId: {
+        localCodec: bookAuthorsCodec,
+        remoteResourceOptions: registryConfig_pgResources_books_books,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["book_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      penNamesByMyPenNameId: {
+        localCodec: bookAuthorsCodec,
+        remoteResourceOptions: registryConfig_pgResources_pen_names_pen_names,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["pen_name_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    bookEditors: {
+      __proto__: null,
+      booksByMyBookId: {
+        localCodec: bookEditorsCodec,
+        remoteResourceOptions: registryConfig_pgResources_books_books,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["book_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      peopleByMyPersonId: {
+        localCodec: bookEditorsCodec,
+        remoteResourceOptions: registryConfig_pgResources_people_people,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["person_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    books: {
+      __proto__: null,
+      bookAuthorsByTheirBookId: {
+        localCodec: booksCodec,
+        remoteResourceOptions: registryConfig_pgResources_book_authors_book_authors,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["book_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      bookEditorsByTheirBookId: {
+        localCodec: booksCodec,
+        remoteResourceOptions: registryConfig_pgResources_book_editors_book_editors,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["book_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
+    penNames: {
+      __proto__: null,
+      peopleByMyPersonId: {
+        localCodec: penNamesCodec,
+        remoteResourceOptions: registryConfig_pgResources_people_people,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["person_id"],
+        remoteAttributes: ["id"],
+        isUnique: true,
+        isReferencee: false,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      bookAuthorsByTheirPenNameId: {
+        localCodec: penNamesCodec,
+        remoteResourceOptions: registryConfig_pgResources_book_authors_book_authors,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["pen_name_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      }
+    },
     people: {
       __proto__: null,
       postsByTheirUserId: {
@@ -276,6 +758,36 @@ const registry = makeRegistry({
           tags: {
             omit: true,
             behavior: ["-select", "-insert -select -node -connection -list -array -single -update -delete -queryField -mutationField -typeField -filter -filterBy -order -orderBy -query:resource:list -query:resource:connection -singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection -manyToMany"]
+          }
+        }
+      },
+      penNamesByTheirPersonId: {
+        localCodec: peopleCodec,
+        remoteResourceOptions: registryConfig_pgResources_pen_names_pen_names,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["person_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
+          }
+        }
+      },
+      bookEditorsByTheirPersonId: {
+        localCodec: peopleCodec,
+        remoteResourceOptions: registryConfig_pgResources_book_editors_book_editors,
+        localCodecPolymorphicTypes: undefined,
+        localAttributes: ["id"],
+        remoteAttributes: ["person_id"],
+        isUnique: false,
+        isReferencee: true,
+        description: undefined,
+        extensions: {
+          tags: {
+            behavior: []
           }
         }
       }
@@ -301,8 +813,85 @@ const registry = makeRegistry({
     }
   }
 });
+const resource_book_authorsPgResource = registry.pgResources["book_authors"];
+const resource_book_editorsPgResource = registry.pgResources["book_editors"];
 const resource_peoplePgResource = registry.pgResources["people"];
 const resource_postsPgResource = registry.pgResources["posts"];
+const resource_booksPgResource = registry.pgResources["books"];
+const resource_pen_namesPgResource = registry.pgResources["pen_names"];
+const nodeIdHandler_BookAuthor = {
+  typeName: "BookAuthor",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("book_authors", false), $record.get("book_id"), $record.get("pen_name_id")]);
+  },
+  getSpec($list) {
+    return {
+      book_id: inhibitOnNull(access($list, [1])),
+      pen_name_id: inhibitOnNull(access($list, [2]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_book_authorsPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "book_authors";
+  }
+};
+function specForHandler(handler) {
+  function spec(nodeId) {
+    // We only want to return the specifier if it matches
+    // this handler; otherwise return null.
+    if (nodeId == null) return null;
+    try {
+      const specifier = handler.codec.decode(nodeId);
+      if (handler.match(specifier)) {
+        return specifier;
+      }
+    } catch {
+      // Ignore errors
+    }
+    return null;
+  }
+  spec.displayName = `specifier_${handler.typeName}_${handler.codec.name}`;
+  spec.isSyncAndSafe = true; // Optimization
+  return spec;
+}
+const nodeFetcher_BookAuthor = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_BookAuthor));
+  return nodeIdHandler_BookAuthor.get(nodeIdHandler_BookAuthor.getSpec($decoded));
+};
+const nodeIdHandler_BookEditor = {
+  typeName: "BookEditor",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("book_editors", false), $record.get("book_id"), $record.get("person_id")]);
+  },
+  getSpec($list) {
+    return {
+      book_id: inhibitOnNull(access($list, [1])),
+      person_id: inhibitOnNull(access($list, [2]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_book_editorsPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "book_editors";
+  }
+};
+const nodeFetcher_BookEditor = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_BookEditor));
+  return nodeIdHandler_BookEditor.get(nodeIdHandler_BookEditor.getSpec($decoded));
+};
 const nodeIdHandler_Person = {
   typeName: "Person",
   codec: nodeIdCodecs_base64JSON_base64JSON,
@@ -325,25 +914,6 @@ const nodeIdHandler_Person = {
     return obj[0] === "people";
   }
 };
-function specForHandler(handler) {
-  function spec(nodeId) {
-    // We only want to return the specifier if it matches
-    // this handler; otherwise return null.
-    if (nodeId == null) return null;
-    try {
-      const specifier = handler.codec.decode(nodeId);
-      if (handler.match(specifier)) {
-        return specifier;
-      }
-    } catch {
-      // Ignore errors
-    }
-    return null;
-  }
-  spec.displayName = `specifier_${handler.typeName}_${handler.codec.name}`;
-  spec.isSyncAndSafe = true; // Optimization
-  return spec;
-}
 const nodeFetcher_Person = $nodeId => {
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Person));
   return nodeIdHandler_Person.get(nodeIdHandler_Person.getSpec($decoded));
@@ -374,14 +944,70 @@ const nodeFetcher_Post = $nodeId => {
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Post));
   return nodeIdHandler_Post.get(nodeIdHandler_Post.getSpec($decoded));
 };
+const nodeIdHandler_Book = {
+  typeName: "Book",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("books", false), $record.get("id")]);
+  },
+  getSpec($list) {
+    return {
+      id: inhibitOnNull(access($list, [1]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_booksPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "books";
+  }
+};
+const nodeFetcher_Book = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Book));
+  return nodeIdHandler_Book.get(nodeIdHandler_Book.getSpec($decoded));
+};
+const nodeIdHandler_PenName = {
+  typeName: "PenName",
+  codec: nodeIdCodecs_base64JSON_base64JSON,
+  deprecationReason: undefined,
+  plan($record) {
+    return list([constant("pen_names", false), $record.get("id")]);
+  },
+  getSpec($list) {
+    return {
+      id: inhibitOnNull(access($list, [1]))
+    };
+  },
+  getIdentifiers(value) {
+    return value.slice(1);
+  },
+  get(spec) {
+    return resource_pen_namesPgResource.get(spec);
+  },
+  match(obj) {
+    return obj[0] === "pen_names";
+  }
+};
+const nodeFetcher_PenName = $nodeId => {
+  const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_PenName));
+  return nodeIdHandler_PenName.get(nodeIdHandler_PenName.getSpec($decoded));
+};
 function qbWhereBuilder(qb) {
   return qb.whereBuilder();
 }
 const nodeIdHandlerByTypeName = {
   __proto__: null,
   Query: nodeIdHandler_Query,
+  BookAuthor: nodeIdHandler_BookAuthor,
+  BookEditor: nodeIdHandler_BookEditor,
   Person: nodeIdHandler_Person,
-  Post: nodeIdHandler_Post
+  Post: nodeIdHandler_Post,
+  Book: nodeIdHandler_Book,
+  PenName: nodeIdHandler_PenName
 };
 const decodeNodeId = makeDecodeNodeId(Object.values(nodeIdHandlerByTypeName));
 function findTypeNameMatch(specifier) {
@@ -416,11 +1042,42 @@ type Query implements Node {
     nodeId: ID!
   ): Node
 
+  """Get a single \`BookAuthor\`."""
+  bookAuthorByBookIdAndPenNameId(bookId: Int!, penNameId: Int!): BookAuthor
+
+  """Get a single \`BookEditor\`."""
+  bookEditorByBookIdAndPersonId(bookId: Int!, personId: Int!): BookEditor
+
   """Get a single \`Person\`."""
   personById(id: Int!): Person
 
   """Get a single \`Post\`."""
   postById(id: Int!): Post
+
+  """Get a single \`Book\`."""
+  bookById(id: Int!): Book
+
+  """Get a single \`Book\`."""
+  bookByIsbn(isbn: String!): Book
+
+  """Get a single \`PenName\`."""
+  penNameById(id: Int!): PenName
+
+  """Reads a single \`BookAuthor\` using its globally unique \`ID\`."""
+  bookAuthor(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`BookAuthor\`.
+    """
+    nodeId: ID!
+  ): BookAuthor
+
+  """Reads a single \`BookEditor\` using its globally unique \`ID\`."""
+  bookEditor(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`BookEditor\`.
+    """
+    nodeId: ID!
+  ): BookEditor
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
@@ -433,6 +1090,76 @@ type Query implements Node {
     """The globally unique \`ID\` to be used in selecting a single \`Post\`."""
     nodeId: ID!
   ): Post
+
+  """Reads a single \`Book\` using its globally unique \`ID\`."""
+  book(
+    """The globally unique \`ID\` to be used in selecting a single \`Book\`."""
+    nodeId: ID!
+  ): Book
+
+  """Reads a single \`PenName\` using its globally unique \`ID\`."""
+  penName(
+    """The globally unique \`ID\` to be used in selecting a single \`PenName\`."""
+    nodeId: ID!
+  ): PenName
+
+  """Reads and enables pagination through a set of \`BookAuthor\`."""
+  allBookAuthors(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookAuthorCondition
+
+    """The method to use when ordering \`BookAuthor\`."""
+    orderBy: [BookAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookAuthorsConnection
+
+  """Reads and enables pagination through a set of \`BookEditor\`."""
+  allBookEditors(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookEditorCondition
+
+    """The method to use when ordering \`BookEditor\`."""
+    orderBy: [BookEditorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookEditorsConnection
 
   """Reads and enables pagination through a set of \`Person\`."""
   allPeople(
@@ -491,6 +1218,64 @@ type Query implements Node {
     """The method to use when ordering \`Post\`."""
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsConnection
+
+  """Reads and enables pagination through a set of \`Book\`."""
+  allBooks(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookCondition
+
+    """The method to use when ordering \`Book\`."""
+    orderBy: [BooksOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BooksConnection
+
+  """Reads and enables pagination through a set of \`PenName\`."""
+  allPenNames(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PenNameCondition
+
+    """The method to use when ordering \`PenName\`."""
+    orderBy: [PenNamesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PenNamesConnection
 }
 
 """An object with a globally unique \`ID\`."""
@@ -501,6 +1286,246 @@ interface Node {
   nodeId: ID!
 }
 
+type BookAuthor implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  bookId: Int!
+  penNameId: Int!
+
+  """Reads a single \`Book\` that is related to this \`BookAuthor\`."""
+  bookByBookId: Book
+
+  """Reads a single \`PenName\` that is related to this \`BookAuthor\`."""
+  penNameByPenNameId: PenName
+}
+
+type Book implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+  title: String!
+  isbn: String
+
+  """Reads and enables pagination through a set of \`BookAuthor\`."""
+  bookAuthorsByBookId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookAuthorCondition
+
+    """The method to use when ordering \`BookAuthor\`."""
+    orderBy: [BookAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookAuthorsConnection!
+
+  """Reads and enables pagination through a set of \`BookEditor\`."""
+  bookEditorsByBookId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookEditorCondition
+
+    """The method to use when ordering \`BookEditor\`."""
+    orderBy: [BookEditorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookEditorsConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  relatedPeople(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  editors(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection!
+}
+
+"""A connection to a list of \`BookAuthor\` values."""
+type BookAuthorsConnection {
+  """A list of \`BookAuthor\` objects."""
+  nodes: [BookAuthor]!
+
+  """
+  A list of edges which contains the \`BookAuthor\` and cursor to aid in pagination.
+  """
+  edges: [BookAuthorsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`BookAuthor\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`BookAuthor\` edge in the connection."""
+type BookAuthorsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`BookAuthor\` at the end of the edge."""
+  node: BookAuthor
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+}
+
+"""
+A condition to be used against \`BookAuthor\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BookAuthorCondition {
+  """Checks for equality with the object’s \`bookId\` field."""
+  bookId: Int
+
+  """Checks for equality with the object’s \`penNameId\` field."""
+  penNameId: Int
+}
+
+"""Methods to use when ordering \`BookAuthor\`."""
+enum BookAuthorsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  BOOK_ID_ASC
+  BOOK_ID_DESC
+  PEN_NAME_ID_ASC
+  PEN_NAME_ID_DESC
+}
+
+"""A connection to a list of \`BookEditor\` values."""
+type BookEditorsConnection {
+  """A list of \`BookEditor\` objects."""
+  nodes: [BookEditor]!
+
+  """
+  A list of edges which contains the \`BookEditor\` and cursor to aid in pagination.
+  """
+  edges: [BookEditorsEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`BookEditor\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type BookEditor implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  bookId: Int!
+  personId: Int!
+
+  """Reads a single \`Book\` that is related to this \`BookEditor\`."""
+  bookByBookId: Book
+
+  """Reads a single \`Person\` that is related to this \`BookEditor\`."""
+  personByPersonId: Person
+}
+
 type Person implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
@@ -508,17 +1533,191 @@ type Person implements Node {
   nodeId: ID!
   id: Int!
   name: String!
+
+  """Reads and enables pagination through a set of \`PenName\`."""
+  penNamesByPersonId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PenNameCondition
+
+    """The method to use when ordering \`PenName\`."""
+    orderBy: [PenNamesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PenNamesConnection!
+
+  """Reads and enables pagination through a set of \`BookEditor\`."""
+  bookEditorsByPersonId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookEditorCondition
+
+    """The method to use when ordering \`BookEditor\`."""
+    orderBy: [BookEditorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookEditorsConnection!
 }
 
-type Post implements Node {
+"""A connection to a list of \`PenName\` values."""
+type PenNamesConnection {
+  """A list of \`PenName\` objects."""
+  nodes: [PenName]!
+
+  """
+  A list of edges which contains the \`PenName\` and cursor to aid in pagination.
+  """
+  edges: [PenNamesEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`PenName\` you could get from the connection."""
+  totalCount: Int!
+}
+
+type PenName implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
   id: Int!
+  penName: String!
+  personId: Int
 
-  """Reads a single \`Person\` that is related to this \`Post\`."""
-  author: Person!
+  """Reads a single \`Person\` that is related to this \`PenName\`."""
+  personByPersonId: Person
+
+  """Reads and enables pagination through a set of \`BookAuthor\`."""
+  bookAuthorsByPenNameId(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookAuthorCondition
+
+    """The method to use when ordering \`BookAuthor\`."""
+    orderBy: [BookAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookAuthorsConnection!
+}
+
+"""A \`PenName\` edge in the connection."""
+type PenNamesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`PenName\` at the end of the edge."""
+  node: PenName
+}
+
+"""
+A condition to be used against \`PenName\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PenNameCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`penName\` field."""
+  penName: String
+
+  """Checks for equality with the object’s \`personId\` field."""
+  personId: Int
+}
+
+"""Methods to use when ordering \`PenName\`."""
+enum PenNamesOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ID_ASC
+  ID_DESC
+  PEN_NAME_ASC
+  PEN_NAME_DESC
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+}
+
+"""
+A condition to be used against \`BookEditor\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BookEditorCondition {
+  """Checks for equality with the object’s \`bookId\` field."""
+  bookId: Int
+
+  """Checks for equality with the object’s \`personId\` field."""
+  personId: Int
+}
+
+"""Methods to use when ordering \`BookEditor\`."""
+enum BookEditorsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  BOOK_ID_ASC
+  BOOK_ID_DESC
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+}
+
+"""A \`BookEditor\` edge in the connection."""
+type BookEditorsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`BookEditor\` at the end of the edge."""
+  node: BookEditor
 }
 
 """A connection to a list of \`Person\` values."""
@@ -547,24 +1746,6 @@ type PeopleEdge {
   node: Person
 }
 
-"""A location in a connection that can be used for resuming pagination."""
-scalar Cursor
-
-"""Information about pagination in a connection."""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
-}
-
 """
 A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
@@ -585,6 +1766,17 @@ enum PeopleOrderBy {
   ID_DESC
   NAME_ASC
   NAME_DESC
+}
+
+type Post implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  id: Int!
+
+  """Reads a single \`Person\` that is related to this \`Post\`."""
+  author: Person!
 }
 
 """A connection to a list of \`Post\` values."""
@@ -628,6 +1820,59 @@ enum PostsOrderBy {
   PRIMARY_KEY_DESC
   ID_ASC
   ID_DESC
+}
+
+"""A connection to a list of \`Book\` values."""
+type BooksConnection {
+  """A list of \`Book\` objects."""
+  nodes: [Book]!
+
+  """
+  A list of edges which contains the \`Book\` and cursor to aid in pagination.
+  """
+  edges: [BooksEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Book\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Book\` edge in the connection."""
+type BooksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Book\` at the end of the edge."""
+  node: Book
+}
+
+"""
+A condition to be used against \`Book\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input BookCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`title\` field."""
+  title: String
+
+  """Checks for equality with the object’s \`isbn\` field."""
+  isbn: String
+}
+
+"""Methods to use when ordering \`Book\`."""
+enum BooksOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  ID_ASC
+  ID_DESC
+  TITLE_ASC
+  TITLE_DESC
+  ISBN_ASC
+  ISBN_DESC
 }`;
 export const plans = {
   Query: {
@@ -644,6 +1889,24 @@ export const plans = {
     node(_$root, fieldArgs) {
       return fieldArgs.getRaw("nodeId");
     },
+    bookAuthorByBookIdAndPenNameId(_$root, {
+      $bookId,
+      $penNameId
+    }) {
+      return resource_book_authorsPgResource.get({
+        book_id: $bookId,
+        pen_name_id: $penNameId
+      });
+    },
+    bookEditorByBookIdAndPersonId(_$root, {
+      $bookId,
+      $personId
+    }) {
+      return resource_book_editorsPgResource.get({
+        book_id: $bookId,
+        person_id: $personId
+      });
+    },
     personById(_$root, {
       $id
     }) {
@@ -658,6 +1921,35 @@ export const plans = {
         id: $id
       });
     },
+    bookById(_$root, {
+      $id
+    }) {
+      return resource_booksPgResource.get({
+        id: $id
+      });
+    },
+    bookByIsbn(_$root, {
+      $isbn
+    }) {
+      return resource_booksPgResource.get({
+        isbn: $isbn
+      });
+    },
+    penNameById(_$root, {
+      $id
+    }) {
+      return resource_pen_namesPgResource.get({
+        id: $id
+      });
+    },
+    bookAuthor(_$parent, args) {
+      const $nodeId = args.getRaw("nodeId");
+      return nodeFetcher_BookAuthor($nodeId);
+    },
+    bookEditor(_$parent, args) {
+      const $nodeId = args.getRaw("nodeId");
+      return nodeFetcher_BookEditor($nodeId);
+    },
     person(_$parent, args) {
       const $nodeId = args.getRaw("nodeId");
       return nodeFetcher_Person($nodeId);
@@ -665,6 +1957,74 @@ export const plans = {
     post(_$parent, args) {
       const $nodeId = args.getRaw("nodeId");
       return nodeFetcher_Post($nodeId);
+    },
+    book(_$parent, args) {
+      const $nodeId = args.getRaw("nodeId");
+      return nodeFetcher_Book($nodeId);
+    },
+    penName(_$parent, args) {
+      const $nodeId = args.getRaw("nodeId");
+      return nodeFetcher_PenName($nodeId);
+    },
+    allBookAuthors: {
+      plan() {
+        return connection(resource_book_authorsPgResource.find());
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    },
+    allBookEditors: {
+      plan() {
+        return connection(resource_book_editorsPgResource.find());
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
     },
     allPeople: {
       plan() {
@@ -725,6 +2085,66 @@ export const plans = {
           value.apply($select);
         }
       }
+    },
+    allBooks: {
+      plan() {
+        return connection(resource_booksPgResource.find());
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    },
+    allPenNames: {
+      plan() {
+        return connection(resource_pen_namesPgResource.find());
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
     }
   },
   Node: {
@@ -744,46 +2164,211 @@ export const plans = {
       };
     }
   },
-  Person: {
+  BookAuthor: {
     __assertStep: assertPgClassSingleStep,
     __planType($specifier) {
       const spec = Object.create(null);
-      for (const pkCol of peopleUniques[0].attributes) {
+      for (const pkCol of book_authorsUniques[0].attributes) {
         spec[pkCol] = get2($specifier, pkCol);
       }
-      return resource_peoplePgResource.get(spec);
+      return resource_book_authorsPgResource.get(spec);
     },
     nodeId($parent) {
-      const specifier = nodeIdHandler_Person.plan($parent);
-      return lambda(specifier, nodeIdCodecs[nodeIdHandler_Person.codec.name].encode);
-    }
-  },
-  Post: {
-    __assertStep: assertPgClassSingleStep,
-    __planType($specifier) {
-      const spec = Object.create(null);
-      for (const pkCol of postsUniques[0].attributes) {
-        spec[pkCol] = get2($specifier, pkCol);
-      }
-      return resource_postsPgResource.get(spec);
+      const specifier = nodeIdHandler_BookAuthor.plan($parent);
+      return lambda(specifier, nodeIdCodecs[nodeIdHandler_BookAuthor.codec.name].encode);
     },
-    nodeId($parent) {
-      const specifier = nodeIdHandler_Post.plan($parent);
-      return lambda(specifier, nodeIdCodecs[nodeIdHandler_Post.codec.name].encode);
+    bookId($record) {
+      return $record.get("book_id");
     },
-    author($record) {
-      return resource_peoplePgResource.get({
-        id: $record.get("user_id")
+    penNameId($record) {
+      return $record.get("pen_name_id");
+    },
+    bookByBookId($record) {
+      return resource_booksPgResource.get({
+        id: $record.get("book_id")
+      });
+    },
+    penNameByPenNameId($record) {
+      return resource_pen_namesPgResource.get({
+        id: $record.get("pen_name_id")
       });
     }
   },
-  PeopleConnection: {
+  Book: {
+    __assertStep: assertPgClassSingleStep,
+    __planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of booksUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_booksPgResource.get(spec);
+    },
+    nodeId($parent) {
+      const specifier = nodeIdHandler_Book.plan($parent);
+      return lambda(specifier, nodeIdCodecs[nodeIdHandler_Book.codec.name].encode);
+    },
+    bookAuthorsByBookId: {
+      plan($record) {
+        const $records = resource_book_authorsPgResource.find({
+          book_id: $record.get("id")
+        });
+        return connection($records);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    },
+    bookEditorsByBookId: {
+      plan($record) {
+        const $records = resource_book_editorsPgResource.find({
+          book_id: $record.get("id")
+        });
+        return connection($records);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    },
+    relatedPeople: {
+      plan($record) {
+        const $people = resource_peoplePgResource.find();
+        const subquery = sql.identifier(Symbol('subquery'));
+        const selects = [];
+        selects.push(sql`select __l1__.${sql.identifier("person_id")} as "0"
+from ${resource_pen_namesPgResource.from} as __l1__
+inner join ${resource_book_authorsPgResource.from} as __l0__
+on (__l0__.${sql.identifier("pen_name_id")} = __l1__.${sql.identifier("id")})
+where __l0__.${sql.identifier("book_id")} = ${$people.placeholder($record.get("id"))}`);
+        selects.push(sql`select __l0__.${sql.identifier("person_id")} as "0"
+from ${resource_book_editorsPgResource.from} as __l0__
+where __l0__.${sql.identifier("book_id")} = ${$people.placeholder($record.get("id"))}`);
+        $people.join({
+          type: "inner",
+          from: sql`(${sql.indent(sql.join(selects.map(s => sql.indent(s)), '\n\nunion all\n\n'))})`,
+          alias: subquery,
+          conditions: [sql`${$people.alias}.${sql.identifier("id")} = ${subquery}."0"`]
+        });
+        return connection($people);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    },
+    editors: {
+      plan($record) {
+        const $people = resource_peoplePgResource.find();
+        let previousAlias = $people.alias;
+        const book_editorsAlias = sql.identifier(Symbol("book_editors"));
+        $people.join({
+          type: "inner",
+          from: resource_book_editorsPgResource.from,
+          alias: book_editorsAlias,
+          conditions: [sql`${previousAlias}.${sql.identifier("id")} = ${book_editorsAlias}.${sql.identifier("person_id")}`]
+        });
+        previousAlias = book_editorsAlias;
+        $people.where(sql`${previousAlias}.${sql.identifier("book_id")} = ${$people.placeholder($record.get("id"))}`);
+        return connection($people);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    }
+  },
+  BookAuthorsConnection: {
     __assertStep: ConnectionStep,
     totalCount($connection) {
       return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
     }
   },
-  PeopleEdge: {
+  BookAuthorsEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
       return $edge.cursor();
@@ -815,6 +2400,438 @@ export const plans = {
     },
     endCursor($pageInfo) {
       return $pageInfo.endCursor();
+    }
+  },
+  BookAuthorCondition: {
+    bookId($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "book_id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    },
+    penNameId($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "pen_name_id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    }
+  },
+  BookAuthorsOrderBy: {
+    PRIMARY_KEY_ASC(queryBuilder) {
+      book_authorsUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "ASC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PRIMARY_KEY_DESC(queryBuilder) {
+      book_authorsUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "DESC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    BOOK_ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "book_id",
+        direction: "ASC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    BOOK_ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "book_id",
+        direction: "DESC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PEN_NAME_ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "pen_name_id",
+        direction: "ASC"
+      });
+    },
+    PEN_NAME_ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "pen_name_id",
+        direction: "DESC"
+      });
+    }
+  },
+  BookEditorsConnection: {
+    __assertStep: ConnectionStep,
+    totalCount($connection) {
+      return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+    }
+  },
+  BookEditor: {
+    __assertStep: assertPgClassSingleStep,
+    __planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of book_editorsUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_book_editorsPgResource.get(spec);
+    },
+    nodeId($parent) {
+      const specifier = nodeIdHandler_BookEditor.plan($parent);
+      return lambda(specifier, nodeIdCodecs[nodeIdHandler_BookEditor.codec.name].encode);
+    },
+    bookId($record) {
+      return $record.get("book_id");
+    },
+    personId($record) {
+      return $record.get("person_id");
+    },
+    bookByBookId($record) {
+      return resource_booksPgResource.get({
+        id: $record.get("book_id")
+      });
+    },
+    personByPersonId($record) {
+      return resource_peoplePgResource.get({
+        id: $record.get("person_id")
+      });
+    }
+  },
+  Person: {
+    __assertStep: assertPgClassSingleStep,
+    __planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of peopleUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_peoplePgResource.get(spec);
+    },
+    nodeId($parent) {
+      const specifier = nodeIdHandler_Person.plan($parent);
+      return lambda(specifier, nodeIdCodecs[nodeIdHandler_Person.codec.name].encode);
+    },
+    penNamesByPersonId: {
+      plan($record) {
+        const $records = resource_pen_namesPgResource.find({
+          person_id: $record.get("id")
+        });
+        return connection($records);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    },
+    bookEditorsByPersonId: {
+      plan($record) {
+        const $records = resource_book_editorsPgResource.find({
+          person_id: $record.get("id")
+        });
+        return connection($records);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    }
+  },
+  PenNamesConnection: {
+    __assertStep: ConnectionStep,
+    totalCount($connection) {
+      return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+    }
+  },
+  PenName: {
+    __assertStep: assertPgClassSingleStep,
+    __planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of pen_namesUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_pen_namesPgResource.get(spec);
+    },
+    nodeId($parent) {
+      const specifier = nodeIdHandler_PenName.plan($parent);
+      return lambda(specifier, nodeIdCodecs[nodeIdHandler_PenName.codec.name].encode);
+    },
+    penName($record) {
+      return $record.get("pen_name");
+    },
+    personId($record) {
+      return $record.get("person_id");
+    },
+    personByPersonId($record) {
+      return resource_peoplePgResource.get({
+        id: $record.get("person_id")
+      });
+    },
+    bookAuthorsByPenNameId: {
+      plan($record) {
+        const $records = resource_book_authorsPgResource.find({
+          pen_name_id: $record.get("id")
+        });
+        return connection($records);
+      },
+      args: {
+        first(_, $connection, arg) {
+          $connection.setFirst(arg.getRaw());
+        },
+        last(_, $connection, val) {
+          $connection.setLast(val.getRaw());
+        },
+        offset(_, $connection, val) {
+          $connection.setOffset(val.getRaw());
+        },
+        before(_, $connection, val) {
+          $connection.setBefore(val.getRaw());
+        },
+        after(_, $connection, val) {
+          $connection.setAfter(val.getRaw());
+        },
+        condition(_condition, $connection, arg) {
+          const $select = $connection.getSubplan();
+          arg.apply($select, qbWhereBuilder);
+        },
+        orderBy(parent, $connection, value) {
+          const $select = $connection.getSubplan();
+          value.apply($select);
+        }
+      }
+    }
+  },
+  PenNamesEdge: {
+    __assertStep: assertEdgeCapableStep,
+    cursor($edge) {
+      return $edge.cursor();
+    },
+    node($edge) {
+      return $edge.node();
+    }
+  },
+  PenNameCondition: {
+    id($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    },
+    penName($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "pen_name",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.text)}`;
+        }
+      });
+    },
+    personId($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "person_id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    }
+  },
+  PenNamesOrderBy: {
+    PRIMARY_KEY_ASC(queryBuilder) {
+      pen_namesUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "ASC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PRIMARY_KEY_DESC(queryBuilder) {
+      pen_namesUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "DESC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "id",
+        direction: "ASC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "id",
+        direction: "DESC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PEN_NAME_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "pen_name",
+        direction: "ASC"
+      });
+    },
+    PEN_NAME_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "pen_name",
+        direction: "DESC"
+      });
+    },
+    PERSON_ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "person_id",
+        direction: "ASC"
+      });
+    },
+    PERSON_ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "person_id",
+        direction: "DESC"
+      });
+    }
+  },
+  BookEditorCondition: {
+    bookId($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "book_id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    },
+    personId($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "person_id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    }
+  },
+  BookEditorsOrderBy: {
+    PRIMARY_KEY_ASC(queryBuilder) {
+      book_editorsUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "ASC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PRIMARY_KEY_DESC(queryBuilder) {
+      book_editorsUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "DESC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    BOOK_ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "book_id",
+        direction: "ASC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    BOOK_ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "book_id",
+        direction: "DESC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PERSON_ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "person_id",
+        direction: "ASC"
+      });
+    },
+    PERSON_ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "person_id",
+        direction: "DESC"
+      });
+    }
+  },
+  BookEditorsEdge: {
+    __assertStep: assertEdgeCapableStep,
+    cursor($edge) {
+      return $edge.cursor();
+    },
+    node($edge) {
+      return $edge.node();
+    }
+  },
+  PeopleConnection: {
+    __assertStep: ConnectionStep,
+    totalCount($connection) {
+      return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+    }
+  },
+  PeopleEdge: {
+    __assertStep: assertEdgeCapableStep,
+    cursor($edge) {
+      return $edge.cursor();
+    },
+    node($edge) {
+      return $edge.node();
     }
   },
   PersonCondition: {
@@ -883,6 +2900,25 @@ export const plans = {
       });
     }
   },
+  Post: {
+    __assertStep: assertPgClassSingleStep,
+    __planType($specifier) {
+      const spec = Object.create(null);
+      for (const pkCol of postsUniques[0].attributes) {
+        spec[pkCol] = get2($specifier, pkCol);
+      }
+      return resource_postsPgResource.get(spec);
+    },
+    nodeId($parent) {
+      const specifier = nodeIdHandler_Post.plan($parent);
+      return lambda(specifier, nodeIdCodecs[nodeIdHandler_Post.codec.name].encode);
+    },
+    author($record) {
+      return resource_peoplePgResource.get({
+        id: $record.get("user_id")
+      });
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     totalCount($connection) {
@@ -938,6 +2974,110 @@ export const plans = {
     ID_DESC(queryBuilder) {
       queryBuilder.orderBy({
         attribute: "id",
+        direction: "DESC"
+      });
+      queryBuilder.setOrderIsUnique();
+    }
+  },
+  BooksConnection: {
+    __assertStep: ConnectionStep,
+    totalCount($connection) {
+      return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+    }
+  },
+  BooksEdge: {
+    __assertStep: assertEdgeCapableStep,
+    cursor($edge) {
+      return $edge.cursor();
+    },
+    node($edge) {
+      return $edge.node();
+    }
+  },
+  BookCondition: {
+    id($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "id",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.int)}`;
+        }
+      });
+    },
+    title($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "title",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.text)}`;
+        }
+      });
+    },
+    isbn($condition, val) {
+      $condition.where({
+        type: "attribute",
+        attribute: "isbn",
+        callback(expression) {
+          return val === null ? sql`${expression} is null` : sql`${expression} = ${sqlValueWithCodec(val, TYPES.text)}`;
+        }
+      });
+    }
+  },
+  BooksOrderBy: {
+    PRIMARY_KEY_ASC(queryBuilder) {
+      booksUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "ASC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    PRIMARY_KEY_DESC(queryBuilder) {
+      booksUniques[0].attributes.forEach(attributeName => {
+        queryBuilder.orderBy({
+          attribute: attributeName,
+          direction: "DESC"
+        });
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    ID_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "id",
+        direction: "ASC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    ID_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "id",
+        direction: "DESC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    TITLE_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "title",
+        direction: "ASC"
+      });
+    },
+    TITLE_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "title",
+        direction: "DESC"
+      });
+    },
+    ISBN_ASC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "isbn",
+        direction: "ASC"
+      });
+      queryBuilder.setOrderIsUnique();
+    },
+    ISBN_DESC(queryBuilder) {
+      queryBuilder.orderBy({
+        attribute: "isbn",
         direction: "DESC"
       });
       queryBuilder.setOrderIsUnique();

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.graphql
@@ -1,3 +1,310 @@
+type Book implements Node {
+  """Reads and enables pagination through a set of `BookAuthor`."""
+  bookAuthorsByBookId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookAuthorCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `BookAuthor`."""
+    orderBy: [BookAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookAuthorsConnection!
+
+  """Reads and enables pagination through a set of `BookEditor`."""
+  bookEditorsByBookId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookEditorCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `BookEditor`."""
+    orderBy: [BookEditorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookEditorsConnection!
+
+  """Reads and enables pagination through a set of `Person`."""
+  editors(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Person`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection!
+  id: Int!
+  isbn: String
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of `Person`."""
+  relatedPeople(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Person`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection!
+  title: String!
+}
+
+type BookAuthor implements Node {
+  """Reads a single `Book` that is related to this `BookAuthor`."""
+  bookByBookId: Book
+  bookId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single `PenName` that is related to this `BookAuthor`."""
+  penNameByPenNameId: PenName
+  penNameId: Int!
+}
+
+"""
+A condition to be used against `BookAuthor` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BookAuthorCondition {
+  """Checks for equality with the object’s `bookId` field."""
+  bookId: Int
+
+  """Checks for equality with the object’s `penNameId` field."""
+  penNameId: Int
+}
+
+"""A connection to a list of `BookAuthor` values."""
+type BookAuthorsConnection {
+  """
+  A list of edges which contains the `BookAuthor` and cursor to aid in pagination.
+  """
+  edges: [BookAuthorsEdge]!
+
+  """A list of `BookAuthor` objects."""
+  nodes: [BookAuthor]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `BookAuthor` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `BookAuthor` edge in the connection."""
+type BookAuthorsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `BookAuthor` at the end of the edge."""
+  node: BookAuthor
+}
+
+"""Methods to use when ordering `BookAuthor`."""
+enum BookAuthorsOrderBy {
+  BOOK_ID_ASC
+  BOOK_ID_DESC
+  NATURAL
+  PEN_NAME_ID_ASC
+  PEN_NAME_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `Book` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input BookCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `isbn` field."""
+  isbn: String
+
+  """Checks for equality with the object’s `title` field."""
+  title: String
+}
+
+type BookEditor implements Node {
+  """Reads a single `Book` that is related to this `BookEditor`."""
+  bookByBookId: Book
+  bookId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single `Person` that is related to this `BookEditor`."""
+  personByPersonId: Person
+  personId: Int!
+}
+
+"""
+A condition to be used against `BookEditor` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input BookEditorCondition {
+  """Checks for equality with the object’s `bookId` field."""
+  bookId: Int
+
+  """Checks for equality with the object’s `personId` field."""
+  personId: Int
+}
+
+"""A connection to a list of `BookEditor` values."""
+type BookEditorsConnection {
+  """
+  A list of edges which contains the `BookEditor` and cursor to aid in pagination.
+  """
+  edges: [BookEditorsEdge]!
+
+  """A list of `BookEditor` objects."""
+  nodes: [BookEditor]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `BookEditor` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `BookEditor` edge in the connection."""
+type BookEditorsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `BookEditor` at the end of the edge."""
+  node: BookEditor
+}
+
+"""Methods to use when ordering `BookEditor`."""
+enum BookEditorsOrderBy {
+  BOOK_ID_ASC
+  BOOK_ID_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""A connection to a list of `Book` values."""
+type BooksConnection {
+  """
+  A list of edges which contains the `Book` and cursor to aid in pagination.
+  """
+  edges: [BooksEdge]!
+
+  """A list of `Book` objects."""
+  nodes: [Book]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Book` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Book` edge in the connection."""
+type BooksEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Book` at the end of the edge."""
+  node: Book
+}
+
+"""Methods to use when ordering `Book`."""
+enum BooksOrderBy {
+  ID_ASC
+  ID_DESC
+  ISBN_ASC
+  ISBN_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TITLE_ASC
+  TITLE_DESC
+}
+
 """A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
@@ -22,6 +329,101 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
+}
+
+type PenName implements Node {
+  """Reads and enables pagination through a set of `BookAuthor`."""
+  bookAuthorsByPenNameId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookAuthorCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `BookAuthor`."""
+    orderBy: [BookAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookAuthorsConnection!
+  id: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  penName: String!
+
+  """Reads a single `Person` that is related to this `PenName`."""
+  personByPersonId: Person
+  personId: Int
+}
+
+"""
+A condition to be used against `PenName` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PenNameCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+
+  """Checks for equality with the object’s `penName` field."""
+  penName: String
+
+  """Checks for equality with the object’s `personId` field."""
+  personId: Int
+}
+
+"""A connection to a list of `PenName` values."""
+type PenNamesConnection {
+  """
+  A list of edges which contains the `PenName` and cursor to aid in pagination.
+  """
+  edges: [PenNamesEdge]!
+
+  """A list of `PenName` objects."""
+  nodes: [PenName]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `PenName` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `PenName` edge in the connection."""
+type PenNamesEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PenName` at the end of the edge."""
+  node: PenName
+}
+
+"""Methods to use when ordering `PenName`."""
+enum PenNamesOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PEN_NAME_ASC
+  PEN_NAME_DESC
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
 }
 
 """A connection to a list of `Person` values."""
@@ -62,6 +464,34 @@ enum PeopleOrderBy {
 }
 
 type Person implements Node {
+  """Reads and enables pagination through a set of `BookEditor`."""
+  bookEditorsByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookEditorCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `BookEditor`."""
+    orderBy: [BookEditorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookEditorsConnection!
   id: Int!
   name: String!
 
@@ -69,6 +499,35 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+
+  """Reads and enables pagination through a set of `PenName`."""
+  penNamesByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PenNameCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `PenName`."""
+    orderBy: [PenNamesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PenNamesConnection!
 }
 
 """
@@ -138,6 +597,122 @@ enum PostsOrderBy {
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
+  """Reads and enables pagination through a set of `BookAuthor`."""
+  allBookAuthors(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookAuthorCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `BookAuthor`."""
+    orderBy: [BookAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookAuthorsConnection
+
+  """Reads and enables pagination through a set of `BookEditor`."""
+  allBookEditors(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookEditorCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `BookEditor`."""
+    orderBy: [BookEditorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BookEditorsConnection
+
+  """Reads and enables pagination through a set of `Book`."""
+  allBooks(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BookCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Book`."""
+    orderBy: [BooksOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BooksConnection
+
+  """Reads and enables pagination through a set of `PenName`."""
+  allPenNames(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PenNameCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `PenName`."""
+    orderBy: [PenNamesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PenNamesConnection
+
   """Reads and enables pagination through a set of `Person`."""
   allPeople(
     """Read all values in the set after (below) this cursor."""
@@ -196,6 +771,40 @@ type Query implements Node {
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PostsConnection
 
+  """Reads a single `Book` using its globally unique `ID`."""
+  book(
+    """The globally unique `ID` to be used in selecting a single `Book`."""
+    nodeId: ID!
+  ): Book
+
+  """Reads a single `BookAuthor` using its globally unique `ID`."""
+  bookAuthor(
+    """
+    The globally unique `ID` to be used in selecting a single `BookAuthor`.
+    """
+    nodeId: ID!
+  ): BookAuthor
+
+  """Get a single `BookAuthor`."""
+  bookAuthorByBookIdAndPenNameId(bookId: Int!, penNameId: Int!): BookAuthor
+
+  """Get a single `Book`."""
+  bookById(id: Int!): Book
+
+  """Get a single `Book`."""
+  bookByIsbn(isbn: String!): Book
+
+  """Reads a single `BookEditor` using its globally unique `ID`."""
+  bookEditor(
+    """
+    The globally unique `ID` to be used in selecting a single `BookEditor`.
+    """
+    nodeId: ID!
+  ): BookEditor
+
+  """Get a single `BookEditor`."""
+  bookEditorByBookIdAndPersonId(bookId: Int!, personId: Int!): BookEditor
+
   """Fetches an object given its globally unique `ID`."""
   node(
     """The globally unique `ID`."""
@@ -206,6 +815,15 @@ type Query implements Node {
   The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
   """
   nodeId: ID!
+
+  """Reads a single `PenName` using its globally unique `ID`."""
+  penName(
+    """The globally unique `ID` to be used in selecting a single `PenName`."""
+    nodeId: ID!
+  ): PenName
+
+  """Get a single `PenName`."""
+  penNameById(id: Int!): PenName
 
   """Reads a single `Person` using its globally unique `ID`."""
   person(


### PR DESCRIPTION
`pgUnionAll` was incorrectly being used, we needed to build our own union all to make multi-path refs work without polymorphism.

<details>
<summary>Original message</summary>

## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->
This PR adds 3 test suites related to [issue #2496](https://github.com/graphile/crystal/issues/2496).

- ✅ 2 test suites are expected to **pass**
- ❌ 1 test suite is expected to **fail**, as it reproduces the current bug

These tests were requested by the maintainer to help reproduce and fix the issue.

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
</details>