### PR TITLE
Implement workaround for loading worker files from remote URLs

### DIFF
--- a/.changeset/petite-turkeys-matter.md
+++ b/.changeset/petite-turkeys-matter.md
@@ -1,0 +1,5 @@
+---
+"ruru": patch
+---
+
+Fix loading worker scripts from remote URLs.

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -143,21 +143,6 @@ export function makeHTMLParts(config: RuruServerConfig): RuruHTMLParts {
   const baseMetaTags = html`
     <meta charset="utf-8" />
     <link rel="modulepreload" href="${escapeHTML(staticPath + "ruru.js")}" />
-    <link
-      rel="modulepreload"
-      href="${escapeHTML(staticPath + "jsonWorker.js")}"
-      as="worker"
-    />
-    <link
-      rel="modulepreload"
-      href="${escapeHTML(staticPath + "graphqlWorker.js")}"
-      as="worker"
-    />
-    <link
-      rel="modulepreload"
-      href="${escapeHTML(staticPath + "editorWorker.js")}"
-      as="worker"
-    />
   `;
   const baseStyleTags = html`
     <link rel="stylesheet" href="${staticPath}ruru.css" />


### PR DESCRIPTION
No idea why this works... but it fixes an issue serving Ruru from unpkg.com due to cross-origin permissions issues.