### PR TITLE
Theoretically the ability to add a 'scope' to orderBy

### DIFF
--- a/.changeset/four-weeks-see.md
+++ b/.changeset/four-weeks-see.md
@@ -1,0 +1,8 @@
+---
+"graphile-utils": patch
+"grafast": patch
+---
+
+Add experimental `applyScope()` method to input objects/enums to provide a
+`scope` to `.apply(...)` methods invoked by the undocumented `applyInput()`.
+**Documentation help welcome.**

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -712,6 +712,22 @@ declare global {
 
     interface InputObjectTypeExtensions {
       baked?: InputObjectTypeBakedResolver;
+      /**
+       * EXPERIMENTAL!
+       *
+       * Scope to pass to `.apply()` methods called by `applyInput()` step.
+       *
+       * IMPORTANT: the scope is only evaluated for the top-level named type
+       * that `applyInput()` is applied against, so any type that nests this
+       * (e.g. other input objects) needs to ensure they have an `applyScope()`
+       * that's compatible; similarly this `applyPlan()` needs to supply values
+       * that are compatible with all the descendant input objects, enums and
+       * scalars. For this reason we recommend that you return an object with a
+       * scoped key that you care about so it's easily merged.
+       *
+       * @experimental
+       */
+      applyScope?: () => Step;
     }
 
     interface InputFieldExtensions {
@@ -787,7 +803,22 @@ declare global {
       ): AbstractTypePlanner;
     }
 
-    interface EnumTypeExtensions {}
+    interface EnumTypeExtensions {
+      /**
+       * EXPERIMENTAL!
+       *
+       * Scope to pass to `.apply()` methods called by `applyInput()` step.
+       *
+       * IMPORTANT: the scope is only evaluated for the top-level named type
+       * that `applyInput()` is applied against, so any type that nests this
+       * (e.g. input objects) needs to ensure they have an `applyScope()`
+       * that's compatible. For this reason we recommend that you return an
+       * object with a scoped key that you care about so it's easily merged.
+       *
+       * @experimental
+       */
+      applyScope?: () => Step;
+    }
 
     interface EnumValueExtensions {
       /**
@@ -804,6 +835,20 @@ declare global {
     interface ScalarTypeExtensions {
       plan?: ScalarPlanResolver;
       inputPlan?: ScalarInputPlanResolver;
+      /**
+       * EXPERIMENTAL!
+       *
+       * Scope to pass to `.apply()` methods called by `applyInput()` step.
+       *
+       * IMPORTANT: the scope is only evaluated for the top-level named type
+       * that `applyInput()` is applied against, so any type that nests this
+       * (e.g. input objects) needs to ensure they have an `applyScope()`
+       * that's compatible. For this reason we recommend that you return an
+       * object with a scoped key that you care about so it's easily merged.
+       *
+       * @experimental
+       */
+      applyScope?: () => Step;
       /**
        * Set true if `serialize(serialize(foo)) === serialize(foo)` for all foo
        */

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -7,6 +7,7 @@ import type {
   GraphQLArgs,
   GraphQLArgument,
   GraphQLArgumentConfig,
+  GraphQLEnumValue,
   GraphQLField,
   GraphQLFieldConfig,
   GraphQLInputField,
@@ -374,7 +375,7 @@ export type ScalarInputPlanResolver<TResultStep extends Step = Step> = (
  */
 export type EnumValueApplyResolver<TParent = any> = (
   parent: TParent,
-  info: { scope: any },
+  info: { value: GraphQLEnumValue; scope: any },
 ) => void;
 
 /**

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -304,14 +304,18 @@ export type FieldPlanResolver<
   info: FieldInfo,
 ) => TResultStep | null;
 
-export type InputObjectFieldApplyResolver<TParent = any, TData = any> = (
+export type InputObjectFieldApplyResolver<
+  TParent = any,
+  TData = any,
+  TScope = any,
+> = (
   target: TParent,
   input: TData, // Don't use unknown here, otherwise users can't easily cast it
   info: {
     schema: GraphQLSchema;
     fieldName: string;
     field: GraphQLInputField;
-    scope: any;
+    scope: TScope;
   },
 ) => any;
 
@@ -373,9 +377,9 @@ export type ScalarInputPlanResolver<TResultStep extends Step = Step> = (
  *
  * @experimental
  */
-export type EnumValueApplyResolver<TParent = any> = (
+export type EnumValueApplyResolver<TParent = any, TScope = any> = (
   parent: TParent,
-  info: { value: GraphQLEnumValue; scope: any },
+  info: { value: GraphQLEnumValue; scope: TScope },
 ) => void;
 
 /**

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -310,6 +310,7 @@ export type InputObjectFieldApplyResolver<TParent = any, TData = any> = (
     schema: GraphQLSchema;
     fieldName: string;
     field: GraphQLInputField;
+    scope: any;
   },
 ) => any;
 
@@ -371,7 +372,10 @@ export type ScalarInputPlanResolver<TResultStep extends Step = Step> = (
  *
  * @experimental
  */
-export type EnumValueApplyResolver<TParent = any> = (parent: TParent) => void;
+export type EnumValueApplyResolver<TParent = any> = (
+  parent: TParent,
+  info: { scope: any },
+) => void;
 
 /**
  * Basically GraphQLFieldConfig but with an easy to access `plan` method.

--- a/grafast/grafast/src/steps/applyInput.ts
+++ b/grafast/grafast/src/steps/applyInput.ts
@@ -21,7 +21,6 @@ let inputArgsApplyDepth = 0;
 export class ApplyInputStep<
   TParent extends object = any,
   TTarget extends object = TParent,
-  TScope = any,
 > extends UnbatchedStep<(arg: TParent) => void> {
   static $$export = {
     moduleName: "grafast",
@@ -39,9 +38,10 @@ export class ApplyInputStep<
       | ((
           parent: TParent,
           inputValue: any,
+          info: { scope: unknown },
         ) => TTarget | undefined | (() => TTarget))
       | undefined,
-    $scope?: Step<TScope> | null,
+    $scope?: Step | null,
   ) {
     super();
     this.valueDepId = this.addUnaryDependency($value) as 0;
@@ -90,7 +90,7 @@ export class ApplyInputStep<
     return this;
   }
 
-  unbatchedExecute(extra: UnbatchedExecutionExtra, value: any, scope: TScope) {
+  unbatchedExecute(extra: UnbatchedExecutionExtra, value: any, scope: unknown) {
     const { getTargetFromParent } = this;
     return (parentThing: TParent) =>
       inputArgsApply(
@@ -107,7 +107,6 @@ export class ApplyInputStep<
 export function inputArgsApply<
   TArg extends object,
   TTarget extends object = TArg,
-  TScope = any,
 >(
   schema: GraphQLSchema,
   inputType: GraphQLInputType,
@@ -117,10 +116,10 @@ export function inputArgsApply<
     | ((
         parent: TArg,
         inputValue: any,
-        info: { scope: TScope },
+        info: { scope: unknown },
       ) => TTarget | undefined | (() => TTarget))
     | undefined,
-  scope: TScope,
+  scope: unknown,
 ): void {
   try {
     inputArgsApplyDepth++;
@@ -156,6 +155,7 @@ export function applyInput<
   getTargetFromParent?: (
     parent: TParent,
     inputValue: any,
+    info: { scope: unknown },
   ) => TTarget | undefined,
 ) {
   const opPlan = operationPlan();
@@ -203,12 +203,12 @@ const defaultInputObjectTypeInputPlanResolver: InputObjectTypeInputPlanResolver 
   };
 */
 
-function _inputArgsApply<TArg extends object, TScope = any>(
+function _inputArgsApply<TArg extends object>(
   schema: GraphQLSchema,
   inputType: GraphQLInputType,
   target: TArg | (() => TArg),
   inputValue: unknown,
-  scope: TScope,
+  scope: unknown,
 ): void {
   // PERF: we should have the plan generate a digest of `inputType` so that we
   // can jump right to the relevant parts without too much traversal cost.

--- a/grafast/grafast/src/steps/applyInput.ts
+++ b/grafast/grafast/src/steps/applyInput.ts
@@ -117,7 +117,7 @@ export function inputArgsApply<
     | ((
         parent: TArg,
         inputValue: any,
-        scope: TScope,
+        info: { scope: TScope },
       ) => TTarget | undefined | (() => TTarget))
     | undefined,
   scope: TScope,
@@ -125,7 +125,7 @@ export function inputArgsApply<
   try {
     inputArgsApplyDepth++;
     const target = getTargetFromParent
-      ? getTargetFromParent(parent, inputValue, scope)
+      ? getTargetFromParent(parent, inputValue, { scope })
       : (parent as unknown as TTarget);
     if (target != null) {
       _inputArgsApply<TTarget>(schema, inputType, target, inputValue, scope);

--- a/grafast/grafast/src/steps/applyInput.ts
+++ b/grafast/grafast/src/steps/applyInput.ts
@@ -264,7 +264,7 @@ function _inputArgsApply<TArg extends object, TScope = any>(
     const value = values.find((v) => v.value === inputValue);
     if (value) {
       if (value.extensions.grafast?.apply) {
-        value.extensions.grafast.apply(target, { scope });
+        value.extensions.grafast.apply(target, { scope, value });
       }
     } else {
       throw new Error(`Couldn't find value in ${inputType} for ${inputValue}`);

--- a/grafast/grafast/src/steps/bakedInput.ts
+++ b/grafast/grafast/src/steps/bakedInput.ts
@@ -104,11 +104,25 @@ export function bakedInputRuntime(
       schema,
       applyChildren(parent) {
         applied = true;
-        inputArgsApply(schema, nullableInputType, parent, value, undefined);
+        inputArgsApply(
+          schema,
+          nullableInputType,
+          parent,
+          value,
+          undefined,
+          undefined,
+        );
       },
     });
     if (!applied) {
-      inputArgsApply(schema, nullableInputType, bakedObj, value, undefined);
+      inputArgsApply(
+        schema,
+        nullableInputType,
+        bakedObj,
+        value,
+        undefined,
+        undefined,
+      );
     }
     return bakedObj;
   }

--- a/grafast/website/grafast/step-library/standard-steps/applyInput.md
+++ b/grafast/website/grafast/step-library/standard-steps/applyInput.md
@@ -1,3 +1,10 @@
 # applyInput()
 
 TODO: DOCUMENT ME!
+
+TODO: when documenting me, don't forget about the new `$scope` step you can
+return from input objects and enums, e.g.
+`EnumType.extensions.grafast.applyScope()`, which should yield a value to be
+passed as the `scope` property inside the `info` object in input object fields
+(`inputField.extensions.grafast.apply(target, fieldValue, { scope })`) or enum
+values (`enumValue.extensions.grafast.apply(target, { scope })`).

--- a/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
@@ -10,7 +10,10 @@ import { EXPORTABLE } from "./exportable.js";
 type OrderBySpecIdentity =
   | string // Attribute name
   | Omit<PgOrderSpec, "direction"> // Expression
-  | ((queryBuilder: PgSelectQueryBuilder) => Omit<PgOrderSpec, "direction">); // Callback, allows for joins/etc
+  | ((
+      queryBuilder: PgSelectQueryBuilder,
+      info: { scope: any }, // The `info` argument to `EnumValueApplyResolver`
+    ) => Omit<PgOrderSpec, "direction">); // Callback, allows for joins/etc
 
 export interface MakeAddPgTableOrderByPluginOrders {
   [orderByEnumValue: string]: GraphQLEnumValueConfig;
@@ -155,10 +158,13 @@ export function orderByAscDesc(
       : typeof attributeOrSqlFragment === "function"
         ? EXPORTABLE(
             (ascendingNulls, attributeOrSqlFragment, nullable, unique) =>
-              function apply(queryBuilder: PgSelectQueryBuilder) {
+              function apply(
+                queryBuilder: PgSelectQueryBuilder,
+                info: { scope: any },
+              ) {
                 queryBuilder.orderBy({
                   nulls: ascendingNulls,
-                  ...attributeOrSqlFragment(queryBuilder),
+                  ...attributeOrSqlFragment(queryBuilder, info),
                   direction: "ASC",
                   nullable,
                 } as PgOrderSpec);
@@ -206,10 +212,13 @@ export function orderByAscDesc(
       : typeof attributeOrSqlFragment === "function"
         ? EXPORTABLE(
             (attributeOrSqlFragment, descendingNulls, nullable, unique) =>
-              function apply(queryBuilder: PgSelectQueryBuilder) {
+              function apply(
+                queryBuilder: PgSelectQueryBuilder,
+                info: { scope: any },
+              ) {
                 queryBuilder.orderBy({
                   nulls: descendingNulls,
-                  ...attributeOrSqlFragment(queryBuilder),
+                  ...attributeOrSqlFragment(queryBuilder, info),
                   direction: "DESC",
                   nullable,
                 } as PgOrderSpec);

--- a/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
@@ -12,7 +12,7 @@ type OrderBySpecIdentity =
   | Omit<PgOrderSpec, "direction"> // Expression
   | ((
       queryBuilder: PgSelectQueryBuilder,
-      info: { scope: any }, // The `info` argument to `EnumValueApplyResolver`
+      info: { scope: unknown }, // The `info` argument to `EnumValueApplyResolver`
     ) => Omit<PgOrderSpec, "direction">); // Callback, allows for joins/etc
 
 export interface MakeAddPgTableOrderByPluginOrders {
@@ -160,7 +160,7 @@ export function orderByAscDesc(
             (ascendingNulls, attributeOrSqlFragment, nullable, unique) =>
               function apply(
                 queryBuilder: PgSelectQueryBuilder,
-                info: { scope: any },
+                info: { scope: unknown },
               ) {
                 queryBuilder.orderBy({
                   nulls: ascendingNulls,
@@ -214,7 +214,7 @@ export function orderByAscDesc(
             (attributeOrSqlFragment, descendingNulls, nullable, unique) =>
               function apply(
                 queryBuilder: PgSelectQueryBuilder,
-                info: { scope: any },
+                info: { scope: unknown },
               ) {
                 queryBuilder.orderBy({
                   nulls: descendingNulls,

--- a/postgraphile/website/postgraphile/add-pg-table-order-by.md
+++ b/postgraphile/website/postgraphile/add-pg-table-order-by.md
@@ -44,11 +44,11 @@ export default addPgTableOrderBy(
     const sqlIdentifier = sql.identifier(Symbol("lastPostInForum"));
     return orderByAscDesc(
       "LAST_POST_CREATED_AT",
-      ($select) => {
+      (queryBuilder) => {
         const orderByFrag = sql`(
           select ${sqlIdentifier}.created_at
           from app_public.posts as ${sqlIdentifier}
-          where ${sqlIdentifier}.forum_id = ${$select.alias}.id
+          where ${sqlIdentifier}.forum_id = ${queryBuilder.alias}.id
           order by ${sqlIdentifier}.created_at desc
           limit 1
         )`;
@@ -116,10 +116,10 @@ interface MakeAddPgTableOrderByPluginOrders {
 object) which maps from the name of the enum value to [a
 `GraphQLEnumValueConfig`
 spec](https://graphql.org/graphql-js/type/#graphqlenumtype). Importantly, these
-enum values have an associated `extensions.grafast.applyPlan` method which will
-be used to apply the ordering to the parent PgSelectStep via
-`$select.orderBy(...)`. The `applyPlan` can also choose to set the order as
-unique via `$select.setOrderIsUnique()`, which will mean that the primary key
+enum values have an associated `extensions.grafast.apply` method which will
+be used to apply the ordering to the parent PgSelectQueryBuilder via
+`queryBuilder.orderBy(...)`. The `apply` can also choose to set the order as
+unique via `queryBuilder.setOrderIsUnique()`, which will mean that the primary key
 will not need to be added to the order by clause.
 
 :::tip[Use helpers]
@@ -144,7 +144,10 @@ export function orderByAscDesc(
 type OrderBySpecIdentity =
   | string // Column name
   | Omit<PgOrderSpec, "direction"> // Expression
-  | (($select: PgSelectStep) => Omit<PgOrderSpec, "direction">); // Callback, allows for joins/etc
+  | ((
+      queryBuilder: PgSelectQueryBuilder,
+      info: { scope: any },
+    ) => Omit<PgOrderSpec, "direction">); // Callback, allows for joins/etc
 ```
 
 The `baseName` will have `_ASC` and `_DESC` appended for the two enum values
@@ -195,12 +198,12 @@ or lowest-rated first (meaning the average of the movie’s reviews):
 ```ts
 const customOrderBy = orderByAscDesc(
   "RATING",
-  ($select) => {
+  (queryBuilder) => {
     const sqlIdentifier = sql.identifier(Symbol("movie_reviews"));
     return sql`(
       select avg(${sqlIdentifier}.rating)
       from app_public.movie_reviews as ${sqlIdentifier}
-      where ${sqlIdentifier}.movie_id = ${$select.alias}.id
+      where ${sqlIdentifier}.movie_id = ${queryBuilder.alias}.id
     )`;
   },
   { nulls: "last" },

--- a/postgraphile/website/postgraphile/add-pg-table-order-by.md
+++ b/postgraphile/website/postgraphile/add-pg-table-order-by.md
@@ -146,7 +146,7 @@ type OrderBySpecIdentity =
   | Omit<PgOrderSpec, "direction"> // Expression
   | ((
       queryBuilder: PgSelectQueryBuilder,
-      info: { scope: any },
+      info: { scope: unknown },
     ) => Omit<PgOrderSpec, "direction">); // Callback, allows for joins/etc
 ```
 

--- a/postgraphile/website/postgraphile/add-pg-table-order-by.md
+++ b/postgraphile/website/postgraphile/add-pg-table-order-by.md
@@ -105,7 +105,7 @@ interface MakeAddPgTableOrderByPluginOrders {
   [orderByEnumValue: string]: {
     extensions: {
       grafast: {
-        applyPlan($select: PgSelectStep): void;
+        apply(queryBuilder: PgSelectQueryBuilder): void;
       };
     };
   };


### PR DESCRIPTION
## Description

Fixes:

- #2568

@hos Please a) test this, b) write tests for this, c) scribble up some documentation for this.

Essentially this is to solve the issue you raised. You can:

1. Augment the existing `...OrderBy` type that exists, and give it a `applyScope()` method that returns e.g. `context()` or `object({ locale: get(context(), 'locale') })` or whatever:
   ```ts
   const AddApplyScopeToBlahOrderByPlugin: GraphileConfig.Plugin = {
     name: "AddApplyScopeToBlahOrderByPlugin",
     schema: {
       hooks: {
         GraphQLEnumType(config, build, context) {
           if (config.name === 'BlahOrderBy') {
             const { grafast: { context } } = build;
             config.extensions ??= {};
             config.extensions.grafast ??= {};
             config.extensions.grafast.applyScope = () => context();
           }
           return config;
         }
       }
     }
   }
   ```
2. Access this via `info.scope` in the `orderByAscDesc` callback:

   ```diff
    return orderByAscDesc(
      "LAST_POST_CREATED_AT",
   -  (queryBuilder) => {
   +  (queryBuilder, { scope: { locale } }) => {
        const orderByFrag = sql`(
          select coalesce(
            (
              select ${sqlIdentifier}.value
              from public.translations as ${sqlIdentifier}
              where ${sqlIdentifier}.key = ${queryBuilder.alias}.name
   -            and ${sqlIdentifier}.language = ${/*???*/}
   +            and ${sqlIdentifier}.language = ${sqlValueWithCodec(locale, TYPES.text)}
            ),
            ${queryBuilder.alias}.name
          )
        )`;
        return { fragment: orderByFrag, codec: TYPES.timestamptz };
      },
      { nulls: "last-iff-ascending" },
    );
   ```

## Performance impact

Marginal; I doubt it's measurable in a regular query. Bit more object allocation and GC when it comes to processing enum values on input.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've tasked @hos on adding tests for the new feature.
- [x] I've tasked @hos on detailing the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
