### PR TITLE
websites: fix warning and caution admonitions

### DIFF
--- a/grafast/website/grafast/plan-resolvers.md
+++ b/grafast/website/grafast/plan-resolvers.md
@@ -302,7 +302,7 @@ TODO: expand this section with examples of why you might do these things.
 
 ## ~~Automatic application of `applyPlan` plan resolvers~~
 
-:::warning
+:::danger
 
 ~~This section is now _wrong_. We changed this behavior, and now you need to add
 `autoApplyAfterParentApplyPlan` or similar in order to trigger your field to

--- a/grafast/website/grafast/request-overview.md
+++ b/grafast/website/grafast/request-overview.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 
 # Request overview
 
-:::caution
+:::info[This is an approximation]
 
 The following deliberately over-simplifies the inner workings of <Grafast /> by
 focussing on single-payload GraphQL requests rather than those that return

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -43,7 +43,7 @@ conflicts occurring.
 
 :::
 
-:::warning Don't subclass steps.
+:::danger Don't subclass steps.
 
 Don't subclass steps, this will make things very confusing for you. Always
 inherit directly from `Step`.
@@ -135,7 +135,7 @@ i'th entry in this list corresponds to the `dep.at(i)` value for each `dep` in
 the "values tuple". The result of `execute` may or may not be a promise, and
 each entry in the resulting list may or may not be a promise.
 
-:::warning If your step has no dependencies
+:::danger If your step has no dependencies
 
 If the step has no dependencies then `values` will be a 0-tuple (an empty
 tuple), but that doesn't mean the batch is empty or has size one, `count` may
@@ -195,7 +195,7 @@ execute method then returns the same number of results in the same order: `[3,
 
 ### stream
 
-:::warning REMOVED!
+:::info REMOVED!
 
 `stream` is no longer its own method; it has been merged with `execute`.
 
@@ -331,7 +331,7 @@ done just once. A step that deals with a database might precompile its SQL, a
 step that transforms an object might build an optimized function to do so, there
 are so many other actions that this step can be used for.
 
-:::warning
+:::danger
 
 It is critical that the step calls `super.finalize()` at the end of the
 `finalize()` step:
@@ -390,7 +390,7 @@ class MyListStep extends Step {
 }
 ```
 
-:::caution
+:::warning
 
 If your step implements `.at()`, make sure it meets the expectations:
 ie it correctly accepts a single argument an integer.
@@ -417,7 +417,7 @@ class MyObjectStep extends Step {
 }
 ```
 
-:::caution
+:::warning
 
 If your step implements `.get()`, make sure it meets the expectations:
 i.e. it correctly accepts a single argument of a string.
@@ -451,7 +451,7 @@ class MyCollectionStep extends Step /* implements ConnectionCapableStep */ {
 }
 ```
 
-:::caution
+:::warning
 
 If your step implements `.items()`, make sure it meets the expectations:
 i.e. it does not require any arguments.
