### PR TITLE
PostGraphile website: add DocCardList

### DIFF
--- a/postgraphile/website/postgraphile/extending.mdx
+++ b/postgraphile/website/postgraphile/extending.mdx
@@ -2,6 +2,8 @@
 title: GraphQL Schema Plugins
 ---
 
+import DocCardList from "@theme/DocCardList";
+
 PostGraphile’s schema generator is built from a number of
 [graphile-build plugins](https://build.graphile.org/graphile-build/5/plugins). You can
 write your own plugins — either using the helpers available in `graphile-utils`,
@@ -73,3 +75,7 @@ Remember: multiple versions of `graphql` in your `node_modules` will cause
 problems; so we **strongly** recommend using the `graphql` object that's
 available on the `Build` object (second argument to hooks) rather than requiring
 your own version.
+
+### Schema plugins
+
+<DocCardList />

--- a/postgraphile/website/versioned_docs/version-4/examples/index.mdx
+++ b/postgraphile/website/versioned_docs/version-4/examples/index.mdx
@@ -3,6 +3,8 @@ title: PostGraphile Example Gallery
 sidebar_position: 1
 ---
 
+import DocCardList from "@theme/DocCardList";
+
 # Example queries and mutations
 
 _If you are new to GraphQL then we recommend you read through the official
@@ -23,3 +25,5 @@ following commands:
 yarn add postgraphile @graphile-contrib/pg-simplify-inflector
 yarn postgraphile --append-plugins @graphile-contrib/pg-simplify-inflector
 ```
+
+<DocCardList />

--- a/postgraphile/website/versioned_docs/version-4/extending.mdx
+++ b/postgraphile/website/versioned_docs/version-4/extending.mdx
@@ -2,6 +2,8 @@
 title: Schema Plugins
 ---
 
+import DocCardList from "@theme/DocCardList";
+
 # GraphQL Schema Plugins
 
 PostGraphile's schema generator is built from a number of
@@ -86,3 +88,7 @@ Remember: multiple versions of `graphql` in your `node_modules` will cause
 problems; so we **strongly** recommend using the `graphql` object that's
 available on the `Build` object (second argument to hooks) rather than requiring
 your own version.
+
+### Schema Plugins
+
+<DocCardList />

--- a/postgraphile/website/versioned_docs/version-4/plugin-gallery/index.mdx
+++ b/postgraphile/website/versioned_docs/version-4/plugin-gallery/index.mdx
@@ -2,6 +2,10 @@
 title: PostGraphile Plugin Gallery
 ---
 
+import DocCardList from "@theme/DocCardList";
+
 In this section, you'll find some small plugins that people have written. Larger plugins likely have their own dedicated repositories, these are typically just examples of how to achieve a small goal.
 
 _This is a work in progress, in future these plugins will be automatically tested but we've not got quite that far yet, so my apologies if you come across any issues._
+
+<DocCardList />


### PR DESCRIPTION
## Description

Add `DocCardList` to some category style pages to make the page make more sense: 

<img width="687" height="531" alt="Screenshot 2025-07-15 at 11 45 32" src="https://github.com/user-attachments/assets/164c731e-4a80-4420-a9a8-34a74b65761e" />
