### PR TITLE
Add condensed mode to Ruru (enabled by default)

### DIFF
--- a/.changeset/cool-news-nail.md
+++ b/.changeset/cool-news-nail.md
@@ -1,0 +1,7 @@
+---
+"ruru-components": patch
+"ruru": patch
+---
+
+Add condensed mode for Ruru, enabled by default. (To disable, use the settings
+cog in the editor view and uncheck condensed.)

--- a/grafast/ruru-components/ruru.css
+++ b/grafast/ruru-components/ruru.css
@@ -76,3 +76,109 @@
   font-size: 0.75rem;
   white-space: pre-wrap;
 }
+
+.ruru-footer {
+  padding: 10px var(--px-8) 10px var(--px-8);
+}
+
+/* Ruru overrides for GraphiQL styles */
+
+.graphiql-explorer-root input {
+  /* Fixes 'ch' unit inputs so text isn't truncated */
+  font-family: var(--font-family-mono);
+  padding: 0;
+}
+
+.graphiql-container {
+  button,
+  button:focus {
+    outline: 0;
+  }
+}
+
+/* condensed layout */
+.graphiql-container {
+  --sidebar-width: 40px;
+  --line-height: 1.25;
+  --session-header-height: 34.5px;
+  --font-size-caption: 1rem;
+
+  .graphiql-sessions {
+    border-radius: 0;
+    margin: 0;
+  }
+
+  .graphiql-plugin {
+    padding: var(--px-8);
+  }
+
+  .graphiql-explorer-graphql-arguments > div > span > svg {
+    margin-top: 3px;
+    margin-bottom: -3px;
+  }
+
+  .graphiql-editor-tools {
+    padding: 0;
+  }
+  .graphiql-editor-tools > button,
+  .graphiql-tab {
+    outline: 0;
+    border-bottom: 3px solid transparent;
+    border-radius: 0;
+  }
+  .graphiql-editor-tools > button.active,
+  .graphiql-tab.graphiql-tab-active {
+    border-bottom-color: hsl(var(--color-primary));
+  }
+  .graphiql-tab {
+    background: none;
+    &:hover {
+      background-color: hsla(
+        var(--color-neutral),
+        var(--alpha-background-light)
+      );
+    }
+    &.graphiql-tab-active {
+      background-color: var(--bg);
+    }
+  }
+  .graphiql-query-editor,
+  .graphiql-editor-tool {
+    padding: var(--px-8);
+  }
+
+  .graphiql-session-header,
+  #graphiql-session {
+    padding: 0;
+    padding-right: var(--px-8);
+    height: initial;
+  }
+  .graphiql-session-header {
+    padding-top: var(--px-8);
+  }
+  .graphiql-horizontal-drag-bar {
+    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
+    width: var(--px-8);
+  }
+  #graphiql-session .graphiql-horizontal-drag-bar {
+    background-color: transparent;
+  }
+  .graphiql-editors {
+    box-shadow: none;
+    border-radius: 0;
+    border-top-right-radius: 13px;
+  }
+  .graphiql-tab-button {
+    border-radius: 0;
+  }
+  .graphiql-logo {
+    padding-right: var(--px-8);
+  }
+  .graphiql-doc-explorer-content > * {
+    margin-top: var(--px-16);
+  }
+  .graphiql-doc-explorer-section-content > * + *,
+  .graphiql-markdown-description {
+    margin-top: var(--px-8);
+  }
+}

--- a/grafast/ruru-components/ruru.css
+++ b/grafast/ruru-components/ruru.css
@@ -120,10 +120,15 @@
   .graphiql-editor-tools {
     padding: 0;
   }
+  .graphiql-tabs {
+    border-radius: 0;
+    padding: 0;
+  }
   .graphiql-editor-tools > button,
   .graphiql-tab {
     outline: 0;
     border-bottom: 3px solid transparent;
+    border-top: 3px solid transparent;
     border-radius: 0;
   }
   .graphiql-editor-tools > button.active,
@@ -155,9 +160,6 @@
     padding: 0;
     padding-right: var(--px-8);
     height: initial;
-  }
-  .graphiql-session-header {
-    padding-top: var(--px-8);
   }
   .graphiql-horizontal-drag-bar {
     background-color: hsla(var(--color-neutral), var(--alpha-background-light));

--- a/grafast/ruru-components/ruru.css
+++ b/grafast/ruru-components/ruru.css
@@ -146,6 +146,9 @@
   .graphiql-editor-tool {
     padding: var(--px-8);
   }
+  .graphiql-query-editor {
+    column-gap: var(--px-8);
+  }
 
   .graphiql-session-header,
   #graphiql-session {

--- a/grafast/ruru-components/ruru.css
+++ b/grafast/ruru-components/ruru.css
@@ -97,7 +97,7 @@
 }
 
 /* condensed layout */