@@ -626,7 +626,7 @@ class AddStep extends Step {
   }
 ```
 
-:::warning Steps are ethemeral, never store a reference to a step.
+:::danger Steps are ephemeral, never store a reference to a step.
 
 You must never store a reference to another step directly (or indirectly) in
 your step class. Steps come and go at quite a rate during planning - being
@@ -654,7 +654,7 @@ useful when a parameter to a remote service request needs to be the same for
 all entries in the batch; typically this will be the case for ordering,
 pagination and access control.
 
-:::warning Use with caution.
+:::warning Only for use with steps which will always be unary
 
 `this.addUnaryDependency($step)` will raise an error during planning if the
 given `$step` is not unary, so you should be very careful using it. If in
@@ -731,7 +731,7 @@ any output.
 
 ### isSyncAndSafe
 
-:::warning
+:::danger
 
 This is a very dangerous optimization, only use it if you're 100% sure you know
 what you are doing!
@@ -766,7 +766,7 @@ This is set `true` after the step has been optimized.
 
 Set this true if your plan's optimize method can be called a second time.
 
-:::warning Your dependencies may change classes!
+:::danger Your dependencies may change classes!
 
 In this situation it's likely that your dependencies (or their dependencies)
 will not be what you expect them to be (e.g. a `PgSelectSingleStep` might

--- a/grafast/website/grafast/step-library/dataplan-pg/pgCondition.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgCondition.md
@@ -1,6 +1,6 @@
 # pgCondition
 
-:::warning OUT OF DATE
+:::danger OUT OF DATE
 
 This documentation page is out of date! We've not had time to update it
 correctly yet, but here's an incredibly quick and poor overview... (Please do

--- a/grafast/website/grafast/step-library/dataplan-pg/pgInsertSingle.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgInsertSingle.md
@@ -23,7 +23,7 @@ $insertedUser.set("bio", $bio);
 
 ## $pgInsertSingle.setPlan()
 
-:::warning OUT OF DATE
+:::danger OUT OF DATE
 
 This method no longer exists! There's a runtime equivalent now via `.apply()`.
 

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -32,7 +32,7 @@ are forbidden.
 
 :::
 
-:::warning
+:::danger[pgSelect with side-effects must be marked as such]
 
 If you are using a pgSelect in a mutation plan resolver, and that pgSelect has
 side effects (e.g. calls a `VOLATILE` database function), then ensure that the

--- a/grafast/website/grafast/step-library/dataplan-pg/pgUpdateSingle.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgUpdateSingle.md
@@ -29,7 +29,7 @@ $updatedUser.set("bio", $bio);
 
 ## $pgUpdateSingle.setPlan()
 
-:::warning OUT OF DATE
+:::danger OUT OF DATE
 
 This method no longer exists! There's a runtime equivalent now via `.apply()`.
 

--- a/grafast/website/grafast/step-library/dataplan-pg/withPgClient.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/withPgClient.md
@@ -4,9 +4,9 @@ Sometimes you want to use your PostgreSQL client directly, e.g. to run
 arbitrary SQL, or use your specific database client's helper methods; that's
 what `withPgClient` is there to help you with.
 
-:::warning
+:::danger
 
-Like `lambda`, `withPgClient` is an escape hatch and does not use batching.
+Like `lambda`, `withPgClient` is an escape hatch and does not use batching. It is only intended for use in top-level mutations where batch size is always one.When desired elsewhere, consider using `pgSelect` or `loadOne` instead. In future, we intend to add a batched version of these functions.
 
 :::
 

--- a/grafast/website/grafast/step-library/standard-steps/access.md
+++ b/grafast/website/grafast/step-library/standard-steps/access.md
@@ -4,7 +4,7 @@ Creates a step representing a (potentially nested) property from the result of a
 source step _without informing the step you're accessing it_. In general, you
 should prefer [`get()`](./get).
 
-:::warning
+:::danger[Prefer `get()` to `access()`]
 
 Many steps require that you use `.get()` or `.at()` in order to function
 properly, for example if you don't call `.get('attribute_name')` on a [`loadOne()`
@@ -34,7 +34,7 @@ const $firstPatchUserId = access($args.get("input"), [
 ]);
 ```
 
-:::warning
+:::danger
 
 This could lead to unexpected results (which could introduce security issues) if
 it is not used carefully; only use it on JSON-like data, preferably where the

