### PR TITLE
Switch from deflate to brotli, compress HTML on the fly

### DIFF
--- a/grafast/grafserv/src/middleware/graphiql.ts
+++ b/grafast/grafserv/src/middleware/graphiql.ts
@@ -14,7 +14,7 @@ import type {
 } from "../interfaces.js";
 import type { OptionsFromConfig } from "../options.js";
 
-const brotliCompress = promisify(brotliCompressCb)
+const brotliCompress = promisify(brotliCompressCb);
 
 export function makeGraphiQLHandler(
   resolvedPreset: GraphileConfig.ResolvedPreset,
@@ -56,24 +56,31 @@ export function makeGraphiQLHandler(
     }
 
     const statusCode = 200;
-    const headers: Record<string, string> = Object.create(null)
-    let payload = Buffer.from(html, 'utf8')
+    const headers: Record<string, string> = Object.create(null);
+    let payload = Buffer.from(html, "utf8");
 
-    const accept = request.getHeader('accept-encoding')
-    if (typeof accept === 'string' && /\bbr\b/.test(accept)) {
-      headers['content-encoding'] = 'br'
+    const accept = request.getHeader("accept-encoding");
+    if (typeof accept === "string" && /\bbr\b/.test(accept)) {
+      headers["content-encoding"] = "br";
       payload = await brotliCompress(payload, {
         params: {
           // No compression is ~3.2KB and 100,000 compresses takes 195ms
           // Level 1 compression is ~1.2KB and 100,000 compresses takes 1.46s
           // Level 5 compression is ~0.96KB and 100,000 compresses takes 3.12s
           // Level 11 compression is ~0.85KB and 100,000 compresses takes 211s
-          [constants.BROTLI_PARAM_QUALITY]: 5
-        }
-      })
+          [constants.BROTLI_PARAM_QUALITY]: 5,
+        },
+      });
     }
 
-    return { type: "html", request, dynamicOptions, statusCode, headers, payload };
+    return {
+      type: "html",
+      request,
+      dynamicOptions,
+      statusCode,
+      headers,
+      payload,
+    };
   };
 }
 

