### PR TITLE
docs: some small updates after beta 39+

### DIFF
--- a/grafast/website/grafast/step-library/dataplan-pg/pgCondition.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgCondition.md
@@ -1,22 +1,22 @@
 # pgCondition
 
-This "modifier step" (**not** an ExecutableStep) is commonly acquired from
+This "Modifier" class (**not** a Step) is commonly acquired from
 `$pgSelect.wherePlan()`, `$pgSelect.havingPlan()`, or similar methods. It's
-useful for building up a condition (`WHERE` or `HAVING` clause) bit by bit.
+useful for building up a condition (`WHERE` or `HAVING` clause) bit by bit, and is used at runtime.
 
 :::tip
 
-This is an advanced step, you probably will never use it unless you're building
+This is an advanced class, you probably will never use it unless you're building
 advanced filtering capabilities into your GraphQL schema.
 
 :::
 
-pgConditions are created with a parent (a PgConditionCapableStep - typically another PgConditionStep, a PgSelectStep, or similar) and a mode:
+pgConditions are created with a parent (a PgConditionCapableParent - typically another PgCondition, a [PgSelect](./pgSelect.md), or similar) and a mode:
 
 - `PASS_THRU` - passes conditions directly up to the parent
-- `AND` - combines conditons with `AND` and passes the result up to the parent
+- `AND` - combines conditions with `AND` and passes the result up to the parent
 - `OR` - combines the conditions with `OR` and passes the result up to the parent
-- `NOT` - combines the conditons with `AND`, groups them together and does a `NOT` of the result, which is then passed up to the parent
+- `NOT` - combines the conditions with `AND`, groups them together and does a `NOT` of the result, which is then passed up to the parent
 - `EXISTS` - builds an `EXISTS(...)` expression utilising the conditions and passes it up to the parent
 
 ## $pgCondition.orPlan()

--- a/grafast/website/grafast/step-library/dataplan-pg/pgCondition.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgCondition.md
@@ -1,5 +1,7 @@
 # pgCondition
 
+<!-- TODO This explanation is out of date, pgSelect doesn't have wherePlan or havingPlan -->
+
 This "Modifier" class (**not** a Step) is commonly acquired from
 `$pgSelect.wherePlan()`, `$pgSelect.havingPlan()`, or similar methods. It's
 useful for building up a condition (`WHERE` or `HAVING` clause) bit by bit, and is used at runtime.

--- a/grafast/website/grafast/step-library/dataplan-pg/pgDeleteSingle.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgDeleteSingle.md
@@ -11,7 +11,7 @@ const $deletedUser = pgDeleteSingle(usersResource, {
 
 ## $pgDeleteSingle.get(attr)
 
-Returns a PgClassExpressionStep representing the given attribute from the
+Returns a PgClassExpression representing the given attribute from the
 deleted row. This is achieved by selecting the value using the
 `DELETE FROM ... WHERE ... RETURNING ...` syntax.
 
@@ -21,4 +21,4 @@ const $username = $deletedUser.get("username");
 
 ## $pgDeleteSingle.record()
 
-Returns a PgClassExpressionStep representing the full record that was deleted.
+Returns a PgClassExpression representing the full record that was deleted.

--- a/grafast/website/grafast/step-library/dataplan-pg/pgInsertSingle.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgInsertSingle.md
@@ -23,14 +23,16 @@ $insertedUser.set("bio", $bio);
 
 ## $pgInsertSingle.setPlan()
 
-Returns a `SetterStep` (a "modifier step", rather than an `ExecutableStep`)
+<!-- TODO: I think the explanation below still needs a bit of an update -->
+
+Returns a `Setter` (a Modifier, rather than an Step)
 that can be useful when combined with `applyPlan` plan resolvers in arguments
 and input fields to build up the attributes to set on the inserted row bit by
 bit.
 
 ## $pgInsertSingle.get(attr)
 
-Returns a PgClassExpressionStep representing the given attribute from the
+Returns a PgClassExpression representing the given attribute from the
 inserted row. This is achieved by selecting the value using the
 `INSERT INTO ... RETURNING ...` syntax.
 
@@ -40,4 +42,4 @@ const $id = $insertedUser.get("id");
 
 ## $pgInsertSingle.record()
 
-Returns a PgClassExpressionStep representing the full record that was inserted.
+Returns a PgClassExpression representing the full record that was inserted.

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -150,6 +150,11 @@ you don't do this then we might (if unique order is required, for example for
 cursor pagination) add the primary key or similar unique constraint to the
 ordering in order to make it stable.
 
+<!--
+TODO: where() has been removed https://github.com/graphile/crystal/blob/main/postgraphile/postgraphile/CHANGELOG.md#500-beta39
+What to use instead?
+Other methods which have been impacted?
+
 ### $pgSelect.where(condition)
 
 Adds a `WHERE` clause to the query, can be called multiple times and the
@@ -160,6 +165,7 @@ const $users = usersResource.find();
 const tbl = $users.alias;
 $users.where(sql`${tbl}.username = 'Benjie'`);
 ```
+-->
 
 ### $pgSelect.placeholder($step, codec)
 

--- a/grafast/website/grafast/step-library/dataplan-pg/pgUnionAll.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgUnionAll.md
@@ -60,6 +60,16 @@ matches the entry in the union.
 
 ## Applying conditions
 
+:::warning
+
+The following documentation may be out of date as of PostGraphile 5.0.0.beta.40 &amp;
+Grafast 0.1.1.beta.21 (March 2025). `ModifierStep` classes are now simply `Modifier` classes
+and are now used at runtime instead of planning time. This has an effect on pgUnionAll, in
+particular: instead of `PgUnionAllStep.wherePlan` - use `fieldArg.apply($unionAll, qb => qb.whereBuilder())`
+and instead of `PgUnionAllStep.havingPlan` - use `fieldArg.apply($unionAll, qb => qb.havingBuilder())`
+
+:::
+
 Conditions can be applied to the resulting step via the `.where()` method,
 which accepts an object containing the following keys:
 


### PR DESCRIPTION
## Description

Slowly tweaking some documentation to align with changes made in grafast beta 39 onwards

ref https://github.com/graphile/crystal/blob/main/postgraphile/postgraphile/CHANGELOG.md#500-beta39
- "modifier step" now becomes "`Modifier` class"
- dropping the "Step" suffix as needed
- "where" and "having" have been removed from pgUnionAll and pgSelect
