### PR TITLE
Give Graphile Export a way to disable optimize

### DIFF
--- a/.changeset/fuzzy-facts-throw.md
+++ b/.changeset/fuzzy-facts-throw.md
@@ -1,0 +1,5 @@
+---
+"graphile-export": patch
+---
+
+Provide option to allow disabling optimize (to reduce memory pressure).

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -2075,13 +2075,13 @@ export async function exportSchemaAsString(
     exportSchemaGraphQLJS(schemaExportDetails);
   }
 
-  return exportFile(file);
+  return exportFile(file, options);
 }
 
-function exportFile(file: CodegenFile) {
+function exportFile(file: CodegenFile, { disableOptimize }: ExportOptions) {
   const ast = file.toAST();
 
-  const optimizedAst = optimize(ast);
+  const optimizedAst = disableOptimize ? ast : optimize(ast);
 
   const { code } = reallyGenerate(optimizedAst, {});
   return { code };
@@ -2106,7 +2106,7 @@ export async function exportValueAsString(
     ),
   );
 
-  return exportFile(file);
+  return exportFile(file, options);
 }
 
 async function loadESLint() {

--- a/utils/graphile-export/src/interfaces.ts
+++ b/utils/graphile-export/src/interfaces.ts
@@ -24,4 +24,15 @@ export interface ExportOptions {
    * Set 'true' if we should use prettier to format the exported code.
    */
   prettier?: boolean;
+
+  /**
+   * Set 'true' if you're facing memory exhaustion issues on large schemas and
+   * wish to skip optimizing the export.
+   *
+   * Optimizing the export can make the export smaller and more readable,
+   * involving fewer IIFEs and similar constructs used throughout EXPORTABLE
+   * expressions. It may also have a (positive, hopefully) impact on
+   * performance. In general it's recommended to leave optimize enabled.
+   */
+  disableOptimize?: boolean;
 }


### PR DESCRIPTION
Relates to:

- #2565 

This allows a user to pass `{ disableOptimize: true}` to export and the optimize step will be skipped.