### PR TITLE
Enhance playground

### DIFF
--- a/.changeset/open-pugs-lose.md
+++ b/.changeset/open-pugs-lose.md
@@ -1,0 +1,7 @@
+---
+"ruru-components": patch
+"ruru": patch
+---
+
+Fix issue where ruru wasn't hiding explain output in incremental delivery
+results.

--- a/grafast/website/src/components/Playground/PlaygroundInner.jsx
+++ b/grafast/website/src/components/Playground/PlaygroundInner.jsx
@@ -11,7 +11,7 @@ import "ruru-components/ruru.css";
 import CodeMirror from "@uiw/react-codemirror";
 import * as Grafast from "grafast";
 import { grafast, makeGrafastSchema } from "grafast";
-import { GraphQLError } from "graphql";
+import { parse, GraphQLError } from "graphql";
 import React, { useCallback, useMemo, useState } from "react";
 import { Ruru } from "ruru-components";
 
@@ -85,6 +85,9 @@ with (Grafast) {
         typeDefs,
         enableDeferStream: false,
         ...config,
+        ...(typeof config.typeDefs === "string"
+          ? { typeDefs: parse(config.typeDefs) }
+          : null),
       });
     } catch (e) {
       return e;


### PR DESCRIPTION
Can now supply typeDefs via code, and enable defer and stream:

```ts
const typeDefs = `
type Query {
  addTwoNumbers(a: Int!, b: Int!): Int
  list: [Int]
}
`;
const objects = {
  Query: {
    plans: {
      addTwoNumbers(_, { $a, $b }) {
        return lambda([$a, $b], ([a, b]) => a + b, true);
      },
      list() {
        return constant([1,2,3])
      }
    },
  },
};
const enableDeferStream = true;
```

This also fixes ruru to hide extensions in incremental delivery results via hard deletion.