### PR TITLE
Fix bug allowing two different plugins with the same name

### DIFF
--- a/.changeset/stale-pans-sit.md
+++ b/.changeset/stale-pans-sit.md
@@ -1,0 +1,9 @@
+---
+"graphile-config": patch
+"postgraphile": patch
+---
+
+Fixes bug where two different plugins with the same name would be allowed to
+exist in the same (resolved) preset. Users of dynamically created presets and
+plugins (e.g. `makeV4Preset(...)` in PostGraphile) should be wary not to include
+two calls to the same factory in their preset (directly or indirectly).

--- a/postgraphile/postgraphile/src/presets/v4.ts
+++ b/postgraphile/postgraphile/src/presets/v4.ts
@@ -114,32 +114,8 @@ function isNotNullish<T>(arg: T | undefined | null): arg is T {
   return arg != null;
 }
 
-const makeV4Plugin = (
-  options: Pick<
-    V4Options,
-    "simpleCollections" | "skipPlugins" | "classicIds" | "defaultRole"
-  >,
-): GraphileConfig.Plugin => {
+const makeV4Plugin = (options: V4Options): GraphileConfig.Plugin => {
   const { classicIds = false, defaultRole } = options;
-  const skipNodeIdPlugin =
-    options.skipPlugins?.some((p) => p.name === "NodePlugin") ?? false;
-  const parts: string[] = [];
-  if (classicIds) {
-    parts.push("classicIds");
-  }
-  if (skipNodeIdPlugin) {
-    parts.push("skipNodeIdPlugin");
-  }
-  if (options.simpleCollections) {
-    parts.push(`simpleCollections=${options.simpleCollections}`);
-  }
-  if (defaultRole) {
-    parts.push(`defaultRole=${defaultRole}`);
-  }
-  const name = `PostGraphileV4CompatibilityPlugin${
-    parts.length ? `_${parts.join("_")}` : ""
-  }`;
-
   if (defaultRole) {
     throw new Error(
       `The 'defaultRole' V4 option is not currently supported in V5; please use the \`preset.grafast.context\` callback instead.`,
@@ -162,7 +138,7 @@ const makeV4Plugin = (
     }
   })();
   return {
-    name,
+    name: "PostGraphileV4CompatibilityPlugin",
     version: "0.0.0",
     after: ["PgAttributesPlugin", "PgMutationUpdateDeletePlugin"],
     inflection: {
@@ -186,7 +162,8 @@ const makeV4Plugin = (
                 return name;
               },
             }),
-        ...(classicIds || skipNodeIdPlugin
+        ...(classicIds ||
+        options.skipPlugins?.some((p) => p.name === "NodePlugin")
           ? null
           : {
               // Rename GraphQL Global Object Identification 'id' to 'nodeId'

--- a/utils/graphile-config/__tests__/duplicate-plugins.test.ts
+++ b/utils/graphile-config/__tests__/duplicate-plugins.test.ts
@@ -26,6 +26,18 @@ it("allows the same plugin to be referenced multiple times", () => {
   expect(p.plugins[0]).to.equal(SomePluginA);
 });
 
+it("still only returns each plugin once, even if duplicated", () => {
+  const p = resolvePreset({
+    extends: [
+      { plugins: [SomePluginA] },
+      { extends: [{ plugins: [SomePluginA] }] },
+    ],
+    plugins: [SomePluginA, SomePluginA],
+  });
+  expect(p.plugins).to.have.length(1);
+  expect(p.plugins[0]).to.equal(SomePluginA);
+});
+
 it("throws an error if two different plugins with the same name are loaded", () => {
   let error: Error | undefined;
   try {

--- a/utils/graphile-config/__tests__/duplicate-plugins.test.ts
+++ b/utils/graphile-config/__tests__/duplicate-plugins.test.ts
@@ -44,3 +44,18 @@ it("throws an error if two different plugins with the same name are loaded", () 
     /different plugins.*same name.*PluginWithSameName/,
   );
 });
+
+it("throws an error if two different plugins with the same name are loaded (directly)", () => {
+  let error: Error | undefined;
+  try {
+    resolvePreset({
+      plugins: [SomePluginA, SomePluginB],
+    });
+  } catch (e) {
+    error = e;
+  }
+  expect(error).to.exist;
+  expect(error!.message).to.match(
+    /different plugins.*same name.*PluginWithSameName/,
+  );
+});

--- a/utils/graphile-config/__tests__/duplicate-plugins.test.ts
+++ b/utils/graphile-config/__tests__/duplicate-plugins.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import { it } from "mocha";
+
+import { resolvePreset } from "../dist/index.js";
+
+const SAME_NAME = "PluginWithSameName";
+
+const SomePluginA: GraphileConfig.Plugin = {
+  name: SAME_NAME,
+  version: "0.0.0",
+};
+const SomePluginB: GraphileConfig.Plugin = {
+  name: SAME_NAME,
+  version: "0.0.1",
+};
+
+it("allows the same plugin to be referenced multiple times", () => {
+  const p = resolvePreset({
+    extends: [
+      { plugins: [SomePluginA] },
+      { extends: [{ plugins: [SomePluginA] }] },
+    ],
+    plugins: [SomePluginA],
+  });
+  expect(p.plugins).to.have.length(1);
+  expect(p.plugins[0]).to.equal(SomePluginA);
+});
+
+it("throws an error if two different plugins with the same name are loaded", () => {
+  let error: Error | undefined;
+  try {
+    resolvePreset({
+      extends: [
+        { plugins: [SomePluginA] },
+        { extends: [{ plugins: [SomePluginB] }] },
+      ],
+      plugins: [SomePluginA],
+    });
+  } catch (e) {
+    error = e;
+  }
+  expect(error).to.exist;
+  expect(error!.message).to.match(
+    /different plugins.*same name.*PluginWithSameName/,
+  );
+});

--- a/utils/graphile-config/__tests__/duplicate-plugins.test.ts
+++ b/utils/graphile-config/__tests__/duplicate-plugins.test.ts
@@ -50,7 +50,9 @@ it("throws an error if two different plugins with the same name are loaded (dire
   try {
     resolvePreset({
       plugins: [SomePluginA, SomePluginB],
-    });
+      disablePlugins: [],
+      lib: { versions: {} },
+    } as GraphileConfig.ResolvedPreset);
   } catch (e) {
     error = e;
   }

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -41,15 +41,14 @@ try {
 export function isResolvedPreset(
   preset: GraphileConfig.Preset,
 ): preset is GraphileConfig.ResolvedPreset {
-  return (
-    (preset.extends == null &&
-      preset.plugins &&
-      preset.disablePlugins &&
-      typeof preset.lib === "object" &&
-      preset.lib !== null &&
-      !preset.plugins.some((p) => preset.disablePlugins!.includes(p.name))) ||
-    false
-  );
+  if (preset.extends != null) return false;
+  if (!preset.plugins) return false;
+  if (!preset.disablePlugins) return false;
+  if (typeof preset.lib !== "object" || preset.lib === null) return false;
+  for (const plugin of preset.plugins) {
+    if (preset.disablePlugins.includes(plugin.name)) return false;
+  }
+  return true;
 }
 
 /** @deprecated Use `resolvePreset({ extends: presets })` instead */

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -285,6 +285,15 @@ function mergePreset(
   if (sourcePreset.plugins) {
     for (const plugin of sourcePreset.plugins) {
       assertPlugin(plugin);
+
+      // Check that we don't have two different plugins with the same name
+      const existing = targetPreset.plugins.find((p) => p.name === plugin.name);
+      if (existing && existing !== plugin) {
+        throw new Error(
+          `Two different plugins have been registered with the same name '${existing.name}'; this is likely an issue where you are using the same preset or plugin factory function more than once, though it could also be caused by duplicate dependencies in your 'node_modules' folder.`,
+        );
+      }
+
       seenPluginNames.add(plugin.name);
       sourcePluginNames.push(plugin.name);
     }

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -45,8 +45,16 @@ export function isResolvedPreset(
   if (!preset.plugins) return false;
   if (!preset.disablePlugins) return false;
   if (typeof preset.lib !== "object" || preset.lib === null) return false;
+  const seenPluginNames = new Set<string>();
   for (const plugin of preset.plugins) {
     if (preset.disablePlugins.includes(plugin.name)) return false;
+
+    if (seenPluginNames.has(plugin.name)) {
+      // Contains duplicate; handle on default path
+      return false;
+    } else {
+      seenPluginNames.add(plugin.name);
+    }
   }
   return true;
 }


### PR DESCRIPTION
Plugins should be uniquely identified by their name; therefore we should not allow two different plugins (`pluginA !== pluginB`) to be loaded if they have the same name.