### PR TITLE
See SQL without being verbose

### DIFF
--- a/grafast/dataplan-pg/src/executor.ts
+++ b/grafast/dataplan-pg/src/executor.ts
@@ -200,7 +200,7 @@ export class PgExecutor<const TName extends string = string, TSettings = any> {
             JSON.stringify(firstResult[key], null, 2)
           : explainResult.rows.map((r) => r[key]).join("\n");
     }
-    if (debugVerbose.enabled || debugExplain.enabled) {
+    if (debug.enabled || debugVerbose.enabled || debugExplain.enabled) {
       const duration = (Number((end - start) / 10000n) / 100).toFixed(2) + "ms";
       const rows = queryResult?.rows;
       const rowResults =
@@ -221,7 +221,11 @@ export class PgExecutor<const TName extends string = string, TSettings = any> {
               .join("\n  ") +
             "\n]"
           : inspect(queryResult?.rows, { colors: true, depth: 6 });
-      (debugExplain.enabled ? debugExplain : debugVerbose)(
+      (debugExplain.enabled
+        ? debugExplain
+        : debug.enabled
+          ? debug
+          : debugVerbose)(
         `\
 
 

--- a/grafast/website/grafast/step-library/dataplan-pg/registry/resources.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/registry/resources.md
@@ -35,8 +35,8 @@ could not be found).
 PgExecutor is also responsible for things like caching.
 
 See the SQL queries that are being executed with the
-`DEBUG="@dataplan/pg:PgExecutor:verbose"` envvar. (Or replace `:verbose` with
-`:explain` if you want to see even more information.)
+`DEBUG="@dataplan/pg:PgExecutor"` envvar. (Append `:explain` if you want to see
+even more information.)
 
 A PgExecutor is constructed with an options object containing two properties:
 

--- a/postgraphile/website/postgraphile/debugging.md
+++ b/postgraphile/website/postgraphile/debugging.md
@@ -207,7 +207,7 @@ the ones you might care about:
 - `graphile-build:SchemaBuilder` - this hook is useful for understanding the
   order in which hooks execute, and how hook executions can nest - a must for
   people getting started with graphile-build plugins
-- `@dataplan/pg:PgExecutor:verbose` - details of the SQL queries being executed, their inputs, and their results
+- `@dataplan/pg:PgExecutor` - details of the SQL queries being executed, their inputs, and their results
 - `@dataplan/pg:PgExecutor:explain` - as above, but also their EXPLAIN results
 
 To enable these DEBUG modes, join them with commas when setting a DEBUG envvar,


### PR DESCRIPTION
`DEBUG=@dataplan/pg:PgExecutor` should show the SQL/results. `:verbose` includes caching. `:explain` includes explain results.