-.graphiql-container {
+.graphiql-container.condensed {
   --sidebar-width: 40px;
   --line-height: 1.25;
   --session-header-height: 34.5px;

--- a/grafast/ruru-components/ruru.css
+++ b/grafast/ruru-components/ruru.css
@@ -78,7 +78,7 @@
 }
 
 .ruru-footer {
-  padding: 10px var(--px-8) 10px var(--px-8);
+  padding: var(--px-16) var(--px-8);
 }
 
 /* Ruru overrides for GraphiQL styles */
@@ -123,6 +123,9 @@
   .graphiql-tabs {
     border-radius: 0;
     padding: 0;
+  }
+  .graphiql-editor-tools > button:not(.graphiql-toggle-editor-tools) {
+    padding: var(--px-4) var(--px-8);
   }
   .graphiql-editor-tools > button,
   .graphiql-tab {
@@ -200,5 +203,13 @@
   .graphiql-doc-explorer-search:not(:focus-within) [role="combobox"] {
     font-size: 1rem;
     width: 5em;
+  }
+  .graphiql-chevron-icon {
+    height: var(--px-12);
+    width: var(--px-12);
+    margin: var(--px-8);
+  }
+  .ruru-footer {
+    padding: var(--px-8) var(--px-4);
   }
 }

--- a/grafast/ruru-components/ruru.css
+++ b/grafast/ruru-components/ruru.css
@@ -181,4 +181,19 @@
   .graphiql-markdown-description {
     margin-top: var(--px-8);
   }
+  .graphiql-doc-explorer-title,
+  .graphiql-history-header,
+  .doc-explorer-title {
+    font-size: var(--font-size-h3);
+  }
+  .graphiql-history-header {
+    align-items: flex-start;
+  }
+  .graphiql-doc-explorer-search-input {
+    padding: var(--px-4) var(--px-8);
+  }
+  .graphiql-doc-explorer-search:not(:focus-within) [role="combobox"] {
+    font-size: 1rem;
+    width: 5em;
+  }
 }

--- a/grafast/ruru-components/src/components/Footer.tsx
+++ b/grafast/ruru-components/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 
 export const RuruFooter: FC = () => (
-  <div style={{ padding: 7 }}>
+  <div className="ruru-footer">
     Community-funded OSS 🙏{" "}
     <a
       title="All our projects are supported by the community, please sponsor ongoing development"

--- a/grafast/ruru-components/src/hooks/useStorage.ts
+++ b/grafast/ruru-components/src/hooks/useStorage.ts
@@ -7,6 +7,7 @@ export interface StoredKeys {
   explainAtBottom: "true" | "";
   explainSize: string;
   verbose: "true" | "";
+  condensed: "true" | "";
 }
 
 const KEYS: { [key in keyof StoredKeys]: string } = {
@@ -16,6 +17,7 @@ const KEYS: { [key in keyof StoredKeys]: string } = {
   explainAtBottom: "Ruru:explainAtBottom",
   explorerIsOpen: "graphiql:explorerIsOpen",
   verbose: "Ruru:verbose",
+  condensed: "Ruru:condensed",
 };
 
 const up = (v: number) => v + 1;
@@ -62,7 +64,8 @@ export const useStorage = (): RuruStorage => {
         bump(up);
       },
       toggle(key) {
-        if (this.get(key)) {
+        const val = this.get(key);
+        if (val || (val == null && key === "condensed")) {
           this.set(key, "");
         } else {
           this.set(key, "true");

--- a/grafast/ruru-components/src/ruru.tsx
+++ b/grafast/ruru-components/src/ruru.tsx
@@ -147,10 +147,14 @@ export const RuruInner: FC<{
   const prettify = usePrettify();
   const { copyQuery, mergeQuery, introspect } = useGraphiQLActions();
   useGraphQLChangeStream(props, introspect, streamEndpoint);
+  const condensed = storage.get("condensed") !== "";
 
   return (
     <>
-      <GraphiQLInterface {...graphiqlInterfaceProps}>
+      <GraphiQLInterface
+        {...graphiqlInterfaceProps}
+        className={`${graphiqlInterfaceProps.className ?? ""}${condensed ? " condensed" : ""}`}
+      >
         <GraphiQL.Logo>
           <a
             href="https://grafast.org/ruru"
@@ -206,6 +210,15 @@ export const RuruInner: FC<{
               <span>
                 {storage.get("verbose") === "true" ? check : nocheck}
                 Verbose
+              </span>
+            </ToolbarMenu.Item>
+            <ToolbarMenu.Item
+              title="Condensed"
+              onSelect={() => storage.toggle("condensed")}
+            >
+              <span>
+                {storage.get("condensed") !== "" ? check : nocheck}
+                Condensed
               </span>
             </ToolbarMenu.Item>
           </ToolbarMenu>

--- a/grafast/ruru/src/server.ts
+++ b/grafast/ruru/src/server.ts
@@ -36,7 +36,7 @@ function html(arr: TemplateStringsArray, ...placeholders: string[]) {
 const baseTitleTag = html` <title>Ruru - GraphQL/Grafast IDE</title> `;
 const baseElements = html`
   <div id="ruru-root">
-    <div class="graphiql-container">
+    <div class="graphiql-container condensed">
       <div class="graphiql-sidebar"></div>
       <div class="graphiql-main">
         <div


### PR DESCRIPTION
Normal GraphiQL style has a lot of whitespace, seriously limiting space for editor. This reworks it a bit.