### PR TITLE
Capture PostgreSQL notices

### DIFF
--- a/.changeset/deep-eels-post.md
+++ b/.changeset/deep-eels-post.md
@@ -1,0 +1,72 @@
+---
+"graphile-build-pg": patch
+"@dataplan/pg": patch
+---
+
+Add ability for Postgres client to capture `RAISE NOTIFY` issued during an SQL
+query. An example follows:
+
+Database:
+
+```sql
+create table foo (id serial primary key, bar text);
+create function tg_foo() returns trigger language plpgsql volatile as $$
+begin
+  raise notice 'Hello World' using hint = 'Hi, ' || NEW.bar;
+  return NEW;
+end;
+$$;
+create trigger _insert before insert on foo for each row execute function tg_foo();
+```
+
+Plugin:
+
+```ts
+const plugin = extendSchema({
+  typeDefs: /* GraphQL */ `
+    type PgNotice {
+      severity: String
+      message: String
+      code: String
+      detail: String
+      hint: String
+    }
+    extend type CreateFooPayload {
+      messages: [PgNotice]
+    }
+  `,
+  plans: {
+    CreateFooPayload: {
+      messages($payload: any) {
+        const $result = get($payload, "result") as PgInsertSingleStep;
+        return $result.getNotices();
+      },
+    },
+  },
+});
+```
+
+Result:
+
+```json
+{
+  "data": {
+    "createFoo": {
+      "clientMutationId": null,
+      "foo": {
+        "id": "WyJmb29zIiwzXQ==",
+        "bar": "inputvalue"
+      },
+      "messages": [
+        {
+          "severity": "NOTICE",
+          "message": "Hello World",
+          "code": "00000",
+          "detail": null,
+          "hint": "Hi, inputvalue"
+        }
+      ]
+    }
+  }
+}
+```

--- a/grafast/dataplan-pg/src/adaptors/pg.ts
+++ b/grafast/dataplan-pg/src/adaptors/pg.ts
@@ -19,6 +19,8 @@ import type {
   QueryConfig,
 } from "pg";
 import * as pg from "pg";
+/** @internal */
+import type { NoticeMessage } from "pg-protocol/dist/messages.js";
 
 import type {
   PgClient,
@@ -202,9 +204,6 @@ function newNodePostgresPgClient(
     },
   };
 }
-
-/** @internal */
-type NoticeMessage = import("pg-protocol/dist/messages.js").NoticeMessage;
 
 const EMPTY_ARRAY = Object.freeze([]) as never[];
 

--- a/grafast/dataplan-pg/src/adaptors/pg.ts
+++ b/grafast/dataplan-pg/src/adaptors/pg.ts
@@ -24,6 +24,8 @@ import type {
   PgClient,
   PgClientQuery,
   PgClientResult,
+  PgNotice,
+  PgRaiseSeverity,
   WithPgClient,
 } from "../executor.js";
 import type { MakePgServiceOptions } from "../interfaces.js";
@@ -162,15 +164,8 @@ function newNodePostgresPgClient(
       function doIt() {
         const { text, name, values, arrayMode } = opts;
         const queryObj: QueryConfig | QueryArrayConfig = arrayMode
-          ? {
-              text,
-              values,
-              rowMode: "array",
-            }
-          : {
-              text,
-              values,
-            };
+          ? { text, values, rowMode: "array" }
+          : { text, values };
 
         if (PREPARED_STATEMENT_CACHE_SIZE > 0 && name != null) {
           // Hacking into pgClient internals - this is dangerous, but it's the only way I know to get a prepared statement LRU
@@ -202,9 +197,58 @@ function newNodePostgresPgClient(
           }
         }
 
-        return pgClient.query<any>(queryObj);
+        return pgClientQuery(pgClient, queryObj);
       }
     },
+  };
+}
+
+type NoticeMessage = import("pg-protocol/dist/messages.js").NoticeMessage;
+
+const EMPTY_ARRAY = Object.freeze([]) as never[];
+
+async function pgClientQuery(
+  pgClient: PoolClient,
+  queryObj: QueryArrayConfig<any[]> | QueryConfig<any[]>,
+) {
+  let notices: PgNotice[] | null = null;
+  const addNotice = (n: NoticeMessage) => {
+    const converted = convertNotice(n);
+    if (notices === null) {
+      notices = [converted];
+    } else {
+      notices.push(converted);
+    }
+  };
+  pgClient.addListener("notice", addNotice);
+  try {
+    const { rows, rowCount } = await pgClient.query<any>(queryObj);
+    return { rows, rowCount, notices: notices ?? EMPTY_ARRAY };
+  } finally {
+    pgClient.removeListener("notice", addNotice);
+  }
+}
+
+function convertNotice(n: NoticeMessage): PgNotice {
+  return {
+    severity: (n.severity ?? "NOTICE") as PgRaiseSeverity,
+    message: n.message ?? "",
+    code: n.code,
+    detail: n.detail,
+    hint: n.hint,
+    position: n.position != null ? parseInt(n.position, 10) : undefined,
+    internalPosition:
+      n.internalPosition != null ? parseInt(n.internalPosition, 10) : undefined,
+    internalQuery: n.internalQuery,
+    where: n.where,
+    schema: n.schema,
+    table: n.table,
+    column: n.column,
+    dataType: n.dataType,
+    constraint: n.constraint,
+    file: n.file,
+    line: n.line != null ? parseInt(n.line, 10) : undefined,
+    routine: n.routine,
   };
 }
 

