### PR TITLE
Fix type of shared/unary arg in loadOneWithPgClient/loadManyWithPgClient

### DIFF
--- a/.changeset/polite-kids-see.md
+++ b/.changeset/polite-kids-see.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+Fixes type error in `loadOneWithPgClient()`/`loadManyWithPgClient()`

--- a/grafast/dataplan-pg/src/steps/withPgClient.ts
+++ b/grafast/dataplan-pg/src/steps/withPgClient.ts
@@ -183,7 +183,13 @@ type LoadOneWithPgClientLoader<
 > =
   | LoadOneWithPgClientCallback<TSpec, TItem, TData, TParams, never>
   | (Omit<LoadOneLoader<TSpec, TItem, TData, TParams, TShared>, "load"> & {
-      load: LoadOneWithPgClientCallback<TSpec, TItem, TData, TParams, TShared>;
+      load: LoadOneWithPgClientCallback<
+        TSpec,
+        TItem,
+        TData,
+        TParams,
+        UnwrapMultistep<TShared>
+      >;
     });
 const transformedLoaderCache = new WeakMap<PgExecutor, WeakMap<any, any>>();
 
@@ -333,7 +339,13 @@ type LoadManyWithPgClientLoader<
 > =
   | LoadManyWithPgClientCallback<TSpec, TItem, TData, TParams, never>
   | (Omit<LoadManyLoader<TSpec, TItem, TData, TParams, TShared>, "load"> & {
-      load: LoadManyWithPgClientCallback<TSpec, TItem, TData, TParams, TShared>;
+      load: LoadManyWithPgClientCallback<
+        TSpec,
+        TItem,
+        TData,
+        TParams,
+        UnwrapMultistep<TShared>
+      >;
     });
 
 export function loadManyWithPgClient<


### PR DESCRIPTION
Fixes #2703