### PR TITLE
Add support for --experimental-trip-types to graphile-config

### DIFF
--- a/.changeset/witty-moments-tan.md
+++ b/.changeset/witty-moments-tan.md
@@ -1,0 +1,6 @@
+---
+"graphile-config": patch
+---
+
+Add support for `--experimental-strip-types` to `graphile-config`'s loading of
+config files. No need for `ts-node`/`tsx` now.

--- a/utils/graphile-config/src/loadConfig.ts
+++ b/utils/graphile-config/src/loadConfig.ts
@@ -60,6 +60,36 @@ function fixESMShenanigans(requiredModule: any): any {
   return requiredModule;
 }
 
+async function tryLoad(resolvedPath: string, extension: string) {
+  // Attempt to import using native TypeScript support if appropriate
+  if (process.features.typescript && /\.m?tsx?$/.test(extension)) {
+    try {
+      return (await import(pathToFileURL(resolvedPath).href)).default;
+    } catch {
+      // Nevermind; try a loader
+    }
+  }
+
+  // No luck? Let's try loading the loaders
+  try {
+    registerLoader(jsVariants[extension]);
+  } catch (e) {
+    console.error(`No loader could be loaded for ${extension} files: ${e}`);
+  }
+
+  // And now lets attempt to import
+  try {
+    return fixESMShenanigans(require(resolvedPath));
+  } catch (e) {
+    if (e.code === "ERR_REQUIRE_ESM") {
+      // It's an ESModule, so `require()` won't work. Let's use `import()`!
+      return (await import(pathToFileURL(resolvedPath).href)).default;
+    } else {
+      throw e;
+    }
+  }
+}
+
 export async function loadConfig(
   configPath?: string | null,
 ): Promise<GraphileConfig.Preset | null> {
@@ -68,14 +98,14 @@ export async function loadConfig(
 
     const resolvedPath = resolve(process.cwd(), configPath);
 
-    // First try one of the supported loaders
+    // First try one of the supported loaders.
     for (const extension of extensions) {
       if (resolvedPath.endsWith(extension)) {
-        registerLoader(jsVariants[extension]);
         try {
-          return fixESMShenanigans(require(resolvedPath));
+          return await tryLoad(resolvedPath, extension);
         } catch {
-          /* continue to the next one */
+          // Multiple extensions might match - e.g. both `.swc.tsx` and `.tsx`;
+          // continue to the next one.
         }
       }
     }
@@ -89,15 +119,12 @@ export async function loadConfig(
     for (const extension of extensions) {
       const resolvedPath = basePath + extension;
       if (await exists(resolvedPath)) {
-        registerLoader(jsVariants[extension]);
+        // This file exists; whatever happens, we will try this file only.
         try {
-          return fixESMShenanigans(require(resolvedPath));
-        } catch (e) {
-          if (e.code === "ERR_REQUIRE_ESM") {
-            return (await import(pathToFileURL(resolvedPath).href)).default;
-          } else {
-            throw e;
-          }
+          return await tryLoad(resolvedPath, extension);
+        } catch {
+          // Fallback to direct import
+          return (await import(pathToFileURL(resolvedPath).href)).default;
         }
       }
     }


### PR DESCRIPTION
Previously we only used `interpret` for determining how to process a file; but if we have `--experimental-strip-types` enabled then we should try and use that first as we might not need a loader at all.