### PR TITLE
websites: fix news links

### DIFF
--- a/grafast/website/news/2025-06-07-last-epic-solved.22.mdx
+++ b/grafast/website/news/2025-06-07-last-epic-solved.22.mdx
@@ -226,7 +226,7 @@ sensible defaults if you only specify the first two generics.
 In reaching this epic milestone, we have <strong>bumped the minimum version of node.js to
 Node 22</strong> (the latest LTS); we have also found and fixed a number of other issues both
 in Gra*fast* and the wider Graphile suite, you can see a full list at
-[graphile.org](htts://graphile.org/news/20250606-last-epic-reached).
+[graphile.org](https://www.graphile.org/news/20250607-last-epic-solved/).
 
 ## Thank you Sponsors
 

--- a/postgraphile/website/news/2025-06-07-last-epic-solved.41.mdx
+++ b/postgraphile/website/news/2025-06-07-last-epic-solved.41.mdx
@@ -161,7 +161,7 @@ perfectly! YMMV.)_
 In reaching this epic milestone, we have <strong>bumped the minimum version of node.js to
 Node 22</strong> (the latest LTS); we have also found and fixed a number of other issues both
 in PostGraphile and the wider Graphile suite, you can see a full list at
-[graphile.org](htts://graphile.org/news/20250606-last-epic-reached).
+[graphile.org](https://www.graphile.org/news/20250607-last-epic-solved/).
 
 ## Thank you Sponsors
 

--- a/postgraphile/website/src/pages/v5beta.mdx
+++ b/postgraphile/website/src/pages/v5beta.mdx
@@ -126,7 +126,7 @@ Everyone else can see some detail in the PostGraphile [changelog](https://github
   <td>beta.41</td>
   <td>
     Polymorphism epic achieved (
-    <a href="https://www.graphile.org/news/20250606-last-epic-reached/">
+    <a href="https://www.graphile.org/news/20250607-last-epic-solved/">
       read more
     </a>
     )


### PR DESCRIPTION
## Description

We changed the slug of the page on graphile.org but never updated the link from the other webpages!