### PR TITLE
Fix ruruHTML function for some users

### DIFF
--- a/.changeset/sour-paws-bathe.md
+++ b/.changeset/sour-paws-bathe.md
@@ -1,0 +1,6 @@
+---
+"ruru": patch
+---
+
+Improve backwards compatibility of ruruHTML function; explicitly deprecate the
+htmlParts argument.

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -227,10 +227,21 @@ export function makeHTMLParts(config: RuruServerConfig): RuruHTMLParts {
   return parts;
 }
 
+/**
+ * Generate the HTML file to serve Ruru.
+ *
+ * @param config Configuration
+ * @param deprecatedHTMLParts @deprecated Use config.htmlParts instead.
+ */
 export function ruruHTML(
   config: RuruServerConfig,
-  htmlParts = makeHTMLParts(config),
+  /** @deprecated */
+  deprecatedHTMLParts?: Partial<RuruHTMLParts>,
 ) {
+  const partsFromConfig = makeHTMLParts(config);
+  const htmlParts = deprecatedHTMLParts
+    ? { ...partsFromConfig, ...deprecatedHTMLParts }
+    : partsFromConfig;
   return `\
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
It seems some users were passing empty object to `htmlParts` resulting in broken output. This option is now explicitly deprecated, and we back-fill the values just in case.