### PR TITLE
Remove obsolete requirement docs in `@dataplan/pg`

### DIFF
--- a/grafast/dataplan-pg/REQUIREMENTS.md
+++ b/grafast/dataplan-pg/REQUIREMENTS.md
@@ -1,4 +1,0 @@
-The following Postgres settings must be set (these are typically the Postgres
-defaults):
-
-- `intervalstyle = 'postgres'`


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->
Remove obsolete requirement docs in `@dataplan/pg`, which previously included a requirement for `intervalstyle` parameter config but wasn't valid at this point.

I've verified the support for other `intervalstyle` parameters by running tests with `set intervalstyle = 'iso_8601';` query added in `withTestWithPgClient()`.

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->
None

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
None

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