--- a/grafast/grafserv/src/middleware/graphiql.ts
+++ b/grafast/grafserv/src/middleware/graphiql.ts
@@ -57,7 +57,7 @@ export function makeGraphiQLHandler(
 
     let payload = Buffer.from(html, "utf8");
     const accept = request.getHeader("accept-encoding");
-    if (typeof accept === "string" && /\bbr\b/.test(accept)) {
+    if (typeof accept === "string" && /\bbr\b/i.test(accept)) {
       payload = await brotliCompress(payload, {
         params: {
           // No compression is ~3.2KB and 100,000 compresses takes 195ms

--- a/grafast/grafserv/src/middleware/graphiql.ts
+++ b/grafast/grafserv/src/middleware/graphiql.ts
@@ -1,4 +1,5 @@
 import { promisify } from "node:util";
+import type { BrotliOptions } from "node:zlib";
 import { brotliCompress as brotliCompressCb, constants } from "node:zlib";
 
 import type { PromiseOrDirect } from "grafast";
@@ -15,6 +16,20 @@ import type {
 import type { OptionsFromConfig } from "../options.js";
 
 const brotliCompress = promisify(brotliCompressCb);
+
+const BROTLI_OPTIONS: BrotliOptions = {
+  params: {
+    // No compression is ~3.2KB and 100,000 compresses takes 195ms
+    // Level 1 compression is ~1.2KB and 100,000 compresses takes 1.46s
+    // Level 5 compression is ~0.96KB and 100,000 compresses takes 3.12s
+    // Level 11 compression is ~0.85KB and 100,000 compresses takes 211s
+    [constants.BROTLI_PARAM_QUALITY]: 5,
+  },
+};
+const BROTLI_HEADERS = {
+  "content-encoding": "br",
+  "content-type": "text/html; charset=utf-8",
+};
 
 export function makeGraphiQLHandler(
   resolvedPreset: GraphileConfig.ResolvedPreset,
@@ -58,32 +73,11 @@ export function makeGraphiQLHandler(
     let payload = Buffer.from(html, "utf8");
     const accept = request.getHeader("accept-encoding");
     if (typeof accept === "string" && /\bbr\b/i.test(accept)) {
-      payload = await brotliCompress(payload, {
-        params: {
-          // No compression is ~3.2KB and 100,000 compresses takes 195ms
-          // Level 1 compression is ~1.2KB and 100,000 compresses takes 1.46s
-          // Level 5 compression is ~0.96KB and 100,000 compresses takes 3.12s
-          // Level 11 compression is ~0.85KB and 100,000 compresses takes 211s
-          [constants.BROTLI_PARAM_QUALITY]: 5,
-        },
-      });
-      return {
-        type: "raw",
-        request,
-        dynamicOptions,
-        headers: {
-          "content-encoding": "br",
-          "content-type": "text/html; charset=utf-8",
-        },
-        payload,
-      };
+      payload = await brotliCompress(payload, BROTLI_OPTIONS);
+      const headers = BROTLI_HEADERS;
+      return { type: "raw", request, dynamicOptions, headers, payload };
     } else {
-      return {
-        type: "html",
-        request,
-        dynamicOptions,
-        payload,
-      };
+      return { type: "html", request, dynamicOptions, payload };
     }
   };
 }

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -94,7 +94,7 @@ const baseElements = html`
   </div>
 `;
 const baseBodyScripts = html`
-  <script>
+  <script type="module">
     const $ = (s) => document.querySelector(s);
     if (!localStorage.getItem("graphiql:visiblePlugin")) {
       $(".graphiql-plugin").style.display = "none";

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -18,6 +18,14 @@ const escapeJS = (str: string) => {
     .replaceAll("<script", "<\\script");
 };
 
+const ENTITIES: Record<string, string> = {
+  "&": "&amp;",
+  '"': "&quot;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+const escapeHTML = (str: string) => str.replace(/[&"<>]/g, (c) => ENTITIES[c]!);
+
 function trim(arr: TemplateStringsArray, ...placeholders: string[]) {
   const final = arr
     .map((str, i) => (i === 0 ? str : placeholders[i - 1] + str))
@@ -25,9 +33,6 @@ function trim(arr: TemplateStringsArray, ...placeholders: string[]) {
   return final.trim().replace(/^\s+/gm, "");
 }
 
-const baseMetaTags = trim`
-<meta charset="utf-8" />
-`;
 const baseTitleTag = trim`
 <title>Ruru - GraphQL/Grafast IDE</title>
 `;
@@ -120,6 +125,13 @@ export function makeHTMLParts(config: RuruServerConfig): RuruHTMLParts {
     subscriptionEndpoint,
   };
 
+  const baseMetaTags = trim`
+<meta charset="utf-8" />
+<link rel="modulepreload" href="${escapeHTML(staticPath + "ruru.js")}" />
+<link rel="modulepreload" href="${escapeHTML(staticPath + "jsonWorker.js")}" as="worker" />
+<link rel="modulepreload" href="${escapeHTML(staticPath + "graphqlWorker.js")}" as="worker" />
+<link rel="modulepreload" href="${escapeHTML(staticPath + "editorWorker.js")}" as="worker" />
+`;
   const baseStyleTags = trim`
 <link rel="stylesheet" href="${staticPath}ruru.css" />
 <style>

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -82,6 +82,8 @@ const baseElements = /* HTML */ trim`<div id="ruru-root">
     </div>
   </div>
 </div>
+`;
+const baseBodyScripts = trim`
 <script>
   const $ = s => document.querySelector(s);
   if (!localStorage.getItem('graphiql:visiblePlugin')) {
@@ -93,8 +95,8 @@ const baseElements = /* HTML */ trim`<div id="ruru-root">
     const val = localStorage.getItem('graphiql:' + key);
     if (val) $(sel).style.flex = val + " 1 0%";
   }
-</script>`;
-const baseBodyScripts = ``;
+</script>
+`;
 
 export interface RuruServerConfig extends RuruConfig {
   // ----- Legacy -----
@@ -160,7 +162,8 @@ export function makeHTMLParts(config: RuruServerConfig): RuruHTMLParts {
   import { React, createRoot, Ruru } from ${JSON.stringify(staticPath + "ruru.js")};
   createRoot(document.getElementById("ruru-root"))
     .render(React.createElement(Ruru, RURU_CONFIG));
-</script>`;
+</script>
+`;
   const parts: RuruHTMLParts = {
     metaTags: baseMetaTags,
     titleTag: baseTitleTag,

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -26,76 +26,89 @@ const ENTITIES: Record<string, string> = {
 };
 const escapeHTML = (str: string) => str.replace(/[&"<>]/g, (c) => ENTITIES[c]!);
 
-function trim(arr: TemplateStringsArray, ...placeholders: string[]) {
+function html(arr: TemplateStringsArray, ...placeholders: string[]) {
   const final = arr
     .map((str, i) => (i === 0 ? str : placeholders[i - 1] + str))
     .join("");
   return final.trim().replace(/^\s+/gm, "");
 }
 
-const baseTitleTag = trim`
-<title>Ruru - GraphQL/Grafast IDE</title>
-`;
-const baseElements = /* HTML */ trim`<div id="ruru-root">
-  <div class="graphiql-container">
-    <div class="graphiql-sidebar"></div>
-    <div class="graphiql-main">
-      <div class="graphiql-plugin" style="min-width: 200px; flex: 0.333333 1 0%;">
-        <div>
-          <div class="graphiql-doc-explorer-header">
-            <div class="graphiql-doc-explorer-title">Loading...</div>
-          </div>
-          <div class="graphiql-doc-explorer-content">
-            <p>Ruru is loading, this should only take a moment...</p>
-          </div>
-        </div>
-      </div>
-      <div class="graphiql-horizontal-drag-bar"></div>
-      <div class="graphiql-sessions" style="flex: 1 1 0%;">
-        <div class="graphiql-session-header">
-          <ul role="tablist" class="graphiql-tabs no-scrollbar">
-            <li class="graphiql-tab graphiql-tab-active">
-              <button type="button" class="graphiql-un-styled graphiql-tab-button" disabled>
-                Loading...
-              </button>
-            </li>
-          </ul>
-        </div>
-        <div role="tabpanel" id="graphiql-session">
-          <div class="graphiql-editors" style="flex: 1 1 0%;">
-            <section class="graphiql-query-editor" style="flex: 3 1 0%;">
-              <div class="graphiql-editor"></div>
-              <div class="graphiql-toolbar"></div>
-            </section>
-            <div class="graphiql-editor-tools">
-              <button type="button" class="graphiql-un-styled active" disabled>
-                &nbsp;
-              </button>
+const baseTitleTag = html` <title>Ruru - GraphQL/Grafast IDE</title> `;
+const baseElements = html`
+  <div id="ruru-root">
+    <div class="graphiql-container">
+      <div class="graphiql-sidebar"></div>
+      <div class="graphiql-main">
+        <div
+          class="graphiql-plugin"
+          style="min-width: 200px; flex: 0.333333 1 0%;"
+        >
+          <div>
+            <div class="graphiql-doc-explorer-header">
+              <div class="graphiql-doc-explorer-title">Loading...</div>
+            </div>
+            <div class="graphiql-doc-explorer-content">
+              <p>Ruru is loading, this should only take a moment...</p>
             </div>
           </div>
-          <div class="graphiql-horizontal-drag-bar"></div>
-          <div class="graphiql-response" style="flex: 1 1 0%;">
-            <section class="result-window"></section>
+        </div>
+        <div class="graphiql-horizontal-drag-bar"></div>
+        <div class="graphiql-sessions" style="flex: 1 1 0%;">
+          <div class="graphiql-session-header">
+            <ul role="tablist" class="graphiql-tabs no-scrollbar">
+              <li class="graphiql-tab graphiql-tab-active">
+                <button
+                  type="button"
+                  class="graphiql-un-styled graphiql-tab-button"
+                  disabled
+                >
+                  Loading...
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div role="tabpanel" id="graphiql-session">
+            <div class="graphiql-editors" style="flex: 1 1 0%;">
+              <section class="graphiql-query-editor" style="flex: 3 1 0%;">
+                <div class="graphiql-editor"></div>
+                <div class="graphiql-toolbar"></div>
+              </section>
+              <div class="graphiql-editor-tools">
+                <button
+                  type="button"
+                  class="graphiql-un-styled active"
+                  disabled
+                >
+                  &nbsp;
+                </button>
+              </div>
+            </div>
+            <div class="graphiql-horizontal-drag-bar"></div>
+            <div class="graphiql-response" style="flex: 1 1 0%;">
+              <section class="result-window"></section>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 `;
-const baseBodyScripts = trim`
-<script>
-  const $ = s => document.querySelector(s);
-  if (!localStorage.getItem('graphiql:visiblePlugin')) {
-    $('.graphiql-plugin').style.display = 'none';
-    $('.graphiql-horizontal-drag-bar').style.display = 'none';
-  }
-  const flexes = [['docExplorerFlex','.graphiql-plugin'], ['editorFlex','.graphiql-editors']];
-  for (const [key, sel] of flexes) {
-    const val = localStorage.getItem('graphiql:' + key);
-    if (val) $(sel).style.flex = val + " 1 0%";
-  }
-</script>
+const baseBodyScripts = html`
+  <script>
+    const $ = (s) => document.querySelector(s);
+    if (!localStorage.getItem("graphiql:visiblePlugin")) {
+      $(".graphiql-plugin").style.display = "none";
+      $(".graphiql-horizontal-drag-bar").style.display = "none";
+    }
+    const flexes = [
+      ["docExplorerFlex", ".graphiql-plugin"],
+      ["editorFlex", ".graphiql-editors"],
+    ];
+    for (const [key, sel] of flexes) {
+      const val = localStorage.getItem("graphiql:" + key);
+      if (val) $(sel).style.flex = val + " 1 0%";
+    }
+  </script>
 `;
 
 export interface RuruServerConfig extends RuruConfig {
@@ -127,43 +140,71 @@ export function makeHTMLParts(config: RuruServerConfig): RuruHTMLParts {
     subscriptionEndpoint,
   };
 
-  const baseMetaTags = trim`
-<meta charset="utf-8" />
-<link rel="modulepreload" href="${escapeHTML(staticPath + "ruru.js")}" />
-<link rel="modulepreload" href="${escapeHTML(staticPath + "jsonWorker.js")}" as="worker" />
-<link rel="modulepreload" href="${escapeHTML(staticPath + "graphqlWorker.js")}" as="worker" />
-<link rel="modulepreload" href="${escapeHTML(staticPath + "editorWorker.js")}" as="worker" />
-`;
-  const baseStyleTags = trim`
-<link rel="stylesheet" href="${staticPath}ruru.css" />
-<style>
-  body{margin:0;}
-  #ruru-root {height:100vh;}
-</style>`;
-  const baseConfigScript = trim`
-<script>const RURU_CONFIG = ${escapeJS(JSON.stringify(clientConfig))};</script>`;
-  const baseHeaderScripts = trim`
-<script type="module">
-  const worker = (file) =>
-    new Worker(new URL(${JSON.stringify(staticPath)} + file, import.meta.url), { type: "module" });
-  globalThis.MonacoEnvironment = {
-    getWorker(_, label) {
-      switch (label) {
-        case "json": return worker('jsonWorker.js');
-        case "graphql": return worker('graphqlWorker.js');
-        default: return worker('editorWorker.js');
+  const baseMetaTags = html`
+    <meta charset="utf-8" />
+    <link rel="modulepreload" href="${escapeHTML(staticPath + "ruru.js")}" />
+    <link
+      rel="modulepreload"
+      href="${escapeHTML(staticPath + "jsonWorker.js")}"
+      as="worker"
+    />
+    <link
+      rel="modulepreload"
+      href="${escapeHTML(staticPath + "graphqlWorker.js")}"
+      as="worker"
+    />
+    <link
+      rel="modulepreload"
+      href="${escapeHTML(staticPath + "editorWorker.js")}"
+      as="worker"
+    />
+  `;
+  const baseStyleTags = html`
+    <link rel="stylesheet" href="${staticPath}ruru.css" />
+    <style>
+      body {
+        margin: 0;
       }
-    }
-  }
-</script>
-`;
-  const baseBodyInitScript = trim`
-<script type="module">
-  import { React, createRoot, Ruru } from ${JSON.stringify(staticPath + "ruru.js")};
-  createRoot(document.getElementById("ruru-root"))
-    .render(React.createElement(Ruru, RURU_CONFIG));
-</script>
-`;
+      #ruru-root {
+        height: 100vh;
+      }
+    </style>
+  `;
+  const baseConfigScript = html`
+    <script>
+      const RURU_CONFIG = ${escapeJS(JSON.stringify(clientConfig))};
+    </script>
+  `;
+  const baseHeaderScripts = html`
+    <script type="module">
+      const worker = (file) =>
+        new Worker(
+          new URL(${JSON.stringify(staticPath)} + file, import.meta.url),
+          { type: "module" },
+        );
+      globalThis.MonacoEnvironment = {
+        getWorker(_, label) {
+          switch (label) {
+            case "json":
+              return worker("jsonWorker.js");
+            case "graphql":
+              return worker("graphqlWorker.js");
+            default:
+              return worker("editorWorker.js");
+          }
+        },
+      };
+    </script>
+  `;
+  const baseBodyInitScript = html`
+    <script type="module">
+      import { React, createRoot, Ruru } from ${JSON.stringify(
+        staticPath + "ruru.js",
+      )};
+      createRoot(document.getElementById("ruru-root"))
+        .render(React.createElement(Ruru, RURU_CONFIG));
+    </script>
+  `;
   const parts: RuruHTMLParts = {
     metaTags: baseMetaTags,
     titleTag: baseTitleTag,


### PR DESCRIPTION
- Reduces HTML payload from 4kB to 1.2kB
- Reduces ruru.js from 1.4MB to 1.06MB
- Adds preload for various things
