### PR TITLE
Remove error step from documentation

### DIFF
--- a/grafast/website/grafast/step-library/standard-steps/error.md
+++ b/grafast/website/grafast/step-library/standard-steps/error.md
@@ -1,9 +1,0 @@
-# error
-
-A bit like [constant](./constant), except it always throws the given error.
-
-Usage:
-
-```ts
-const $error = error(new Error("Error"));
-```

--- a/grafast/website/grafast/step-library/standard-steps/index.mdx
+++ b/grafast/website/grafast/step-library/standard-steps/index.mdx
@@ -42,7 +42,6 @@ business logic layer.
 ## Utility
 
 - [constant][]: always returns the given value
-- [error][]: always throws the given error
 - [access][]: accesses the property at the given path for each value
 - [lambda][]: executes a lambda function for each set of values
 


### PR DESCRIPTION
Users are never going to need this now we don't have `$step.eval*()`. They can just use a lambda to throw if they really want.