### PR TITLE
Unref the pgServices cache timer to prevent blocking process exit

### DIFF
--- a/grafast/dataplan-pg/src/pgServices.ts
+++ b/grafast/dataplan-pg/src/pgServices.ts
@@ -84,7 +84,7 @@ export function getWithPgClientFromPgService<
         cachedValue.retainers--;
 
         // To allow for other promises to resolve and add/remove from the retaininers, check after a tick
-        setTimeout(
+        const tid = setTimeout(
           () => {
             if (cachedValue.retainers === 0 && !released) {
               released = true;
@@ -97,6 +97,7 @@ export function getWithPgClientFromPgService<
           },
           isTest ? 500 : 5000,
         );
+        tid.unref?.(); // Don't block process exit
       };
       withPgClientDetailsByConfigCache.set(config, cachedValue);
       return cachedValue;


### PR DESCRIPTION
## Description

Fixes #2609 

## Performance impact

unknown - should be none
possibly positive in case user code anywhere is waiting for process exit?

## Security impact

unknown - should be none.

## Checklist

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

I have no idea how/if this would be tested - sorry, and it's such a tiny change so dunno about the others.
