### PR TITLE
postgraphile website: Fix v5 page

### DIFF
--- a/postgraphile/website/src/pages/v5beta.mdx
+++ b/postgraphile/website/src/pages/v5beta.mdx
@@ -107,6 +107,8 @@ Everyone else can see some detail in the PostGraphile [changelog](https://github
 
 </div>
 
+{
+
 <table className={v5betaStyles.releasesTable}>
 
 <thead>
@@ -193,6 +195,8 @@ Everyone else can see some detail in the PostGraphile [changelog](https://github
 </tbody>
 
 </table>
+
+}
 
 <SecondarySection
   title={`Development Support`}


### PR DESCRIPTION
## Description

I missed that the table on the v5 updates page was broken after the Docusaurus update! Two simple braces fix that. 