### PR TITLE
Fix eslint-plugin-graphile-export to support member expressions

### DIFF
--- a/.changeset/tangy-papers-repair.md
+++ b/.changeset/tangy-papers-repair.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-graphile-export": patch
+---
+
+Lint plugin now supports `build.EXPORTABLE` expressions.

--- a/utils/eslint-plugin-graphile-export/src/ExhaustiveDeps.ts
+++ b/utils/eslint-plugin-graphile-export/src/ExhaustiveDeps.ts
@@ -23,6 +23,7 @@ import type {
 } from "estree";
 
 import { fastFindReferenceWithParent, reportProblem } from "./common.js";
+import { isExportableCall } from "./utils.js";
 
 interface CommonOptions {
   disableAutofix: boolean;
@@ -451,7 +452,7 @@ export const ExhaustiveDeps: Rule.RuleModule = {
 
     return {
       CallExpression(node) {
-        const callbackIndex = getScopesCallbackIndex(node.callee);
+        const callbackIndex = getScopesCallbackIndex(node);
         if (callbackIndex === -1) {
           // Not a EXPORTABLE call that needs deps.
           return;
@@ -762,7 +763,7 @@ function analyzePropertyChain(node: Node | ESTreeNode): string {
 function getScopesCallbackIndex(
   node: Expression | Super | ESTreeExpression | ESTreeSuper,
 ) {
-  if (node.type === "Identifier" && node.name === "EXPORTABLE") {
+  if (isExportableCall(node)) {
     return 0;
   } else {
     return -1;

--- a/utils/eslint-plugin-graphile-export/src/NoNested.ts
+++ b/utils/eslint-plugin-graphile-export/src/NoNested.ts
@@ -1,4 +1,3 @@
-import type { CallExpression } from "@babel/types";
 import type { Rule } from "eslint";
 import type { Node as ESTreeNode } from "estree";
 

--- a/utils/eslint-plugin-graphile-export/src/NoNested.ts
+++ b/utils/eslint-plugin-graphile-export/src/NoNested.ts
@@ -88,4 +88,3 @@ export function hasExportableParent(node: any): boolean {
   }
   return false;
 }
-

--- a/utils/eslint-plugin-graphile-export/src/NoNested.ts
+++ b/utils/eslint-plugin-graphile-export/src/NoNested.ts
@@ -3,6 +3,7 @@ import type { Rule } from "eslint";
 import type { Node as ESTreeNode } from "estree";
 
 import { reportProblem } from "./common.js";
+import { isExportableCall } from "./utils.js";
 
 interface CommonOptions {
   disableAutofix: boolean;
@@ -89,10 +90,3 @@ export function hasExportableParent(node: any): boolean {
   return false;
 }
 
-function isExportableCall(node: any): node is CallExpression {
-  return (
-    node.type === "CallExpression" &&
-    node.callee.type === "Identifier" &&
-    node.callee.name === "EXPORTABLE"
-  );
-}

--- a/utils/eslint-plugin-graphile-export/src/utils.ts
+++ b/utils/eslint-plugin-graphile-export/src/utils.ts
@@ -1,0 +1,10 @@
+import type { CallExpression } from "@babel/types";
+
+export function isExportableCall(node: any): node is CallExpression {
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === "EXPORTABLE"
+  );
+}
+

--- a/utils/eslint-plugin-graphile-export/src/utils.ts
+++ b/utils/eslint-plugin-graphile-export/src/utils.ts
@@ -1,10 +1,16 @@
 import type { CallExpression } from "@babel/types";
 
 export function isExportableCall(node: any): node is CallExpression {
-  return (
-    node.type === "CallExpression" &&
-    node.callee.type === "Identifier" &&
-    node.callee.name === "EXPORTABLE"
-  );
+  return node.type === "CallExpression" && isEXPORTABLE(node.callee);
 }
 
+export function isEXPORTABLE(node: any): boolean {
+  switch (node.type) {
+    case "Identifier":
+      return node.name === "EXPORTABLE";
+    case "MemberExpression":
+      return isEXPORTABLE(node.property);
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
Previously we only supported `EXPORTABLE(...)`; we now also support `build.EXPORTABLE(...)` (i.e. "MemberExpression"s).