### PR TITLE
Track data only steps

### DIFF
--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -3265,6 +3265,7 @@ export class OperationPlan {
       dependencies: deps,
       dependencyForbiddenFlags: flags,
       dependencyOnReject: onReject,
+      dependencyDataOnly: dataOnly,
       layerPlan: layerPlan,
       constructor: stepConstructor,
       peerKey,
@@ -3333,13 +3334,15 @@ export class OperationPlan {
           layerPlan: peerLayerPlan,
           dependencyForbiddenFlags: peerFlags,
           dependencyOnReject: peerOnReject,
+          dependencyDataOnly: peerDataOnly,
         } = possiblyPeer;
         if (
           peerLayerPlan.depth >= minDepth &&
           possiblyPeer.dependencies.length === dependencyCount &&
           isPeerLayerPlan(peerLayerPlan, ancestry[peerLayerPlan.depth]) &&
           peerFlags[dependencyIndex] === flags[dependencyIndex] &&
-          peerOnReject[dependencyIndex] === onReject[dependencyIndex]
+          peerOnReject[dependencyIndex] === onReject[dependencyIndex] &&
+          peerDataOnly[dependencyIndex] === dataOnly[dependencyIndex]
         ) {
           if (allPeers === null) {
             allPeers = [possiblyPeer];
@@ -3399,13 +3402,15 @@ export class OperationPlan {
               layerPlan: peerLayerPlan,
               dependencyForbiddenFlags: peerFlags,
               dependencyOnReject: peerOnReject,
+              dependencyDataOnly: peerDataOnly,
               dependencies: peerDependencies,
             } = possiblyPeer;
             if (
               peerDependencies.length === dependencyCount &&
               isPeerLayerPlan(peerLayerPlan, ancestry[peerLayerPlan.depth]) &&
               peerFlags[dependencyIndex] === flags[dependencyIndex] &&
-              peerOnReject[dependencyIndex] === onReject[dependencyIndex]
+              peerOnReject[dependencyIndex] === onReject[dependencyIndex] &&
+              peerDataOnly[dependencyIndex] === dataOnly[dependencyIndex]
             ) {
               possiblePeers.push(possiblyPeer);
             }
@@ -4237,10 +4242,16 @@ export class OperationPlan {
           const {
             $dependent,
             dependencyIndex,
-            inlineDetails: { onReject, acceptFlags = DEFAULT_ACCEPT_FLAGS },
+            inlineDetails: {
+              onReject,
+              acceptFlags = DEFAULT_ACCEPT_FLAGS,
+              dataOnly = false,
+            },
           } = todo;
           writeableArray($dependent.dependencyOnReject)[dependencyIndex] =
             onReject;
+          writeableArray($dependent.dependencyDataOnly)[dependencyIndex] =
+            dataOnly;
           writeableArray($dependent.dependencyForbiddenFlags)[dependencyIndex] =
             ALL_FLAGS & ~acceptFlags;
         }
@@ -4933,6 +4944,7 @@ export class OperationPlan {
         dependencyOnReject: sstep.dependencyOnReject.map((or) =>
           or ? String(or) : or,
         ),
+        dependencyDataOnly: sstep.dependencyDataOnly.slice(),
         polymorphicPaths: step.polymorphicPaths
           ? [...step.polymorphicPaths]
           : undefined,

--- a/grafast/grafast/src/engine/StepTracker.ts
+++ b/grafast/grafast/src/engine/StepTracker.ts
@@ -368,10 +368,14 @@ export class StepTracker {
     const dependentDependencyOnReject = writeableArray(
       $dependent.dependencyOnReject,
     );
+    const dependentDependencyDataOnly = writeableArray(
+      $dependent.dependencyDataOnly,
+    );
     const {
       skipDeduplication,
       acceptFlags = ALL_FLAGS & ~$dependent.defaultForbiddenFlags,
       onReject,
+      dataOnly = false,
     } = options;
     // When copying dependencies between classes, we might not want to
     // deduplicate because we might refer to the dependency by its index. As
@@ -403,6 +407,7 @@ export class StepTracker {
     const dependencyIndex = dependentDependencies.push($dependency) - 1;
     dependentDependencyForbiddenFlags[dependencyIndex] = forbiddenFlags;
     dependentDependencyOnReject[dependencyIndex] = onReject;
+    dependentDependencyDataOnly[dependencyIndex] = dataOnly;
     writeableArray($dependency.dependents).push({
       step: $dependent,
       dependencyIndex,

--- a/grafast/grafast/src/mermaid.ts
+++ b/grafast/grafast/src/mermaid.ts
@@ -343,6 +343,11 @@ export function planToMermaid(
   const depDeets = (step: GrafastPlanStepJSONv1, idx: number) => {
     const forbiddenFlags = step.dependencyForbiddenFlags[idx];
     const onReject = step.dependencyOnReject[idx];
+
+    // TODO: factor 'data only' into the diagrams
+    //
+    // const dataOnly = step.dependencyDataOnly[idx];
+
     const info: string[] = [];
     if (forbiddenFlags) {
       if ((forbiddenFlags & 2) === 2) {

--- a/grafast/grafast/src/planJSONInterfaces.ts
+++ b/grafast/grafast/src/planJSONInterfaces.ts
@@ -14,6 +14,7 @@ export interface GrafastPlanStepJSONv1 {
   dependencyIds: ReadonlyArray<string | number>;
   dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
   dependencyOnReject: ReadonlyArray<string | null | undefined>;
+  dependencyDataOnly: ReadonlyArray<boolean>;
   polymorphicPaths: readonly string[] | undefined;
   isSyncAndSafe: boolean | undefined;
   supportsUnbatched: boolean | undefined;

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -196,6 +196,15 @@ export /* abstract */ class Step<TData = any> {
   protected readonly dependencyOnReject: ReadonlyArray<
     Error | null | undefined
   >;
+  /**
+   * In future we'll be able to merge "data only" dependencies somehow. For now
+   * we want people to use the right method so we encourage data only as the
+   * default and also forbid `getDep` on data only deps (no talking to your
+   * data only dependencies!)
+   *
+   * @internal
+   */
+  protected readonly dependencyDataOnly: ReadonlyArray<boolean>;
 
   /**
    * Just for mermaid
@@ -349,6 +358,7 @@ export /* abstract */ class Step<TData = any> {
     this.dependencies = [];
     this.dependencyForbiddenFlags = [];
     this.dependencyOnReject = [];
+    this.dependencyDataOnly = [];
     this.dependents = [];
     this.isOptimized = false;
     this.allowMultipleOptimizations = false;
@@ -399,7 +409,7 @@ export /* abstract */ class Step<TData = any> {
     const step = this.dependencies[depId] as TStep;
     const forbiddenFlags = this.dependencyForbiddenFlags[depId];
     const onReject = this.dependencyOnReject[depId];
-    const dataOnly = false;
+    const dataOnly = this.dependencyDataOnly[depId];
     const acceptFlags = ALL_FLAGS & ~forbiddenFlags;
     return { step, acceptFlags, onReject, dataOnly };
   }

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -171,6 +171,7 @@ export class __FlagStep<TStep extends Step> extends Step<DataFromStep<TStep>> {
     const step = this.dependencies[0];
     const forbiddenFlags = this.dependencyForbiddenFlags[0];
     const onReject = this.dependencyOnReject[0];
+    const dataOnly = this.dependencyDataOnly[0];
     const acceptFlags = ALL_FLAGS & ~forbiddenFlags;
     if (
       // TODO: this logic could be improved so that more flag checks were
@@ -191,7 +192,7 @@ export class __FlagStep<TStep extends Step> extends Step<DataFromStep<TStep>> {
         options.acceptFlags === acceptFlags ||
         false
       ) {
-        return { step, acceptFlags, onReject };
+        return { step, acceptFlags, onReject, dataOnly };
       }
     }
     return null;

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -980,6 +980,7 @@ export type Sudo<T> =
         implicitSideEffectStep: Step | null;
         dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
         dependencyOnReject: ReadonlyArray<Error | null | undefined>;
+        dependencyDataOnly: ReadonlyArray<boolean>;
         defaultForbiddenFlags: ExecutionEntryFlags;
         getDepOptions: Step["getDepOptions"];
         _refs: Array<number>;


### PR DESCRIPTION
Long term I want to make it so that steps can be "merged" together for execution even if they can't be merged in the plan diagram; e.g.:

```mermaid
graph TD
  Constant1["Constant<101>[1]"]
  Constant2["Constant<102>[2]"]
  Constant3["Constant<103>[3]"]
  Constant4["Constant<104>[4]"]
  Constant1 -->|dataOnly| Process5[["Process<1>[5]"]]
  Constant2 -->|dataOnly| Process6[["Process<2>[6]"]]
  Constant3 -->|dataOnly| Process7[["Process<3>[7]"]]
  Constant4 -->|dataOnly| Process8[["Process<4>[8]"]]
  Process5 & Process6 --> DoSomething
  Process7 & Process8 --> DoSomethingElse
```

Assuming all other things are equal, this would require us to run `Process` 4 separate times. However; if, whilst excluding the "data only" dependencies, all these `Process` nodes should be able to execute as one. We should be able to combine the 4 constants into one "execution value" and then feed it into `Process[5]` for execution, and then split the results back out again spreading them across `Process[5-8]` for the dependent steps to consume.

To make way for this, we've introduced "data only" dependencies, but they're not data only if their dependents can still communicate with them. We need to block that communication