### PR TITLE
Allow list items to error

### DIFF
--- a/grafast/grafast/src/engine/LayerPlan.ts
+++ b/grafast/grafast/src/engine/LayerPlan.ts
@@ -9,6 +9,7 @@ import {
   FORBIDDEN_BY_NULLABLE_BOUNDARY_FLAGS,
   NO_FLAGS,
 } from "../constants.js";
+import { isFlaggedValue } from "../error.js";
 import { inspect } from "../inspect.js";
 import type { ExecutionValue, UnaryExecutionValue } from "../interfaces.js";
 import type { Step, UnbatchedStep } from "../step";
@@ -779,9 +780,16 @@ export class LayerPlan<TReason extends LayerPlanReason = LayerPlanReason> {
             for (let j = 0, l = list.length; j < l; j++) {
               const newIndex = size++;
               newIndexes.push(newIndex);
-              const val = list[j];
-              // TODO: are these the right flags?
-              ev._setResult(newIndex, val, val == null ? FLAG_NULL : NO_FLAGS);
+              let val = list[j];
+              let flags = NO_FLAGS;
+              if (isFlaggedValue(val)) {
+                flags = val.flags;
+                val = val.value;
+              }
+              if (val == null) {
+                flags = flags | FLAG_NULL;
+              }
+              ev._setResult(newIndex, val, flags);
 
               polymorphicPathList[newIndex] =
                 parentBucket.polymorphicPathList[originalIndex];

--- a/grafast/grafast/src/engine/executeBucket.ts
+++ b/grafast/grafast/src/engine/executeBucket.ts
@@ -13,7 +13,7 @@ import {
   NO_FLAGS,
 } from "../constants.js";
 import { isDev } from "../dev.js";
-import { isFlaggedValue, SafeError } from "../error.js";
+import { flagError, isFlaggedValue, SafeError } from "../error.js";
 import { inspect } from "../inspect.js";
 import type {
   BatchExecutionValue,
@@ -355,7 +355,11 @@ export function executeBucket(
                   if (resolvedResult.done) {
                     break;
                   }
-                  arr.push(await resolvedResult.value);
+                  try {
+                    arr.push(await resolvedResult.value);
+                  } catch (e) {
+                    arr.push(flagError(e));
+                  }
                   if (++valuesSeen >= initialCount) {
                     // This is safe to do in the `while` since we checked
                     // the `0` entries condition in the optimization


### PR DESCRIPTION
It previously wasn't possible to return errors inside list items deliberately ([because why would you want to do that?](https://github.com/benjie/.dev/issues/25)), but this PR addresses that limitation.

Demo:

```ts
makeExtendSchemaPlugin({
  typeDefs: gql`
    extend type Query {
      testError: [Int]
    }
  `,
  objects: {
    Query: {
      plans: {
        testError() {
          return loadMany(null, (v) =>
            v.map(() => [1, 2, Promise.reject(new GraphQLError("Test"))]),
          );
        },
      },
    },
  },
})
```