--- a/grafast/website/grafast/step-library/standard-steps/each.md
+++ b/grafast/website/grafast/step-library/standard-steps/each.md
@@ -26,7 +26,7 @@ const $derivatives = each($list, ($item) =>
 return $derivatives;
 ```
 
-:::warning Remember: `applyTransforms()` if passing to another step
+:::tip Remember: `applyTransforms()` if passing to another step
 
 If you aren't returning the result of `each()` from a plan resolver, but are
 instead feeding it into another step, you will likely need to perform

--- a/grafast/website/grafast/step-library/standard-steps/get.md
+++ b/grafast/website/grafast/step-library/standard-steps/get.md
@@ -10,7 +10,7 @@ Usage:
 const $userId = get($user, "id");
 ```
 
-:::warning
+:::danger
 
 This could lead to unexpected results (which could introduce security issues) if
 it is not used carefully; only use it on JSON-like data, preferably where the

--- a/postgraphile/website/postgraphile/bundling-webpack.md
+++ b/postgraphile/website/postgraphile/bundling-webpack.md
@@ -51,7 +51,7 @@ module.exports = {
 
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -21,7 +21,7 @@ The PostGraphile base presets are named after crystals; the first base preset
 available is `postgraphile/presets/amber`, so you’ll almost definitely want
 that.
 
-:::caution Avoid naming conflicts!
+:::warning Avoid naming conflicts!
 
 Please don’t name your own presets after crystals, or we may end up having
 confusion!
@@ -349,7 +349,7 @@ const pgServices = [
 ];
 ```
 
-:::caution Don’t set `name` unless you need to!
+:::warning Don’t set `name` unless you need to!
 
 We recommend that you don’t set a `name` unless you have more than one
 pgService. If you do, the different services may need different properties on
@@ -403,7 +403,7 @@ why every adaptor should support them.
 
 :::
 
-:::caution `name` must be unique!
+:::warning `name` must be unique!
 
 The `name` option must be unique across all your `pgServices`; therefore if you
 have more than one entry in `pgServices` you must give each additional entry an
@@ -672,7 +672,7 @@ export default {
 };
 ```
 
-:::caution Naming conventions
+:::warning Naming conventions
 
 You can use `pgSettings` to define variables that your Postgres
 functions/policies depend on, or to tweak internal Postgres settings.

--- a/postgraphile/website/postgraphile/custom-queries.md
+++ b/postgraphile/website/postgraphile/custom-queries.md
@@ -148,7 +148,7 @@ filters which can be exposed as GraphQL field arguments — if you reduce the
 amount of data that the function can produce (e.g. to 100 rows) then it reduces
 the potential cost of having this function in your schema.
 
-:::caution Disclaimer
+:::warning Disclaimer
 
 The information in this advice section is not 100% true, for
 example PostgreSQL can “see through” some `SQL` functions and has a highly

--- a/postgraphile/website/postgraphile/default-role.md
+++ b/postgraphile/website/postgraphile/default-role.md
@@ -8,7 +8,7 @@ dependent on a role not already having been set.
 
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/deploying-docker.md
+++ b/postgraphile/website/postgraphile/deploying-docker.md
@@ -2,7 +2,7 @@
 title: Deploying with Docker
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/deploying-gcp.md
+++ b/postgraphile/website/postgraphile/deploying-gcp.md
@@ -2,7 +2,7 @@
 title: Deploying to GCP
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/deploying-heroku.md
+++ b/postgraphile/website/postgraphile/deploying-heroku.md
@@ -2,7 +2,7 @@
 title: Deploying to Heroku
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/deploying-lambda.md
+++ b/postgraphile/website/postgraphile/deploying-lambda.md
@@ -2,7 +2,7 @@
 title: Deploying to AWS Lambda
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/function-gallery.md
+++ b/postgraphile/website/postgraphile/function-gallery.md
@@ -4,7 +4,7 @@ title: Function Gallery
 
 # Database Function Gallery
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/index.md
+++ b/postgraphile/website/postgraphile/index.md
@@ -4,7 +4,7 @@ title: Introduction
 
 # PostGraphile Introduction
 
-:::caution Use the `@beta` tag
+:::warning Use the `@beta` tag
 
 This software is in beta, please be sure to use the `@beta` tag when installing any of the related modules, for example:
 

--- a/postgraphile/website/postgraphile/jwk-verification.md
+++ b/postgraphile/website/postgraphile/jwk-verification.md
@@ -4,7 +4,7 @@ title: JWK Verification (e.g. Auth0)
 
 # PostGraphile JWT/JWK Verification Quickstart
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/live-queries.mdx
+++ b/postgraphile/website/postgraphile/live-queries.mdx
@@ -6,7 +6,7 @@ import Pro from "@site/src/components/Pro";
 import Spon from "@site/src/components/Spon";
 import styles from "@site/src/css/common.module.css";
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/migrating-from-v4/make-wrap-resolvers-plugin.md
+++ b/postgraphile/website/postgraphile/migrating-from-v4/make-wrap-resolvers-plugin.md
@@ -94,7 +94,7 @@ const plugin = makeWrapPlansPlugin({
 });
 ```
 
-:::caution
+:::warning
 
 Plans with side effects are only expected/supported in field plans on the
 `Mutation` type. Side effect plans elsewhere may lead to unexpected results.
@@ -148,7 +148,7 @@ example by storing emails into a `user_emails` table.
 
 :::
 
-:::warning
+:::danger
 
 Though the above example may mask the `email` field when fetched directly, there
 are side channel attacks that someone could use to determine someones email -

--- a/postgraphile/website/postgraphile/performance.md
+++ b/postgraphile/website/postgraphile/performance.md
@@ -2,7 +2,7 @@
 title: Performance
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/postgresql-schema-design.mdx
+++ b/postgraphile/website/postgraphile/postgresql-schema-design.mdx
@@ -608,7 +608,7 @@ comment on column forum_example_private.person_account.email is 'The email addre
 comment on column forum_example_private.person_account.password_hash is 'An opaque hash of the person’s password.';
 ```
 
-:::warning
+:::danger
 
 Never store passwords in plaintext! The `password_hash` column
 will contain the user’s password _after_ it has gone through a secure hashing
@@ -745,7 +745,7 @@ we said users would never be able to insert into
 `forum_example_private.person_account` because it uses the privileges of the
 definer.
 
-:::warning exercise caution when using security definer
+:::danger Exercise caution when using security definer
 
 Make sure that when you create a function with `security definer`
 there are no ‘holes’ a user could use to see or mutate more data than they are
@@ -854,7 +854,7 @@ create role forum_example_person;
 grant forum_example_person to forum_example_postgraphile;
 ```
 
-:::caution warning
+:::warning
 
 The `forum_example_postgraphile` role will have all of the
 permissions of the roles granted to it. So it can do everything

--- a/postgraphile/website/postgraphile/procedures.md
+++ b/postgraphile/website/postgraphile/procedures.md
@@ -2,7 +2,7 @@
 title: Procedures
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/running-postgraphile-as-a-library-in-docker.md
+++ b/postgraphile/website/postgraphile/running-postgraphile-as-a-library-in-docker.md
@@ -2,7 +2,7 @@
 title: Running PostGraphile as a Library in Docker
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/running-postgraphile-in-docker.md
+++ b/postgraphile/website/postgraphile/running-postgraphile-in-docker.md
@@ -2,7 +2,7 @@
 title: Running PostGraphile in Docker
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/smart-tags.md
+++ b/postgraphile/website/postgraphile/smart-tags.md
@@ -622,7 +622,7 @@ table!):
 
 </div>
 
-:::warning Don't rely on @omit for permissions
+:::danger Don't rely on @omit for permissions
 
 This functionality is not intended for implementing permissions,
 it's for removing things from your API that you don't need. You should back

--- a/postgraphile/website/postgraphile/testing-jest.md
+++ b/postgraphile/website/postgraphile/testing-jest.md
@@ -7,7 +7,7 @@ testing there.
 
 ---
 
-:::caution
+:::warning
 
 This documentation is copied from Version 4 and has not been updated to Version
 5 yet; it may not be valid.

--- a/postgraphile/website/postgraphile/usage-cli.mdx
+++ b/postgraphile/website/postgraphile/usage-cli.mdx
@@ -37,7 +37,7 @@ You can then run PostGraphile equivalent to above via:
 npx postgraphile -P postgraphile/presets/amber -e -c postgres:///mydb
 ```
 
-:::caution
+:::warning
 
 The `-e` option should only be used in development.
 

--- a/postgraphile/website/postgraphile/usage-schema.md
+++ b/postgraphile/website/postgraphile/usage-schema.md
@@ -85,7 +85,7 @@ context_ `requestContext`. If you pass these parameters then `grafast` will
 take care of building the _GraphQL context_ for you based on what is in your
 preset.
 
-:::caution
+:::warning[`requestContext` is not the same as GraphQL's `context`]
 
 Do not confuse `requestContext` with the GraphQL context; `requestContext` is
 the parameter passed to your `preset.grafast.context(requestContext)` callback

--- a/postgraphile/website/versioned_docs/version-4/custom-queries.md
+++ b/postgraphile/website/versioned_docs/version-4/custom-queries.md
@@ -176,7 +176,7 @@ filters which can be exposed as GraphQL field arguments - if you reduce the
 amount of data that the function can produce (e.g. to 100 rows) then it reduces
 the potential cost of having this function in your schema.
 
-:::caution Disclaimer
+:::warning Disclaimer
 
 The information in this advice section is not 100% true, for
 example PostgreSQL can "see through" some `SQL` functions and has a highly

--- a/postgraphile/website/versioned_docs/version-4/extending-raw.md
+++ b/postgraphile/website/versioned_docs/version-4/extending-raw.md
@@ -238,17 +238,21 @@ module.exports = function CreateLinkWrapPlugin(builder) {
 
 ### Removing things from the schema
 
-:::warning warning
+:::danger warning
+
 Removing things from your GraphQL schema this way may have
 unintended consequences - especially if you add back a field or type with the
 same name as that which you removed. It's advised that rather than removing
 things, you instead avoid them being generated in the first place.
+
 :::
 
 :::tip
+
 **If you're looking for an easy way to prevent certain tables, fields, functions
 or relations being added to your GraphQL schema, check out
 [smart comments](./smart-comments).**
+
 :::
 
 If you want to remove a class of things from the schema then you can remove the

--- a/postgraphile/website/versioned_docs/version-4/make-extend-schema-plugin.md
+++ b/postgraphile/website/versioned_docs/version-4/make-extend-schema-plugin.md
@@ -747,7 +747,7 @@ Notes:
 
 **This section applies to PostGraphile v4.4.6+**
 
-:::caution bug
+:::danger bug
 
 It seems `@pgQuery` only supports _scalars_ (not _enums_) right now:
 https://github.com/graphile/postgraphile/issues/1601**

--- a/postgraphile/website/versioned_docs/version-4/node-id.md
+++ b/postgraphile/website/versioned_docs/version-4/node-id.md
@@ -25,12 +25,14 @@ export const client = new ApolloClient({
 });
 ```
 
-:::caution warning
+:::tip
+
 By default, we call the Global Object Identifier `nodeId` to avoid
 clashing with the `id` field that's common practice in database design. If you
 wish to call the Global Object Identifier field `id` instead (as is mandated by
 the specification), you can do so with our `--classic-ids` CLI flag. In doing
 so, any `id` column will automatically be renamed to `rowId`.
+
 :::
 
 ### Disabling the Global Object Identifier

--- a/postgraphile/website/versioned_docs/version-4/plugins.mdx
+++ b/postgraphile/website/versioned_docs/version-4/plugins.mdx
@@ -59,7 +59,7 @@ set GRAPHILE_LICENSE="license_key_from_graphile_store" & postgraphile -c postgre
 $env:GRAPHILE_LICENSE="license_key_from_graphile_store"; postgraphile -c postgres://...
 ```
 
-:::caution important
+:::danger important
 
 These plugins do not "phone home" so you'll need to update your
 license at least once every 9 months. You can check the expiry date of your
@@ -153,7 +153,7 @@ app.use(postGraphileMiddleware);
 
 ### Writing your own plugins
 
-:::caution important
+:::warning important
 
 Here be dragons. This interface is experimental, and
 documentation on it is far from complete. To use this interface you are expected

--- a/postgraphile/website/versioned_docs/version-4/postgresql-schema-design.mdx
+++ b/postgraphile/website/versioned_docs/version-4/postgresql-schema-design.mdx
@@ -588,7 +588,7 @@ comment on column forum_example_private.person_account.email is 'The email addre
 comment on column forum_example_private.person_account.password_hash is 'An opaque hash of the person’s password.';
 ```
 
-:::warning
+:::danger
 Never store passwords in plaintext! The `password_hash` column
 will contain the user’s password _after_ it has gone through a secure hashing
 algorithm like [Bcrypt](https://codahale.com/how-to-safely-store-a-password/).
@@ -717,7 +717,7 @@ we said users would never be able to insert into
 `forum_example_private.person_account` because it uses the privileges of the
 definer.
 
-:::warning exercise caution when using security definer
+:::danger Exercise caution when using security definer
 Make sure that when you create a function with `security definer`
 there are no ‘holes’ a user could use to see or mutate more data than they are
 not allowed to. Since the above is a simple function, we are fine. If you
@@ -802,7 +802,7 @@ create role forum_example_person;
 grant forum_example_person to forum_example_postgraphile;
 ```
 
-:::caution warning
+:::warning
 The `forum_example_postgraphile` role will have all of the
 permissions of the roles granted to it. So it can do everything
 `forum_example_anonymous` can do and everything `forum_example_person` can do.
@@ -1018,8 +1018,10 @@ they were originally defined. Since we defined `role`, `person_id` and `exp`,
 this JWT will have a `role` of `forum_example_person`, a `person_id` of
 `account.person_id`, and an `exp` that is two days from now.
 
-:::warning warning
+:::warning
+
 Be careful about logging around this function too.
+
 :::
 
 Now that we know how to get JWTs for our users, let’s use the JWTs.

--- a/postgraphile/website/versioned_docs/version-5/debugging.md
+++ b/postgraphile/website/versioned_docs/version-5/debugging.md
@@ -131,7 +131,7 @@ export default {
 };
 ```
 
-:::warning Disable Explain in production!
+:::danger Disable Explain in production!
 
 Explain should be disabled in production since it could leak information about
 the internals of your schema that would be useful to an attacker.

--- a/postgraphile/website/versioned_docs/version-5/migrating-from-v4/make-wrap-resolvers-plugin.md
+++ b/postgraphile/website/versioned_docs/version-5/migrating-from-v4/make-wrap-resolvers-plugin.md
@@ -148,7 +148,7 @@ example by storing emails into a `user_emails` table.
 
 :::
 
-:::warning
+:::danger
 
 Though the above example may mask the `email` field when fetched directly, there
 are side channel attacks that someone could use to determine someones email -

--- a/utils/website/graphile-config/plugin/middleware.md
+++ b/utils/website/graphile-config/plugin/middleware.md
@@ -95,7 +95,7 @@ middleware functions call `next()`, the next registered middleware is run. Once
 there are no more registered middleware functions for that action, `next()` will
 perform the underlying action that the library defines.
 
-:::warning Here be dragons
+:::danger Here be dragons
 
 When you write a middleware, you are explicitly choosing to change the way in
 which a library functions&mdash;your modified behaviour may not be compatible


### PR DESCRIPTION
## Description

`:::caution` boxes have been deprecated

`:::warning` boxes were undocumented and incorrectly showed a red box with flame icon. They are now yellow boxes with a caution/warning icon. 

We have gone through the documentation and made sure these two types of admonition boxes now display correctly after the Docusaurus v3 upgrade. 