--- a/grafast/dataplan-pg/src/adaptors/pg.ts
+++ b/grafast/dataplan-pg/src/adaptors/pg.ts
@@ -197,20 +197,21 @@ function newNodePostgresPgClient(
           }
         }
 
-        return pgClientQuery(pgClient, queryObj);
+        return pgClientQuery<TData>(pgClient, queryObj);
       }
     },
   };
 }
 
+/** @internal */
 type NoticeMessage = import("pg-protocol/dist/messages.js").NoticeMessage;
 
 const EMPTY_ARRAY = Object.freeze([]) as never[];
 
-async function pgClientQuery(
+async function pgClientQuery<TData>(
   pgClient: PoolClient,
   queryObj: QueryArrayConfig<any[]> | QueryConfig<any[]>,
-) {
+): Promise<PgClientResult<TData>> {
   let notices: PgNotice[] | null = null;
   const addNotice = (n: NoticeMessage) => {
     const converted = convertNotice(n);

--- a/grafast/dataplan-pg/src/executor.ts
+++ b/grafast/dataplan-pg/src/executor.ts
@@ -60,7 +60,11 @@ export interface PgClientQuery {
 
 export type PgRaiseSeverity = "DEBUG" | "LOG" | "INFO" | "NOTICE" | "WARNING";
 
-/** Shape mirrors Postgres diagnostics fields so different clients can map in. */
+/**
+ * Shape mirrors Postgres diagnostics fields so different clients can map in.
+ *
+ * @see {@link https://www.postgresql.org/docs/current/protocol-error-fields.html}
+ */
 export interface PgNotice {
   severity: PgRaiseSeverity; // e.g. 'NOTICE'
   message: string; // primary message

--- a/grafast/dataplan-pg/src/executor.ts
+++ b/grafast/dataplan-pg/src/executor.ts
@@ -551,7 +551,7 @@ ${duration}
                     name,
                     publishExecute,
                   );
-              const { rows, notices } = queryResult;
+              const { rows } = queryResult;
               const groups: { [valueIndex: number]: any[] } =
                 Object.create(null);
               for (let i = 0, l = rows.length; i < l; i++) {

--- a/grafast/dataplan-pg/src/executor.ts
+++ b/grafast/dataplan-pg/src/executor.ts
@@ -58,17 +58,47 @@ export interface PgClientQuery {
   name?: string;
 }
 
+export type PgRaiseSeverity = "DEBUG" | "LOG" | "INFO" | "NOTICE" | "WARNING";
+
+/** Shape mirrors Postgres diagnostics fields so different clients can map in. */
+export interface PgNotice {
+  severity: PgRaiseSeverity; // e.g. 'NOTICE'
+  message: string; // primary message
+  code?: string; // SQLSTATE, e.g. '00000'
+  detail?: string;
+  hint?: string;
+  position?: number; // 1-based character position
+  internalPosition?: number;
+  internalQuery?: string;
+  where?: string; // context
+  schema?: string;
+  table?: string;
+  column?: string;
+  dataType?: string;
+  constraint?: string;
+  file?: string; // server source file
+  line?: number; // server source line
+  routine?: string; // server source function
+}
+
 export interface PgClientResult<TData> {
   /**
    * For `SELECT` or `INSERT/UPDATE/DELETE ... RETURNING` this will be the list
    * of rows returned.
    */
   rows: readonly TData[];
+
   /**
    * For `INSERT/UPDATE/DELETE` without `RETURNING`, this will be the number of
    * rows created/updated/deleted.
    */
   rowCount: number | null;
+
+  /**
+   * Any non-exception server messages (e.g. RAISE NOTICE/INFO/WARNING).
+   * Empty if none were raised.
+   */
+  notices?: readonly PgNotice[];
 }
 
 /**
@@ -211,6 +241,7 @@ export class PgExecutor<const TName extends string = string, TSettings = any> {
     if (debug.enabled || debugVerbose.enabled || debugExplain.enabled) {
       const duration = (Number((end - start) / 10000n) / 100).toFixed(2) + "ms";
       const rows = queryResult?.rows;
+      const notices = queryResult?.notices;
       const rowResults =
         rows && rows.length > 10
           ? "[\n  " +
@@ -248,9 +279,12 @@ ${
   error
     ? `\
 # ERROR:
-%o`
+%o%s`
     : `\
 # RESULT:
+%s
+
+# NOTICES:
 %s`
 }
 
@@ -268,6 +302,18 @@ ${duration}
         formatSQLForDebugging(text, error),
         values,
         error ? error : rowResults,
+        error
+          ? ""
+          : notices?.length
+            ? notices
+                .map((n) =>
+                  `${n.severity}${n.code ? `[${n.code}]` : ""}: ${n.message}`.replace(
+                    /\n/g,
+                    "\n  ",
+                  ),
+                )
+                .join("\n- ")
+            : `-none-`,
         LOOK_UP,
         explain ??
           (shouldExplain
@@ -501,7 +547,7 @@ ${duration}
                     name,
                     publishExecute,
                   );
-              const { rows } = queryResult;
+              const { rows, notices } = queryResult;
               const groups: { [valueIndex: number]: any[] } =
                 Object.create(null);
               for (let i = 0, l = rows.length; i < l; i++) {

--- a/grafast/dataplan-pg/src/steps/pgDeleteSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgDeleteSingle.ts
@@ -225,6 +225,10 @@ export class PgDeleteSingleStep<
     return access(this, ["m", key]);
   }
 
+  public getNotices() {
+    return access(this, "n");
+  }
+
   public record(): PgClassExpressionStep<
     GetPgResourceCodec<TResource>,
     TResource
@@ -332,7 +336,7 @@ export class PgDeleteSingleStep<
             }
           })
         : rawSqlValues;
-      const { rows, rowCount } = await this.resource.executeMutation({
+      const { rows, rowCount, notices } = await this.resource.executeMutation({
         context,
         text,
         values: sqlValues,
@@ -344,7 +348,13 @@ export class PgDeleteSingleStep<
           ),
         );
       }
-      return { __proto__: null, m: meta, t: rows[0] ?? [] };
+      return {
+        __proto__: null,
+        m: meta,
+        t: rows[0] ?? [],
+        c: rowCount,
+        n: notices,
+      };
     });
   }
 

--- a/grafast/dataplan-pg/src/steps/pgInsertSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgInsertSingle.ts
@@ -235,6 +235,10 @@ export class PgInsertSingleStep<
     return access(this, ["m", key]);
   }
 
+  public getNotices() {
+    return access(this, "n");
+  }
+
   public record(): PgClassExpressionStep<
     GetPgResourceCodec<TResource>,
     TResource
@@ -385,12 +389,18 @@ export class PgInsertSingleStep<
       }
 
       const { text, values: stmtValues } = compileResult;
-      const { rows } = await this.resource.executeMutation({
+      const { rows, notices, rowCount } = await this.resource.executeMutation({
         context,
         text,
         values: stmtValues,
       });
-      return { __proto__: null, m: meta, t: rows[0] ?? [] };
+      return {
+        __proto__: null,
+        m: meta,
+        t: rows[0] ?? [],
+        c: rowCount,
+        n: notices,
+      };
     });
   }
 

--- a/grafast/dataplan-pg/src/steps/pgUpdateSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgUpdateSingle.ts
@@ -270,6 +270,10 @@ export class PgUpdateSingleStep<
     return access(this, ["m", key]);
   }
 
+  public getNotices() {
+    return access(this, "n");
+  }
+
   public record(): PgClassExpressionStep<
     GetPgResourceCodec<TResource>,
     TResource
@@ -430,7 +434,7 @@ export class PgUpdateSingleStep<
             }
           })
         : rawSqlValues;
-      const { rows, rowCount } = await this.resource.executeMutation({
+      const { rows, rowCount, notices } = await this.resource.executeMutation({
         context,
         text,
         values: sqlValues,
@@ -443,6 +447,8 @@ export class PgUpdateSingleStep<
         __proto__: null,
         m: meta,
         t: rows[0] ?? [],
+        c: rowCount,
+        n: notices,
       };
     });
   }


### PR DESCRIPTION
Fixes #2259

Add ability for Postgres client to capture `RAISE NOTIFY` issued during an SQL
query. An example follows:

Database:

```sql
create table foo (id serial primary key, bar text);
create function tg_foo() returns trigger language plpgsql volatile as $$
begin
  raise notice 'Hello World' using hint = 'Hi, ' || NEW.bar;
  return NEW;
end;
$$;
create trigger _insert before insert on foo for each row execute function tg_foo();
```

Plugin:

```ts
const plugin = extendSchema({
  typeDefs: /* GraphQL */ `
    type PgNotice {
      severity: String
      message: String
      code: String
      detail: String
      hint: String
    }
    extend type CreateFooPayload {
      messages: [PgNotice]
    }
  `,
  plans: {
    CreateFooPayload: {
      messages($payload: any) {
        const $result = get($payload, "result") as PgInsertSingleStep;
        return $result.getNotices();
      },
    },
  },
});
```

Mutation:

```graphql
mutation {
  createFoo(input:  {
     foo:  {
        bar: "inputvalue"
     }
  }) {
    foo {
      id
      bar
    }
    messages {
      severity
      message
      code
      detail
      hint
    }
  }
}
```

Result:

```json
{
  "data": {
    "createFoo": {
      "foo": {
        "id": "WyJmb29zIiwzXQ==",
        "bar": "inputvalue"
      },
      "messages": [
        {
          "severity": "NOTICE",
          "message": "Hello World",
          "code": "00000",
          "detail": null,
          "hint": "Hi, inputvalue"
        }
      ]
    }
  }
}
```