### PR TITLE
Have Amber and V4 presets import types

### DIFF
--- a/.changeset/wild-beans-count.md
+++ b/.changeset/wild-beans-count.md
@@ -1,0 +1,6 @@
+---
+"postgraphile": patch
+---
+
+Amber and V4 preset now implicitly import `postgraphile` which imports the
+Graphile Config types you need from graphile-build, grafast, etc automatically.

--- a/postgraphile/postgraphile/src/presets/amber.ts
+++ b/postgraphile/postgraphile/src/presets/amber.ts
@@ -1,4 +1,4 @@
-import "graphile-config";
+import "../index.js";
 
 import {
   AddNodeInterfaceToSuitableTypesPlugin,

--- a/postgraphile/postgraphile/src/presets/lazy-jwt.ts
+++ b/postgraphile/postgraphile/src/presets/lazy-jwt.ts
@@ -1,4 +1,4 @@
-import "graphile-config";
+import "../index.js";
 
 import type {} from "grafserv/node";
 import { PgJWTPlugin } from "graphile-build-pg";

--- a/postgraphile/postgraphile/src/presets/relay.ts
+++ b/postgraphile/postgraphile/src/presets/relay.ts
@@ -1,5 +1,4 @@
-import "graphile-config";
-import "graphile-build-pg";
+import "../index.js";
 
 import type { PgCodecRelation } from "@dataplan/pg";
 

--- a/postgraphile/postgraphile/src/presets/v4.ts
+++ b/postgraphile/postgraphile/src/presets/v4.ts
@@ -1,4 +1,4 @@
-import "graphile-config";
+import "../index.js";
 
 import type { GraphQLError, GraphQLFormattedError } from "grafast/graphql";
 import { formatError as defaultFormatError } from "grafast/graphql";

--- a/postgraphile/website/postgraphile/adding-and-replacing-inflectors.md
+++ b/postgraphile/website/postgraphile/adding-and-replacing-inflectors.md
@@ -31,9 +31,7 @@ This following plugin replaces the `builtin` inflector with one that returns
 
 ```ts
 // Import types for TypeScript, no need in JS
-import "graphile-config";
-import "graphile-build";
-import "graphile-build-pg";
+import "postgraphile";
 
 export const ReplaceInflectorPlugin: GraphileConfig.Plugin = {
   // Unique name for your plugin:
@@ -81,9 +79,7 @@ plugin such as this one:
 
 ```ts
 // Import types for TypeScript, no need in JS
-import "graphile-config";
-import "graphile-build";
-import "graphile-build-pg";
+import "postgraphile";
 
 export const ReplaceInflectorPlugin: GraphileConfig.Plugin = {
   // Unique name for your plugin:
@@ -129,9 +125,7 @@ make other plugins aware of the new inflector:
 
 ```ts
 // Import types for TypeScript, no need in JS
-import "graphile-config";
-import "graphile-build";
-import "graphile-build-pg";
+import "postgraphile";
 
 declare global {
   namespace GraphileBuild {

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -50,6 +50,7 @@ without the overhead of requiring TypeScript.
 Here’s an example preset which only extends the “Amber” preset:
 
 ```js title="graphile.config.mjs"
+// @ts-check
 import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
 
 /** @type {GraphileConfig.Preset} */
@@ -60,13 +61,9 @@ const preset = {
 export default preset;
 ```
 
-You could also have created this in TypeScript, in which case you might add a
-couple of `import` statements to the top in order to ensure that the relevant
-TypeScript types exist.
+Or in TypeScript:
 
-```ts title="graphile.config.ts"
-import "graphile-config";
-import "postgraphile";
+```ts title="graphile.config.mts"
 import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
 
 const preset: GraphileConfig.Preset = {
@@ -76,9 +73,11 @@ const preset: GraphileConfig.Preset = {
 export default preset;
 ```
 
-Similarly, you can create your config as a `.js`, `.cjs`, `.mts` or `.cts` file;
+Similarly, you can create your config as a `.js`, `.cjs`, `.ts` or `.cts` file;
 the PostGraphile CLI will pick up all of these automatically assuming that you
-have TypeScript installed locally.
+have TypeScript installed locally and are running Node 24 or higher. (For Node
+22.6+ you'll need to be running with the `node --experimental-strip-types` flag,
+or have `tsx`, `ts-node`, or similar installed locally.)
 
 ## General structure
 
@@ -105,9 +104,7 @@ registers the `grafast` scope; Grafserv registers the `grafserv` scope; and
 
 We highly recommend using TypeScript for dealing with your preset so that you
 get auto-completion for the options available in each scope; you can also use
-the `graphile config options` command detailed below. It may be necessary to
-add `import "postgraphile"` at the top of the configuration file so that
-TypeScript imports all the available scopes.
+the `graphile config options` command detailed below.
 
 :::tip The Schema Build Process
 
@@ -124,8 +121,7 @@ The schema build process in PostGraphile is:
 
 ### Simple example
 
-```ts title="graphile.config.ts"
-import "postgraphile"; // To import the TypeScript types
+```ts title="graphile.config.mts"
 import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
 import { makePgService } from "postgraphile/adaptors/pg";
 
@@ -138,10 +134,7 @@ const preset: GraphileConfig.Preset = {
 
 ### Larger example
 
-```ts title="graphile.config.ts"
-// Only needed for TypeScript types support
-import "postgraphile";
-
+```ts title="graphile.config.mts"
 // The standard base preset to use, includes the main PostGraphile features
 import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
 

--- a/postgraphile/website/postgraphile/migrating-from-v4/index.mdx
+++ b/postgraphile/website/postgraphile/migrating-from-v4/index.mdx
@@ -103,8 +103,6 @@ export default preset;
 Here's a larger documented preset with more details:
 
 ```ts title="graphile.config.js"
-import "graphile-config";
-
 import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
 import { makeV4Preset } from "postgraphile/presets/v4";
 // Use the 'pg' module to connect to the database

--- a/postgraphile/website/postgraphile/migrating-from-v4/make-add-inflectors-plugin.md
+++ b/postgraphile/website/postgraphile/migrating-from-v4/make-add-inflectors-plugin.md
@@ -19,9 +19,7 @@ This following plugin replaces the `builtin` inflector with one that returns
 
 ```ts
 // Import types for TypeScript, no need in JS
-import "graphile-config";
-import "graphile-build";
-import "graphile-build-pg";
+import "postgraphile";
 
 export const ReplaceInflectorPlugin: GraphileConfig.Plugin = {
   // Unique name for your plugin:
@@ -88,9 +86,7 @@ make other plugins aware of the new inflector:
 
 ```ts
 // Import types for TypeScript, no need in JS
-import "graphile-config";
-import "graphile-build";
-import "graphile-build-pg";
+import "postgraphile";
 
 declare global {
   namespace GraphileBuild {

--- a/postgraphile/website/postgraphile/migrating-from-v4/migrating-custom-plugins.md
+++ b/postgraphile/website/postgraphile/migrating-from-v4/migrating-custom-plugins.md
@@ -719,8 +719,7 @@ property to `GraphileBuild.Build`, you might do:
 
 ```ts
 // Ensure that the types are imported for TypeScript
-import "graphile-build";
-import "graphile-config";
+import "postgraphile";
 
 // Extend the global GraphileBuild.Build type to add our 'flibble' attribute:
 declare global {

--- a/postgraphile/website/postgraphile/usage-library.md
+++ b/postgraphile/website/postgraphile/usage-library.md
@@ -254,30 +254,37 @@ postgraphile_express/
  ├── .env
  ├── .gitignore
  ├── node_modules/
- ├── package-lock.json
  ├── package.json
+ ├── package-lock.json
  └── server.js
 ```
 
-The `package.json` file should have the content similar to the following (with
+Configure your project by setting some options in `package.json`:
+
+```bash
+# Delete things we're not configuring right now
+npm pkg delete author license description keywords scripts main
+# Don't allow publishing to npm
+npm pkg set private=true --json
+# Use ESModule syntax and set our start script
+npm pkg set type=module scripts.start="node server.js"
+```
+
+The `package.json` file should now have content similar to the following (with
 the versions of `express` and `postgraphile` being the most recent):
 
 ```json
 {
   "name": "postgraphile_express",
   "version": "1.0.0",
-  "main": "index.js",
-  "type": "module",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
   "dependencies": {
     "express": "^4.21.2",
     "postgraphile": "^5.0.0-beta.38"
+  },
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
   }
 }
 ```
@@ -369,13 +376,22 @@ cd postgraphile_express_typescript
 npm init -y
 ```
 
+You should also ensure you're running Node v24+. If you're running earlier
+versions, then you may need to pass `--experimental-strip-types` to Node.
+
+```bash
+# For nvm; other Node version managers exist.
+echo 24 > .nvmrc
+nvm use
+```
+
 ### Installing dependencies
 
 Install the required packages:
 
 ```bash npm2yarn
 npm install --save express postgraphile@beta @graphile/simplify-inflection@beta
-npm install --save-dev typescript @tsconfig/node22 @types/express @types/node
+npm install --save-dev typescript @tsconfig/node24 @types/express @types/node
 ```
 
 ### Environment variables
@@ -402,7 +418,7 @@ Node.js major version; e.g. if you're using Node v22.14.0 that would be
 
 ```json title="tsconfig.json"
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "erasableSyntaxOnly": true,
     "rewriteRelativeImportExtensions": true,
@@ -421,8 +437,6 @@ and `server.ts` with the contents shown below:
 #### `src/graphile.config.ts`
 
 ```ts title="src/graphile.config.ts"
-import type {} from "graphile-config";
-import "postgraphile";
 import { makePgService } from "postgraphile/adaptors/pg";
 import { PostGraphileAmberPreset } from "postgraphile/presets/amber";
 import { PgSimplifyInflectionPreset } from "@graphile/simplify-inflection";
@@ -454,11 +468,11 @@ export const pgl = postgraphile(preset);
 
 :::note Import from `.ts` along with `rewriteRelativeImportExtensions`
 
-With Node's new `--experimental-strip-types` flag, TypeScript syntax is removed
-so that the TS can be executed directly as if it were JS. However, the files
-still need to be able to reference each other. In the source code, that means
-referencing the `.ts` file; but when TypeScript compiles the code for
-production the output will be `.js` files.
+With Node's new `--experimental-strip-types` flag (automatically enabled from
+Node 24+), TypeScript syntax is removed so that the TS can be executed directly
+as if it were JS. However, the files still need to be able to reference each
+other. In the source code, that means referencing the `.ts` file; but when
+TypeScript compiles the code for production the output will be `.js` files.
 
 Fortunately, TypeScript has added the configuration option
 `rewriteRelativeImportExtensions` to ensure that you can use `.ts` to reference
@@ -493,39 +507,50 @@ console.log("Server listening at http://localhost:5050");
 
 ### Contents of `package.json`
 
-After making similar changes to `package.json` as we did with Example 1 above, we should
-end up with a `package.json` file that looks something like:
+Configure `package.json` to fit our project
 
-```diff title="package.json"
- {
-   "name": "simple_node_project",
-   "version": "1.0.0",
-+  "private": true,
-+  "type": "module",
-   "scripts": {
-+    "start": "node --env-file=./.env src/server.ts",
-+    "build": "tsc",
-+    "prod": "node dist/server.js"
-   },
-   "dependencies": {
-     "@graphile/simplify-inflection": "^8.0.0-beta.6",
-     "express": "^4.21.2",
-     "postgraphile": "^5.0.0-beta.38"
-   },
-   "devDependencies": {
-     "@tsconfig/node22": "^22.0.0",
-     "@types/express": "^5.0.0",
-     "@types/node": "^22.15.32",
-     "typescript": "^5.7.3"
-   }
- }
+```bash
+# Delete things we're not configuring right now
+npm pkg delete author license description keywords scripts main
+# Don't allow publishing to npm
+npm pkg set private=true --json
+# Use ESModule syntax and set some scripts
+npm pkg set type=module scripts.start="node src/server.ts" scripts.build=tsc scripts.prod="node dist/server.js"
 ```
 
-Note that we have three scripts:
+The `package.json` file should now have content similar to the following (likely
+with different version numbers):
 
-- `start` runs our source files directly using Node 22's type stripping
-- `build` compiles our `.ts` files to `.js` files to run in production
-- `prod` runs the compiled `.js` files in production, and expects the environment variables to already be set in the environment rather than reading them from a file
+```diff title="package.json"
+{
+  "name": "simple_node_project",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@graphile/simplify-inflection": "^8.0.0-beta.6",
+    "express": "^4.21.2",
+    "postgraphile": "^5.0.0-beta.38"
+  },
+  "devDependencies": {
+    "@tsconfig/node22": "^22.0.0",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.15.32",
+    "typescript": "^5.7.3"
+  },
+  "private": true,
+  "scripts": {
+    "start": "node --env-file=./.env src/server.ts",
+    "build": "tsc",
+    "prod": "node dist/server.js"
+  }
+}
+```
+
+Note that we have defined three scripts:
+
+- `start` runs our source files directly using Node 24's type stripping
+- `build` compiles our `src/*.ts` files to `dist/*.js` files to run in production
+- `prod` runs the compiled `dist/*.js` files in production, and expects the environment variables to already be set in the environment rather than reading them from a file
 
 ### Project Structure
 
@@ -535,9 +560,10 @@ The project structure should be
 postgraphile_express_typescript/
  ├── .env
  ├── .gitignore
+ ├── .nvmrc
  ├── node_modules/
- ├── package-lock.json
  ├── package.json
+ ├── package-lock.json
  ├── src/
  │    ├── graphile.config.ts
  │    ├── pgl.ts
@@ -569,10 +595,11 @@ query {
 :::danger Errors running `npm start`?
 
 If you get errors when running `npm start` it might be because you are not
-running a sufficiently up to date version of Node.js, lacking the type
-stripping features. If this is the case, you'll want to run TypeScript in watch
-mode (`yarn tsc --watch`) in one terminal, and then execute the compiled JS
-code directly: `npde --env-file=./.env dist/server.js`.
+running a sufficiently up to date version of Node.js, lacking the type stripping
+features. If this is the case and you can't update to Node 24 for some reason,
+you'll want to run TypeScript in watch mode (`yarn tsc --watch`) in one
+terminal, and then execute the compiled JS code directly:
+`node --env-file=./.env dist/server.js`.
 
 :::
 


### PR DESCRIPTION
## Description

Fixes #2597 by ensuring that importing amber is enough to import the types.

Also overhauls the library TypeScript example using Node 24 and `npm pkg set` commands.

Imports the root file from the presets, so:

```ts
import { AmberPreset } from 'postgraphile/presets/amber';

export default {
  extends: [AmberPreset],
  schema: {
    // ...
  },
}
```

should now be valid according to TypeScript.

## Performance impact

Not super happy with this because it pulls in code that's not _necessarily_ needed... But also I can't think when that would matter.

## Security impact

Types only.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
