### PR TITLE
Fix a number of bugs relating to incremental delivery

### DIFF
--- a/.changeset/plenty-carrots-arrive.md
+++ b/.changeset/plenty-carrots-arrive.md
@@ -1,0 +1,13 @@
+---
+"grafast": patch
+---
+
+Fix a number of edge-case issues relating to incremental delivery:
+
+- If a `@stream`'d step was `isSyncAndSafe` then the stream code wouldn't fire.
+  Fixed by forcing all `@stream`'d steps to have `.isSyncAndSafe = false`.
+- If a `@stream`'d step was an `AccessStep` then the output plan would skip over
+  it using the optimized expression, thus reading data from the wrong place.
+  AccessSteps are now only skipped by OutputPlan if they are `isSyncAndSafe`.
+- Fixed a bug in our iterable where an error would not correctly surface errors
+  to consumers.

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.deopt.mermaid
@@ -21,7 +21,7 @@ graph TD
     Bucket3 --> Bucket4 & Bucket5
 
     %% plan dependencies
-    Listen9["Listen[9∈0@s] ➊"]:::plan
+    Listen9[["Listen[9∈0@s] ➊"]]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊<br />More deps:<br />- Constantᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ[45]"}}:::plan
     Access8 & Lambda7 --> Listen9

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-messages.mermaid
@@ -21,7 +21,7 @@ graph TD
     Bucket3 --> Bucket4 & Bucket5
 
     %% plan dependencies
-    Listen9["Listen[9∈0@s] ➊"]:::plan
+    Listen9[["Listen[9∈0@s] ➊"]]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊<br />More deps:<br />- Constantᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ[53]"}}:::plan
     Access8 & Lambda7 --> Listen9

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.deopt.mermaid
@@ -21,7 +21,7 @@ graph TD
     Bucket3 --> Bucket4 & Bucket5
 
     %% plan dependencies
-    Listen9["Listen[9∈0@s] ➊"]:::plan
+    Listen9[["Listen[9∈0@s] ➊"]]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊<br />More deps:<br />- Constantᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ[45]"}}:::plan
     Access8 & Lambda7 --> Listen9

--- a/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.mermaid
+++ b/grafast/dataplan-pg/__tests__/subscriptions/basics/forum-single-message-evolve.mermaid
@@ -21,7 +21,7 @@ graph TD
     Bucket3 --> Bucket4 & Bucket5
 
     %% plan dependencies
-    Listen9["Listen[9∈0@s] ➊"]:::plan
+    Listen9[["Listen[9∈0@s] ➊"]]:::plan
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSubscriberᐳ"}}:::plan
     Lambda7{{"Lambda[7∈0] ➊<br />More deps:<br />- Constantᐸ'ca700000-0000-0000-0000-000000000ca7'ᐳ[53]"}}:::plan
     Access8 & Lambda7 --> Listen9

--- a/grafast/grafast/src/engine/LayerPlan.ts
+++ b/grafast/grafast/src/engine/LayerPlan.ts
@@ -379,6 +379,22 @@ export class LayerPlan<TReason extends LayerPlanReason = LayerPlanReason> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   stepsByConstructor: Map<Function, Set<Step>>;
 
+  // TODO: is it possible for this to go wrong by one of the stream items not
+  // streaming and the other one streaming? Technically the arguments need to
+  // match or it wouldn't be allowed to combine (the planning paths would
+  // differ because they factor in the argument step ids) but what if we
+  // decided to fulfil one without streaming and the other streaming only?
+  /**
+   * Populated during `finalize`, this will be empty except for phase
+   * transition layer plans (defer/stream) wherein it will contain a list of
+   * "unreachable" layer plan IDs relevant to the "combined" layer plans trying
+   * to refer to parent layer plans which are outside of this incremental
+   * boundary (e.g. if two lists both stream, we might combine those, but at
+   * runtime only one will be populated so we can't wait for the other to
+   * complete otherwise nothing will happen).
+   */
+  public outOfBoundsLayerPlanIds = new Set<number>();
+
   constructor(
     public readonly operationPlan: OperationPlan,
     public readonly reason: TReason, //parentStep: ExecutableStep | null,

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -492,6 +492,7 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
     );
     if (
       $root instanceof AccessStep &&
+      $root.isSyncAndSafe && // Make sure we're not using it for streaming!
       $root.fallback === undefined &&
       $root.implicitSideEffectStep === null &&
       (!this.sideEffectStep || !stepADependsOnStepB($root, this.sideEffectStep))

--- a/grafast/grafast/src/prepare.ts
+++ b/grafast/grafast/src/prepare.ts
@@ -757,7 +757,7 @@ function newIterator<T = any>(
         abort(e);
         for (const entry of pullQueue) {
           try {
-            entry[0]({ done, value: undefined });
+            entry[1](e);
           } catch (e) {
             // ignore
           }

--- a/grafast/grafast/src/prepare.ts
+++ b/grafast/grafast/src/prepare.ts
@@ -287,7 +287,7 @@ function outputBucket(
     );
     if (!c) {
       throw new Error(
-        `GrafastInternalError<8bbf56c1-8e2a-4ee9-b5fc-724fd0ee222b>: could not find relevant bucket for output plan`,
+        `GrafastInternalError<8bbf56c1-8e2a-4ee9-b5fc-724fd0ee222b>: could not find relevant bucket for output plan ${outputPlan} from ${rootBucket}[${rootBucketIndex}]`,
       );
     }
     [childBucket, childBucketIndex] = c;

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -22,7 +22,12 @@ import * as graphql from "graphql";
 import * as assert from "./assert.js";
 import type { Deferred } from "./deferred.js";
 import { isDev } from "./dev.js";
-import type { LayerPlan } from "./engine/LayerPlan.js";
+import type {
+  LayerPlan,
+  LayerPlanReasonDefer,
+  LayerPlanReasonListItem,
+  LayerPlanReasonSubscription,
+} from "./engine/LayerPlan.js";
 import type { OperationPlan } from "./engine/OperationPlan.js";
 import { SafeError } from "./error.js";
 import { inspect } from "./inspect.js";
@@ -1243,7 +1248,12 @@ export function stepsAreInSamePhase(ancestor: Step, descendent: Step) {
   return true;
 }
 
-export function isPhaseTransitionLayerPlan(layerPlan: LayerPlan): boolean {
+export function isPhaseTransitionLayerPlan(
+  layerPlan: LayerPlan,
+): layerPlan is
+  | LayerPlan<LayerPlanReasonListItem>
+  | LayerPlan<LayerPlanReasonDefer>
+  | LayerPlan<LayerPlanReasonSubscription> {
   const t = layerPlan.reason.type;
   switch (t) {
     case "subscription":


### PR DESCRIPTION
Discovered thanks to @jemgillam's test suite which, due to using very simple access methods, triggered a lot of issues in our optimizations which our more complex PostGraphile queries weren't triggering!

Also fixes an issue with combined layer plans inside of `@stream`'d layer plans, whereby the data would never be output. This was an issue I was expecting and was holding up the release, but we had to fix the other issues to be able to reproduce it. This is now reproduced and fixed. (Since that issue never made it out, I've omitted it from the changelog.)