### PR TITLE
Faster webpack in dev

### DIFF
--- a/grafast/ruru/package.json
+++ b/grafast/ruru/package.json
@@ -31,7 +31,7 @@
     "webpack": "node --loader ts-node/esm \"$(yarn bin webpack-cli)\" --config webpack.config.mts",
     "watch": "yarn webpack --watch --mode=development",
     "make-ruru-html": "node --experimental-strip-types scripts/make-ruru-html.mts",
-    "prepack": "rm -Rf dist static tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo && yarn webpack --mode=production && tsc -b tsconfig.build.json && cp src/.npmignore dist/ && chmod +x dist/cli-run.js && yarn make-ruru-html"
+    "prepack": "rm -Rf dist static tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo && yarn webpack --mode=${BUILD_MODE:-production} && tsc -b tsconfig.build.json && cp src/.npmignore dist/ && chmod +x dist/cli-run.js && yarn make-ruru-html"
   },
   "repository": {
     "type": "git",

--- a/grafast/ruru/webpack.config.mts
+++ b/grafast/ruru/webpack.config.mts
@@ -80,10 +80,13 @@ class OutputDataToSrcPlugin {
         const buf = Buffer.isBuffer(source) ? source : Buffer.from(source);
         const compressed = brotliCompressSync(buf, {
           params: {
-            [constants.BROTLI_PARAM_QUALITY]: 11, // max compression
-          }
+            [constants.BROTLI_PARAM_QUALITY]:
+              compiler.options.mode === "production" ? 11 : 1, // max compression for prod, min for dev
+          },
         });
-        const hash = createHash("sha256").update(compressed).digest("base64url");
+        const hash = createHash("sha256")
+          .update(compressed)
+          .digest("base64url");
         const etag = `"sha256-${hash}"`; // quoted per HTTP spec
         const base64 = compressed.toString("base64");
         const sourceLine = `\

--- a/grafast/ruru/webpack.config.mts
+++ b/grafast/ruru/webpack.config.mts
@@ -1,12 +1,15 @@
 import { createHash } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { brotliCompressSync, constants } from "node:zlib";
+import { promisify } from "node:util";
+import { brotliCompress as brotliCompressCb, constants } from "node:zlib";
 
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import type { Compiler, Configuration, Resolver } from "webpack";
 // import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
+
+const brotliCompress = promisify(brotliCompressCb);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -70,37 +73,48 @@ const outro = ["};", ""];
 
 class OutputDataToSrcPlugin {
   apply(compiler: Compiler) {
-    compiler.hooks.emit.tap("OutputDataToSrcPlugin", (compilation) => {
-      const code: string[] = [...intro];
-      const meta: string[] = [...intro];
-      const entries = Object.entries(compilation.assets);
-      entries.sort((a, z) => (a[0] < z[0] ? -1 : a[0] > z[0] ? 1 : 0));
-      for (const [filename, asset] of entries) {
-        const source = asset.source();
-        const buf = Buffer.isBuffer(source) ? source : Buffer.from(source);
-        const compressed = brotliCompressSync(buf, {
-          params: {
-            [constants.BROTLI_PARAM_QUALITY]:
-              compiler.options.mode === "production" ? 11 : 1, // max compression for prod, min for dev
-          },
-        });
-        const hash = createHash("sha256")
-          .update(compressed)
-          .digest("base64url");
-        const etag = `"sha256-${hash}"`; // quoted per HTTP spec
-        const base64 = compressed.toString("base64");
-        const sourceLine = `\
+    compiler.hooks.emit.tapPromise(
+      "OutputDataToSrcPlugin",
+      async (compilation) => {
+        const code: string[] = [...intro];
+        const meta: string[] = [...intro];
+        const entries = Object.entries(compilation.assets);
+        entries.sort((a, z) => (a[0] < z[0] ? -1 : a[0] > z[0] ? 1 : 0));
+        const toAdd = await Promise.all(
+          entries.map(async ([filename, asset]) => {
+            const source = asset.source();
+            const buf = Buffer.isBuffer(source) ? source : Buffer.from(source);
+            const compressed = await brotliCompress(buf, {
+              params: {
+                [constants.BROTLI_PARAM_QUALITY]:
+                  compiler.options.mode === "production" ? 11 : 1, // max compression for prod, min for dev
+              },
+            });
+            const hash = createHash("sha256")
+              .update(compressed)
+              .digest("base64url");
+            const etag = `"sha256-${hash}"`; // quoted per HTTP spec
+            const base64 = compressed.toString("base64");
+            const sourceLine = `\
   ${JSON.stringify(filename)}: {
     etag: ${JSON.stringify(etag)},
     buffer: Buffer.from(${JSON.stringify(base64)}, "base64"),
   },`;
-        (isDevAsset(filename) ? meta : code).push(sourceLine);
-      }
-      code.push(...outro);
-      meta.push(...outro);
-      writeFileSync(`${__dirname}/src/bundleCode.ts`, code.join("\n"));
-      writeFileSync(`${__dirname}/src/bundleMeta.ts`, meta.join("\n"));
-    });
+            return [isDevAsset(filename) ? meta : code, sourceLine] as const;
+          }),
+        );
+        // To ensure they're added in order
+        for (const [target, line] of toAdd) {
+          target.push(line);
+        }
+        code.push(...outro);
+        meta.push(...outro);
+        await Promise.all([
+          writeFile(`${__dirname}/src/bundleCode.ts`, code.join("\n")),
+          writeFile(`${__dirname}/src/bundleMeta.ts`, meta.join("\n")),
+        ]);
+      },
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "posttest": "NODE_ENV=test yarn workspaces foreach --all --topological run posttest && node scripts/benjies-depcheck.mjs",
     "prepack:all": "scripts/prepack-all",
     "build": "yarn && yarn workspace ruru-components prepack && yarn workspace ruru prepack && tsc -b",
-    "watch": "yarn build && tsc -b --watch",
+    "watch": "BUILD_MODE=development yarn build && tsc -b --watch",
     "clean": "( jest --clearCache || true ) && ( rm -Rf {utils,grafast,graphile-build,postgraphile}/*/{dist,bundle,tsconfig.tsbuildinfo,tsconfig.*.tsbuildinfo} postgraphile/postgraphile/.tests_tmp/ grafast/ruru/static grafast/ruru/src/bundleCode.ts grafast/ruru/src/bundleMeta.ts || true )",
     "tsc:watch:clean": "( rm -Rf {utils,grafast,graphile-build,postgraphile}/*/{dist,tsconfig.tsbuildinfo,tsconfig.*.tsbuildinfo} || true ) && tsc -b --watch",
     "changeset:version": "yarn changeset version && node scripts/postversion.mjs",


### PR DESCRIPTION
- Fixes #2628

Solution:

- detect dev mode, and only use compression 1 in dev mode
- parallelize the brotli compression, rather than doing it sync
- parallelize file writing

Back to just a couple seconds in development now.