### PR TITLE
websites: styles.intro fix after Docusaurus update

### DIFF
--- a/grafast/website/news/2023-10-13-grafast-0.1.mdx
+++ b/grafast/website/news/2023-10-13-grafast-0.1.mdx
@@ -13,11 +13,11 @@ hide_table_of_contents: true
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 Gra*fast* is finally here &mdash; a new holistic execution engine for GraphQL. It enables greater efficiency across the entire backend stack by leveraging the declarative nature of GraphQL to give your business logic a better understanding of everything it needs to do. It’s backwards compatible, so you can adopt it incrementally within your existing schema and it’s finally ready to try with [the `grafast` module on npm](https://www.npmjs.com/package/grafast); or check out [the source code on GitHub](https://github.com/graphile/crystal/tree/main/grafast/grafast)!
 
-</p>
+</div>
 
 <figure>
   <iframe

--- a/grafast/website/news/2025-03-24-grafast-0.1-beta.21.mdx
+++ b/grafast/website/news/2025-03-24-grafast-0.1-beta.21.mdx
@@ -14,7 +14,7 @@ tags: [0.1]
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 In the first Gra<em>fast</em> Working Group, we outlined 4 <em>major</em> issues in Gra<em>fast</em>
 that needed to be addressed before we could think about general release. With
@@ -29,7 +29,7 @@ We’re proud to announce that the third of these, eradicating eval, is now
 addressed with the launch of `grafast@0.1.1-beta.21`, and the approach has been
 fully adopted and tested via incorporation into `postgraphile@5.0.0-beta.40`.
 
-</p>
+</div>
 
 ## Input evaluation moved to runtime
 

--- a/grafast/website/news/2025-06-07-last-epic-solved.22.mdx
+++ b/grafast/website/news/2025-06-07-last-epic-solved.22.mdx
@@ -18,7 +18,7 @@ tags: [0.1]
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 In the first Gra<em>fast</em> Working Group, we outlined 4 <em>major</em> issues in Gra<em>fast</em>
 that needed to be addressed before we could think about general release. The fourth, and final,
@@ -35,7 +35,7 @@ issue raised in the first Gra*fast* working group as one of four “epics” to 
 solved before v1.0. This release of `grafast@0.1.1-beta.22` fixes this final epic through
 a complete overhaul of the polymorphism system. Let’s take a look!
 
-</p>
+</div>
 
 ### Polymorphism epic achieved
 

--- a/postgraphile/website/news/2023-08-03-beta-release.mdx
+++ b/postgraphile/website/news/2023-08-03-beta-release.mdx
@@ -18,11 +18,11 @@ toc_max_heading_level: 2
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 It’s finally here! The day has come that you can get your hands on an _early release_ of PostGraphile Version 5; but we do have an ask: please help us to get it ready for release.
 
-</p>
+</div>
 
 We need help writing automated tests, validating it works in your real-world applications, improving the documentation, keeping up with issues and community support, porting plugins, smoothing edges, and as always we need financial support so we can keep investing our time into V5 and our other projects.
 

--- a/postgraphile/website/news/2025-03-24-beta-40-release.mdx
+++ b/postgraphile/website/news/2025-03-24-beta-40-release.mdx
@@ -14,7 +14,7 @@ toc_max_heading_level: 2
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 In the first Gra<em>fast</em> Working Group, we outlined 4 <em>major</em> issues in Gra<em>fast</em>
 that needed to be addressed before we could think about general release. With
@@ -29,7 +29,7 @@ We’re proud to announce that the third of these, eradicating eval, is now
 addressed with the launch of `grafast@0.1.1-beta.21`, and the approach has been
 fully adopted and tested via incorporation into `postgraphile@5.0.0-beta.40`.
 
-</p>
+</div>
 
 ## What does this mean for PostGraphile?
 

--- a/postgraphile/website/news/2025-06-07-last-epic-solved.41.mdx
+++ b/postgraphile/website/news/2025-06-07-last-epic-solved.41.mdx
@@ -18,7 +18,7 @@ tags: [Beta]
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 In the first Gra<em>fast</em> Working Group, we outlined 4 <em>major</em> issues in Gra<em>fast</em>
 that needed to be addressed before we could think about general release. The fourth, and final,
@@ -29,7 +29,7 @@ epic has now been solved!
 - ✅ Eradicating eval
 - ✅ **Polymorphism — this release!**
 
-</p>
+</div>
 
 Gra*fast* is the cutting-edge GraphQL planning and execution engine which PostGraphile
 uses, allowing it to build much more efficient SQL queries than PostGraphile V4 could

--- a/postgraphile/website/postgraphile/jwt-guide.mdx
+++ b/postgraphile/website/postgraphile/jwt-guide.mdx
@@ -4,14 +4,14 @@ title: PostGraphile JWT guide
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
-This specification was authored by
-[Caleb Meredith](https://twitter.com/calebmer) for use in the PostGraphQL
-project. The language of the specification is meant to be generally applicable
-and adoptable by any who might want to use it.
+This specification was authored by [Caleb
+Meredith](https://twitter.com/calebmer) for use in the PostGraphQL project.
+The language of the specification is meant to be generally applicable and
+adoptable by any who might want to use it.
 
-</p>
+</div>
 
 :::info There are alternatives to JWTs available
 

--- a/postgraphile/website/postgraphile/live-queries.mdx
+++ b/postgraphile/website/postgraphile/live-queries.mdx
@@ -13,11 +13,12 @@ This documentation is copied from Version 4 and has not been updated to Version
 
 :::
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
-A “live query” monitors the query a user provides and gives the client an updated version whenever the query would return a different result.
+A “live query” monitors the query a user provides and gives the client an
+updated version whenever the query would return a different result.=
 
-</p>
+</div>
 
 :::info Version 4.4.0+ required
 

--- a/postgraphile/website/postgraphile/live-queries.mdx
+++ b/postgraphile/website/postgraphile/live-queries.mdx
@@ -16,7 +16,7 @@ This documentation is copied from Version 4 and has not been updated to Version
 <div className={styles.intro}>
 
 A “live query” monitors the query a user provides and gives the client an
-updated version whenever the query would return a different result.=
+updated version whenever the query would return a different result.
 
 </div>
 

--- a/postgraphile/website/postgraphile/postgresql-schema-design.mdx
+++ b/postgraphile/website/postgraphile/postgresql-schema-design.mdx
@@ -5,7 +5,7 @@ title: PostgreSQL Schema Design
 import TOCInline from "@theme/TOCInline";
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 The Postgres database is rich with features well beyond that of any other
 database. However, most developers do not know the extent to which they can
@@ -33,7 +33,7 @@ should be useful for anyone designing a Postgres schema.
 If you haven't installed PostGraphile already, you can follow our
 [Quick Start Guide](./quick-start-guide) to get PostGraphile up and running.
 
-</p>
+</div>
 
 # Table of Contents
 

--- a/postgraphile/website/postgraphile/quick-start-guide.mdx
+++ b/postgraphile/website/postgraphile/quick-start-guide.mdx
@@ -5,12 +5,13 @@ title: Quick Start Guide
 import TOCInline from "@theme/TOCInline";
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
-This quick start guide will walk you through spinning up your first PostGraphile
-server, including installing the prerequisites such as Node and PostgreSQL.
+This quick start guide will walk you through spinning up your
+firstPostGraphile server, including installing the prerequisites such as Node
+andPostgreSQL.
 
-</p>
+</div>
 
 # Table of Contents
 

--- a/postgraphile/website/postgraphile/quick-start-guide.mdx
+++ b/postgraphile/website/postgraphile/quick-start-guide.mdx
@@ -9,7 +9,7 @@ import styles from "@site/src/css/common.module.css";
 
 This quick start guide will walk you through spinning up your
 firstPostGraphile server, including installing the prerequisites such as Node
-andPostgreSQL.
+and PostgreSQL.
 
 </div>
 

--- a/postgraphile/website/postgraphile/smart-comments.mdx
+++ b/postgraphile/website/postgraphile/smart-comments.mdx
@@ -6,14 +6,14 @@ import styles from "@site/src/css/common.module.css";
 
 _Ensure you've read the [Smart Tags](./smart-tags) page before referring here._
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 You can customize your PostGraphile GraphQL schema without making breaking
 changes to your database schema by adding specially formatted comments to
 tables, columns, functions, relations, etc. within your PostgreSQL database. We
 call these "smart comments".
 
-</p>
+</div>
 
 ## Smart comment spec
 

--- a/postgraphile/website/postgraphile/subscriptions.mdx
+++ b/postgraphile/website/postgraphile/subscriptions.mdx
@@ -6,7 +6,7 @@ import styles from "@site/src/css/common.module.css";
 
 # GraphQL Subscriptions
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 Subscriptions notify you when an event occurs on the server side. PostGraphile
 supports subscriptions out of the box (assuming you are using it with a
@@ -14,7 +14,7 @@ supported webserver), but you are responsible for adding subscription fields to
 your schema — without any subscription fields, the `subscription` operation is
 not possible.
 
-</p>
+</div>
 
 ## Websockets
 

--- a/postgraphile/website/versioned_docs/version-4/index.mdx
+++ b/postgraphile/website/versioned_docs/version-4/index.mdx
@@ -6,13 +6,13 @@ import styles from "@site/src/css/common.module.css";
 
 # PostGraphile Introduction
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 PostGraphile (formerly PostGraphQL) builds a powerful, extensible and
 performant GraphQL API from a PostgreSQL schema in seconds; saving you
 weeks if not months of development time.
 
-</p>
+</div>
 
 If you already use PostgreSQL then you understand the value that a strongly
 typed and well defined schema can bring to application development; GraphQL is

--- a/postgraphile/website/versioned_docs/version-4/jwt-guide.mdx
+++ b/postgraphile/website/versioned_docs/version-4/jwt-guide.mdx
@@ -4,14 +4,14 @@ title: PostGraphile JWT Guide
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 This specification was authored by
 [Caleb Meredith](https://twitter.com/calebmer) for use in the PostGraphQL
 project. The language of the specification is meant to be generally applicable
 and adoptable by any who might want to use it.
 
-</p>
+</div>
 
 :::info
 

--- a/postgraphile/website/versioned_docs/version-4/live-queries.mdx
+++ b/postgraphile/website/versioned_docs/version-4/live-queries.mdx
@@ -6,11 +6,12 @@ import Pro from "@site/src/components/Pro";
 import Spon from "@site/src/components/Spon";
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
-A “live query” monitors the query a user provides and gives the client an updated version whenever the query would return a different result.
+A “live query” monitors the query a user provides and gives the client an
+updated version whenever the query would return a different result.
 
-</p>
+</div>
 
 :::info Version 4.4.0+ required
 

--- a/postgraphile/website/versioned_docs/version-4/postgresql-schema-design.md
+++ b/postgraphile/website/versioned_docs/version-4/postgresql-schema-design.md
@@ -5,7 +5,7 @@ title: PostgreSQL Schema Design
 import TOCInline from '@theme/TOCInline';
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 The Postgres database is rich with features well beyond that of any other
 database. However, most developers do not know the extent to which they can
@@ -33,7 +33,7 @@ should be useful for anyone designing a Postgres schema.
 If you haven't installed PostGraphile already, you can follow our
 [Quick Start Guide](./quick-start-guide) to get PostGraphile up and running.
 
-</p>
+</div>
 
 # Table of Contents
 

--- a/postgraphile/website/versioned_docs/version-4/quick-start-guide.mdx
+++ b/postgraphile/website/versioned_docs/version-4/quick-start-guide.mdx
@@ -5,12 +5,12 @@ title: Quick Start Guide
 import TOCInline from "@theme/TOCInline";
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 This quick start guide will walk you through spinning up your first PostGraphile
 server, including installing the prerequisites such as Node and PostgreSQL.
 
-</p>
+</div>
 
 # Table of Contents
 

--- a/postgraphile/website/versioned_docs/version-4/smart-comments.mdx
+++ b/postgraphile/website/versioned_docs/version-4/smart-comments.mdx
@@ -6,14 +6,14 @@ import styles from "@site/src/css/common.module.css";
 
 _Ensure you've read the [Smart Tags](./smart-tags) page before referring here._
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 You can customize your PostGraphile GraphQL schema without making breaking
 changes to your database schema by adding specially formatted comments to
 tables, columns, functions, relations, etc. within your PostgreSQL database. We
 call these "smart comments".
 
-</p>
+</div>
 
 ## Smart comment spec
 

--- a/postgraphile/website/versioned_docs/version-4/subscriptions.mdx
+++ b/postgraphile/website/versioned_docs/version-4/subscriptions.mdx
@@ -6,11 +6,11 @@ import styles from "@site/src/css/common.module.css";
 
 # GraphQL Subscriptions
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 Subscriptions notify you when an event occurs on the server side.
 
-</p>
+</div>
 
 :::note
 This feature requires PostGraphile v4.4.0 or higher.

--- a/postgraphile/website/versioned_docs/version-5/jwt-guide.mdx
+++ b/postgraphile/website/versioned_docs/version-5/jwt-guide.mdx
@@ -4,14 +4,14 @@ title: PostGraphile JWT guide
 
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 This specification was authored by
 [Caleb Meredith](https://twitter.com/calebmer) for use in the PostGraphQL
 project. The language of the specification is meant to be generally applicable
 and adoptable by any who might want to use it.
 
-</p>
+</div>
 
 :::info There are alternatives to JWTs available
 

--- a/postgraphile/website/versioned_docs/version-5/live-queries.mdx
+++ b/postgraphile/website/versioned_docs/version-5/live-queries.mdx
@@ -13,11 +13,12 @@ This documentation is copied from Version 4 and has not been updated to Version
 
 :::
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
-A “live query” monitors the query a user provides and gives the client an updated version whenever the query would return a different result.
+A “live query” monitors the query a user provides and gives the client an
+updated version whenever the query would return a different result.
 
-</p>
+</div>
 
 :::info Version 4.4.0+ required
 

--- a/postgraphile/website/versioned_docs/version-5/postgresql-schema-design.mdx
+++ b/postgraphile/website/versioned_docs/version-5/postgresql-schema-design.mdx
@@ -5,7 +5,7 @@ title: PostgreSQL Schema Design
 import TOCInline from "@theme/TOCInline";
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 The Postgres database is rich with features well beyond that of any other
 database. However, most developers do not know the extent to which they can
@@ -33,7 +33,7 @@ should be useful for anyone designing a Postgres schema.
 If you haven't installed PostGraphile already, you can follow our
 [Quick Start Guide](./quick-start-guide) to get PostGraphile up and running.
 
-</p>
+</div>
 
 # Table of Contents
 

--- a/postgraphile/website/versioned_docs/version-5/quick-start-guide.mdx
+++ b/postgraphile/website/versioned_docs/version-5/quick-start-guide.mdx
@@ -5,12 +5,12 @@ title: Quick Start Guide
 import TOCInline from "@theme/TOCInline";
 import styles from "@site/src/css/common.module.css";
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 This quick start guide will walk you through spinning up your first PostGraphile
 server, including installing the prerequisites such as Node and PostgreSQL.
 
-</p>
+</div>
 
 # Table of Contents
 

--- a/postgraphile/website/versioned_docs/version-5/smart-comments.mdx
+++ b/postgraphile/website/versioned_docs/version-5/smart-comments.mdx
@@ -6,14 +6,14 @@ import styles from "@site/src/css/common.module.css";
 
 _Ensure you've read the [Smart Tags](./smart-tags) page before referring here._
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 You can customize your PostGraphile GraphQL schema without making breaking
 changes to your database schema by adding specially formatted comments to
 tables, columns, functions, relations, etc. within your PostgreSQL database. We
 call these "smart comments".
 
-</p>
+</div>
 
 ## Smart comment spec
 

--- a/postgraphile/website/versioned_docs/version-5/subscriptions.mdx
+++ b/postgraphile/website/versioned_docs/version-5/subscriptions.mdx
@@ -6,7 +6,7 @@ import styles from "@site/src/css/common.module.css";
 
 # GraphQL Subscriptions
 
-<p className={styles.intro}>
+<div className={styles.intro}>
 
 Subscriptions notify you when an event occurs on the server side. PostGraphile
 supports subscriptions out of the box (assuming you are using it with a
@@ -14,7 +14,7 @@ supported webserver), but you are responsible for adding subscription fields to
 your schema — without any subscription fields, the `subscription` operation is
 not possible.
 
-</p>
+</div>
 
 ## Websockets
 


### PR DESCRIPTION
## Description

After the update to Docusaurus 3, we need a few tweaks: 

- update `styles.intro` to use a div instead of p - stops extra p tags from being inserted and fixes the unintentional nesting of ul inside a p block
