### PR TITLE
Remove eval and manually optimize functions

### DIFF
--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 77, 78, 11, 13, 28<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 20<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[29], PgSelect[35]<br />ᐳ: 34, 46, 45, 47, 48, 49<br />2: PgSelectRows[37]<br />ᐳ: 36, 38, 39"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 20<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[29], PgSelect[35]<br />ᐳ: 34, 43, 44, 46, 45, 47, 48, 49<br />2: PgSelectRows[37]<br />ᐳ: 36, 38, 39"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 46, 11<br /><br />ROOT __Item{6}ᐸ29ᐳ[40]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 41, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[41]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 42, 41, 11, 51<br /><br />ROOT Edge{6}[42]"):::bucket
@@ -79,6 +79,10 @@ graph TD
     First36 --> PgSelectSingle38
     PgClassExpression39{{"PgClassExpression[39∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
+    Access43{{"Access[43∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access43
+    Access44{{"Access[44∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access44
     ConnectionItems29 --> First45
     PgSelect20 --> Access46
     ConnectionItems29 --> Last48
@@ -131,7 +135,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression19,PgSelect20,Connection24,PgClassExpression25 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems29,PageInfo34,PgSelect35,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First45,Access46,PgCursor47,Last48,PgCursor49 bucket3
+    class Bucket3,ConnectionItems29,PageInfo34,PgSelect35,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access43,Access44,First45,Access46,PgCursor47,Last48,PgCursor49 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41,Edge42,PgCursor51 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-4.mermaid
@@ -88,6 +88,10 @@ graph TD
     First36 --> PgSelectSingle38
     PgClassExpression39{{"PgClassExpression[39∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
+    Access43{{"Access[43∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access43
+    Access44{{"Access[44∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access44
     ConnectionItems29 --> First45
     Lambda82 --> Access46
     ConnectionItems29 --> Last48
@@ -142,7 +146,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,Connection24,List81,Lambda82,List85,Lambda86 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems29,PageInfo34,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First45,Access46,PgCursor47,Last48,PgCursor49,Access76 bucket3
+    class Bucket3,ConnectionItems29,PageInfo34,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access43,Access44,First45,Access46,PgCursor47,Last48,PgCursor49,Access76 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41,Edge42,PgCursor51 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 72, 73, 11, 13, 28<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 20<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[29], PgSelect[35]<br />ᐳ: PageInfo[34], Access[55]<br />2: PgSelectRows[37]<br />ᐳ: 36, 38, 39"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 20<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[29], PgSelect[35]<br />ᐳ: 34, 43, 44, 55<br />2: PgSelectRows[37]<br />ᐳ: 36, 38, 39"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 55, 11<br /><br />ROOT __Item{6}ᐸ29ᐳ[40]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 41, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[41]<br />1: <br />ᐳ: 45, 47<br />2: PgSelect[48]<br />3: PgSelectRows[53]<br />ᐳ: First[52], PgSelectSingle[54]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 42, 41, 11, 56<br /><br />ROOT Edge{6}[42]"):::bucket
@@ -71,6 +71,10 @@ graph TD
     First36 --> PgSelectSingle38
     PgClassExpression39{{"PgClassExpression[39∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
+    Access43{{"Access[43∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access43
+    Access44{{"Access[44∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access44
     Access55{{"Access[55∈3]<br />ᐸ20.cursorDetailsᐳ"}}:::plan
     PgSelect20 --> Access55
     Edge42{{"Edge[42∈6]"}}:::plan
@@ -122,7 +126,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression19,PgSelect20,Connection24,PgClassExpression25 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems29,PageInfo34,PgSelect35,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access55 bucket3
+    class Bucket3,ConnectionItems29,PageInfo34,PgSelect35,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access43,Access44,Access55 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41,Edge42,PgCursor56 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.defer-5.mermaid
@@ -81,6 +81,10 @@ graph TD
     First36 --> PgSelectSingle38
     PgClassExpression39{{"PgClassExpression[39∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
+    Access43{{"Access[43∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access43
+    Access44{{"Access[44∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access44
     Access55{{"Access[55∈3]<br />ᐸ81.cursorDetailsᐳ"}}:::plan
     Lambda81 --> Access55
     Access71{{"Access[71∈3]<br />ᐸ81.m.joinDetailsFor48ᐳ"}}:::plan
@@ -136,7 +140,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,Connection24,List80,Lambda81,List84,Lambda85 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems29,PageInfo34,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access55,Access71,Access75 bucket3
+    class Bucket3,ConnectionItems29,PageInfo34,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access43,Access44,Access55,Access71,Access75 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41,Edge42,PgCursor56 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 77, 78, 11, 13, 28<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 20<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[29], PgSelect[35]<br />ᐳ: 34, 46, 45, 47, 48, 49<br />2: PgSelectRows[37]<br />ᐳ: 36, 38, 39"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 20<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[29], PgSelect[35]<br />ᐳ: 34, 43, 44, 46, 45, 47, 48, 49<br />2: PgSelectRows[37]<br />ᐳ: 36, 38, 39"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 46, 11<br /><br />ROOT __Item{6}ᐸ29ᐳ[40]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 41, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[41]<br />1: <br />ᐳ: 50, 53<br />2: PgSelect[54]<br />3: PgSelectRows[59]<br />ᐳ: First[58], PgSelectSingle[60]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 42, 41, 11, 52<br /><br />ROOT Edge{6}[42]"):::bucket
@@ -77,6 +77,10 @@ graph TD
     First36 --> PgSelectSingle38
     PgClassExpression39{{"PgClassExpression[39∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
+    Access43{{"Access[43∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access43
+    Access44{{"Access[44∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access44
     ConnectionItems29 --> First45
     PgSelect20 --> Access46
     ConnectionItems29 --> Last48
@@ -129,7 +133,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression19,PgSelect20,Connection24,PgClassExpression25 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems29,PageInfo34,PgSelect35,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First45,Access46,PgCursor47,Last48,PgCursor49 bucket3
+    class Bucket3,ConnectionItems29,PageInfo34,PgSelect35,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access43,Access44,First45,Access46,PgCursor47,Last48,PgCursor49 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41,Edge42,PgCursor52 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.mermaid
@@ -87,6 +87,10 @@ graph TD
     First36 --> PgSelectSingle38
     PgClassExpression39{{"PgClassExpression[39∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle38 --> PgClassExpression39
+    Access43{{"Access[43∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access43
+    Access44{{"Access[44∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access44
     ConnectionItems29 --> First45
     Lambda86 --> Access46
     ConnectionItems29 --> Last48
@@ -143,7 +147,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,Connection24,List85,Lambda86,List89,Lambda90 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems29,PageInfo34,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,First45,Access46,PgCursor47,Last48,PgCursor49,Access76,Access80 bucket3
+    class Bucket3,ConnectionItems29,PageInfo34,First36,PgSelectRows37,PgSelectSingle38,PgClassExpression39,Access43,Access44,First45,Access46,PgCursor47,Last48,PgCursor49,Access76,Access80 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item40,PgSelectSingle41,Edge42,PgCursor52 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 29, 30, 81, 82, 83, 11, 13, 28, 32<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28, 32, 29, 30, 6<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28, 32, 29, 30, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 32, 20, 29, 30, 6<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33], PgSelect[41]<br />ᐳ: PageInfo[40], Access[55]<br />2: 43, 46, 47<br />ᐳ: 42, 44, 45"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 11, 19, 25, 28, 32, 20, 29, 30, 6<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33], PgSelect[41]<br />ᐳ: 40, 52, 53, 55<br />2: 43, 46, 47<br />ᐳ: 42, 44, 45"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 11<br /><br />ROOT __Item{6}ᐸ46ᐳ[48]"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 55, 11<br /><br />ROOT __Item{7}ᐸ47ᐳ[50]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[49]<br />1: <br />ᐳ: 54, 57<br />2: PgSelect[58]<br />3: PgSelectRows[63]<br />ᐳ: First[62], PgSelectSingle[64]"):::bucket
@@ -77,6 +77,10 @@ graph TD
     ConnectionItems33 --> __CloneStream46
     __CloneStream47[["__CloneStream[47∈3@s]"]]:::plan
     ConnectionItems33 --> __CloneStream47
+    Access52{{"Access[52∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access52
+    Access53{{"Access[53∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access53
     Access55{{"Access[55∈3]<br />ᐸ20.cursorDetailsᐳ"}}:::plan
     PgSelect20 --> Access55
     __Item48[/"__Item[48∈6]<br />ᐸ46ᐳ"\]:::itemplan
@@ -132,7 +136,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression19,PgSelect20,Connection24,PgClassExpression25 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems33,PageInfo40,PgSelect41,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,__CloneStream46,__CloneStream47,Access55 bucket3
+    class Bucket3,ConnectionItems33,PageInfo40,PgSelect41,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,__CloneStream46,__CloneStream47,Access52,Access53,Access55 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item48,PgSelectSingle49 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-2.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 6, 9, 10, 29, 30, 85, 86, 87, 11, 13, 28, 32<br />2: PgSelectInlineApply[79]<br />3: PgSelect[8]<br />ᐳ: Access[80]<br />4: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28, 32, 80, 29, 30, 6<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28, 32, 80, 15, 29, 30, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25, 81, 82<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 82, 20, 29, 30, 6, 11<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33], PgSelectRows[43]<br />ᐳ: 40, 55, 42, 44, 45<br />2: __CloneStream[46], __CloneStream[47]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 82, 20, 29, 30, 6, 11<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33], PgSelectRows[43]<br />ᐳ: 40, 52, 53, 55, 42, 44, 45<br />2: __CloneStream[46], __CloneStream[47]"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 11<br /><br />ROOT __Item{6}ᐸ46ᐳ[48]"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 55, 11<br /><br />ROOT __Item{7}ᐸ47ᐳ[50]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 49, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[49]<br />1: <br />ᐳ: 54, 57<br />2: PgSelect[58]<br />3: PgSelectRows[63]<br />ᐳ: First[62], PgSelectSingle[64]"):::bucket
@@ -83,6 +83,10 @@ graph TD
     ConnectionItems33 --> __CloneStream46
     __CloneStream47[["__CloneStream[47∈3@s]"]]:::plan
     ConnectionItems33 --> __CloneStream47
+    Access52{{"Access[52∈3]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access52
+    Access53{{"Access[53∈3]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access53
     Access55{{"Access[55∈3]<br />ᐸ20.cursorDetailsᐳ"}}:::plan
     PgSelect20 --> Access55
     __Item48[/"__Item[48∈6]<br />ᐸ46ᐳ"\]:::itemplan
@@ -138,7 +142,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression19,PgSelect20,Connection24,PgClassExpression25,List81,Lambda82 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems33,PageInfo40,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,__CloneStream46,__CloneStream47,Access55 bucket3
+    class Bucket3,ConnectionItems33,PageInfo40,First42,PgSelectRows43,PgSelectSingle44,PgClassExpression45,__CloneStream46,__CloneStream47,Access52,Access53,Access55 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item48,PgSelectSingle49 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.deopt.mermaid
@@ -12,7 +12,7 @@ graph TD
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28, 32, 29, 30, 6<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28, 32, 29, 30, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 20, 11, 19, 25, 28, 32, 29, 30, 6<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33]<br />ᐳ: Access[55]<br />2: __CloneStream[40], __CloneStream[41]"):::bucket
-    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[43]<br />ᐳ: PageInfo[42]<br />2: PgSelectRows[45]<br />ᐳ: 44, 46, 47"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[43]<br />ᐳ: PageInfo[42], Access[52], Access[53]<br />2: PgSelectRows[45]<br />ᐳ: 44, 46, 47"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 11<br /><br />ROOT __Item{7}ᐸ40ᐳ[48]"):::bucket
     Bucket8("Bucket 8 (listItem)<br />Deps: 55, 11<br /><br />ROOT __Item{8}ᐸ41ᐳ[50]"):::bucket
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 49, 11<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[49]<br />1: <br />ᐳ: 54, 57<br />2: PgSelect[58]<br />3: PgSelectRows[63]<br />ᐳ: First[62], PgSelectSingle[64]"):::bucket
@@ -80,6 +80,10 @@ graph TD
     First44 --> PgSelectSingle46
     PgClassExpression47{{"PgClassExpression[47∈6]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle46 --> PgClassExpression47
+    Access52{{"Access[52∈6]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access52
+    Access53{{"Access[53∈6]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access53
     __Item48[/"__Item[48∈7]<br />ᐸ40ᐳ"\]:::itemplan
     __CloneStream40 ==> __Item48
     PgSelectSingle49{{"PgSelectSingle[49∈7]<br />ᐸmessagesᐳ"}}:::plan
@@ -135,7 +139,7 @@ graph TD
     classDef bucket3 stroke:#ffa500
     class Bucket3,ConnectionItems33,__CloneStream40,__CloneStream41,Access55 bucket3
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo42,PgSelect43,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47 bucket6
+    class Bucket6,PageInfo42,PgSelect43,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47,Access52,Access53 bucket6
     classDef bucket7 stroke:#808000
     class Bucket7,__Item48,PgSelectSingle49 bucket7
     classDef bucket8 stroke:#dda0dd

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-6.mermaid
@@ -12,7 +12,7 @@ graph TD
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28, 32, 29, 30, 6<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28, 32, 29, 30, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 20, 11, 19, 25, 28, 32, 29, 30, 6<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33]<br />ᐳ: Access[55]<br />2: __CloneStream[40], __CloneStream[41]"):::bucket
-    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[43]<br />ᐳ: PageInfo[42]<br />2: PgSelectRows[45]<br />ᐳ: 44, 46, 47"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[43]<br />ᐳ: PageInfo[42], Access[52], Access[53]<br />2: PgSelectRows[45]<br />ᐳ: 44, 46, 47"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 11<br /><br />ROOT __Item{7}ᐸ40ᐳ[48]"):::bucket
     Bucket8("Bucket 8 (listItem)<br />Deps: 55, 11<br /><br />ROOT __Item{8}ᐸ41ᐳ[50]"):::bucket
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 49, 11<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[49]<br />1: <br />ᐳ: 54, 57<br />2: PgSelect[58]<br />3: PgSelectRows[63]<br />ᐳ: First[62], PgSelectSingle[64]"):::bucket
@@ -80,6 +80,10 @@ graph TD
     First44 --> PgSelectSingle46
     PgClassExpression47{{"PgClassExpression[47∈6]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle46 --> PgClassExpression47
+    Access52{{"Access[52∈6]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access52
+    Access53{{"Access[53∈6]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access53
     __Item48[/"__Item[48∈7]<br />ᐸ40ᐳ"\]:::itemplan
     __CloneStream40 ==> __Item48
     PgSelectSingle49{{"PgSelectSingle[49∈7]<br />ᐸmessagesᐳ"}}:::plan
@@ -135,7 +139,7 @@ graph TD
     classDef bucket3 stroke:#ffa500
     class Bucket3,ConnectionItems33,__CloneStream40,__CloneStream41,Access55 bucket3
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo42,PgSelect43,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47 bucket6
+    class Bucket6,PageInfo42,PgSelect43,First44,PgSelectRows45,PgSelectSingle46,PgClassExpression47,Access52,Access53 bucket6
     classDef bucket7 stroke:#808000
     class Bucket7,__Item48,PgSelectSingle49 bucket7
     classDef bucket8 stroke:#dda0dd

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.deopt.mermaid
@@ -12,7 +12,7 @@ graph TD
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 28, 32, 29, 30, 6<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 28, 32, 29, 30, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 19, 25<br />2: PgSelect[20]<br />3: Connection[24]"):::bucket
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 20, 11, 19, 25, 28, 32, 29, 30, 6<br /><br />ROOT Connection{2}ᐸ20ᐳ[24]<br />1: ConnectionItems[33]<br />ᐳ: Access[52]<br />2: __CloneStream[38]"):::bucket
-    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[40]<br />ᐳ: PageInfo[39]<br />2: PgSelectRows[42]<br />ᐳ: 41, 43, 44"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[40]<br />ᐳ: PageInfo[39], Access[49], Access[50]<br />2: PgSelectRows[42]<br />ᐳ: 41, 43, 44"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 11<br /><br />ROOT __Item{7}ᐸ38ᐳ[45]"):::bucket
     Bucket8("Bucket 8 (listItem)<br />Deps: 52, 11<br /><br />ROOT __Item{8}ᐸ33ᐳ[47]"):::bucket
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 46, 11<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[46]<br />1: <br />ᐳ: 51, 54<br />2: PgSelect[55]<br />3: PgSelectRows[60]<br />ᐳ: First[59], PgSelectSingle[61]"):::bucket
@@ -78,6 +78,10 @@ graph TD
     First41 --> PgSelectSingle43
     PgClassExpression44{{"PgClassExpression[44∈6]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle43 --> PgClassExpression44
+    Access49{{"Access[49∈6]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access49
+    Access50{{"Access[50∈6]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access50
     __Item45[/"__Item[45∈7]<br />ᐸ38ᐳ"\]:::itemplan
     __CloneStream38 ==> __Item45
     PgSelectSingle46{{"PgSelectSingle[46∈7]<br />ᐸmessagesᐳ"}}:::plan
@@ -129,7 +133,7 @@ graph TD
     classDef bucket3 stroke:#ffa500
     class Bucket3,ConnectionItems33,__CloneStream38,Access52 bucket3
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo39,PgSelect40,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44 bucket6
+    class Bucket6,PageInfo39,PgSelect40,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,Access49,Access50 bucket6
     classDef bucket7 stroke:#808000
     class Bucket7,__Item45,PgSelectSingle46 bucket7
     classDef bucket8 stroke:#dda0dd

--- a/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/archived-forum-inherited-messages.stream-7.mermaid
@@ -12,7 +12,7 @@ graph TD
     Bucket1("Bucket 1 (listItem)<br />Deps: 79, 11, 28, 32, 29, 30, 6<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 79, 15, 11, 28, 32, 29, 30, 6<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 80, 81<br />2: Connection[24]"):::bucket
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 16, 24, 81, 11, 28, 32, 29, 30, 6<br /><br />ROOT Connection{2}ᐸ81ᐳ[24]<br />1: ConnectionItems[33]<br />ᐳ: 19, 25, 52, 75<br />2: __CloneStream[38]"):::bucket
-    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[40]<br />ᐳ: PageInfo[39]<br />2: PgSelectRows[42]<br />ᐳ: 41, 43, 44"):::bucket
+    Bucket6("Bucket 6 (defer)<br />Deps: 24, 11, 19, 25, 28, 32<br /><br />1: PgSelect[40]<br />ᐳ: PageInfo[39], Access[49], Access[50]<br />2: PgSelectRows[42]<br />ᐳ: 41, 43, 44"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 11<br /><br />ROOT __Item{7}ᐸ38ᐳ[45]"):::bucket
     Bucket8("Bucket 8 (listItem)<br />Deps: 52, 75<br /><br />ROOT __Item{8}ᐸ33ᐳ[47]"):::bucket
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 46, 11<br /><br />ROOT PgSelectSingle{7}ᐸmessagesᐳ[46]<br />1: <br />ᐳ: 51, 54<br />2: PgSelect[55]<br />3: PgSelectRows[60]<br />ᐳ: First[59], PgSelectSingle[61]"):::bucket
@@ -87,6 +87,10 @@ graph TD
     First41 --> PgSelectSingle43
     PgClassExpression44{{"PgClassExpression[44∈6]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle43 --> PgClassExpression44
+    Access49{{"Access[49∈6]<br />ᐸ24.hasNextPageᐳ"}}:::plan
+    Connection24 --> Access49
+    Access50{{"Access[50∈6]<br />ᐸ24.hasPreviousPageᐳ"}}:::plan
+    Connection24 --> Access50
     __Item45[/"__Item[45∈7]<br />ᐸ38ᐳ"\]:::itemplan
     __CloneStream38 ==> __Item45
     PgSelectSingle46{{"PgSelectSingle[46∈7]<br />ᐸmessagesᐳ"}}:::plan
@@ -138,7 +142,7 @@ graph TD
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression19,PgClassExpression25,ConnectionItems33,__CloneStream38,Access52,Access75 bucket3
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo39,PgSelect40,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44 bucket6
+    class Bucket6,PageInfo39,PgSelect40,First41,PgSelectRows42,PgSelectSingle43,PgClassExpression44,Access49,Access50 bucket6
     classDef bucket7 stroke:#808000
     class Bucket7,__Item45,PgSelectSingle46 bucket7
     classDef bucket8 stroke:#dda0dd

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 38, 39, 40, 41, 11, 13, 18, 26, 30<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 40, 26, 30<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 40, 26, 30<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 20, 27<br />2: PgSelect[21]<br />3: Connection[25]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 11, 20, 40, 26, 27, 30<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: PgSelect[32]<br />ᐳ: PageInfo[31]<br />2: PgSelectRows[34]<br />ᐳ: 33, 35, 36"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 11, 20, 40, 26, 27, 30<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: PgSelect[32]<br />ᐳ: PageInfo[31], Access[37]<br />2: PgSelectRows[34]<br />ᐳ: 33, 35, 36"):::bucket
     end
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
@@ -58,6 +58,8 @@ graph TD
     First33 --> PgSelectSingle35
     PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
+    Access37{{"Access[37∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access37
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -67,5 +69,5 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression20,PgSelect21,Connection25,PgClassExpression27 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo31,PgSelect32,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36 bucket3
+    class Bucket3,PageInfo31,PgSelect32,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Access37 bucket3
 

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages-minimal.mermaid
@@ -66,6 +66,8 @@ graph TD
     First33 --> PgSelectSingle35
     PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression36
+    Access37{{"Access[37∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access37
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -75,5 +77,5 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,Connection25,List40,Lambda41,List44,Lambda45 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo31,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36 bucket3
+    class Bucket3,PageInfo31,First33,PgSelectRows34,PgSelectSingle35,PgClassExpression36,Access37 bucket3
 

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 79, 80, 81, 83, 11, 13, 19, 28, 32<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 80, 28, 32<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 80, 28, 32<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 22, 29<br />2: PgSelect[23]<br />3: Connection[27]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 27, 11, 22, 80, 28, 29, 32, 23<br /><br />ROOT Connection{2}ᐸ23ᐳ[27]<br />1: ConnectionItems[33], PgSelect[39]<br />ᐳ: 38, 50, 49, 51, 52, 53<br />2: PgSelectRows[41]<br />ᐳ: 40, 42, 43"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 27, 11, 22, 80, 28, 29, 32, 23<br /><br />ROOT Connection{2}ᐸ23ᐳ[27]<br />1: ConnectionItems[33], PgSelect[39]<br />ᐳ: 38, 47, 48, 50, 49, 51, 52, 53<br />2: PgSelectRows[41]<br />ᐳ: 40, 42, 43"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 50, 11<br /><br />ROOT __Item{6}ᐸ33ᐳ[44]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 45, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[45]<br />1: <br />ᐳ: 54, 57<br />2: PgSelect[58]<br />3: PgSelectRows[63]<br />ᐳ: First[62], PgSelectSingle[64]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 46, 45, 11, 56<br /><br />ROOT Edge{6}[46]"):::bucket
@@ -80,6 +80,10 @@ graph TD
     First40 --> PgSelectSingle42
     PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle42 --> PgClassExpression43
+    Access47{{"Access[47∈3]<br />ᐸ27.hasNextPageᐳ"}}:::plan
+    Connection27 --> Access47
+    Access48{{"Access[48∈3]<br />ᐸ27.hasPreviousPageᐳ"}}:::plan
+    Connection27 --> Access48
     ConnectionItems33 --> First49
     PgSelect23 --> Access50
     ConnectionItems33 --> Last52
@@ -132,7 +136,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression22,PgSelect23,Connection27,PgClassExpression29 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems33,PageInfo38,PgSelect39,First40,PgSelectRows41,PgSelectSingle42,PgClassExpression43,First49,Access50,PgCursor51,Last52,PgCursor53 bucket3
+    class Bucket3,ConnectionItems33,PageInfo38,PgSelect39,First40,PgSelectRows41,PgSelectSingle42,PgClassExpression43,Access47,Access48,First49,Access50,PgCursor51,Last52,PgCursor53 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item44,PgSelectSingle45,Edge46,PgCursor56 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/condition-featured-messages.mermaid
@@ -90,6 +90,10 @@ graph TD
     First40 --> PgSelectSingle42
     PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle42 --> PgClassExpression43
+    Access47{{"Access[47∈3]<br />ᐸ27.hasNextPageᐳ"}}:::plan
+    Connection27 --> Access47
+    Access48{{"Access[48∈3]<br />ᐸ27.hasPreviousPageᐳ"}}:::plan
+    Connection27 --> Access48
     ConnectionItems33 --> First49
     Lambda90 --> Access50
     ConnectionItems33 --> Last52
@@ -146,7 +150,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,Connection27,List89,Lambda90,List93,Lambda94 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems33,PageInfo38,First40,PgSelectRows41,PgSelectSingle42,PgClassExpression43,First49,Access50,PgCursor51,Last52,PgCursor53,Access80,Access84 bucket3
+    class Bucket3,ConnectionItems33,PageInfo38,First40,PgSelectRows41,PgSelectSingle42,PgClassExpression43,Access47,Access48,First49,Access50,PgCursor51,Last52,PgCursor53,Access80,Access84 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item44,PgSelectSingle45,Edge46,PgCursor56 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 9, 10, 77, 79, 80, 11, 13, 29<br />2: PgSelect[8]<br />3: PgSelectRows[14]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 11, 77, 29<br /><br />ROOT __Item{1}ᐸ14ᐳ[15]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 16, 11, 77, 29<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[16]<br />1: <br />ᐳ: 17, 20, 26<br />2: PgSelect[21]<br />3: Connection[25]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 11, 20, 77, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[36]<br />ᐳ: 35, 47, 46, 48, 49, 50<br />2: PgSelectRows[38]<br />ᐳ: 37, 39, 40"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 11, 20, 77, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[36]<br />ᐳ: 35, 44, 45, 47, 46, 48, 49, 50<br />2: PgSelectRows[38]<br />ᐳ: 37, 39, 40"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 47, 11<br /><br />ROOT __Item{6}ᐸ30ᐳ[41]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 42, 11<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[42]<br />1: <br />ᐳ: 51, 54<br />2: PgSelect[55]<br />3: PgSelectRows[60]<br />ᐳ: First[59], PgSelectSingle[61]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 43, 42, 11, 53<br /><br />ROOT Edge{6}[43]"):::bucket
@@ -77,6 +77,10 @@ graph TD
     First37 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
+    Access44{{"Access[44∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access44
+    Access45{{"Access[45∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access45
     ConnectionItems30 --> First46
     PgSelect21 --> Access47
     ConnectionItems30 --> Last49
@@ -129,7 +133,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression20,PgSelect21,Connection25,PgClassExpression26 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo35,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,First46,Access47,PgCursor48,Last49,PgCursor50 bucket3
+    class Bucket3,ConnectionItems30,PageInfo35,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Access44,Access45,First46,Access47,PgCursor48,Last49,PgCursor50 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item41,PgSelectSingle42,Edge43,PgCursor53 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/conditions/exclusively-archived-messages.mermaid
@@ -87,6 +87,10 @@ graph TD
     First37 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
+    Access44{{"Access[44∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access44
+    Access45{{"Access[45∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access45
     ConnectionItems30 --> First46
     Lambda87 --> Access47
     ConnectionItems30 --> Last49
@@ -143,7 +147,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,Connection25,List86,Lambda87,List90,Lambda91 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,First46,Access47,PgCursor48,Last49,PgCursor50,Access77,Access81 bucket3
+    class Bucket3,ConnectionItems30,PageInfo35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Access44,Access45,First46,Access47,PgCursor48,Last49,PgCursor50,Access77,Access81 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item41,PgSelectSingle42,Edge43,PgCursor53 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.deopt.mermaid
@@ -31,7 +31,7 @@ graph TD
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
-    Connection13[["Connection[13∈0] ➊<br />ᐸ9ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[49]"]]:::plan
+    Connection13[["Connection[13∈0] ➊<br />ᐸ9ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[49]"]]:::plan
     PgSelect9 --> Connection13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
@@ -48,6 +48,8 @@ graph TD
     PgSelect9 --> Access30
     Last32{{"Last[32∈0] ➊<br />More deps:<br />- ConnectionItems[16]"}}:::plan
     PageInfo19{{"PageInfo[19∈1] ➊<br />More deps:<br />- Connection[13]"}}:::plan
+    Access27{{"Access[27∈1] ➊<br />ᐸ13.hasNextPageᐳ<br />More deps:<br />- Connection[13]"}}:::plan
+    Access28{{"Access[28∈1] ➊<br />ᐸ13.hasPreviousPageᐳ<br />More deps:<br />- Connection[13]"}}:::plan
     Edge26{{"Edge[26∈3]"}}:::plan
     __Item25[/"__Item[25∈3]<br />ᐸ16ᐳ<br />More deps:<br />- ConnectionItems[16]"\]:::itemplan
     PgCursor35{{"PgCursor[35∈3]<br />More deps:<br />- Access[30]"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect9,Access10,Access11,Object12,Connection13,Lambda15,ConnectionItems16,PgSelect20,First21,PgSelectRows22,PgSelectSingle23,First29,Access30,Last32 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo19 bucket1
+    class Bucket1,PageInfo19,Access27,Access28 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item25,Edge26,PgCursor35 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics-limit3.mermaid
@@ -32,7 +32,7 @@ graph TD
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
-    Connection13[["Connection[13∈0] ➊<br />ᐸ9ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[53]"]]:::plan
+    Connection13[["Connection[13∈0] ➊<br />ᐸ9ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[53]"]]:::plan
     PgSelect9 --> Connection13
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access10
@@ -51,6 +51,8 @@ graph TD
     Access49{{"Access[49∈0] ➊<br />ᐸ9.m.joinDetailsFor39ᐳ"}}:::plan
     PgSelect9 --> Access49
     PageInfo19{{"PageInfo[19∈1] ➊<br />More deps:<br />- Connection[13]"}}:::plan
+    Access27{{"Access[27∈1] ➊<br />ᐸ13.hasNextPageᐳ<br />More deps:<br />- Connection[13]"}}:::plan
+    Access28{{"Access[28∈1] ➊<br />ᐸ13.hasPreviousPageᐳ<br />More deps:<br />- Connection[13]"}}:::plan
     Edge26{{"Edge[26∈3]"}}:::plan
     __Item25[/"__Item[25∈3]<br />ᐸ16ᐳ<br />More deps:<br />- ConnectionItems[16]"\]:::itemplan
     PgCursor35{{"PgCursor[35∈3]<br />More deps:<br />- Access[30]"}}:::plan
@@ -79,7 +81,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect9,Access10,Access11,Object12,Connection13,Lambda15,ConnectionItems16,PgSelect20,First21,PgSelectRows22,PgSelectSingle23,First29,Access30,Last32,PgSelectInlineApply48,Access49 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo19 bucket1
+    class Bucket1,PageInfo19,Access27,Access28 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item25,Edge26,PgCursor35 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics.deopt.mermaid
@@ -34,7 +34,7 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     ConnectionItems15[["ConnectionItems[15∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[12]"]]:::plan
     First20{{"First[20∈0] ➊"}}:::plan
@@ -48,6 +48,8 @@ graph TD
     PgSelect8 --> Access29
     Last31{{"Last[31∈0] ➊<br />More deps:<br />- ConnectionItems[15]"}}:::plan
     PageInfo18{{"PageInfo[18∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access26{{"Access[26∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access27{{"Access[27∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     Edge25{{"Edge[25∈3]"}}:::plan
     __Item24[/"__Item[24∈3]<br />ᐸ15ᐳ<br />More deps:<br />- ConnectionItems[15]"\]:::itemplan
     PgCursor34{{"PgCursor[34∈3]<br />More deps:<br />- Access[29]"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,Lambda14,ConnectionItems15,PgSelect19,First20,PgSelectRows21,PgSelectSingle22,First28,Access29,Last31 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo18 bucket1
+    class Bucket1,PageInfo18,Access26,Access27 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item24,Edge25,PgCursor34 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/basics.mermaid
@@ -35,7 +35,7 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     ConnectionItems15[["ConnectionItems[15∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[12]"]]:::plan
     First20{{"First[20∈0] ➊"}}:::plan
@@ -51,6 +51,8 @@ graph TD
     Access48{{"Access[48∈0] ➊<br />ᐸ8.m.joinDetailsFor38ᐳ"}}:::plan
     PgSelect8 --> Access48
     PageInfo18{{"PageInfo[18∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access26{{"Access[26∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access27{{"Access[27∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     Edge25{{"Edge[25∈3]"}}:::plan
     __Item24[/"__Item[24∈3]<br />ᐸ15ᐳ<br />More deps:<br />- ConnectionItems[15]"\]:::itemplan
     PgCursor34{{"PgCursor[34∈3]<br />More deps:<br />- Access[29]"}}:::plan
@@ -79,7 +81,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,Lambda14,ConnectionItems15,PgSelect19,First20,PgSelectRows21,PgSelectSingle22,First28,Access29,Last31,PgSelectInlineApply47,Access48 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo18 bucket1
+    class Bucket1,PageInfo18,Access26,Access27 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item24,Edge25,PgCursor34 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/empty.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/empty.deopt.mermaid
@@ -47,6 +47,10 @@ graph TD
     PgSelectSingle16 --> PgClassExpression24
     PageInfo28{{"PageInfo[28∈3]"}}:::plan
     Connection23 --> PageInfo28
+    Access29{{"Access[29∈3]<br />ᐸ23.hasNextPageᐳ"}}:::plan
+    Connection23 --> Access29
+    Access30{{"Access[30∈3]<br />ᐸ23.hasPreviousPageᐳ"}}:::plan
+    Connection23 --> Access30
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -56,5 +60,5 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,PgClassExpression18,PgSelect19,Connection23,PgClassExpression24 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo28 bucket3
+    class Bucket3,PageInfo28,Access29,Access30 bucket3
 

--- a/grafast/dataplan-pg/__tests__/queries/connections/empty.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/empty.mermaid
@@ -49,6 +49,10 @@ graph TD
     List33 --> Lambda34
     PageInfo28{{"PageInfo[28∈3]"}}:::plan
     Connection23 --> PageInfo28
+    Access29{{"Access[29∈3]<br />ᐸ23.hasNextPageᐳ"}}:::plan
+    Connection23 --> Access29
+    Access30{{"Access[30∈3]<br />ᐸ23.hasPreviousPageᐳ"}}:::plan
+    Connection23 --> Access30
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -58,5 +62,5 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression17,Connection23,List33,Lambda34 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo28 bucket3
+    class Bucket3,PageInfo28,Access29,Access30 bucket3
 

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.deopt.mermaid
@@ -31,7 +31,7 @@ graph TD
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[51]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[51]"]]:::plan
     PgSelect10 --> Connection14
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
@@ -48,6 +48,8 @@ graph TD
     PgSelect10 --> Access32
     Last34{{"Last[34∈0] ➊<br />More deps:<br />- ConnectionItems[18]"}}:::plan
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -76,7 +78,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.mermaid
@@ -32,7 +32,7 @@ graph TD
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[55]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[55]"]]:::plan
     PgSelect10 --> Connection14
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
@@ -51,6 +51,8 @@ graph TD
     Access51{{"Access[51∈0] ➊<br />ᐸ10.m.joinDetailsFor41ᐳ"}}:::plan
     PgSelect10 --> Access51
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -79,7 +81,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34,PgSelectInlineApply50,Access51 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.array.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.array.deopt.mermaid
@@ -32,7 +32,7 @@ graph TD
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access12 & Access13 --> Object14
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[52]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[52]"]]:::plan
     PgSelect11 --> Connection15
     Access9{{"Access[9∈0] ➊<br />ᐸ0.arrayᐳ"}}:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
@@ -53,6 +53,8 @@ graph TD
     PgSelect11 --> Access33
     Last35{{"Last[35∈0] ➊<br />More deps:<br />- ConnectionItems[19]"}}:::plan
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -81,7 +83,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,ApplyInput16,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.array.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.array.mermaid
@@ -33,7 +33,7 @@ graph TD
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access12 & Access13 --> Object14
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[56]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[56]"]]:::plan
     PgSelect11 --> Connection15
     Access9{{"Access[9∈0] ➊<br />ᐸ0.arrayᐳ"}}:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
@@ -56,6 +56,8 @@ graph TD
     Access52{{"Access[52∈0] ➊<br />ᐸ11.m.joinDetailsFor42ᐳ"}}:::plan
     PgSelect11 --> Access52
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,ApplyInput16,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35,PgSelectInlineApply51,Access52 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.deopt.mermaid
@@ -33,7 +33,7 @@ graph TD
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
-    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 2"]]:::plan
+    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 4"]]:::plan
     PgSelect12 & Access8 --> Connection16
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access8
@@ -55,6 +55,8 @@ graph TD
     PgSelect12 --> Access34
     Last36{{"Last[36∈0] ➊<br />More deps:<br />- ConnectionItems[20]"}}:::plan
     PageInfo23{{"PageInfo[23∈1] ➊<br />More deps:<br />- Connection[16]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ16.hasNextPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ16.hasPreviousPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
     Edge30{{"Edge[30∈3]"}}:::plan
     __Item29[/"__Item[29∈3]<br />ᐸ20ᐳ<br />More deps:<br />- ConnectionItems[20]"\]:::itemplan
     PgCursor39{{"PgCursor[39∈3]<br />More deps:<br />- Access[34]"}}:::plan
@@ -83,7 +85,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access8,Access10,PgSelect12,Access13,Access14,Object15,Connection16,ApplyInput17,Lambda19,ConnectionItems20,PgSelect24,First25,PgSelectRows26,PgSelectSingle27,First33,Access34,Last36 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo23 bucket1
+    class Bucket1,PageInfo23,Access31,Access32 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item29,Edge30,PgCursor39 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.mermaid
@@ -34,7 +34,7 @@ graph TD
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
-    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 2"]]:::plan
+    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 4"]]:::plan
     PgSelect12 & Access8 --> Connection16
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access8
@@ -58,6 +58,8 @@ graph TD
     Access53{{"Access[53∈0] ➊<br />ᐸ12.m.joinDetailsFor43ᐳ"}}:::plan
     PgSelect12 --> Access53
     PageInfo23{{"PageInfo[23∈1] ➊<br />More deps:<br />- Connection[16]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ16.hasNextPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ16.hasPreviousPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
     Edge30{{"Edge[30∈3]"}}:::plan
     __Item29[/"__Item[29∈3]<br />ᐸ20ᐳ<br />More deps:<br />- ConnectionItems[20]"\]:::itemplan
     PgCursor39{{"PgCursor[39∈3]<br />More deps:<br />- Access[34]"}}:::plan
@@ -86,7 +88,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access8,Access10,PgSelect12,Access13,Access14,Object15,Connection16,ApplyInput17,Lambda19,ConnectionItems20,PgSelect24,First25,PgSelectRows26,PgSelectSingle27,First33,Access34,Last36,PgSelectInlineApply52,Access53 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo23 bucket1
+    class Bucket1,PageInfo23,Access31,Access32 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item29,Edge30,PgCursor39 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.multiple.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.multiple.deopt.mermaid
@@ -33,7 +33,7 @@ graph TD
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
-    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 2"]]:::plan
+    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 4"]]:::plan
     PgSelect12 & Access8 --> Connection16
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access8
@@ -55,6 +55,8 @@ graph TD
     PgSelect12 --> Access34
     Last36{{"Last[36∈0] ➊<br />More deps:<br />- ConnectionItems[20]"}}:::plan
     PageInfo23{{"PageInfo[23∈1] ➊<br />More deps:<br />- Connection[16]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ16.hasNextPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ16.hasPreviousPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
     Edge30{{"Edge[30∈3]"}}:::plan
     __Item29[/"__Item[29∈3]<br />ᐸ20ᐳ<br />More deps:<br />- ConnectionItems[20]"\]:::itemplan
     PgCursor39{{"PgCursor[39∈3]<br />More deps:<br />- Access[34]"}}:::plan
@@ -83,7 +85,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access8,Access10,PgSelect12,Access13,Access14,Object15,Connection16,ApplyInput17,Lambda19,ConnectionItems20,PgSelect24,First25,PgSelectRows26,PgSelectSingle27,First33,Access34,Last36 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo23 bucket1
+    class Bucket1,PageInfo23,Access31,Access32 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item29,Edge30,PgCursor39 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.multiple.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.multiple.mermaid
@@ -34,7 +34,7 @@ graph TD
     Access13{{"Access[13∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access14{{"Access[14∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access13 & Access14 --> Object15
-    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 2"]]:::plan
+    Connection16[["Connection[16∈0] ➊<br />ᐸ12ᐳ<br />Dependents: 4"]]:::plan
     PgSelect12 & Access8 --> Connection16
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access8
@@ -58,6 +58,8 @@ graph TD
     Access53{{"Access[53∈0] ➊<br />ᐸ12.m.joinDetailsFor43ᐳ"}}:::plan
     PgSelect12 --> Access53
     PageInfo23{{"PageInfo[23∈1] ➊<br />More deps:<br />- Connection[16]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ16.hasNextPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ16.hasPreviousPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
     Edge30{{"Edge[30∈3]"}}:::plan
     __Item29[/"__Item[29∈3]<br />ᐸ20ᐳ<br />More deps:<br />- ConnectionItems[20]"\]:::itemplan
     PgCursor39{{"PgCursor[39∈3]<br />More deps:<br />- Access[34]"}}:::plan
@@ -86,7 +88,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access8,Access10,PgSelect12,Access13,Access14,Object15,Connection16,ApplyInput17,Lambda19,ConnectionItems20,PgSelect24,First25,PgSelectRows26,PgSelectSingle27,First33,Access34,Last36,PgSelectInlineApply52,Access53 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo23 bucket1
+    class Bucket1,PageInfo23,Access31,Access32 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item29,Edge30,PgCursor39 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.string.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.string.deopt.mermaid
@@ -32,7 +32,7 @@ graph TD
     Access14{{"Access[14∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access14 & Access15 --> Object16
-    Connection17[["Connection[17∈0] ➊<br />ᐸ13ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[55]"]]:::plan
+    Connection17[["Connection[17∈0] ➊<br />ᐸ13ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[55]"]]:::plan
     PgSelect13 --> Connection17
     List53{{"List[53∈0] ➊<br />ᐸ10,56ᐳ<br />More deps:<br />- Constantᐸ'BODY_ASC'ᐳ[56]"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ0.stringᐳ"}}:::plan
@@ -55,6 +55,8 @@ graph TD
     PgSelect13 --> Access35
     Last37{{"Last[37∈0] ➊<br />More deps:<br />- ConnectionItems[21]"}}:::plan
     PageInfo24{{"PageInfo[24∈1] ➊<br />More deps:<br />- Connection[17]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ17.hasNextPageᐳ<br />More deps:<br />- Connection[17]"}}:::plan
+    Access33{{"Access[33∈1] ➊<br />ᐸ17.hasPreviousPageᐳ<br />More deps:<br />- Connection[17]"}}:::plan
     Edge31{{"Edge[31∈3]"}}:::plan
     __Item30[/"__Item[30∈3]<br />ᐸ21ᐳ<br />More deps:<br />- ConnectionItems[21]"\]:::itemplan
     PgCursor40{{"PgCursor[40∈3]<br />More deps:<br />- Access[35]"}}:::plan
@@ -83,7 +85,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access10,PgSelect13,Access14,Access15,Object16,Connection17,ApplyInput18,Lambda20,ConnectionItems21,PgSelect25,First26,PgSelectRows27,PgSelectSingle28,First34,Access35,Last37,List53 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo24 bucket1
+    class Bucket1,PageInfo24,Access32,Access33 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item30,Edge31,PgCursor40 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.string.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.string.mermaid
@@ -33,7 +33,7 @@ graph TD
     Access14{{"Access[14∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access15{{"Access[15∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access14 & Access15 --> Object16
-    Connection17[["Connection[17∈0] ➊<br />ᐸ13ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[59]"]]:::plan
+    Connection17[["Connection[17∈0] ➊<br />ᐸ13ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[59]"]]:::plan
     PgSelect13 --> Connection17
     List57{{"List[57∈0] ➊<br />ᐸ10,60ᐳ<br />More deps:<br />- Constantᐸ'BODY_ASC'ᐳ[60]"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ0.stringᐳ"}}:::plan
@@ -58,6 +58,8 @@ graph TD
     Access54{{"Access[54∈0] ➊<br />ᐸ13.m.joinDetailsFor44ᐳ"}}:::plan
     PgSelect13 --> Access54
     PageInfo24{{"PageInfo[24∈1] ➊<br />More deps:<br />- Connection[17]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ17.hasNextPageᐳ<br />More deps:<br />- Connection[17]"}}:::plan
+    Access33{{"Access[33∈1] ➊<br />ᐸ17.hasPreviousPageᐳ<br />More deps:<br />- Connection[17]"}}:::plan
     Edge31{{"Edge[31∈3]"}}:::plan
     __Item30[/"__Item[30∈3]<br />ᐸ21ᐳ<br />More deps:<br />- ConnectionItems[21]"\]:::itemplan
     PgCursor40{{"PgCursor[40∈3]<br />More deps:<br />- Access[35]"}}:::plan
@@ -86,7 +88,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access10,PgSelect13,Access14,Access15,Object16,Connection17,ApplyInput18,Lambda20,ConnectionItems21,PgSelect25,First26,PgSelectRows27,PgSelectSingle28,First34,Access35,Last37,PgSelectInlineApply53,Access54,List57 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo24 bucket1
+    class Bucket1,PageInfo24,Access32,Access33 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item30,Edge31,PgCursor40 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.strings.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.strings.deopt.mermaid
@@ -32,7 +32,7 @@ graph TD
     Access15{{"Access[15∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access15 & Access16 --> Object17
-    Connection18[["Connection[18∈0] ➊<br />ᐸ14ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[56]"]]:::plan
+    Connection18[["Connection[18∈0] ➊<br />ᐸ14ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[56]"]]:::plan
     PgSelect14 --> Connection18
     List54{{"List[54∈0] ➊<br />ᐸ10,12ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ0.string1ᐳ"}}:::plan
@@ -57,6 +57,8 @@ graph TD
     PgSelect14 --> Access36
     Last38{{"Last[38∈0] ➊<br />More deps:<br />- ConnectionItems[22]"}}:::plan
     PageInfo25{{"PageInfo[25∈1] ➊<br />More deps:<br />- Connection[18]"}}:::plan
+    Access33{{"Access[33∈1] ➊<br />ᐸ18.hasNextPageᐳ<br />More deps:<br />- Connection[18]"}}:::plan
+    Access34{{"Access[34∈1] ➊<br />ᐸ18.hasPreviousPageᐳ<br />More deps:<br />- Connection[18]"}}:::plan
     Edge32{{"Edge[32∈3]"}}:::plan
     __Item31[/"__Item[31∈3]<br />ᐸ22ᐳ<br />More deps:<br />- ConnectionItems[22]"\]:::itemplan
     PgCursor41{{"PgCursor[41∈3]<br />More deps:<br />- Access[36]"}}:::plan
@@ -85,7 +87,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access10,Access12,PgSelect14,Access15,Access16,Object17,Connection18,ApplyInput19,Lambda21,ConnectionItems22,PgSelect26,First27,PgSelectRows28,PgSelectSingle29,First35,Access36,Last38,List54 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo25 bucket1
+    class Bucket1,PageInfo25,Access33,Access34 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item31,Edge32,PgCursor41 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/order.variables.strings.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/order.variables.strings.mermaid
@@ -33,7 +33,7 @@ graph TD
     Access15{{"Access[15∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access15 & Access16 --> Object17
-    Connection18[["Connection[18∈0] ➊<br />ᐸ14ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[60]"]]:::plan
+    Connection18[["Connection[18∈0] ➊<br />ᐸ14ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[60]"]]:::plan
     PgSelect14 --> Connection18
     List58{{"List[58∈0] ➊<br />ᐸ10,12ᐳ"}}:::plan
     Access10{{"Access[10∈0] ➊<br />ᐸ0.string1ᐳ"}}:::plan
@@ -60,6 +60,8 @@ graph TD
     Access55{{"Access[55∈0] ➊<br />ᐸ14.m.joinDetailsFor45ᐳ"}}:::plan
     PgSelect14 --> Access55
     PageInfo25{{"PageInfo[25∈1] ➊<br />More deps:<br />- Connection[18]"}}:::plan
+    Access33{{"Access[33∈1] ➊<br />ᐸ18.hasNextPageᐳ<br />More deps:<br />- Connection[18]"}}:::plan
+    Access34{{"Access[34∈1] ➊<br />ᐸ18.hasPreviousPageᐳ<br />More deps:<br />- Connection[18]"}}:::plan
     Edge32{{"Edge[32∈3]"}}:::plan
     __Item31[/"__Item[31∈3]<br />ᐸ22ᐳ<br />More deps:<br />- ConnectionItems[22]"\]:::itemplan
     PgCursor41{{"PgCursor[41∈3]<br />More deps:<br />- Access[36]"}}:::plan
@@ -88,7 +90,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access10,Access12,PgSelect14,Access15,Access16,Object17,Connection18,ApplyInput19,Lambda21,ConnectionItems22,PgSelect26,First27,PgSelectRows28,PgSelectSingle29,First35,Access36,Last38,PgSelectInlineApply54,Access55,List58 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo25 bucket1
+    class Bucket1,PageInfo25,Access33,Access34 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item31,Edge32,PgCursor41 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda16 & Lambda17 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[51]"]]:::plan
     Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -49,6 +49,8 @@ graph TD
     PgSelect10 --> Access32
     Last34{{"Last[34∈0] ➊<br />More deps:<br />- ConnectionItems[18]"}}:::plan
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -77,7 +79,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-after.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object13 & Lambda16 & Lambda17 & PgSelectInlineApply50 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     Object13 & Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -52,6 +52,8 @@ graph TD
     Access51{{"Access[51∈0] ➊<br />ᐸ10.m.joinDetailsFor41ᐳ"}}:::plan
     PgSelect10 --> Access51
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -80,7 +82,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34,PgSelectInlineApply50,Access51 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda16 & Lambda17 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[51]"]]:::plan
     Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -49,6 +49,8 @@ graph TD
     PgSelect10 --> Access32
     Last34{{"Last[34∈0] ➊<br />More deps:<br />- ConnectionItems[18]"}}:::plan
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -77,7 +79,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object13 & Lambda16 & Lambda17 & PgSelectInlineApply50 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     Object13 & Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -52,6 +52,8 @@ graph TD
     Access51{{"Access[51∈0] ➊<br />ᐸ10.m.joinDetailsFor41ᐳ"}}:::plan
     PgSelect10 --> Access51
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -80,7 +82,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34,PgSelectInlineApply50,Access51 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.variables.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda17 & Lambda18 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[14]<br />- Constantᐸ3ᐳ[52]"]]:::plan
     Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -53,6 +53,8 @@ graph TD
     PgSelect11 --> Access33
     Last35{{"Last[35∈0] ➊<br />More deps:<br />- ConnectionItems[19]"}}:::plan
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -81,7 +83,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end-last.variables.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object14 & Lambda17 & Lambda18 & PgSelectInlineApply51 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     Object14 & Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -56,6 +56,8 @@ graph TD
     Access52{{"Access[52∈0] ➊<br />ᐸ11.m.joinDetailsFor42ᐳ"}}:::plan
     PgSelect11 --> Access52
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35,PgSelectInlineApply51,Access52 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda16 & Lambda17 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[51]"]]:::plan
     Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -49,6 +49,8 @@ graph TD
     PgSelect10 --> Access32
     Last34{{"Last[34∈0] ➊<br />More deps:<br />- ConnectionItems[18]"}}:::plan
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -77,7 +79,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object13 & Lambda16 & Lambda17 & PgSelectInlineApply50 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     Object13 & Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -52,6 +52,8 @@ graph TD
     Access51{{"Access[51∈0] ➊<br />ᐸ10.m.joinDetailsFor41ᐳ"}}:::plan
     PgSelect10 --> Access51
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -80,7 +82,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34,PgSelectInlineApply50,Access51 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.variables.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda17 & Lambda18 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[14]<br />- Constantᐸ3ᐳ[52]"]]:::plan
     Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -53,6 +53,8 @@ graph TD
     PgSelect11 --> Access33
     Last35{{"Last[35∈0] ➊<br />More deps:<br />- ConnectionItems[19]"}}:::plan
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -81,7 +83,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-end.variables.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object14 & Lambda17 & Lambda18 & PgSelectInlineApply51 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     Object14 & Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -56,6 +56,8 @@ graph TD
     Access52{{"Access[52∈0] ➊<br />ᐸ11.m.joinDetailsFor42ᐳ"}}:::plan
     PgSelect11 --> Access52
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35,PgSelectInlineApply51,Access52 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.deopt.mermaid
@@ -37,10 +37,14 @@ graph TD
     First20 --> PgSelectSingle22
     PageInfo18{{"PageInfo[18∈1] ➊"}}:::plan
     Connection14 --> PageInfo18
+    Access24{{"Access[24∈1] ➊<br />ᐸ14.hasNextPageᐳ"}}:::plan
+    Connection14 --> Access24
+    Access25{{"Access[25∈1] ➊<br />ᐸ14.hasPreviousPageᐳ"}}:::plan
+    Connection14 --> Access25
 
     %% define steps
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,PgSelect19,First20,PgSelectRows21,PgSelectSingle22 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo18 bucket1
+    class Bucket1,PageInfo18,Access24,Access25 bucket1
 

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.mermaid
@@ -37,10 +37,14 @@ graph TD
     First20 --> PgSelectSingle22
     PageInfo18{{"PageInfo[18∈1] ➊"}}:::plan
     Connection14 --> PageInfo18
+    Access24{{"Access[24∈1] ➊<br />ᐸ14.hasNextPageᐳ"}}:::plan
+    Connection14 --> Access24
+    Access25{{"Access[25∈1] ➊<br />ᐸ14.hasPreviousPageᐳ"}}:::plan
+    Connection14 --> Access25
 
     %% define steps
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,PgSelect19,First20,PgSelectRows21,PgSelectSingle22 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo18 bucket1
+    class Bucket1,PageInfo18,Access24,Access25 bucket1
 

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.variables.deopt.mermaid
@@ -41,10 +41,14 @@ graph TD
     First21 --> PgSelectSingle23
     PageInfo19{{"PageInfo[19∈1] ➊"}}:::plan
     Connection15 --> PageInfo19
+    Access25{{"Access[25∈1] ➊<br />ᐸ15.hasNextPageᐳ"}}:::plan
+    Connection15 --> Access25
+    Access26{{"Access[26∈1] ➊<br />ᐸ15.hasPreviousPageᐳ"}}:::plan
+    Connection15 --> Access26
 
     %% define steps
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,PgSelect20,First21,PgSelectRows22,PgSelectSingle23 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo19 bucket1
+    class Bucket1,PageInfo19,Access25,Access26 bucket1
 

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last-pagination-only.variables.mermaid
@@ -41,10 +41,14 @@ graph TD
     First21 --> PgSelectSingle23
     PageInfo19{{"PageInfo[19∈1] ➊"}}:::plan
     Connection15 --> PageInfo19
+    Access25{{"Access[25∈1] ➊<br />ᐸ15.hasNextPageᐳ"}}:::plan
+    Connection15 --> Access25
+    Access26{{"Access[26∈1] ➊<br />ᐸ15.hasPreviousPageᐳ"}}:::plan
+    Connection15 --> Access26
 
     %% define steps
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,PgSelect20,First21,PgSelectRows22,PgSelectSingle23 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo19 bucket1
+    class Bucket1,PageInfo19,Access25,Access26 bucket1
 

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda16 & Lambda17 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[51]"]]:::plan
     Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -49,6 +49,8 @@ graph TD
     PgSelect10 --> Access32
     Last34{{"Last[34∈0] ➊<br />More deps:<br />- ConnectionItems[18]"}}:::plan
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -77,7 +79,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object13 & Lambda16 & Lambda17 & PgSelectInlineApply50 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     Object13 & Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -52,6 +52,8 @@ graph TD
     Access51{{"Access[51∈0] ➊<br />ᐸ10.m.joinDetailsFor41ᐳ"}}:::plan
     PgSelect10 --> Access51
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -80,7 +82,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34,PgSelectInlineApply50,Access51 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.variables.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda17 & Lambda18 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[14]<br />- Constantᐸ3ᐳ[52]"]]:::plan
     Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -53,6 +53,8 @@ graph TD
     PgSelect11 --> Access33
     Last35{{"Last[35∈0] ➊<br />More deps:<br />- ConnectionItems[19]"}}:::plan
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -81,7 +83,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before-last.variables.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object14 & Lambda17 & Lambda18 & PgSelectInlineApply51 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     Object14 & Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -56,6 +56,8 @@ graph TD
     Access52{{"Access[52∈0] ➊<br />ᐸ11.m.joinDetailsFor42ᐳ"}}:::plan
     PgSelect11 --> Access52
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35,PgSelectInlineApply51,Access52 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda16 & Lambda17 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[51]"]]:::plan
     Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[51]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -49,6 +49,8 @@ graph TD
     PgSelect10 --> Access32
     Last34{{"Last[34∈0] ➊<br />More deps:<br />- ConnectionItems[18]"}}:::plan
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -77,7 +79,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object13 & Lambda16 & Lambda17 & PgSelectInlineApply50 --> PgSelect10
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     Object13 & Lambda16 & Lambda17 --> PgSelect22
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[55]"]]:::plan
     PgSelect10 & Lambda17 --> Connection14
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -52,6 +52,8 @@ graph TD
     Access51{{"Access[51∈0] ➊<br />ᐸ10.m.joinDetailsFor41ᐳ"}}:::plan
     PgSelect10 --> Access51
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge28{{"Edge[28∈3]"}}:::plan
     __Item27[/"__Item[27∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgCursor37{{"PgCursor[37∈3]<br />More deps:<br />- Access[32]"}}:::plan
@@ -80,7 +82,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda16,Lambda17,ConnectionItems18,PgSelect22,First23,PgSelectRows24,PgSelectSingle25,First31,Access32,Last34,PgSelectInlineApply50,Access51 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access29,Access30 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item27,Edge28,PgCursor37 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.variables.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.variables.deopt.mermaid
@@ -28,7 +28,7 @@ graph TD
     Lambda17 & Lambda18 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Object[14]<br />- Constantᐸ3ᐳ[52]"]]:::plan
     Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[52]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 3"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -53,6 +53,8 @@ graph TD
     PgSelect11 --> Access33
     Last35{{"Last[35∈0] ➊<br />More deps:<br />- ConnectionItems[19]"}}:::plan
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -81,7 +83,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.variables.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-before.variables.mermaid
@@ -30,7 +30,7 @@ graph TD
     Object14 & Lambda17 & Lambda18 & PgSelectInlineApply51 --> PgSelect11
     PgSelect23[["PgSelect[23∈0] ➊<br />ᐸmessages(aggregate)ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     Object14 & Lambda17 & Lambda18 --> PgSelect23
-    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
+    Connection15[["Connection[15∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[56]"]]:::plan
     PgSelect11 & Lambda18 --> Connection15
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access13{{"Access[13∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -56,6 +56,8 @@ graph TD
     Access52{{"Access[52∈0] ➊<br />ᐸ11.m.joinDetailsFor42ᐳ"}}:::plan
     PgSelect11 --> Access52
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[15]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ15.hasNextPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ15.hasPreviousPageᐳ<br />More deps:<br />- Connection[15]"}}:::plan
     Edge29{{"Edge[29∈3]"}}:::plan
     __Item28[/"__Item[28∈3]<br />ᐸ19ᐳ<br />More deps:<br />- ConnectionItems[19]"\]:::itemplan
     PgCursor38{{"PgCursor[38∈3]<br />More deps:<br />- Access[33]"}}:::plan
@@ -84,7 +86,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,Connection15,Lambda17,Lambda18,ConnectionItems19,PgSelect23,First24,PgSelectRows25,PgSelectSingle26,First32,Access33,Last35,PgSelectInlineApply51,Access52 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item28,Edge29,PgCursor38 bucket3
     classDef bucket4 stroke:#0000ff

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 59, 62, 63, 12, 14, 29<br />2: PgSelect[9]<br />3: PgSelectRows[15]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 12, 59, 29<br /><br />ROOT __Item{1}ᐸ15ᐳ[16]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 12, 59, 29<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[17]<br />1: <br />ᐳ: 18, 20, 26<br />2: PgSelect[21]<br />3: Connection[25]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 12, 20, 59, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[34]<br />ᐳ: 33, 44, 43, 45, 46, 47<br />2: PgSelectRows[36]<br />ᐳ: 35, 37, 38"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 12, 20, 59, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[34]<br />ᐳ: 33, 41, 42, 44, 43, 45, 46, 47<br />2: PgSelectRows[36]<br />ᐳ: 35, 37, 38"):::bucket
     Bucket5("Bucket 5 (listItem)<br />Deps: 12<br /><br />ROOT __Item{5}ᐸ30ᐳ[39]"):::bucket
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 40, 12<br /><br />ROOT PgSelectSingle{5}ᐸmessagesᐳ[40]<br />1: <br />ᐳ: 48, 49<br />2: PgSelect[50]<br />3: PgSelectRows[55]<br />ᐳ: First[54], PgSelectSingle[56]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 56<br /><br />ROOT PgSelectSingle{6}ᐸusersᐳ[56]"):::bucket
@@ -72,6 +72,10 @@ graph TD
     First35 --> PgSelectSingle37
     PgClassExpression38{{"PgClassExpression[38∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle37 --> PgClassExpression38
+    Access41{{"Access[41∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access41
+    Access42{{"Access[42∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access42
     ConnectionItems30 --> First43
     PgSelect21 --> Access44
     ConnectionItems30 --> Last46
@@ -104,7 +108,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression18,PgClassExpression20,PgSelect21,Connection25,PgClassExpression26 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo33,PgSelect34,First35,PgSelectRows36,PgSelectSingle37,PgClassExpression38,First43,Access44,PgCursor45,Last46,PgCursor47 bucket3
+    class Bucket3,ConnectionItems30,PageInfo33,PgSelect34,First35,PgSelectRows36,PgSelectSingle37,PgClassExpression38,Access41,Access42,First43,Access44,PgCursor45,Last46,PgCursor47 bucket3
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item39,PgSelectSingle40 bucket5
     classDef bucket6 stroke:#ff1493

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards-nodes-only.mermaid
@@ -81,6 +81,10 @@ graph TD
     First35 --> PgSelectSingle37
     PgClassExpression38{{"PgClassExpression[38∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle37 --> PgClassExpression38
+    Access41{{"Access[41∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access41
+    Access42{{"Access[42∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access42
     ConnectionItems30 --> First43
     Lambda66 --> Access44
     ConnectionItems30 --> Last46
@@ -115,7 +119,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression18,Connection25,List65,Lambda66,List69,Lambda70 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo33,First35,PgSelectRows36,PgSelectSingle37,PgClassExpression38,First43,Access44,PgCursor45,Last46,PgCursor47,Access60 bucket3
+    class Bucket3,ConnectionItems30,PageInfo33,First35,PgSelectRows36,PgSelectSingle37,PgClassExpression38,Access41,Access42,First43,Access44,PgCursor45,Last46,PgCursor47,Access60 bucket3
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item39,PgSelectSingle40 bucket5
     classDef bucket6 stroke:#ff1493

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 76, 79, 80, 12, 14, 29<br />2: PgSelect[9]<br />3: PgSelectRows[15]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 12, 76, 29<br /><br />ROOT __Item{1}ᐸ15ᐳ[16]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 12, 76, 29<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[17]<br />1: <br />ᐳ: 18, 20, 26<br />2: PgSelect[21]<br />3: Connection[25]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 12, 20, 76, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[36]<br />ᐳ: 35, 47, 46, 48, 49, 50<br />2: PgSelectRows[38]<br />ᐳ: 37, 39, 40"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 12, 20, 76, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[36]<br />ᐳ: 35, 44, 45, 47, 46, 48, 49, 50<br />2: PgSelectRows[38]<br />ᐳ: 37, 39, 40"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 47, 12<br /><br />ROOT __Item{6}ᐸ30ᐳ[41]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 42, 12<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[42]<br />1: <br />ᐳ: 51, 54<br />2: PgSelect[55]<br />3: PgSelectRows[60]<br />ᐳ: First[59], PgSelectSingle[61]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 43, 42, 12, 53<br /><br />ROOT Edge{6}[43]"):::bucket
@@ -77,6 +77,10 @@ graph TD
     First37 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
+    Access44{{"Access[44∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access44
+    Access45{{"Access[45∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access45
     ConnectionItems30 --> First46
     PgSelect21 --> Access47
     ConnectionItems30 --> Last49
@@ -129,7 +133,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression18,PgClassExpression20,PgSelect21,Connection25,PgClassExpression26 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo35,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,First46,Access47,PgCursor48,Last49,PgCursor50 bucket3
+    class Bucket3,ConnectionItems30,PageInfo35,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Access44,Access45,First46,Access47,PgCursor48,Last49,PgCursor50 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item41,PgSelectSingle42,Edge43,PgCursor53 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined-backwards.mermaid
@@ -87,6 +87,10 @@ graph TD
     First37 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
+    Access44{{"Access[44∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access44
+    Access45{{"Access[45∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access45
     ConnectionItems30 --> First46
     Lambda87 --> Access47
     ConnectionItems30 --> Last49
@@ -143,7 +147,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression18,Connection25,List86,Lambda87,List90,Lambda91 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,First46,Access47,PgCursor48,Last49,PgCursor50,Access77,Access81 bucket3
+    class Bucket3,ConnectionItems30,PageInfo35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Access44,Access45,First46,Access47,PgCursor48,Last49,PgCursor50,Access77,Access81 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item41,PgSelectSingle42,Edge43,PgCursor53 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 10, 11, 76, 79, 80, 12, 14, 29<br />2: PgSelect[9]<br />3: PgSelectRows[15]"):::bucket
     Bucket1("Bucket 1 (listItem)<br />Deps: 12, 76, 29<br /><br />ROOT __Item{1}ᐸ15ᐳ[16]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 12, 76, 29<br /><br />ROOT PgSelectSingle{1}ᐸforumsᐳ[17]<br />1: <br />ᐳ: 18, 20, 26<br />2: PgSelect[21]<br />3: Connection[25]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 12, 20, 76, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[36]<br />ᐳ: 35, 47, 46, 48, 49, 50<br />2: PgSelectRows[38]<br />ᐳ: 37, 39, 40"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 25, 12, 20, 76, 26, 29, 21<br /><br />ROOT Connection{2}ᐸ21ᐳ[25]<br />1: ConnectionItems[30], PgSelect[36]<br />ᐳ: 35, 44, 45, 47, 46, 48, 49, 50<br />2: PgSelectRows[38]<br />ᐳ: 37, 39, 40"):::bucket
     Bucket6("Bucket 6 (listItem)<br />Deps: 47, 12<br /><br />ROOT __Item{6}ᐸ30ᐳ[41]"):::bucket
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 42, 12<br /><br />ROOT PgSelectSingle{6}ᐸmessagesᐳ[42]<br />1: <br />ᐳ: 51, 54<br />2: PgSelect[55]<br />3: PgSelectRows[60]<br />ᐳ: First[59], PgSelectSingle[61]"):::bucket
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 43, 42, 12, 53<br /><br />ROOT Edge{6}[43]"):::bucket
@@ -77,6 +77,10 @@ graph TD
     First37 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
+    Access44{{"Access[44∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access44
+    Access45{{"Access[45∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access45
     ConnectionItems30 --> First46
     PgSelect21 --> Access47
     ConnectionItems30 --> Last49
@@ -129,7 +133,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression18,PgClassExpression20,PgSelect21,Connection25,PgClassExpression26 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo35,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,First46,Access47,PgCursor48,Last49,PgCursor50 bucket3
+    class Bucket3,ConnectionItems30,PageInfo35,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Access44,Access45,First46,Access47,PgCursor48,Last49,PgCursor50 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item41,PgSelectSingle42,Edge43,PgCursor53 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/connections/pagination-when-inlined.mermaid
@@ -87,6 +87,10 @@ graph TD
     First37 --> PgSelectSingle39
     PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸcount(*)ᐳ"}}:::plan
     PgSelectSingle39 --> PgClassExpression40
+    Access44{{"Access[44∈3]<br />ᐸ25.hasNextPageᐳ"}}:::plan
+    Connection25 --> Access44
+    Access45{{"Access[45∈3]<br />ᐸ25.hasPreviousPageᐳ"}}:::plan
+    Connection25 --> Access45
     ConnectionItems30 --> First46
     Lambda87 --> Access47
     ConnectionItems30 --> Last49
@@ -143,7 +147,7 @@ graph TD
     classDef bucket2 stroke:#7f007f
     class Bucket2,PgClassExpression18,Connection25,List86,Lambda87,List90,Lambda91 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,ConnectionItems30,PageInfo35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,First46,Access47,PgCursor48,Last49,PgCursor50,Access77,Access81 bucket3
+    class Bucket3,ConnectionItems30,PageInfo35,First37,PgSelectRows38,PgSelectSingle39,PgClassExpression40,Access44,Access45,First46,Access47,PgCursor48,Last49,PgCursor50,Access77,Access81 bucket3
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item41,PgSelectSingle42,Edge43,PgCursor53 bucket6
     classDef bucket7 stroke:#808000

--- a/grafast/grafast/package.json
+++ b/grafast/grafast/package.json
@@ -71,7 +71,6 @@
     "graphile-config": "workspace:^",
     "graphql": "^16.1.0-experimental-stream-defer.6",
     "iterall": "^1.3.0",
-    "tamedevil": "workspace:^",
     "tslib": "^2.8.1"
   },
   "peerDependencies": {

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -13,7 +13,6 @@ import type {
   OperationDefinitionNode,
 } from "graphql";
 import * as graphql from "graphql";
-import te from "tamedevil";
 
 import * as assert from "../assert.js";
 import {
@@ -480,9 +479,7 @@ export class OperationPlan {
     this.lap("treeShakeSteps", "optimize");
 
     // Replace/inline/optimise steps
-    te.batch(() => {
-      this.optimizeSteps();
-    });
+    this.optimizeSteps();
 
     this.checkTimeout();
     this.lap("optimizeSteps");
@@ -511,16 +508,12 @@ export class OperationPlan {
 
     // Plans are expected to execute later; they may take steps here to prepare
     // themselves (e.g. compiling SQL queries ahead of time).
-    te.batch(() => {
-      this.finalizeSteps();
-    });
+    this.finalizeSteps();
 
     this.lap("finalizeSteps");
 
     // Replace access plans with direct access, etc (must come after finalizeSteps)
-    te.batch(() => {
-      this.optimizeOutputPlans();
-    });
+    this.optimizeOutputPlans();
 
     this.checkTimeout();
     this.lap("optimizeOutputPlans");
@@ -533,15 +526,11 @@ export class OperationPlan {
 
     this.stepTracker.finalizeOutputPlans();
 
-    te.batch(() => {
-      this.finalizeLayerPlans();
-    });
+    this.finalizeLayerPlans();
 
     this.lap("finalizeLayerPlans");
 
-    te.batch(() => {
-      this.finalizeOutputPlans();
-    });
+    this.finalizeOutputPlans();
 
     this.lap("finalizeOutputPlans");
 

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -1,6 +1,4 @@
 import chalk from "chalk";
-import type { TE } from "tamedevil";
-import te from "tamedevil";
 
 import {
   $$deepDepSkip,
@@ -41,6 +39,7 @@ import type {
   UnbatchedExecutionExtra,
 } from "./interfaces.js";
 import type { __FlagStep, __ItemStep } from "./steps/index.js";
+import { buildOptimizedExecute } from "./unbatchedStepExecute.js";
 import { stepADependsOnStepB, stepAMayDependOnStepB } from "./utils.js";
 
 /**
@@ -50,8 +49,6 @@ import { stepADependsOnStepB, stepAMayDependOnStepB } from "./utils.js";
  * @internal
  */
 export const $$noExec = Symbol("noExec");
-
-const ref_flagError = te.ref(flagError, "flagError");
 
 function throwDestroyed(this: Step): any {
   let message: string;
@@ -835,88 +832,6 @@ ${printDeps(step, 1)}
   public toSpecifier?(): Step;
   public toTypename?(): Step<string>;
   // public itemPlan?($item: Step): Step;
-}
-
-function _buildOptimizedExecuteV2Expression(
-  depCount: number,
-  isSyncAndSafe: boolean,
-) {
-  const identifiers: TE[] = [];
-  for (let i = 0; i < depCount; i++) {
-    identifiers.push(te.identifier(`value${i}`));
-  }
-  const tryOrNot = (inFrag: TE): TE => {
-    if (isSyncAndSafe) {
-      return inFrag;
-    } else {
-      return te`\
-    try {
-  ${te.indent(inFrag)}
-    } catch (e) {
-      results[i] = ${ref_flagError}(e);
-    }\
-`;
-    }
-  };
-  return te`\
-(function execute({
-  count,
-  values: [${te.join(identifiers, ", ")}],
-  extra,
-}) {
-  const results = [];
-  for (let i = 0; i < count; i++) {
-${tryOrNot(te`\
-    results[i] = this.unbatchedExecute(extra, ${te.join(
-      identifiers.map((identifier) => te`${identifier}.at(i)`),
-      ", ",
-    )});\
-`)}
-  }
-  return results;
-})`;
-}
-
-const MAX_DEPENDENCIES_TO_CACHE = 10;
-const unsafeCache: any[] = [];
-const safeCache: any[] = [];
-te.batch(() => {
-  for (let i = 0; i <= MAX_DEPENDENCIES_TO_CACHE; i++) {
-    const depCount = i;
-    const unsafeExpression = _buildOptimizedExecuteV2Expression(
-      depCount,
-      false,
-    );
-    te.runInBatch(unsafeExpression, (fn) => {
-      unsafeCache[depCount] = fn;
-    });
-    const safeExpression = _buildOptimizedExecuteV2Expression(depCount, true);
-    te.runInBatch(safeExpression, (fn) => {
-      safeCache[depCount] = fn;
-    });
-  }
-});
-
-function buildOptimizedExecute(
-  depCount: number,
-  isSyncAndSafe: boolean,
-  callback: (fn: any) => void,
-) {
-  // Try and satisfy from cache
-  const cache = isSyncAndSafe ? safeCache : unsafeCache;
-  if (depCount <= MAX_DEPENDENCIES_TO_CACHE) {
-    callback(cache[depCount]);
-    return;
-  }
-
-  // Build it
-  const expression = _buildOptimizedExecuteV2Expression(
-    depCount,
-    isSyncAndSafe,
-  );
-  te.runInBatch<any>(expression, (fn) => {
-    callback(fn);
-  });
 }
 
 export abstract class UnbatchedStep<TData = any> extends Step<TData> {

--- a/grafast/grafast/src/steps/access.ts
+++ b/grafast/grafast/src/steps/access.ts
@@ -1,69 +1,48 @@
 import chalk from "chalk";
-import type { TE } from "tamedevil";
-import te from "tamedevil";
 
-import { inspect } from "../inspect.js";
 import type { ExecutionExtra, UnbatchedExecutionExtra } from "../interfaces.js";
 import type { Step } from "../step.js";
 import { UnbatchedStep } from "../step.js";
 import { arraysMatch, digestKeys } from "../utils.js";
 
-/** @internal */
-export const expressionSymbol = Symbol("expression");
-
-// We could use an LRU here, but there's no need - there's only 100 possible values;
-type Factory = (
-  fallback: any,
-  ...path: Array<string | number | symbol>
-) => (_extra: ExecutionExtra, value: any) => any;
-const makeDestructureCache: { [signature: string]: Factory | undefined } =
-  Object.create(null);
-const makingDestructureCache: {
-  [signature: string]: Array<(factory: Factory) => void> | undefined;
-} = Object.create(null);
-
 /**
  * Returns a function that will extract the value at the given path from an
- * incoming object. If possible it will return a dynamically constructed
- * function which will enable V8 to optimise the function over time via the
- * JIT.
+ * incoming object. Optimized functions for common cases
  */
 function constructDestructureFunction(
-  path: (string | number | symbol)[],
+  path: ReadonlyArray<PropertyKey>,
   fallback: any,
   callback: (fn: (_extra: ExecutionExtra, value: any) => any) => void,
 ): void {
   const n = path.length;
-  /** 0 - slow mode; 1 - middle mode; 2 - turbo mode */
-  let mode: 0 | 1 | 2 = n > 50 || n < 1 ? 0 : n > 5 ? 1 : 2;
-
-  for (let i = 0; i < n; i++) {
-    const pathItem = path[i];
-    const t = typeof pathItem;
-    if (t === "symbol") {
-      // Cannot use in superfast mode (because cannot create signature)
-      if (mode === 2) mode = 1;
-    } else if (t === "string") {
-      // Cannot use in superfast mode (because signature becomes ambiguous)
-      if (mode === 2 && (pathItem as string).includes("|")) mode = 1;
-    } else if (t === "number") {
-      if (!Number.isFinite(pathItem)) {
-        mode = 0;
-      }
-    } else if (pathItem == null) {
-      // Slow mode required
-      mode = 0;
+  if (n === 0) {
+    if (fallback !== undefined) {
+      callback((_meta, value) => value ?? fallback);
     } else {
-      throw new Error(
-        `Invalid path item: ${inspect(pathItem)} in path '${JSON.stringify(
-          path,
-        )}'`,
-      );
+      callback((_meta, value) => value);
     }
-  }
-
-  if (mode === 0) {
-    // Slow mode
+  } else if (n === 1) {
+    const [p0] = path;
+    if (fallback !== undefined) {
+      callback((_meta, value) => value?.[p0] ?? fallback);
+    } else {
+      callback((_meta, value) => value?.[p0]);
+    }
+  } else if (n === 2) {
+    const [p0, p1] = path;
+    if (fallback !== undefined) {
+      callback((_meta, value) => value?.[p0]?.[p1] ?? fallback);
+    } else {
+      callback((_meta, value) => value?.[p0]?.[p1]);
+    }
+  } else if (n === 3) {
+    const [p0, p1, p2] = path;
+    if (fallback !== undefined) {
+      callback((_meta, value) => value?.[p0]?.[p1]?.[p2] ?? fallback);
+    } else {
+      callback((_meta, value) => value?.[p0]?.[p1]?.[p2]);
+    }
+  } else {
     callback(function slowlyExtractValueAtPath(_meta: any, value: any): any {
       let current = value;
       for (let i = 0, l = path.length; i < l && current != null; i++) {
@@ -72,56 +51,6 @@ function constructDestructureFunction(
       }
       return current ?? fallback;
     });
-  } else {
-    const signature = (fallback !== undefined ? "f" : "n") + n;
-
-    const done =
-      mode === 2
-        ? (factory: Factory) => {
-            const fn = factory(fallback, ...path);
-            // ?.blah?.bog?.["!!!"]?.[0]
-            const expressionDetail = [path, fallback];
-            (fn as any)[expressionSymbol] = expressionDetail;
-            callback(fn);
-          }
-        : (factory: Factory) => callback(factory(fallback, ...path));
-
-    const fn = makeDestructureCache[signature];
-    if (fn !== undefined) {
-      done(fn);
-      return;
-    }
-    const making = makingDestructureCache[signature];
-    if (making !== undefined) {
-      making.push(done);
-      return;
-    }
-    const doneHandlers: Array<(fn: Factory) => void> = [done];
-    makingDestructureCache[signature] = doneHandlers;
-
-    // DO NOT REFERENCE 'path' BELOW HERE!
-
-    const names: TE[] = [];
-    const access: TE[] = [];
-    for (let i = 0; i < n; i++) {
-      const te_name = te.identifier(`p${i}`);
-      names.push(te_name);
-      access.push(te`[${te_name}]`);
-    }
-    te.runInBatch<Factory>(
-      te`function (fallback, ${te.join(names, ", ")}) {
-return (_meta, value) => value?.${te.join(access, "?.")}${
-        fallback === undefined ? te.blank : te.cache` ?? fallback`
-      };
-}`,
-      (factory) => {
-        makeDestructureCache[signature] = factory;
-        delete makingDestructureCache[signature];
-        for (const doneHandler of doneHandlers) {
-          doneHandler(factory);
-        }
-      },
-    );
   }
 }
 

--- a/grafast/grafast/src/steps/object.ts
+++ b/grafast/grafast/src/steps/object.ts
@@ -1,7 +1,5 @@
 // import debugFactory from "debug";
 
-import te, { isSafeObjectPropertyName } from "tamedevil";
-
 import { isDev } from "../dev.js";
 import type {
   DataFromStep,
@@ -12,6 +10,7 @@ import type {
 } from "../interfaces.js";
 import type { Step } from "../step.js";
 import { UnbatchedStep } from "../step.js";
+import { isSafeObjectPropertyName } from "../tamedevilUtils";
 import { digestKeys } from "../utils.js";
 import { constant, ConstantStep } from "./constant.js";
 
@@ -171,78 +170,110 @@ export class ObjectStep<
       ) => DataFromObjectSteps<TPlans>,
     ) => void,
   ): void {
-    if (this.keys.length === 0) {
-      // Shortcut simple case
-      return callback(() => EMPTY_OBJECT);
-    }
     const keysAreSafe = this.keys.every(isSafeObjectPropertyName);
-    const inner = keysAreSafe
-      ? te`\
-  const newObj = {
-${te.join(
-  this.keys.map(
-    (key, i) => te`    ${te.safeKeyOrThrow(key)}: ${te.identifier(`val${i}`)}`,
-  ),
-  ",\n",
-)}
-  };
-`
-      : te`\
-  const newObj = Object.create(null);
-${te.join(
-  this.keys.map(
-    (key, i) =>
-      te`  newObj${te.set(key, true)} = ${te.identifier(`val${i}`)};\n`,
-  ),
-  "",
-)}\
-`;
-    const vals = te.join(
-      this.keys.map((_k, i) => te.identifier(`val${i}`)),
-      ", ",
-    );
-    if (this.cacheSize > 0) {
-      return te.runInBatch<Parameters<typeof callback>[0]>(
-        te`\
-(function ({ meta }, ${vals}) {
-  if (meta.nextIndex != null) {
-    for (let i = 0, l = meta.results.length; i < l; i++) {
-      const [values, obj] = meta.results[i];
-      if (${te.join(
-        this.keys.map(
-          (_key, i) => te`values[${te.lit(i)}] === ${te.identifier(`val${i}`)}`,
-        ),
-        " && ",
-      )}) {
-        return obj;
+    // Optimize common cases
+    if (keysAreSafe && this.cacheSize === 0) {
+      switch (this.keys.length) {
+        case 0: {
+          return callback(() => EMPTY_OBJECT);
+        }
+        case 1: {
+          const [k1] = this.keys;
+          return callback((_, val1) => ({ [k1]: val1 }) as any);
+        }
+        case 2: {
+          const [k1, k2] = this.keys;
+          return callback(
+            (_, val1, val2) => ({ [k1]: val1, [k2]: val2 }) as any,
+          );
+        }
+        case 3: {
+          const [k1, k2, k3] = this.keys;
+          return callback(
+            (_, val1, val2, val3) =>
+              ({ [k1]: val1, [k2]: val2, [k3]: val3 }) as any,
+          );
+        }
+        case 4: {
+          const [k1, k2, k3, k4] = this.keys;
+          return callback(
+            (_, val1, val2, val3, val4) =>
+              ({ [k1]: val1, [k2]: val2, [k3]: val3, [k4]: val4 }) as any,
+          );
+        }
+        case 5: {
+          const [k1, k2, k3, k4, k5] = this.keys;
+          return callback(
+            (_, val1, val2, val3, val4, val5) =>
+              ({
+                [k1]: val1,
+                [k2]: val2,
+                [k3]: val3,
+                [k4]: val4,
+                [k5]: val5,
+              }) as any,
+          );
+        }
+        case 6: {
+          const [k1, k2, k3, k4, k5, k6] = this.keys;
+          return callback(
+            (_, val1, val2, val3, val4, val5, val6) =>
+              ({
+                [k1]: val1,
+                [k2]: val2,
+                [k3]: val3,
+                [k4]: val4,
+                [k5]: val5,
+                [k6]: val6,
+              }) as any,
+          );
+        }
       }
     }
-  } else {
-    meta.nextIndex = 0;
-    meta.results = [];
-  }
-${inner}
-  meta.results[meta.nextIndex] = [[${te.join(
-    this.keys.map((_key, i) => te.identifier(`val${i}`)),
-    ",",
-  )}], newObj];
-  // Only cache ${te.lit(this.cacheSize)} results, use a round-robin
-  meta.nextIndex = meta.nextIndex === ${te.lit(
-    this.cacheSize - 1,
-  )} ? 0 : meta.nextIndex + 1;
-  return newObj;
-})`,
-        callback,
-      );
+    const keys = this.keys;
+    const keyCount = keys.length;
+    if (this.cacheSize > 0) {
+      // NOTE: `peerKey` ensures that the keys match, so we only need to check values
+      return callback((extra, ...vals) => {
+        const meta = extra.meta as { nextIndex?: number; results: any[] };
+        if (meta.nextIndex != null) {
+          nextMetaResult: for (
+            let metaResultIndex = 0, metaResultLength = meta.results.length;
+            metaResultIndex < metaResultLength;
+            metaResultIndex++
+          ) {
+            const [values, obj] = meta.results[metaResultIndex];
+            for (let keyIndex = 0; keyIndex < keyCount; keyIndex++) {
+              if (values[keyIndex] !== vals[keyIndex]) {
+                continue nextMetaResult;
+              }
+            }
+            return obj;
+          }
+        } else {
+          meta.nextIndex = 0;
+          meta.results = [];
+        }
+
+        const obj = Object.create(null);
+        for (let keyIndex = 0; keyIndex < keyCount; keyIndex++) {
+          obj[keys[keyIndex]] = vals[keyIndex];
+        }
+
+        meta.results[meta.nextIndex] = [vals, obj];
+        // Only cache `this.cacheSize` results, use a round-robin
+        meta.nextIndex =
+          meta.nextIndex >= this.cacheSize - 1 ? 0 : meta.nextIndex + 1;
+        return obj;
+      });
     } else {
-      return te.runInBatch<Parameters<typeof callback>[0]>(
-        te`\
-(function (_, ${vals}) {
-${inner}
-  return newObj;
-})`,
-        callback,
-      );
+      return callback((_, ...values) => {
+        const obj = Object.create(null);
+        for (let keyIndex = 0; keyIndex < keyCount; keyIndex++) {
+          obj[keys[keyIndex]] = values[keyIndex];
+        }
+        return obj;
+      });
     }
   }
 

--- a/grafast/grafast/src/steps/object.ts
+++ b/grafast/grafast/src/steps/object.ts
@@ -172,61 +172,121 @@ export class ObjectStep<
   ): void {
     const keysAreSafe = this.keys.every(isSafeObjectPropertyName);
     // Optimize common cases
-    if (keysAreSafe && this.cacheSize === 0) {
-      switch (this.keys.length) {
-        case 0: {
-          return callback(() => EMPTY_OBJECT);
+    if (keysAreSafe) {
+      if (this.cacheSize === 0 || this.keys.length === 0) {
+        switch (this.keys.length) {
+          case 0: {
+            return callback(() => EMPTY_OBJECT);
+          }
+          case 1: {
+            const [k0] = this.keys;
+            return callback((_, val0) => ({ [k0]: val0 }) as any);
+          }
+          case 2: {
+            const [k0, k1] = this.keys;
+            return callback(
+              (_, val0, val1) => ({ [k0]: val0, [k1]: val1 }) as any,
+            );
+          }
+          case 3: {
+            const [k0, k1, k2] = this.keys;
+            return callback(
+              (_, val0, val1, val2) =>
+                ({ [k0]: val0, [k1]: val1, [k2]: val2 }) as any,
+            );
+          }
+          case 4: {
+            const [k0, k1, k2, k3] = this.keys;
+            return callback(
+              (_, val0, val1, val2, val3) =>
+                ({ [k0]: val0, [k1]: val1, [k2]: val2, [k3]: val3 }) as any,
+            );
+          }
+          case 5: {
+            const [k0, k1, k2, k3, k4] = this.keys;
+            return callback(
+              (_, val0, val1, val2, val3, val4) =>
+                ({
+                  [k0]: val0,
+                  [k1]: val1,
+                  [k2]: val2,
+                  [k3]: val3,
+                  [k4]: val4,
+                }) as any,
+            );
+          }
+          case 6: {
+            const [k0, k1, k2, k3, k4, k5] = this.keys;
+            return callback(
+              (_, val0, val1, val2, val3, val4, val5) =>
+                ({
+                  [k0]: val0,
+                  [k1]: val1,
+                  [k2]: val2,
+                  [k3]: val3,
+                  [k4]: val4,
+                  [k5]: val5,
+                }) as any,
+            );
+          }
         }
-        case 1: {
-          const [k1] = this.keys;
-          return callback((_, val1) => ({ [k1]: val1 }) as any);
-        }
-        case 2: {
-          const [k1, k2] = this.keys;
-          return callback(
-            (_, val1, val2) => ({ [k1]: val1, [k2]: val2 }) as any,
-          );
-        }
-        case 3: {
-          const [k1, k2, k3] = this.keys;
-          return callback(
-            (_, val1, val2, val3) =>
-              ({ [k1]: val1, [k2]: val2, [k3]: val3 }) as any,
-          );
-        }
-        case 4: {
-          const [k1, k2, k3, k4] = this.keys;
-          return callback(
-            (_, val1, val2, val3, val4) =>
-              ({ [k1]: val1, [k2]: val2, [k3]: val3, [k4]: val4 }) as any,
-          );
-        }
-        case 5: {
-          const [k1, k2, k3, k4, k5] = this.keys;
-          return callback(
-            (_, val1, val2, val3, val4, val5) =>
-              ({
-                [k1]: val1,
-                [k2]: val2,
-                [k3]: val3,
-                [k4]: val4,
-                [k5]: val5,
-              }) as any,
-          );
-        }
-        case 6: {
-          const [k1, k2, k3, k4, k5, k6] = this.keys;
-          return callback(
-            (_, val1, val2, val3, val4, val5, val6) =>
-              ({
-                [k1]: val1,
-                [k2]: val2,
-                [k3]: val3,
-                [k4]: val4,
-                [k5]: val5,
-                [k6]: val6,
-              }) as any,
-          );
+      } else {
+        const maxIdx = this.cacheSize - 1;
+        switch (this.keys.length) {
+          case 1: {
+            const [k0] = this.keys;
+            return callback((extra, val0) => {
+              const meta = extra.meta as { nextIndex?: number; results: any[] };
+              if (meta.nextIndex == null) {
+                meta.nextIndex = 0;
+                meta.results = [];
+              } else {
+                const cacheLen = meta.results.length;
+                for (let cacheIdx = 0; cacheIdx < cacheLen; cacheIdx++) {
+                  const [cache0, obj] = meta.results[cacheIdx];
+                  if (cache0 === val0) {
+                    return obj;
+                  }
+                }
+              }
+
+              const obj = { [k0]: val0 } as any;
+
+              meta.results[meta.nextIndex] = [val0, obj];
+              // Only cache `this.cacheSize` results, use a round-robin
+              meta.nextIndex =
+                meta.nextIndex >= maxIdx ? 0 : meta.nextIndex + 1;
+
+              return obj;
+            });
+          }
+          case 2: {
+            const [k0, k1] = this.keys;
+            return callback((extra, val0, val1) => {
+              const meta = extra.meta as { nextIndex?: number; results: any[] };
+              if (meta.nextIndex == null) {
+                meta.nextIndex = 0;
+                meta.results = [];
+              } else {
+                const cacheLen = meta.results.length;
+                for (let cacheIdx = 0; cacheIdx < cacheLen; cacheIdx++) {
+                  const [cache0, cache1, obj] = meta.results[cacheIdx];
+                  if (cache0 === val0 && cache1 === val1) {
+                    return obj;
+                  }
+                }
+              }
+
+              const obj = { [k0]: val0, [k1]: val1 } as any;
+
+              meta.results[meta.nextIndex] = [val0, val1, obj];
+              // Only cache `this.cacheSize` results, use a round-robin
+              meta.nextIndex =
+                meta.nextIndex >= maxIdx ? 0 : meta.nextIndex + 1;
+
+              return obj;
+            });
+          }
         }
       }
     }
@@ -242,9 +302,9 @@ export class ObjectStep<
             metaResultIndex < metaResultLength;
             metaResultIndex++
           ) {
-            const [values, obj] = meta.results[metaResultIndex];
+            const [cacheValues, obj] = meta.results[metaResultIndex];
             for (let keyIndex = 0; keyIndex < keyCount; keyIndex++) {
-              if (values[keyIndex] !== vals[keyIndex]) {
+              if (cacheValues[keyIndex] !== vals[keyIndex]) {
                 continue nextMetaResult;
               }
             }
@@ -264,6 +324,7 @@ export class ObjectStep<
         // Only cache `this.cacheSize` results, use a round-robin
         meta.nextIndex =
           meta.nextIndex >= this.cacheSize - 1 ? 0 : meta.nextIndex + 1;
+
         return obj;
       });
     } else {

--- a/grafast/grafast/src/tamedevilUtils.ts
+++ b/grafast/grafast/src/tamedevilUtils.ts
@@ -1,0 +1,79 @@
+// If we add tamedevil back, we should move back to using its utils. In the
+// mean time, I've copied them here.
+
+/**
+ * A 'short string' has a length less than or equal to this, and can
+ * potentially have JSON.stringify skipped on it if it doesn't contain any of
+ * the forbiddenCharacters. To prevent the forbiddenCharacters regexp running
+ * for a long time, we cap the length of string we test.
+ */
+const MAX_SHORT_STRING_LENGTH = 200; // TODO: what should this be?
+
+const BACKSLASH_CODE = "\\".charCodeAt(0);
+const QUOTE_CODE = '"'.charCodeAt(0);
+
+/**
+ * Similar to `JSON.stringify(string)`, but faster. Bizarrely this seems to be
+ * faster than the regexp approach
+ */
+export function stringifyString(value: string): string {
+  const l = value.length;
+  if (l > MAX_SHORT_STRING_LENGTH) {
+    return JSON.stringify(value);
+  }
+  // Scan through for disallowed charcodes
+  for (let i = 0; i < l; i++) {
+    const code = value.charCodeAt(i);
+    if (
+      code === BACKSLASH_CODE ||
+      code === QUOTE_CODE ||
+      (code & 0xffe0) === 0 || // equivalent to `code <= 0x001f`
+      (code & 0xc000) !== 0 // Not quite equivalent to `code >= 0xd800`, but good enough for our purposes
+    ) {
+      // Backslash, quote, control character or surrogate
+      return JSON.stringify(value);
+    }
+  }
+  return `"${value}"`;
+}
+
+// PERF: more optimal stringifier
+/**
+ * Equivalent to JSON.stringify, but typically faster.
+ */
+export const stringifyJSON = (value: any): string => {
+  if (value == null) return "null";
+  if (value === true) return "true";
+  if (value === false) return "false";
+  const t = typeof value;
+  if (t === "number") return "" + value;
+  if (t === "string") {
+    return stringifyString(value as string);
+  }
+  return JSON.stringify(value);
+};
+
+/**
+ * Values that cannot safely be used as the keys on a POJO (`{}`) due to
+ * security or similar concerns. For example `__proto__` is disallowed.
+ */
+const disallowedKeys: Array<string | symbol | number> = [
+  ...Object.getOwnPropertyNames(Object.prototype),
+  ...Object.getOwnPropertySymbols(Object.prototype),
+];
+if (!disallowedKeys.includes("__proto__")) {
+  // If you're running with `--disable-proto=delete` we still want to check
+  // you're not trying to set __proto__.
+  disallowedKeys.push("__proto__");
+}
+
+/**
+ * Returns true if the given key is safe to set as the key of a POJO (without a
+ * null prototype), false otherwise.
+ */
+export const isSafeObjectPropertyName = (key: string | symbol | number) =>
+  (typeof key === "number" ||
+    typeof key === "symbol" ||
+    (typeof key === "string" &&
+      /^(?:[0-9a-z$]|_[a-z0-9$])[a-z0-9_$]*$/i.test(key))) &&
+  !disallowedKeys.includes(key);

--- a/grafast/grafast/src/unbatchedStepExecute.ts
+++ b/grafast/grafast/src/unbatchedStepExecute.ts
@@ -1,0 +1,94 @@
+import { flagError } from "./error";
+import type { ExecutionDetails, UnbatchedExecutionExtra } from "./interfaces";
+import type { UnbatchedStep } from "./step";
+
+function execute0(this: UnbatchedStep, { count, extra }: ExecutionDetails) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results[i] = this.unbatchedExecute(extra);
+  }
+  return results;
+}
+
+function execute1safe(
+  this: UnbatchedStep,
+  { count, values: [value0], extra }: ExecutionDetails,
+) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results[i] = this.unbatchedExecute(extra, value0.at(i));
+  }
+  return results;
+}
+
+function execute1unsafe(
+  this: UnbatchedStep,
+  { count, values: [value0], extra }: ExecutionDetails,
+) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results[i] = this.unbatchedExecute(extra, value0.at(i));
+  }
+  return results;
+}
+
+function execute2safe(
+  this: UnbatchedStep,
+  { count, values: [value0, value1], extra }: ExecutionDetails,
+) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    results[i] = this.unbatchedExecute(extra, value0.at(i), value1.at(i));
+  }
+  return results;
+}
+
+function execute2unsafe(
+  this: UnbatchedStep,
+  { count, values: [value0, value1], extra }: ExecutionDetails,
+) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    try {
+      results[i] = this.unbatchedExecute(extra, value0.at(i), value1.at(i));
+    } catch (e) {
+      results[i] = flagError(e);
+    }
+  }
+  return results;
+}
+
+function executeN(
+  this: UnbatchedStep,
+  { count, values, extra }: ExecutionDetails,
+) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    const args: [UnbatchedExecutionExtra, ...any[]] = [extra];
+    for (let j = 0; j < values.length; j++) {
+      args.push(values[j].at(i));
+    }
+    try {
+      results[i] = this.unbatchedExecute.apply(this, args);
+    } catch (e) {
+      results[i] = flagError(e);
+    }
+  }
+  return results;
+}
+
+export function buildOptimizedExecute(
+  depCount: number,
+  isSyncAndSafe: boolean,
+  callback: (fn: any) => void,
+): void {
+  if (depCount === 0) {
+    callback(execute0);
+  } else if (depCount === 1) {
+    callback(isSyncAndSafe ? execute1safe : execute1unsafe);
+  } else if (depCount === 2) {
+    callback(isSyncAndSafe ? execute2safe : execute2unsafe);
+  } else {
+    callback(executeN);
+  }
+}

--- a/grafast/grafast/tsconfig.json
+++ b/grafast/grafast/tsconfig.json
@@ -10,7 +10,6 @@
     { "path": "../codegen-plugin" },
     { "path": "../../utils/lru" },
     { "path": "../../utils/pg-sql2" },
-    { "path": "../../utils/graphile-config" },
-    { "path": "../../utils/tamedevil" }
+    { "path": "../../utils/graphile-config" }
   ]
 }

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -45,28 +45,8 @@ export function isForbidden(thing: unknown): thing is { $$export: false } {
 }
 
 export function EXPORTABLE_OBJECT_CLONE<T extends object>(obj: T): T {
-  if (Object.getPrototypeOf(obj) === Object.prototype) {
-    const keys = Object.keys(obj);
-    const values = Object.values(obj);
-    const fn = te.eval<any>`return (${te.join(
-      keys.map((_key, i) => te.identifier(`key${i}`)),
-      ", ",
-    )}) => ({${te.indent(
-      te.join(
-        keys.map(
-          (key, i) =>
-            te`${te.safeKeyOrThrow(key)}: ${te.identifier(`key${i}`)}`,
-        ),
-        ",\n",
-      ),
-    )}});`;
-    // eslint-disable-next-line graphile-export/exhaustive-deps
-    return EXPORTABLE(fn, values);
-  } else {
-    throw new Error(
-      "EXPORTABLE_OBJECT_CLONE can currently only be used with POJOs.",
-    );
-  }
+  const entries = Object.entries(obj);
+  return EXPORTABLE((entries) => Object.fromEntries(entries) as T, [entries]);
 }
 
 export function exportNameHint(obj: any, nameHint: string): void {

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
@@ -13,7 +13,7 @@ graph TD
     Bucket3("Bucket 3 (listItem)<br />Deps: 12, 42, 125, 130, 175, 180, 225, 230<br /><br />ROOT __Item{3}ᐸ15ᐳ[18]"):::bucket
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 19, 12, 42, 125, 130, 175, 180, 225, 230<br /><br />ROOT PgSelectSingle{3}ᐸpeopleᐳ[19]<br />1: <br />ᐳ: 20, 21<br />2: PgUnionAll[22], PgUnionAll[27]<br />ᐳ: 263, 28, 31<br />3: Connection[26]<br />4: ConnectionItems[32]"):::bucket
     Bucket7("Bucket 7 (listItem)<br />Deps: 42, 22, 12, 125, 130, 175, 180, 225, 230<br /><br />ROOT __Item{7}ᐸ32ᐳ[37]"):::bucket
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38, 45, 12, 46, 63, 44<br /><br />ROOT Edge{7}[38]"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 38, 45, 12, 46, 63<br /><br />ROOT Edge{7}[38]"):::bucket
     Bucket9("Bucket 9 (polymorphic)<br />__typename: Access[45]<br />Deps: 45, 12, 46, 125, 130, 175, 180, 225, 230"):::bucket
     Bucket10("Bucket 10 (polymorphicPartition)<br />|AwsApplication<br />Deps: 12, 46, 125, 175, 225<br />ᐳAwsApplication<br /><br />1: PgSelect[47]<br />2: PgSelectRows[52]<br />ᐳ: 51, 53, 65, 67, 69, 71, 72<br />3: 73, 89, 93, 157<br />ᐳ: 257, 258, 259, 77, 123, 124, 126, 127, 158, 161<br />4: Connection[95]<br />5: ConnectionItems[167]"):::bucket
     Bucket11("Bucket 11 (polymorphicPartition)<br />|GcpApplication<br />Deps: 12, 46, 130, 180, 230<br />ᐳGcpApplication<br /><br />1: PgSelect[55]<br />2: PgSelectRows[60]<br />ᐳ: 59, 61, 66, 68, 70, 80, 81<br />3: 82, 91, 96, 162<br />ᐳ: 260, 261, 262, 86, 128, 129, 131, 132, 163, 166<br />4: Connection[98]<br />5: ConnectionItems[170]"):::bucket

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
@@ -35,7 +35,7 @@ graph TD
     PgUnionAll19[["PgUnionAll[19∈0] ➊<br />ᐸFirstPartyVulnerability,ThirdPartyVulnerabilityᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[106]<br />- Constantᐸ1ᐳ[108]<br />- Constantᐸ[Function: applyInputConstant]ᐳ[21]"]]:::plan
     PgUnionAll28[["PgUnionAll[28∈0] ➊<br />ᐸFirstPartyVulnerability,ThirdPartyVulnerabilityᐳ<br />More deps:<br />- Object[13]<br />- Constantᐸ3ᐳ[106]<br />- Constantᐸ[Function: applyInputConstant]ᐳ[16]"]]:::plan
     Lambda15 --> PgUnionAll28
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[106]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[106]"]]:::plan
     PgUnionAll10 & Lambda15 --> Connection14
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 7"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -56,6 +56,8 @@ graph TD
     PgUnionAll19 --> Access104
     PgUnionAll28 --> Access105
     PageInfo33{{"PageInfo[33∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access69{{"Access[69∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access71{{"Access[71∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     List37{{"List[37∈2]<br />ᐸ34,35,36ᐳ<br />More deps:<br />- Constantᐸ[HIDDEN]ᐳ[36]"}}:::plan
     Access34{{"Access[34∈2]<br />ᐸ23.0ᐳ"}}:::plan
     Access35{{"Access[35∈2]<br />ᐸ23.1ᐳ"}}:::plan
@@ -152,7 +154,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgUnionAll10,Access11,Access12,Object13,Connection14,Lambda15,PgUnionAll19,ConnectionItems25,PgUnionAll28,First29,First60,Access61,Last65,Access104,Access105 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo33 bucket1
+    class Bucket1,PageInfo33,Access69,Access71 bucket1
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item23,Access34,Access35,List37,Lambda38,Access39,Access40 bucket2
     classDef bucket4 stroke:#0000ff

--- a/postgraphile/postgraphile/__tests__/queries/v4/bigint.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/bigint.mermaid
@@ -11,8 +11,8 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: First[11], PgSelectSingle[13]"):::bucket
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[13]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14<br /><br />ROOT PgClassExpression{1}ᐸ__range_test__.”int8”ᐳ[14]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 14<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 16, 14<br /><br />ROOT Access{2}ᐸ14.endᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 17, 19<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 16, 18, 20<br /><br />ROOT Access{2}ᐸ14.endᐳ[16]"):::bucket
     end
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
@@ -40,6 +40,14 @@ graph TD
     PgClassExpression14 --> Access15
     Access16{{"Access[16∈2] ➊<br />ᐸ14.endᐳ"}}:::plan
     PgClassExpression14 --> Access16
+    Access17{{"Access[17∈2] ➊<br />ᐸ14.start.valueᐳ"}}:::plan
+    PgClassExpression14 --> Access17
+    Access18{{"Access[18∈2] ➊<br />ᐸ14.end.valueᐳ"}}:::plan
+    PgClassExpression14 --> Access18
+    Access19{{"Access[19∈2] ➊<br />ᐸ14.start.inclusiveᐳ"}}:::plan
+    PgClassExpression14 --> Access19
+    Access20{{"Access[20∈2] ➊<br />ᐸ14.end.inclusiveᐳ"}}:::plan
+    PgClassExpression14 --> Access20
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -47,7 +55,7 @@ graph TD
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access15,Access16 bucket2
+    class Bucket2,Access15,Access16,Access17,Access18,Access19,Access20 bucket2
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
     classDef bucket4 stroke:#0000ff

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections-blankcursor.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections-blankcursor.mermaid
@@ -31,12 +31,12 @@ graph TD
     Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda15{{"Lambda[15∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ''ᐳ[77]"}}:::plan
     Object13 & Lambda15 --> PgSelect10
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[76]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[76]"]]:::plan
     PgSelect10 & Lambda15 --> Connection14
     PgSelect19[["PgSelect[19∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[76]"]]:::plan
     Lambda22{{"Lambda[22∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'27'ᐳ[78]"}}:::plan
     Object13 & Lambda22 --> PgSelect19
-    Connection21[["Connection[21∈0] ➊<br />ᐸ19ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[76]"]]:::plan
+    Connection21[["Connection[21∈0] ➊<br />ᐸ19ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[76]"]]:::plan
     PgSelect19 & Lambda22 --> Connection21
     PgSelect26[["PgSelect[26∈0] ➊<br />ᐸperson(aggregate)ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[76]"]]:::plan
     Object13 & Lambda15 --> PgSelect26
@@ -71,7 +71,11 @@ graph TD
     Last52{{"Last[52∈0] ➊<br />More deps:<br />- ConnectionItems[36]"}}:::plan
     Last54{{"Last[54∈0] ➊<br />More deps:<br />- ConnectionItems[39]"}}:::plan
     PageInfo24{{"PageInfo[24∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access56{{"Access[56∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access58{{"Access[58∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     PageInfo25{{"PageInfo[25∈2] ➊<br />More deps:<br />- Connection[21]"}}:::plan
+    Access57{{"Access[57∈2] ➊<br />ᐸ21.hasNextPageᐳ<br />More deps:<br />- Connection[21]"}}:::plan
+    Access59{{"Access[59∈2] ➊<br />ᐸ21.hasPreviousPageᐳ<br />More deps:<br />- Connection[21]"}}:::plan
     Edge43{{"Edge[43∈5]"}}:::plan
     __Item42[/"__Item[42∈5]<br />ᐸ36ᐳ<br />More deps:<br />- ConnectionItems[36]"\]:::itemplan
     PgCursor61{{"PgCursor[61∈5]<br />More deps:<br />- Access[47]"}}:::plan
@@ -111,9 +115,9 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect10,Access11,Access12,Object13,Connection14,Lambda15,PgSelect19,Connection21,Lambda22,PgSelect26,First27,PgSelectRows28,PgSelectSingle29,PgSelect31,First32,PgSelectRows33,PgSelectSingle34,ConnectionItems36,ConnectionItems39,First46,Access47,First49,Access50,Last52,Last54 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo24 bucket1
+    class Bucket1,PageInfo24,Access56,Access58 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo25 bucket2
+    class Bucket2,PageInfo25,Access57,Access59 bucket2
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item42,Edge43,PgCursor61 bucket5
     classDef bucket6 stroke:#ff1493

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections.boolean.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections.boolean.mermaid
@@ -31,7 +31,7 @@ graph TD
     Object12{{"Object[12∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda20{{"Lambda[20∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyIzNjY0MzE3ZDgwIixmYWxzZSwyLDFd'ᐳ[71]"}}:::plan
     Object12 & Lambda20 --> PgSelect17
-    Connection19[["Connection[19∈0] ➊<br />ᐸ17ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[70]"]]:::plan
+    Connection19[["Connection[19∈0] ➊<br />ᐸ17ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[70]"]]:::plan
     PgSelect17 & Lambda20 --> Connection19
     PgSelect29[["PgSelect[29∈0] ➊<br />ᐸcompound_key(aggregate)ᐳ<br />More deps:<br />- Constantᐸ1ᐳ[70]"]]:::plan
     Object12 & Lambda20 --> PgSelect29
@@ -40,7 +40,7 @@ graph TD
     Access10{{"Access[10∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access11{{"Access[11∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access10 & Access11 --> Object12
-    Connection13[["Connection[13∈0] ➊<br />ᐸ9ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[70]"]]:::plan
+    Connection13[["Connection[13∈0] ➊<br />ᐸ9ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[70]"]]:::plan
     PgSelect9 --> Connection13
     PgSelect24[["PgSelect[24∈0] ➊<br />ᐸcompound_key(aggregate)ᐳ<br />More deps:<br />- Constantᐸ1ᐳ[70]"]]:::plan
     Object12 --> PgSelect24
@@ -70,7 +70,11 @@ graph TD
     Last50{{"Last[50∈0] ➊<br />More deps:<br />- ConnectionItems[34]"}}:::plan
     Last52{{"Last[52∈0] ➊<br />More deps:<br />- ConnectionItems[37]"}}:::plan
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[13]"}}:::plan
+    Access54{{"Access[54∈1] ➊<br />ᐸ13.hasNextPageᐳ<br />More deps:<br />- Connection[13]"}}:::plan
+    Access56{{"Access[56∈1] ➊<br />ᐸ13.hasPreviousPageᐳ<br />More deps:<br />- Connection[13]"}}:::plan
     PageInfo23{{"PageInfo[23∈2] ➊<br />More deps:<br />- Connection[19]"}}:::plan
+    Access55{{"Access[55∈2] ➊<br />ᐸ19.hasNextPageᐳ<br />More deps:<br />- Connection[19]"}}:::plan
+    Access57{{"Access[57∈2] ➊<br />ᐸ19.hasPreviousPageᐳ<br />More deps:<br />- Connection[19]"}}:::plan
     Edge41{{"Edge[41∈5]"}}:::plan
     __Item40[/"__Item[40∈5]<br />ᐸ34ᐳ<br />More deps:<br />- ConnectionItems[34]"\]:::itemplan
     PgCursor59{{"PgCursor[59∈5]<br />More deps:<br />- Access[45]"}}:::plan
@@ -102,9 +106,9 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect9,Access10,Access11,Object12,Connection13,PgSelect17,Connection19,Lambda20,PgSelect24,First25,PgSelectRows26,PgSelectSingle27,PgSelect29,First30,PgSelectRows31,PgSelectSingle32,ConnectionItems34,ConnectionItems37,First44,Access45,First47,Access48,Last50,Last52 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access54,Access56 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo23 bucket2
+    class Bucket2,PageInfo23,Access55,Access57 bucket2
     classDef bucket5 stroke:#7fff00
     class Bucket5,__Item40,Edge41,PgCursor59 bucket5
     classDef bucket6 stroke:#ff1493

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections.mermaid
@@ -190,7 +190,7 @@ graph TD
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda105{{"Lambda[105∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyIwOGUwZDM0MmRlIiw2XQ=='ᐳ[780]"}}:::plan
     Object11 & Lambda105 --> PgSelect102
-    Connection104[["Connection[104∈0] ➊<br />ᐸ102ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸnullᐳ[99]<br />- Constantᐸ2ᐳ[775]"]]:::plan
+    Connection104[["Connection[104∈0] ➊<br />ᐸ102ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸnullᐳ[99]<br />- Constantᐸ2ᐳ[775]"]]:::plan
     PgSelect102 & Lambda105 --> Connection104
     PgSelect260[["PgSelect[260∈0] ➊<br />ᐸperson(aggregate)ᐳ<br />More deps:<br />- Constantᐸnullᐳ[99]<br />- Constantᐸ2ᐳ[775]"]]:::plan
     Object11 & Lambda105 --> PgSelect260
@@ -202,16 +202,16 @@ graph TD
     Object11 & ApplyInput78 --> PgSelect75
     PgSelect82[["PgSelect[82∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[778]<br />- Constantᐸ1ᐳ[777]"]]:::plan
     Object11 --> PgSelect82
-    Connection84[["Connection[84∈0] ➊<br />ᐸ82ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[778]<br />- Constantᐸ1ᐳ[777]"]]:::plan
+    Connection84[["Connection[84∈0] ➊<br />ᐸ82ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[778]<br />- Constantᐸ1ᐳ[777]"]]:::plan
     PgSelect82 --> Connection84
     PgSelect108[["PgSelect[108∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
     Lambda40{{"Lambda[40∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyIwOGUwZDM0MmRlIiwyXQ=='ᐳ[776]"}}:::plan
     Object11 & Lambda40 --> PgSelect108
-    Connection110[["Connection[110∈0] ➊<br />ᐸ108ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
+    Connection110[["Connection[110∈0] ➊<br />ᐸ108ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
     PgSelect108 & Lambda40 --> Connection110
     PgSelect114[["PgSelect[114∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
     Object11 & Lambda40 --> PgSelect114
-    Connection116[["Connection[116∈0] ➊<br />ᐸ114ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
+    Connection116[["Connection[116∈0] ➊<br />ᐸ114ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
     PgSelect114 & Lambda40 --> Connection116
     PgSelect140[["PgSelect[140∈0] ➊<br />ᐸpostᐳ<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
     PgSelectInlineApply771["PgSelectInlineApply[771∈0] ➊"]:::plan
@@ -229,33 +229,33 @@ graph TD
     Access9 & Access10 --> Object11
     PgSelect16[["PgSelect[16∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
     Object11 --> PgSelect16
-    Connection18[["Connection[18∈0] ➊<br />ᐸ16ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
+    Connection18[["Connection[18∈0] ➊<br />ᐸ16ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
     PgSelect16 --> Connection18
     PgSelect21[["PgSelect[21∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
     Object11 --> PgSelect21
-    Connection23[["Connection[23∈0] ➊<br />ᐸ21ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
+    Connection23[["Connection[23∈0] ➊<br />ᐸ21ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
     PgSelect21 --> Connection23
     PgSelect37[["PgSelect[37∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 & Lambda40 --> PgSelect37
-    Connection39[["Connection[39∈0] ➊<br />ᐸ37ᐳ<br />Dependents: 2"]]:::plan
+    Connection39[["Connection[39∈0] ➊<br />ᐸ37ᐳ<br />Dependents: 4"]]:::plan
     PgSelect37 & Lambda40 --> Connection39
     PgSelect43[["PgSelect[43∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 & Lambda40 --> PgSelect43
-    Connection45[["Connection[45∈0] ➊<br />ᐸ43ᐳ<br />Dependents: 2"]]:::plan
+    Connection45[["Connection[45∈0] ➊<br />ᐸ43ᐳ<br />Dependents: 4"]]:::plan
     PgSelect43 & Lambda40 --> Connection45
     __InputObject58{{"__InputObject[58∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ2ᐳ[775]"}}:::plan
     PgSelect60[["PgSelect[60∈0] ➊<br />ᐸpost+1ᐳ"]]:::plan
     ApplyInput63{{"ApplyInput[63∈0] ➊"}}:::plan
     Object11 & ApplyInput63 --> PgSelect60
     __InputObject65{{"__InputObject[65∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ2ᐳ[775]"}}:::plan
-    Connection69[["Connection[69∈0] ➊<br />ᐸ67ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
+    Connection69[["Connection[69∈0] ➊<br />ᐸ67ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[775]"]]:::plan
     PgSelect67 --> Connection69
     __InputObject73{{"__InputObject[73∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ1ᐳ[777]"}}:::plan
-    Connection77[["Connection[77∈0] ➊<br />ᐸ75ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
+    Connection77[["Connection[77∈0] ➊<br />ᐸ75ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[777]"]]:::plan
     PgSelect75 --> Connection77
     PgSelect88[["PgSelect[88∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ0ᐳ[779]"]]:::plan
     Object11 --> PgSelect88
-    Connection90[["Connection[90∈0] ➊<br />ᐸ88ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ0ᐳ[779]"]]:::plan
+    Connection90[["Connection[90∈0] ➊<br />ᐸ88ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ0ᐳ[779]"]]:::plan
     PgSelect88 --> Connection90
     __InputObject92{{"__InputObject[92∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ2ᐳ[775]"}}:::plan
     PgSelect94[["PgSelect[94∈0] ➊<br />ᐸedge_caseᐳ"]]:::plan
@@ -267,7 +267,7 @@ graph TD
     Object11 & ApplyInput124 --> PgSelect121
     PgSelect127[["PgSelect[127∈0] ➊<br />ᐸpost+1ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[778]"]]:::plan
     Object11 --> PgSelect127
-    Connection129[["Connection[129∈0] ➊<br />ᐸ127ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[778]"]]:::plan
+    Connection129[["Connection[129∈0] ➊<br />ᐸ127ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[778]"]]:::plan
     PgSelect127 --> Connection129
     __InputObject131{{"__InputObject[131∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ'192.168.0.1'ᐳ[781]"}}:::plan
     PgSelect134[["PgSelect[134∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
@@ -306,15 +306,15 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     PgSelect26[["PgSelect[26∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 --> PgSelect26
-    Connection28[["Connection[28∈0] ➊<br />ᐸ26ᐳ<br />Dependents: 2"]]:::plan
+    Connection28[["Connection[28∈0] ➊<br />ᐸ26ᐳ<br />Dependents: 4"]]:::plan
     PgSelect26 --> Connection28
     PgSelect31[["PgSelect[31∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 --> PgSelect31
-    Connection33[["Connection[33∈0] ➊<br />ᐸ31ᐳ<br />Dependents: 2"]]:::plan
+    Connection33[["Connection[33∈0] ➊<br />ᐸ31ᐳ<br />Dependents: 4"]]:::plan
     PgSelect31 --> Connection33
     PgSelect49[["PgSelect[49∈0] ➊<br />ᐸupdatable_viewᐳ"]]:::plan
     Object11 --> PgSelect49
@@ -324,7 +324,7 @@ graph TD
     Object11 --> PgSelect54
     Connection56[["Connection[56∈0] ➊<br />ᐸ54ᐳ"]]:::plan
     PgSelect54 --> Connection56
-    Connection62[["Connection[62∈0] ➊<br />ᐸ60ᐳ<br />Dependents: 2"]]:::plan
+    Connection62[["Connection[62∈0] ➊<br />ᐸ60ᐳ<br />Dependents: 4"]]:::plan
     PgSelect60 --> Connection62
     __InputObject58 --> ApplyInput63
     __InputObject65 --> ApplyInput70
@@ -332,16 +332,16 @@ graph TD
     Connection96[["Connection[96∈0] ➊<br />ᐸ94ᐳ"]]:::plan
     PgSelect94 --> Connection96
     __InputObject92 --> ApplyInput97
-    Connection123[["Connection[123∈0] ➊<br />ᐸ121ᐳ<br />Dependents: 2"]]:::plan
+    Connection123[["Connection[123∈0] ➊<br />ᐸ121ᐳ<br />Dependents: 4"]]:::plan
     PgSelect121 --> Connection123
     __InputObject119 --> ApplyInput124
-    Connection136[["Connection[136∈0] ➊<br />ᐸ134ᐳ<br />Dependents: 2"]]:::plan
+    Connection136[["Connection[136∈0] ➊<br />ᐸ134ᐳ<br />Dependents: 4"]]:::plan
     PgSelect134 --> Connection136
     __InputObject131 --> ApplyInput137
-    Connection149[["Connection[149∈0] ➊<br />ᐸ147ᐳ<br />Dependents: 2"]]:::plan
+    Connection149[["Connection[149∈0] ➊<br />ᐸ147ᐳ<br />Dependents: 4"]]:::plan
     PgSelect147 --> Connection149
     __InputObject144 --> ApplyInput150
-    Connection157[["Connection[157∈0] ➊<br />ᐸ155ᐳ<br />Dependents: 2"]]:::plan
+    Connection157[["Connection[157∈0] ➊<br />ᐸ155ᐳ<br />Dependents: 4"]]:::plan
     PgSelect155 --> Connection157
     __InputObject152 --> ApplyInput158
     PgSelect161[["PgSelect[161∈0] ➊<br />ᐸnull_test_recordᐳ"]]:::plan
@@ -557,25 +557,65 @@ graph TD
     Access772{{"Access[772∈0] ➊<br />ᐸ140.m.joinDetailsFor653ᐳ"}}:::plan
     PgSelect140 --> Access772
     PageInfo165{{"PageInfo[165∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access513{{"Access[513∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access533{{"Access[533∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     PageInfo166{{"PageInfo[166∈2] ➊<br />More deps:<br />- Connection[18]"}}:::plan
+    Access514{{"Access[514∈2] ➊<br />ᐸ18.hasNextPageᐳ<br />More deps:<br />- Connection[18]"}}:::plan
+    Access534{{"Access[534∈2] ➊<br />ᐸ18.hasPreviousPageᐳ<br />More deps:<br />- Connection[18]"}}:::plan
     PageInfo167{{"PageInfo[167∈3] ➊<br />More deps:<br />- Connection[23]"}}:::plan
+    Access515{{"Access[515∈3] ➊<br />ᐸ23.hasNextPageᐳ<br />More deps:<br />- Connection[23]"}}:::plan
+    Access535{{"Access[535∈3] ➊<br />ᐸ23.hasPreviousPageᐳ<br />More deps:<br />- Connection[23]"}}:::plan
     PageInfo168{{"PageInfo[168∈4] ➊<br />More deps:<br />- Connection[28]"}}:::plan
+    Access516{{"Access[516∈4] ➊<br />ᐸ28.hasNextPageᐳ<br />More deps:<br />- Connection[28]"}}:::plan
+    Access536{{"Access[536∈4] ➊<br />ᐸ28.hasPreviousPageᐳ<br />More deps:<br />- Connection[28]"}}:::plan
     PageInfo169{{"PageInfo[169∈5] ➊<br />More deps:<br />- Connection[33]"}}:::plan
+    Access517{{"Access[517∈5] ➊<br />ᐸ33.hasNextPageᐳ<br />More deps:<br />- Connection[33]"}}:::plan
+    Access537{{"Access[537∈5] ➊<br />ᐸ33.hasPreviousPageᐳ<br />More deps:<br />- Connection[33]"}}:::plan
     PageInfo170{{"PageInfo[170∈6] ➊<br />More deps:<br />- Connection[39]"}}:::plan
+    Access518{{"Access[518∈6] ➊<br />ᐸ39.hasNextPageᐳ<br />More deps:<br />- Connection[39]"}}:::plan
+    Access538{{"Access[538∈6] ➊<br />ᐸ39.hasPreviousPageᐳ<br />More deps:<br />- Connection[39]"}}:::plan
     PageInfo171{{"PageInfo[171∈7] ➊<br />More deps:<br />- Connection[45]"}}:::plan
+    Access519{{"Access[519∈7] ➊<br />ᐸ45.hasNextPageᐳ<br />More deps:<br />- Connection[45]"}}:::plan
+    Access539{{"Access[539∈7] ➊<br />ᐸ45.hasPreviousPageᐳ<br />More deps:<br />- Connection[45]"}}:::plan
     PageInfo178{{"PageInfo[178∈10] ➊<br />More deps:<br />- Connection[62]"}}:::plan
+    Access520{{"Access[520∈10] ➊<br />ᐸ62.hasNextPageᐳ<br />More deps:<br />- Connection[62]"}}:::plan
+    Access540{{"Access[540∈10] ➊<br />ᐸ62.hasPreviousPageᐳ<br />More deps:<br />- Connection[62]"}}:::plan
     PageInfo179{{"PageInfo[179∈11] ➊<br />More deps:<br />- Connection[69]"}}:::plan
+    Access521{{"Access[521∈11] ➊<br />ᐸ69.hasNextPageᐳ<br />More deps:<br />- Connection[69]"}}:::plan
+    Access541{{"Access[541∈11] ➊<br />ᐸ69.hasPreviousPageᐳ<br />More deps:<br />- Connection[69]"}}:::plan
     PageInfo180{{"PageInfo[180∈12] ➊<br />More deps:<br />- Connection[77]"}}:::plan
+    Access522{{"Access[522∈12] ➊<br />ᐸ77.hasNextPageᐳ<br />More deps:<br />- Connection[77]"}}:::plan
+    Access542{{"Access[542∈12] ➊<br />ᐸ77.hasPreviousPageᐳ<br />More deps:<br />- Connection[77]"}}:::plan
     PageInfo181{{"PageInfo[181∈13] ➊<br />More deps:<br />- Connection[84]"}}:::plan
+    Access523{{"Access[523∈13] ➊<br />ᐸ84.hasNextPageᐳ<br />More deps:<br />- Connection[84]"}}:::plan
+    Access543{{"Access[543∈13] ➊<br />ᐸ84.hasPreviousPageᐳ<br />More deps:<br />- Connection[84]"}}:::plan
     PageInfo182{{"PageInfo[182∈14] ➊<br />More deps:<br />- Connection[90]"}}:::plan
+    Access524{{"Access[524∈14] ➊<br />ᐸ90.hasNextPageᐳ<br />More deps:<br />- Connection[90]"}}:::plan
+    Access544{{"Access[544∈14] ➊<br />ᐸ90.hasPreviousPageᐳ<br />More deps:<br />- Connection[90]"}}:::plan
     PageInfo186{{"PageInfo[186∈16] ➊<br />More deps:<br />- Connection[104]"}}:::plan
+    Access525{{"Access[525∈16] ➊<br />ᐸ104.hasNextPageᐳ<br />More deps:<br />- Connection[104]"}}:::plan
+    Access545{{"Access[545∈16] ➊<br />ᐸ104.hasPreviousPageᐳ<br />More deps:<br />- Connection[104]"}}:::plan
     PageInfo187{{"PageInfo[187∈17] ➊<br />More deps:<br />- Connection[110]"}}:::plan
+    Access526{{"Access[526∈17] ➊<br />ᐸ110.hasNextPageᐳ<br />More deps:<br />- Connection[110]"}}:::plan
+    Access546{{"Access[546∈17] ➊<br />ᐸ110.hasPreviousPageᐳ<br />More deps:<br />- Connection[110]"}}:::plan
     PageInfo188{{"PageInfo[188∈18] ➊<br />More deps:<br />- Connection[116]"}}:::plan
+    Access527{{"Access[527∈18] ➊<br />ᐸ116.hasNextPageᐳ<br />More deps:<br />- Connection[116]"}}:::plan
+    Access547{{"Access[547∈18] ➊<br />ᐸ116.hasPreviousPageᐳ<br />More deps:<br />- Connection[116]"}}:::plan
     PageInfo189{{"PageInfo[189∈19] ➊<br />More deps:<br />- Connection[123]"}}:::plan
+    Access528{{"Access[528∈19] ➊<br />ᐸ123.hasNextPageᐳ<br />More deps:<br />- Connection[123]"}}:::plan
+    Access548{{"Access[548∈19] ➊<br />ᐸ123.hasPreviousPageᐳ<br />More deps:<br />- Connection[123]"}}:::plan
     PageInfo190{{"PageInfo[190∈20] ➊<br />More deps:<br />- Connection[129]"}}:::plan
+    Access529{{"Access[529∈20] ➊<br />ᐸ129.hasNextPageᐳ<br />More deps:<br />- Connection[129]"}}:::plan
+    Access549{{"Access[549∈20] ➊<br />ᐸ129.hasPreviousPageᐳ<br />More deps:<br />- Connection[129]"}}:::plan
     PageInfo191{{"PageInfo[191∈21] ➊<br />More deps:<br />- Connection[136]"}}:::plan
+    Access530{{"Access[530∈21] ➊<br />ᐸ136.hasNextPageᐳ<br />More deps:<br />- Connection[136]"}}:::plan
+    Access550{{"Access[550∈21] ➊<br />ᐸ136.hasPreviousPageᐳ<br />More deps:<br />- Connection[136]"}}:::plan
     PageInfo195{{"PageInfo[195∈23] ➊<br />More deps:<br />- Connection[149]"}}:::plan
+    Access531{{"Access[531∈23] ➊<br />ᐸ149.hasNextPageᐳ<br />More deps:<br />- Connection[149]"}}:::plan
+    Access551{{"Access[551∈23] ➊<br />ᐸ149.hasPreviousPageᐳ<br />More deps:<br />- Connection[149]"}}:::plan
     PageInfo196{{"PageInfo[196∈24] ➊<br />More deps:<br />- Connection[157]"}}:::plan
+    Access532{{"Access[532∈24] ➊<br />ᐸ157.hasNextPageᐳ<br />More deps:<br />- Connection[157]"}}:::plan
+    Access552{{"Access[552∈24] ➊<br />ᐸ157.hasPreviousPageᐳ<br />More deps:<br />- Connection[157]"}}:::plan
     Edge363{{"Edge[363∈52]"}}:::plan
     __Item362[/"__Item[362∈52]<br />ᐸ172ᐳ"\]:::itemplan
     PgCursor554{{"PgCursor[554∈52]"}}:::plan
@@ -1031,53 +1071,53 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,PgSelect16,Connection18,PgSelect21,Connection23,PgSelect26,Connection28,PgSelect31,Connection33,PgSelect37,Connection39,Lambda40,PgSelect43,Connection45,PgSelect49,Connection51,PgSelect54,Connection56,__InputObject58,PgSelect60,Connection62,ApplyInput63,__InputObject65,PgSelect67,Connection69,ApplyInput70,__InputObject73,PgSelect75,Connection77,ApplyInput78,PgSelect82,Connection84,PgSelect88,Connection90,__InputObject92,PgSelect94,Connection96,ApplyInput97,PgSelect102,Connection104,Lambda105,PgSelect108,Connection110,PgSelect114,Connection116,__InputObject119,PgSelect121,Connection123,ApplyInput124,PgSelect127,Connection129,__InputObject131,PgSelect134,Connection136,ApplyInput137,PgSelect140,Connection142,__InputObject144,PgSelect147,Connection149,ApplyInput150,__InputObject152,PgSelect155,Connection157,ApplyInput158,PgSelect161,Connection163,ConnectionItems172,ConnectionItems175,ConnectionItems183,ConnectionItems192,ConnectionItems197,PgSelect200,First201,PgSelectRows202,PgSelectSingle203,PgSelect205,First206,PgSelectRows207,PgSelectSingle208,PgSelect225,First226,PgSelectRows227,PgSelectSingle228,PgSelect235,First236,PgSelectRows237,PgSelectSingle238,PgSelect240,First241,PgSelectRows242,PgSelectSingle243,PgSelect245,First246,PgSelectRows247,PgSelectSingle248,PgSelect250,First251,PgSelectRows252,PgSelectSingle253,PgSelect255,First256,PgSelectRows257,PgSelectSingle258,PgSelect260,First261,PgSelectRows262,PgSelectSingle263,PgSelect265,First266,PgSelectRows267,PgSelectSingle268,PgSelect275,First276,PgSelectRows277,PgSelectSingle278,PgSelect280,First281,PgSelectRows282,PgSelectSingle283,PgSelect285,First286,PgSelectRows287,PgSelectSingle288,PgSelect292,First293,PgSelectRows294,PgSelectSingle295,PgSelect297,First298,PgSelectRows299,PgSelectSingle300,ConnectionItems302,ConnectionItems305,ConnectionItems308,ConnectionItems311,ConnectionItems314,ConnectionItems317,ConnectionItems320,ConnectionItems323,ConnectionItems326,ConnectionItems329,ConnectionItems332,ConnectionItems335,ConnectionItems338,ConnectionItems341,ConnectionItems344,ConnectionItems347,ConnectionItems350,ConnectionItems353,ConnectionItems356,ConnectionItems359,First413,Access414,First416,Access417,First419,Access420,First422,Access423,First425,Access426,First428,Access429,First431,Access432,First434,Access435,First437,Access438,First440,Access441,First443,Access444,First446,Access447,First449,Access450,First452,Access453,First455,Access456,First458,Access459,First461,Access462,First464,Access465,First467,Access468,First470,Access471,Last473,Last475,Last477,Last479,Last481,Last483,Last485,Last487,Last489,Last491,Last493,Last495,Last497,Last499,Last501,Last503,Last505,Last507,Last509,Last511,Access553,Access555,PgSelectInlineApply771,Access772 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo165 bucket1
+    class Bucket1,PageInfo165,Access513,Access533 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo166 bucket2
+    class Bucket2,PageInfo166,Access514,Access534 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo167 bucket3
+    class Bucket3,PageInfo167,Access515,Access535 bucket3
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PageInfo168 bucket4
+    class Bucket4,PageInfo168,Access516,Access536 bucket4
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PageInfo169 bucket5
+    class Bucket5,PageInfo169,Access517,Access537 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo170 bucket6
+    class Bucket6,PageInfo170,Access518,Access538 bucket6
     classDef bucket7 stroke:#808000
-    class Bucket7,PageInfo171 bucket7
+    class Bucket7,PageInfo171,Access519,Access539 bucket7
     classDef bucket8 stroke:#dda0dd
     class Bucket8 bucket8
     classDef bucket9 stroke:#ff0000
     class Bucket9 bucket9
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PageInfo178 bucket10
+    class Bucket10,PageInfo178,Access520,Access540 bucket10
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PageInfo179 bucket11
+    class Bucket11,PageInfo179,Access521,Access541 bucket11
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PageInfo180 bucket12
+    class Bucket12,PageInfo180,Access522,Access542 bucket12
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PageInfo181 bucket13
+    class Bucket13,PageInfo181,Access523,Access543 bucket13
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PageInfo182 bucket14
+    class Bucket14,PageInfo182,Access524,Access544 bucket14
     classDef bucket15 stroke:#ff00ff
     class Bucket15 bucket15
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PageInfo186 bucket16
+    class Bucket16,PageInfo186,Access525,Access545 bucket16
     classDef bucket17 stroke:#696969
-    class Bucket17,PageInfo187 bucket17
+    class Bucket17,PageInfo187,Access526,Access546 bucket17
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PageInfo188 bucket18
+    class Bucket18,PageInfo188,Access527,Access547 bucket18
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PageInfo189 bucket19
+    class Bucket19,PageInfo189,Access528,Access548 bucket19
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PageInfo190 bucket20
+    class Bucket20,PageInfo190,Access529,Access549 bucket20
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PageInfo191 bucket21
+    class Bucket21,PageInfo191,Access530,Access550 bucket21
     classDef bucket22 stroke:#7fff00
     class Bucket22 bucket22
     classDef bucket23 stroke:#ff1493
-    class Bucket23,PageInfo195 bucket23
+    class Bucket23,PageInfo195,Access531,Access551 bucket23
     classDef bucket24 stroke:#808000
-    class Bucket24,PageInfo196 bucket24
+    class Bucket24,PageInfo196,Access532,Access552 bucket24
     classDef bucket25 stroke:#dda0dd
     class Bucket25 bucket25
     classDef bucket52 stroke:#00bfff

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections.variables-orderBy.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections.variables-orderBy.mermaid
@@ -29,7 +29,7 @@ graph TD
     Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access11 & Access12 --> Object13
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[39]"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[39]"]]:::plan
     PgSelect10 --> Connection14
     Access8{{"Access[8∈0] ➊<br />ᐸ0.orderByᐳ"}}:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
@@ -50,6 +50,8 @@ graph TD
     PgSelect10 --> Access28
     Last30{{"Last[30∈0] ➊<br />More deps:<br />- ConnectionItems[22]"}}:::plan
     PageInfo16{{"PageInfo[16∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access32{{"Access[32∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access33{{"Access[33∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     Edge26{{"Edge[26∈3]"}}:::plan
     __Item25[/"__Item[25∈3]<br />ᐸ22ᐳ<br />More deps:<br />- ConnectionItems[22]"\]:::itemplan
     PgCursor35{{"PgCursor[35∈3]<br />More deps:<br />- Access[28]"}}:::plan
@@ -66,7 +68,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access8,PgSelect10,Access11,Access12,Object13,Connection14,ApplyInput15,PgSelect17,First18,PgSelectRows19,PgSelectSingle20,ConnectionItems22,First27,Access28,Last30 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo16 bucket1
+    class Bucket1,PageInfo16,Access32,Access33 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item25,Edge26,PgCursor35 bucket3
     classDef bucket4 stroke:#0000ff

--- a/postgraphile/postgraphile/__tests__/queries/v4/connections.variables.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/connections.variables.mermaid
@@ -190,7 +190,7 @@ graph TD
     Object11{{"Object[11∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda116{{"Lambda[116∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     Object11 & Lambda116 --> PgSelect113
-    Connection115[["Connection[115∈0] ➊<br />ᐸ113ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸnullᐳ[109]<br />- Constantᐸ2ᐳ[790]"]]:::plan
+    Connection115[["Connection[115∈0] ➊<br />ᐸ113ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸnullᐳ[109]<br />- Constantᐸ2ᐳ[790]"]]:::plan
     PgSelect113 & Lambda116 --> Connection115
     PgSelect272[["PgSelect[272∈0] ➊<br />ᐸperson(aggregate)ᐳ<br />More deps:<br />- Constantᐸnullᐳ[109]<br />- Constantᐸ2ᐳ[790]"]]:::plan
     Object11 & Lambda116 --> PgSelect272
@@ -198,7 +198,7 @@ graph TD
     Lambda32{{"Lambda[32∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     Object11 --> PgSelect29
     Lambda32 -- 2 --> PgSelect29
-    Connection31[["Connection[31∈0] ➊<br />ᐸ29ᐳ<br />Dependents: 2"]]:::plan
+    Connection31[["Connection[31∈0] ➊<br />ᐸ29ᐳ<br />Dependents: 4"]]:::plan
     PgSelect29 --> Connection31
     Lambda32 -- 2 --> Connection31
     PgSelect76[["PgSelect[76∈0] ➊<br />ᐸpost+1ᐳ"]]:::plan
@@ -210,16 +210,16 @@ graph TD
     Object11 & ApplyInput87 --> PgSelect84
     PgSelect91[["PgSelect[91∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[788]<br />- Constantᐸ1ᐳ[787]"]]:::plan
     Object11 --> PgSelect91
-    Connection93[["Connection[93∈0] ➊<br />ᐸ91ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[788]<br />- Constantᐸ1ᐳ[787]"]]:::plan
+    Connection93[["Connection[93∈0] ➊<br />ᐸ91ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[788]<br />- Constantᐸ1ᐳ[787]"]]:::plan
     PgSelect91 --> Connection93
     PgSelect119[["PgSelect[119∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
     Lambda49{{"Lambda[49∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     Object11 & Lambda49 --> PgSelect119
-    Connection121[["Connection[121∈0] ➊<br />ᐸ119ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
+    Connection121[["Connection[121∈0] ➊<br />ᐸ119ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
     PgSelect119 & Lambda49 --> Connection121
     PgSelect125[["PgSelect[125∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
     Object11 & Lambda49 --> PgSelect125
-    Connection127[["Connection[127∈0] ➊<br />ᐸ125ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
+    Connection127[["Connection[127∈0] ➊<br />ᐸ125ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
     PgSelect125 & Lambda49 --> Connection127
     PgSelect139[["PgSelect[139∈0] ➊<br />ᐸpost+1ᐳ<br />More deps:<br />- Constantᐸ3ᐳ[788]"]]:::plan
     ApplyInput142{{"ApplyInput[142∈0] ➊"}}:::plan
@@ -245,24 +245,24 @@ graph TD
     Access9 & Access10 --> Object11
     PgSelect17[["PgSelect[17∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 & Access14 --> PgSelect17
-    Connection19[["Connection[19∈0] ➊<br />ᐸ17ᐳ<br />Dependents: 2"]]:::plan
+    Connection19[["Connection[19∈0] ➊<br />ᐸ17ᐳ<br />Dependents: 4"]]:::plan
     PgSelect17 & Access14 --> Connection19
     PgSelect22[["PgSelect[22∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 & Access14 --> PgSelect22
-    Connection24[["Connection[24∈0] ➊<br />ᐸ22ᐳ<br />Dependents: 2"]]:::plan
+    Connection24[["Connection[24∈0] ➊<br />ᐸ22ᐳ<br />Dependents: 4"]]:::plan
     PgSelect22 & Access14 --> Connection24
     PgSelect38[["PgSelect[38∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Lambda41{{"Lambda[41∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     Object11 & Lambda41 --> PgSelect38
-    Connection40[["Connection[40∈0] ➊<br />ᐸ38ᐳ<br />Dependents: 2"]]:::plan
+    Connection40[["Connection[40∈0] ➊<br />ᐸ38ᐳ<br />Dependents: 4"]]:::plan
     PgSelect38 & Lambda41 --> Connection40
     PgSelect46[["PgSelect[46∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 & Lambda49 --> PgSelect46
-    Connection48[["Connection[48∈0] ➊<br />ᐸ46ᐳ<br />Dependents: 2"]]:::plan
+    Connection48[["Connection[48∈0] ➊<br />ᐸ46ᐳ<br />Dependents: 4"]]:::plan
     PgSelect46 & Lambda49 --> Connection48
     PgSelect52[["PgSelect[52∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     Object11 & Lambda49 --> PgSelect52
-    Connection54[["Connection[54∈0] ➊<br />ᐸ52ᐳ<br />Dependents: 2"]]:::plan
+    Connection54[["Connection[54∈0] ➊<br />ᐸ52ᐳ<br />Dependents: 4"]]:::plan
     PgSelect52 & Lambda49 --> Connection54
     __InputObject67{{"__InputObject[67∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]"}}:::plan
     Access14 --> __InputObject67
@@ -271,14 +271,14 @@ graph TD
     Object11 & ApplyInput72 --> PgSelect69
     __InputObject74{{"__InputObject[74∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]"}}:::plan
     Access14 --> __InputObject74
-    Connection78[["Connection[78∈0] ➊<br />ᐸ76ᐳ<br />Dependents: 2"]]:::plan
+    Connection78[["Connection[78∈0] ➊<br />ᐸ76ᐳ<br />Dependents: 4"]]:::plan
     PgSelect76 & Access14 --> Connection78
     __InputObject82{{"__InputObject[82∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ1ᐳ[787]"}}:::plan
-    Connection86[["Connection[86∈0] ➊<br />ᐸ84ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
+    Connection86[["Connection[86∈0] ➊<br />ᐸ84ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ1ᐳ[787]"]]:::plan
     PgSelect84 --> Connection86
     PgSelect97[["PgSelect[97∈0] ➊<br />ᐸperson+1ᐳ<br />More deps:<br />- Constantᐸ0ᐳ[789]"]]:::plan
     Object11 --> PgSelect97
-    Connection99[["Connection[99∈0] ➊<br />ᐸ97ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ0ᐳ[789]"]]:::plan
+    Connection99[["Connection[99∈0] ➊<br />ᐸ97ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ0ᐳ[789]"]]:::plan
     PgSelect97 --> Connection99
     __InputObject101{{"__InputObject[101∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ2ᐳ[790]"}}:::plan
     PgSelect104[["PgSelect[104∈0] ➊<br />ᐸedge_caseᐳ"]]:::plan
@@ -288,7 +288,7 @@ graph TD
     PgSelect132[["PgSelect[132∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
     ApplyInput135{{"ApplyInput[135∈0] ➊"}}:::plan
     Object11 & ApplyInput135 --> PgSelect132
-    Connection141[["Connection[141∈0] ➊<br />ᐸ139ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ3ᐳ[788]"]]:::plan
+    Connection141[["Connection[141∈0] ➊<br />ᐸ139ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ3ᐳ[788]"]]:::plan
     PgSelect139 --> Connection141
     __InputObject143{{"__InputObject[143∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[6]<br />- Constantᐸ'192.168.0.1'ᐳ[791]"}}:::plan
     PgSelect146[["PgSelect[146∈0] ➊<br />ᐸperson+1ᐳ"]]:::plan
@@ -327,7 +327,7 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value0 --> Access14
@@ -348,7 +348,7 @@ graph TD
     Object11 --> PgSelect63
     Connection65[["Connection[65∈0] ➊<br />ᐸ63ᐳ"]]:::plan
     PgSelect63 --> Connection65
-    Connection71[["Connection[71∈0] ➊<br />ᐸ69ᐳ<br />Dependents: 2"]]:::plan
+    Connection71[["Connection[71∈0] ➊<br />ᐸ69ᐳ<br />Dependents: 4"]]:::plan
     PgSelect69 --> Connection71
     __InputObject67 --> ApplyInput72
     __InputObject74 --> ApplyInput79
@@ -359,19 +359,19 @@ graph TD
     Access110{{"Access[110∈0] ➊<br />ᐸ0.cursor6ᐳ"}}:::plan
     __Value0 --> Access110
     Access110 --> Lambda116
-    Connection134[["Connection[134∈0] ➊<br />ᐸ132ᐳ<br />Dependents: 2"]]:::plan
+    Connection134[["Connection[134∈0] ➊<br />ᐸ132ᐳ<br />Dependents: 4"]]:::plan
     PgSelect132 --> Connection134
     __InputObject130 --> ApplyInput135
     Access137{{"Access[137∈0] ➊<br />ᐸ0.orderByᐳ"}}:::plan
     __Value0 --> Access137
     Access137 --> ApplyInput142
-    Connection148[["Connection[148∈0] ➊<br />ᐸ146ᐳ<br />Dependents: 2"]]:::plan
+    Connection148[["Connection[148∈0] ➊<br />ᐸ146ᐳ<br />Dependents: 4"]]:::plan
     PgSelect146 --> Connection148
     __InputObject143 --> ApplyInput149
-    Connection161[["Connection[161∈0] ➊<br />ᐸ159ᐳ<br />Dependents: 2"]]:::plan
+    Connection161[["Connection[161∈0] ➊<br />ᐸ159ᐳ<br />Dependents: 4"]]:::plan
     PgSelect159 --> Connection161
     __InputObject156 --> ApplyInput162
-    Connection169[["Connection[169∈0] ➊<br />ᐸ167ᐳ<br />Dependents: 2"]]:::plan
+    Connection169[["Connection[169∈0] ➊<br />ᐸ167ᐳ<br />Dependents: 4"]]:::plan
     PgSelect167 --> Connection169
     __InputObject164 --> ApplyInput170
     PgSelect173[["PgSelect[173∈0] ➊<br />ᐸnull_test_recordᐳ"]]:::plan
@@ -599,25 +599,65 @@ graph TD
     Access784{{"Access[784∈0] ➊<br />ᐸ152.m.joinDetailsFor665ᐳ"}}:::plan
     PgSelect152 --> Access784
     PageInfo177{{"PageInfo[177∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access525{{"Access[525∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access545{{"Access[545∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     PageInfo178{{"PageInfo[178∈2] ➊<br />More deps:<br />- Connection[19]"}}:::plan
+    Access526{{"Access[526∈2] ➊<br />ᐸ19.hasNextPageᐳ<br />More deps:<br />- Connection[19]"}}:::plan
+    Access546{{"Access[546∈2] ➊<br />ᐸ19.hasPreviousPageᐳ<br />More deps:<br />- Connection[19]"}}:::plan
     PageInfo179{{"PageInfo[179∈3] ➊<br />More deps:<br />- Connection[24]"}}:::plan
+    Access527{{"Access[527∈3] ➊<br />ᐸ24.hasNextPageᐳ<br />More deps:<br />- Connection[24]"}}:::plan
+    Access547{{"Access[547∈3] ➊<br />ᐸ24.hasPreviousPageᐳ<br />More deps:<br />- Connection[24]"}}:::plan
     PageInfo180{{"PageInfo[180∈4] ➊<br />More deps:<br />- Connection[31]"}}:::plan
+    Access528{{"Access[528∈4] ➊<br />ᐸ31.hasNextPageᐳ<br />More deps:<br />- Connection[31]"}}:::plan
+    Access548{{"Access[548∈4] ➊<br />ᐸ31.hasPreviousPageᐳ<br />More deps:<br />- Connection[31]"}}:::plan
     PageInfo181{{"PageInfo[181∈5] ➊<br />More deps:<br />- Connection[40]"}}:::plan
+    Access529{{"Access[529∈5] ➊<br />ᐸ40.hasNextPageᐳ<br />More deps:<br />- Connection[40]"}}:::plan
+    Access549{{"Access[549∈5] ➊<br />ᐸ40.hasPreviousPageᐳ<br />More deps:<br />- Connection[40]"}}:::plan
     PageInfo182{{"PageInfo[182∈6] ➊<br />More deps:<br />- Connection[48]"}}:::plan
+    Access530{{"Access[530∈6] ➊<br />ᐸ48.hasNextPageᐳ<br />More deps:<br />- Connection[48]"}}:::plan
+    Access550{{"Access[550∈6] ➊<br />ᐸ48.hasPreviousPageᐳ<br />More deps:<br />- Connection[48]"}}:::plan
     PageInfo183{{"PageInfo[183∈7] ➊<br />More deps:<br />- Connection[54]"}}:::plan
+    Access531{{"Access[531∈7] ➊<br />ᐸ54.hasNextPageᐳ<br />More deps:<br />- Connection[54]"}}:::plan
+    Access551{{"Access[551∈7] ➊<br />ᐸ54.hasPreviousPageᐳ<br />More deps:<br />- Connection[54]"}}:::plan
     PageInfo190{{"PageInfo[190∈10] ➊<br />More deps:<br />- Connection[71]"}}:::plan
+    Access532{{"Access[532∈10] ➊<br />ᐸ71.hasNextPageᐳ<br />More deps:<br />- Connection[71]"}}:::plan
+    Access552{{"Access[552∈10] ➊<br />ᐸ71.hasPreviousPageᐳ<br />More deps:<br />- Connection[71]"}}:::plan
     PageInfo191{{"PageInfo[191∈11] ➊<br />More deps:<br />- Connection[78]"}}:::plan
+    Access533{{"Access[533∈11] ➊<br />ᐸ78.hasNextPageᐳ<br />More deps:<br />- Connection[78]"}}:::plan
+    Access553{{"Access[553∈11] ➊<br />ᐸ78.hasPreviousPageᐳ<br />More deps:<br />- Connection[78]"}}:::plan
     PageInfo192{{"PageInfo[192∈12] ➊<br />More deps:<br />- Connection[86]"}}:::plan
+    Access534{{"Access[534∈12] ➊<br />ᐸ86.hasNextPageᐳ<br />More deps:<br />- Connection[86]"}}:::plan
+    Access554{{"Access[554∈12] ➊<br />ᐸ86.hasPreviousPageᐳ<br />More deps:<br />- Connection[86]"}}:::plan
     PageInfo193{{"PageInfo[193∈13] ➊<br />More deps:<br />- Connection[93]"}}:::plan
+    Access535{{"Access[535∈13] ➊<br />ᐸ93.hasNextPageᐳ<br />More deps:<br />- Connection[93]"}}:::plan
+    Access555{{"Access[555∈13] ➊<br />ᐸ93.hasPreviousPageᐳ<br />More deps:<br />- Connection[93]"}}:::plan
     PageInfo194{{"PageInfo[194∈14] ➊<br />More deps:<br />- Connection[99]"}}:::plan
+    Access536{{"Access[536∈14] ➊<br />ᐸ99.hasNextPageᐳ<br />More deps:<br />- Connection[99]"}}:::plan
+    Access556{{"Access[556∈14] ➊<br />ᐸ99.hasPreviousPageᐳ<br />More deps:<br />- Connection[99]"}}:::plan
     PageInfo198{{"PageInfo[198∈16] ➊<br />More deps:<br />- Connection[115]"}}:::plan
+    Access537{{"Access[537∈16] ➊<br />ᐸ115.hasNextPageᐳ<br />More deps:<br />- Connection[115]"}}:::plan
+    Access557{{"Access[557∈16] ➊<br />ᐸ115.hasPreviousPageᐳ<br />More deps:<br />- Connection[115]"}}:::plan
     PageInfo199{{"PageInfo[199∈17] ➊<br />More deps:<br />- Connection[121]"}}:::plan
+    Access538{{"Access[538∈17] ➊<br />ᐸ121.hasNextPageᐳ<br />More deps:<br />- Connection[121]"}}:::plan
+    Access558{{"Access[558∈17] ➊<br />ᐸ121.hasPreviousPageᐳ<br />More deps:<br />- Connection[121]"}}:::plan
     PageInfo200{{"PageInfo[200∈18] ➊<br />More deps:<br />- Connection[127]"}}:::plan
+    Access539{{"Access[539∈18] ➊<br />ᐸ127.hasNextPageᐳ<br />More deps:<br />- Connection[127]"}}:::plan
+    Access559{{"Access[559∈18] ➊<br />ᐸ127.hasPreviousPageᐳ<br />More deps:<br />- Connection[127]"}}:::plan
     PageInfo201{{"PageInfo[201∈19] ➊<br />More deps:<br />- Connection[134]"}}:::plan
+    Access540{{"Access[540∈19] ➊<br />ᐸ134.hasNextPageᐳ<br />More deps:<br />- Connection[134]"}}:::plan
+    Access560{{"Access[560∈19] ➊<br />ᐸ134.hasPreviousPageᐳ<br />More deps:<br />- Connection[134]"}}:::plan
     PageInfo202{{"PageInfo[202∈20] ➊<br />More deps:<br />- Connection[141]"}}:::plan
+    Access541{{"Access[541∈20] ➊<br />ᐸ141.hasNextPageᐳ<br />More deps:<br />- Connection[141]"}}:::plan
+    Access561{{"Access[561∈20] ➊<br />ᐸ141.hasPreviousPageᐳ<br />More deps:<br />- Connection[141]"}}:::plan
     PageInfo203{{"PageInfo[203∈21] ➊<br />More deps:<br />- Connection[148]"}}:::plan
+    Access542{{"Access[542∈21] ➊<br />ᐸ148.hasNextPageᐳ<br />More deps:<br />- Connection[148]"}}:::plan
+    Access562{{"Access[562∈21] ➊<br />ᐸ148.hasPreviousPageᐳ<br />More deps:<br />- Connection[148]"}}:::plan
     PageInfo207{{"PageInfo[207∈23] ➊<br />More deps:<br />- Connection[161]"}}:::plan
+    Access543{{"Access[543∈23] ➊<br />ᐸ161.hasNextPageᐳ<br />More deps:<br />- Connection[161]"}}:::plan
+    Access563{{"Access[563∈23] ➊<br />ᐸ161.hasPreviousPageᐳ<br />More deps:<br />- Connection[161]"}}:::plan
     PageInfo208{{"PageInfo[208∈24] ➊<br />More deps:<br />- Connection[169]"}}:::plan
+    Access544{{"Access[544∈24] ➊<br />ᐸ169.hasNextPageᐳ<br />More deps:<br />- Connection[169]"}}:::plan
+    Access564{{"Access[564∈24] ➊<br />ᐸ169.hasPreviousPageᐳ<br />More deps:<br />- Connection[169]"}}:::plan
     Edge375{{"Edge[375∈52]"}}:::plan
     __Item374[/"__Item[374∈52]<br />ᐸ184ᐳ"\]:::itemplan
     PgCursor566{{"PgCursor[566∈52]"}}:::plan
@@ -1073,53 +1113,53 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,Access14,PgSelect17,Connection19,PgSelect22,Connection24,Access26,PgSelect29,Connection31,Lambda32,Access35,PgSelect38,Connection40,Lambda41,Access43,PgSelect46,Connection48,Lambda49,PgSelect52,Connection54,PgSelect58,Connection60,PgSelect63,Connection65,__InputObject67,PgSelect69,Connection71,ApplyInput72,__InputObject74,PgSelect76,Connection78,ApplyInput79,__InputObject82,PgSelect84,Connection86,ApplyInput87,PgSelect91,Connection93,PgSelect97,Connection99,__InputObject101,PgSelect104,Connection106,ApplyInput107,Access110,PgSelect113,Connection115,Lambda116,PgSelect119,Connection121,PgSelect125,Connection127,__InputObject130,PgSelect132,Connection134,ApplyInput135,Access137,PgSelect139,Connection141,ApplyInput142,__InputObject143,PgSelect146,Connection148,ApplyInput149,PgSelect152,Connection154,__InputObject156,PgSelect159,Connection161,ApplyInput162,__InputObject164,PgSelect167,Connection169,ApplyInput170,PgSelect173,Connection175,ConnectionItems184,ConnectionItems187,ConnectionItems195,ConnectionItems204,ConnectionItems209,PgSelect212,First213,PgSelectRows214,PgSelectSingle215,PgSelect217,First218,PgSelectRows219,PgSelectSingle220,PgSelect227,First228,PgSelectRows229,PgSelectSingle230,PgSelect232,First233,PgSelectRows234,PgSelectSingle235,PgSelect237,First238,PgSelectRows239,PgSelectSingle240,PgSelect247,First248,PgSelectRows249,PgSelectSingle250,PgSelect252,First253,PgSelectRows254,PgSelectSingle255,PgSelect257,First258,PgSelectRows259,PgSelectSingle260,PgSelect262,First263,PgSelectRows264,PgSelectSingle265,PgSelect267,First268,PgSelectRows269,PgSelectSingle270,PgSelect272,First273,PgSelectRows274,PgSelectSingle275,PgSelect277,First278,PgSelectRows279,PgSelectSingle280,PgSelect287,First288,PgSelectRows289,PgSelectSingle290,PgSelect292,First293,PgSelectRows294,PgSelectSingle295,PgSelect297,First298,PgSelectRows299,PgSelectSingle300,PgSelect304,First305,PgSelectRows306,PgSelectSingle307,PgSelect309,First310,PgSelectRows311,PgSelectSingle312,ConnectionItems314,ConnectionItems317,ConnectionItems320,ConnectionItems323,ConnectionItems326,ConnectionItems329,ConnectionItems332,ConnectionItems335,ConnectionItems338,ConnectionItems341,ConnectionItems344,ConnectionItems347,ConnectionItems350,ConnectionItems353,ConnectionItems356,ConnectionItems359,ConnectionItems362,ConnectionItems365,ConnectionItems368,ConnectionItems371,First425,Access426,First428,Access429,First431,Access432,First434,Access435,First437,Access438,First440,Access441,First443,Access444,First446,Access447,First449,Access450,First452,Access453,First455,Access456,First458,Access459,First461,Access462,First464,Access465,First467,Access468,First470,Access471,First473,Access474,First476,Access477,First479,Access480,First482,Access483,Last485,Last487,Last489,Last491,Last493,Last495,Last497,Last499,Last501,Last503,Last505,Last507,Last509,Last511,Last513,Last515,Last517,Last519,Last521,Last523,Access565,Access567,PgSelectInlineApply783,Access784 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo177 bucket1
+    class Bucket1,PageInfo177,Access525,Access545 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo178 bucket2
+    class Bucket2,PageInfo178,Access526,Access546 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo179 bucket3
+    class Bucket3,PageInfo179,Access527,Access547 bucket3
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PageInfo180 bucket4
+    class Bucket4,PageInfo180,Access528,Access548 bucket4
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PageInfo181 bucket5
+    class Bucket5,PageInfo181,Access529,Access549 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo182 bucket6
+    class Bucket6,PageInfo182,Access530,Access550 bucket6
     classDef bucket7 stroke:#808000
-    class Bucket7,PageInfo183 bucket7
+    class Bucket7,PageInfo183,Access531,Access551 bucket7
     classDef bucket8 stroke:#dda0dd
     class Bucket8 bucket8
     classDef bucket9 stroke:#ff0000
     class Bucket9 bucket9
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PageInfo190 bucket10
+    class Bucket10,PageInfo190,Access532,Access552 bucket10
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PageInfo191 bucket11
+    class Bucket11,PageInfo191,Access533,Access553 bucket11
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PageInfo192 bucket12
+    class Bucket12,PageInfo192,Access534,Access554 bucket12
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PageInfo193 bucket13
+    class Bucket13,PageInfo193,Access535,Access555 bucket13
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PageInfo194 bucket14
+    class Bucket14,PageInfo194,Access536,Access556 bucket14
     classDef bucket15 stroke:#ff00ff
     class Bucket15 bucket15
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PageInfo198 bucket16
+    class Bucket16,PageInfo198,Access537,Access557 bucket16
     classDef bucket17 stroke:#696969
-    class Bucket17,PageInfo199 bucket17
+    class Bucket17,PageInfo199,Access538,Access558 bucket17
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PageInfo200 bucket18
+    class Bucket18,PageInfo200,Access539,Access559 bucket18
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PageInfo201 bucket19
+    class Bucket19,PageInfo201,Access540,Access560 bucket19
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PageInfo202 bucket20
+    class Bucket20,PageInfo202,Access541,Access561 bucket20
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PageInfo203 bucket21
+    class Bucket21,PageInfo203,Access542,Access562 bucket21
     classDef bucket22 stroke:#7fff00
     class Bucket22 bucket22
     classDef bucket23 stroke:#ff1493
-    class Bucket23,PageInfo207 bucket23
+    class Bucket23,PageInfo207,Access543,Access563 bucket23
     classDef bucket24 stroke:#808000
-    class Bucket24,PageInfo208 bucket24
+    class Bucket24,PageInfo208,Access544,Access564 bucket24
     classDef bucket25 stroke:#dda0dd
     class Bucket25 bucket25
     classDef bucket52 stroke:#00bfff

--- a/postgraphile/postgraphile/__tests__/queries/v4/function-return-types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/function-return-types.mermaid
@@ -793,6 +793,10 @@ graph TD
     PgSelectSingle282 --> PgClassExpression382
     PgClassExpression393{{"PgClassExpression[393∈45]<br />ᐸ__func_ret...l__.”col2”ᐳ"}}:::plan
     PgSelectSingle282 --> PgClassExpression393
+    Access383{{"Access[383∈46]<br />ᐸ287.hoursᐳ"}}:::plan
+    PgClassExpression287 --> Access383
+    Access394{{"Access[394∈46]<br />ᐸ287.minutesᐳ"}}:::plan
+    PgClassExpression287 --> Access394
     PgClassExpression401{{"PgClassExpression[401∈47] ➊<br />ᐸ__person__.”id”ᐳ"}}:::plan
     PgSelectSingle308 --> PgClassExpression401
     PgClassExpression413{{"PgClassExpression[413∈47] ➊<br />ᐸ__person__...full_name”ᐳ"}}:::plan
@@ -1008,7 +1012,7 @@ graph TD
     classDef bucket45 stroke:#00ffff
     class Bucket45,PgClassExpression382,PgClassExpression393 bucket45
     classDef bucket46 stroke:#4169e1
-    class Bucket46 bucket46
+    class Bucket46,Access383,Access394 bucket46
     classDef bucket47 stroke:#3cb371
     class Bucket47,PgClassExpression401,PgClassExpression413 bucket47
     classDef bucket48 stroke:#a52a2a

--- a/postgraphile/postgraphile/__tests__/queries/v4/geometry.queries.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/geometry.queries.mermaid
@@ -68,18 +68,82 @@ graph TD
     PgSelectSingle18 --> PgClassExpression26
     PgClassExpression27{{"PgClassExpression[27∈4]<br />ᐸ__geom__.”circle”ᐳ"}}:::plan
     PgSelectSingle18 --> PgClassExpression27
+    Access28{{"Access[28∈5]<br />ᐸ20.xᐳ"}}:::plan
+    PgClassExpression20 --> Access28
+    Access36{{"Access[36∈5]<br />ᐸ20.yᐳ"}}:::plan
+    PgClassExpression20 --> Access36
+    Access29{{"Access[29∈6]<br />ᐸ21.aᐳ"}}:::plan
+    PgClassExpression21 --> Access29
+    Access37{{"Access[37∈6]<br />ᐸ21.bᐳ"}}:::plan
+    PgClassExpression21 --> Access37
+    Access46{{"Access[46∈6]<br />ᐸ21.a.xᐳ"}}:::plan
+    PgClassExpression21 --> Access46
+    Access50{{"Access[50∈6]<br />ᐸ21.b.xᐳ"}}:::plan
+    PgClassExpression21 --> Access50
+    Access53{{"Access[53∈6]<br />ᐸ21.a.yᐳ"}}:::plan
+    PgClassExpression21 --> Access53
+    Access57{{"Access[57∈6]<br />ᐸ21.b.yᐳ"}}:::plan
+    PgClassExpression21 --> Access57
+    Access30{{"Access[30∈7]<br />ᐸ22.aᐳ"}}:::plan
+    PgClassExpression22 --> Access30
+    Access38{{"Access[38∈7]<br />ᐸ22.bᐳ"}}:::plan
+    PgClassExpression22 --> Access38
+    Access47{{"Access[47∈7]<br />ᐸ22.a.xᐳ"}}:::plan
+    PgClassExpression22 --> Access47
+    Access51{{"Access[51∈7]<br />ᐸ22.b.xᐳ"}}:::plan
+    PgClassExpression22 --> Access51
+    Access54{{"Access[54∈7]<br />ᐸ22.a.yᐳ"}}:::plan
+    PgClassExpression22 --> Access54
+    Access58{{"Access[58∈7]<br />ᐸ22.b.yᐳ"}}:::plan
+    PgClassExpression22 --> Access58
+    Access31{{"Access[31∈8]<br />ᐸ23.aᐳ"}}:::plan
+    PgClassExpression23 --> Access31
+    Access39{{"Access[39∈8]<br />ᐸ23.bᐳ"}}:::plan
+    PgClassExpression23 --> Access39
+    Access48{{"Access[48∈8]<br />ᐸ23.a.xᐳ"}}:::plan
+    PgClassExpression23 --> Access48
+    Access52{{"Access[52∈8]<br />ᐸ23.b.xᐳ"}}:::plan
+    PgClassExpression23 --> Access52
+    Access55{{"Access[55∈8]<br />ᐸ23.a.yᐳ"}}:::plan
+    PgClassExpression23 --> Access55
+    Access59{{"Access[59∈8]<br />ᐸ23.b.yᐳ"}}:::plan
+    PgClassExpression23 --> Access59
+    Access32{{"Access[32∈9]<br />ᐸ24.isOpenᐳ"}}:::plan
+    PgClassExpression24 --> Access32
     Access40{{"Access[40∈9]<br />ᐸ24.pointsᐳ"}}:::plan
     PgClassExpression24 --> Access40
+    Access33{{"Access[33∈10]<br />ᐸ25.isOpenᐳ"}}:::plan
+    PgClassExpression25 --> Access33
     Access41{{"Access[41∈10]<br />ᐸ25.pointsᐳ"}}:::plan
     PgClassExpression25 --> Access41
     Access34{{"Access[34∈11]<br />ᐸ26.pointsᐳ"}}:::plan
     PgClassExpression26 --> Access34
+    Access35{{"Access[35∈12]<br />ᐸ27.centerᐳ"}}:::plan
+    PgClassExpression27 --> Access35
+    Access42{{"Access[42∈12]<br />ᐸ27.radiusᐳ"}}:::plan
+    PgClassExpression27 --> Access42
+    Access49{{"Access[49∈12]<br />ᐸ27.center.xᐳ"}}:::plan
+    PgClassExpression27 --> Access49
+    Access56{{"Access[56∈12]<br />ᐸ27.center.yᐳ"}}:::plan
+    PgClassExpression27 --> Access56
     __Item43[/"__Item[43∈13]<br />ᐸ34ᐳ"\]:::itemplan
     Access34 ==> __Item43
+    Access60{{"Access[60∈13]<br />ᐸ43.xᐳ"}}:::plan
+    __Item43 --> Access60
+    Access63{{"Access[63∈13]<br />ᐸ43.yᐳ"}}:::plan
+    __Item43 --> Access63
     __Item44[/"__Item[44∈14]<br />ᐸ40ᐳ"\]:::itemplan
     Access40 ==> __Item44
+    Access61{{"Access[61∈14]<br />ᐸ44.xᐳ"}}:::plan
+    __Item44 --> Access61
+    Access64{{"Access[64∈14]<br />ᐸ44.yᐳ"}}:::plan
+    __Item44 --> Access64
     __Item45[/"__Item[45∈15]<br />ᐸ41ᐳ"\]:::itemplan
     Access41 ==> __Item45
+    Access62{{"Access[62∈15]<br />ᐸ45.xᐳ"}}:::plan
+    __Item45 --> Access62
+    Access65{{"Access[65∈15]<br />ᐸ45.yᐳ"}}:::plan
+    __Item45 --> Access65
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -91,25 +155,25 @@ graph TD
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgClassExpression23,PgClassExpression24,PgClassExpression25,PgClassExpression26,PgClassExpression27 bucket4
     classDef bucket5 stroke:#7fff00
-    class Bucket5 bucket5
+    class Bucket5,Access28,Access36 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6 bucket6
+    class Bucket6,Access29,Access37,Access46,Access50,Access53,Access57 bucket6
     classDef bucket7 stroke:#808000
-    class Bucket7 bucket7
+    class Bucket7,Access30,Access38,Access47,Access51,Access54,Access58 bucket7
     classDef bucket8 stroke:#dda0dd
-    class Bucket8 bucket8
+    class Bucket8,Access31,Access39,Access48,Access52,Access55,Access59 bucket8
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Access40 bucket9
+    class Bucket9,Access32,Access40 bucket9
     classDef bucket10 stroke:#ffff00
-    class Bucket10,Access41 bucket10
+    class Bucket10,Access33,Access41 bucket10
     classDef bucket11 stroke:#00ffff
     class Bucket11,Access34 bucket11
     classDef bucket12 stroke:#4169e1
-    class Bucket12 bucket12
+    class Bucket12,Access35,Access42,Access49,Access56 bucket12
     classDef bucket13 stroke:#3cb371
-    class Bucket13,__Item43 bucket13
+    class Bucket13,__Item43,Access60,Access63 bucket13
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,__Item44 bucket14
+    class Bucket14,__Item44,Access61,Access64 bucket14
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,__Item45 bucket15
+    class Bucket15,__Item45,Access62,Access65 bucket15
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/issue2210.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/issue2210.mermaid
@@ -24,7 +24,7 @@ graph TD
     PgFromExpression15{{"PgFromExpression[15∈0] ➊<br />More deps:<br />- Constantᐸ'0d126c0c-9710-478c-9aee-0be34b250573'ᐳ[41]"}}:::plan
     Lambda17{{"Lambda[17∈0] ➊<br />ᐸparseCursorᐳ"}}:::plan
     PgFromExpression15 & Lambda17 --> PgSelect11
-    Connection16[["Connection[16∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ50ᐳ[42]"]]:::plan
+    Connection16[["Connection[16∈0] ➊<br />ᐸ11ᐳ<br />Dependents: 3<br />More deps:<br />- Constantᐸ50ᐳ[42]"]]:::plan
     PgSelect11 & Lambda17 --> Connection16
     Object14{{"Object[14∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ<br />Dependents: 2"}}:::plan
     Access12{{"Access[12∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
@@ -42,6 +42,7 @@ graph TD
     Access26{{"Access[26∈0] ➊<br />ᐸ11.cursorDetailsᐳ"}}:::plan
     PgSelect11 --> Access26
     PageInfo21{{"PageInfo[21∈1] ➊<br />More deps:<br />- Connection[16]"}}:::plan
+    Access24{{"Access[24∈1] ➊<br />ᐸ16.hasNextPageᐳ<br />More deps:<br />- Connection[16]"}}:::plan
     __Item22[/"__Item[22∈3]<br />ᐸ18ᐳ<br />More deps:<br />- ConnectionItems[18]"\]:::itemplan
     PgSelectSingle23{{"PgSelectSingle[23∈3]<br />ᐸsome_messagesᐳ"}}:::plan
     __Item22 --> PgSelectSingle23
@@ -70,7 +71,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value0,__Value2,Access9,PgSelect11,Access12,Access13,Object14,PgFromExpression15,Connection16,Lambda17,ConnectionItems18,Last25,Access26 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo21 bucket1
+    class Bucket1,PageInfo21,Access24 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item22,PgSelectSingle23 bucket3
     classDef bucket4 stroke:#0000ff

--- a/postgraphile/postgraphile/__tests__/queries/v4/network_types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/network_types.mermaid
@@ -59,13 +59,13 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4"]]:::plan
     PgSelect10 --> Connection14
     __InputObject7 --> ApplyInput15
-    Connection22[["Connection[22∈0] ➊<br />ᐸ20ᐳ<br />Dependents: 2"]]:::plan
+    Connection22[["Connection[22∈0] ➊<br />ᐸ20ᐳ<br />Dependents: 4"]]:::plan
     PgSelect20 --> Connection22
     __InputObject17 --> ApplyInput23
-    Connection30[["Connection[30∈0] ➊<br />ᐸ28ᐳ<br />Dependents: 2"]]:::plan
+    Connection30[["Connection[30∈0] ➊<br />ᐸ28ᐳ<br />Dependents: 4"]]:::plan
     PgSelect28 --> Connection30
     __InputObject25 --> ApplyInput31
     First37{{"First[37∈0] ➊"}}:::plan
@@ -102,8 +102,14 @@ graph TD
     Last77{{"Last[77∈0] ➊<br />More deps:<br />- ConnectionItems[54]"}}:::plan
     Last79{{"Last[79∈0] ➊<br />More deps:<br />- ConnectionItems[57]"}}:::plan
     PageInfo33{{"PageInfo[33∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access81{{"Access[81∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access84{{"Access[84∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     PageInfo34{{"PageInfo[34∈2] ➊<br />More deps:<br />- Connection[22]"}}:::plan
+    Access82{{"Access[82∈2] ➊<br />ᐸ22.hasNextPageᐳ<br />More deps:<br />- Connection[22]"}}:::plan
+    Access85{{"Access[85∈2] ➊<br />ᐸ22.hasPreviousPageᐳ<br />More deps:<br />- Connection[22]"}}:::plan
     PageInfo35{{"PageInfo[35∈3] ➊<br />More deps:<br />- Connection[30]"}}:::plan
+    Access83{{"Access[83∈3] ➊<br />ᐸ30.hasNextPageᐳ<br />More deps:<br />- Connection[30]"}}:::plan
+    Access86{{"Access[86∈3] ➊<br />ᐸ30.hasPreviousPageᐳ<br />More deps:<br />- Connection[30]"}}:::plan
     Edge61{{"Edge[61∈7]"}}:::plan
     __Item60[/"__Item[60∈7]<br />ᐸ51ᐳ<br />More deps:<br />- ConnectionItems[51]"\]:::itemplan
     PgCursor88{{"PgCursor[88∈7]<br />More deps:<br />- Access[67]"}}:::plan
@@ -154,11 +160,11 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,__InputObject7,PgSelect10,Access11,Access12,Object13,Connection14,ApplyInput15,__InputObject17,PgSelect20,Connection22,ApplyInput23,__InputObject25,PgSelect28,Connection30,ApplyInput31,PgSelect36,First37,PgSelectRows38,PgSelectSingle39,PgSelect41,First42,PgSelectRows43,PgSelectSingle44,PgSelect46,First47,PgSelectRows48,PgSelectSingle49,ConnectionItems51,ConnectionItems54,ConnectionItems57,First66,Access67,First69,Access70,First72,Access73,Last75,Last77,Last79 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo33 bucket1
+    class Bucket1,PageInfo33,Access81,Access84 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo34 bucket2
+    class Bucket2,PageInfo34,Access82,Access85 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo35 bucket3
+    class Bucket3,PageInfo35,Access83,Access86 bucket3
     classDef bucket7 stroke:#808000
     class Bucket7,__Item60,Edge61,PgCursor88 bucket7
     classDef bucket8 stroke:#dda0dd

--- a/postgraphile/postgraphile/__tests__/queries/v4/numeric.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/numeric.mermaid
@@ -11,8 +11,8 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 21, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: First[11], PgSelectSingle[13]"):::bucket
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[13]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14<br /><br />ROOT PgClassExpression{1}ᐸ__range_test__.”num”ᐳ[14]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 14<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 16, 14<br /><br />ROOT Access{2}ᐸ14.endᐳ[16]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 17, 19<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 16, 18, 20<br /><br />ROOT Access{2}ᐸ14.endᐳ[16]"):::bucket
     end
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
@@ -40,6 +40,14 @@ graph TD
     PgClassExpression14 --> Access15
     Access16{{"Access[16∈2] ➊<br />ᐸ14.endᐳ"}}:::plan
     PgClassExpression14 --> Access16
+    Access17{{"Access[17∈2] ➊<br />ᐸ14.start.valueᐳ"}}:::plan
+    PgClassExpression14 --> Access17
+    Access18{{"Access[18∈2] ➊<br />ᐸ14.end.valueᐳ"}}:::plan
+    PgClassExpression14 --> Access18
+    Access19{{"Access[19∈2] ➊<br />ᐸ14.start.inclusiveᐳ"}}:::plan
+    PgClassExpression14 --> Access19
+    Access20{{"Access[20∈2] ➊<br />ᐸ14.end.inclusiveᐳ"}}:::plan
+    PgClassExpression14 --> Access20
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -47,7 +55,7 @@ graph TD
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access15,Access16 bucket2
+    class Bucket2,Access15,Access16,Access17,Access18,Access19,Access20 bucket2
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
     classDef bucket4 stroke:#0000ff

--- a/postgraphile/postgraphile/__tests__/queries/v4/partitions.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/partitions.mermaid
@@ -32,7 +32,7 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     ConnectionItems14[["ConnectionItems[14∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[12]"]]:::plan
     PgSelect17[["PgSelect[17∈0] ➊<br />ᐸmeasurements(aggregate)ᐳ"]]:::plan
@@ -50,6 +50,8 @@ graph TD
     Access49{{"Access[49∈0] ➊<br />ᐸ8.m.joinDetailsFor39ᐳ"}}:::plan
     PgSelect8 --> Access49
     PageInfo22{{"PageInfo[22∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access30{{"Access[30∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access31{{"Access[31∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     Edge24{{"Edge[24∈3]"}}:::plan
     __Item23[/"__Item[23∈3]<br />ᐸ14ᐳ<br />More deps:<br />- ConnectionItems[14]"\]:::itemplan
     PgCursor33{{"PgCursor[33∈3]<br />More deps:<br />- Access[26]"}}:::plan
@@ -82,7 +84,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,ConnectionItems14,PgSelect17,First18,PgSelectRows19,PgSelectSingle20,First25,Access26,Last28,PgSelectInlineApply48,Access49 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo22 bucket1
+    class Bucket1,PageInfo22,Access30,Access31 bucket1
     classDef bucket3 stroke:#ffa500
     class Bucket3,__Item23,Edge24,PgCursor33 bucket3
     classDef bucket4 stroke:#0000ff

--- a/postgraphile/postgraphile/__tests__/queries/v4/pg11.network_types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/pg11.network_types.mermaid
@@ -72,16 +72,16 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access11
     __Value2 --> Access12
-    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 2"]]:::plan
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4"]]:::plan
     PgSelect10 --> Connection14
     __InputObject7 --> ApplyInput15
-    Connection22[["Connection[22∈0] ➊<br />ᐸ20ᐳ<br />Dependents: 2"]]:::plan
+    Connection22[["Connection[22∈0] ➊<br />ᐸ20ᐳ<br />Dependents: 4"]]:::plan
     PgSelect20 --> Connection22
     __InputObject17 --> ApplyInput23
-    Connection30[["Connection[30∈0] ➊<br />ᐸ28ᐳ<br />Dependents: 2"]]:::plan
+    Connection30[["Connection[30∈0] ➊<br />ᐸ28ᐳ<br />Dependents: 4"]]:::plan
     PgSelect28 --> Connection30
     __InputObject25 --> ApplyInput31
-    Connection38[["Connection[38∈0] ➊<br />ᐸ36ᐳ<br />Dependents: 2"]]:::plan
+    Connection38[["Connection[38∈0] ➊<br />ᐸ36ᐳ<br />Dependents: 4"]]:::plan
     PgSelect36 --> Connection38
     __InputObject33 --> ApplyInput39
     First46{{"First[46∈0] ➊"}}:::plan
@@ -129,9 +129,17 @@ graph TD
     Last101{{"Last[101∈0] ➊<br />More deps:<br />- ConnectionItems[71]"}}:::plan
     Last103{{"Last[103∈0] ➊<br />More deps:<br />- ConnectionItems[74]"}}:::plan
     PageInfo41{{"PageInfo[41∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access105{{"Access[105∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access109{{"Access[109∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
     PageInfo42{{"PageInfo[42∈2] ➊<br />More deps:<br />- Connection[22]"}}:::plan
+    Access106{{"Access[106∈2] ➊<br />ᐸ22.hasNextPageᐳ<br />More deps:<br />- Connection[22]"}}:::plan
+    Access110{{"Access[110∈2] ➊<br />ᐸ22.hasPreviousPageᐳ<br />More deps:<br />- Connection[22]"}}:::plan
     PageInfo43{{"PageInfo[43∈3] ➊<br />More deps:<br />- Connection[30]"}}:::plan
+    Access107{{"Access[107∈3] ➊<br />ᐸ30.hasNextPageᐳ<br />More deps:<br />- Connection[30]"}}:::plan
+    Access111{{"Access[111∈3] ➊<br />ᐸ30.hasPreviousPageᐳ<br />More deps:<br />- Connection[30]"}}:::plan
     PageInfo44{{"PageInfo[44∈4] ➊<br />More deps:<br />- Connection[38]"}}:::plan
+    Access108{{"Access[108∈4] ➊<br />ᐸ38.hasNextPageᐳ<br />More deps:<br />- Connection[38]"}}:::plan
+    Access112{{"Access[112∈4] ➊<br />ᐸ38.hasPreviousPageᐳ<br />More deps:<br />- Connection[38]"}}:::plan
     Edge78{{"Edge[78∈9]"}}:::plan
     __Item77[/"__Item[77∈9]<br />ᐸ65ᐳ<br />More deps:<br />- ConnectionItems[65]"\]:::itemplan
     PgCursor114{{"PgCursor[114∈9]<br />More deps:<br />- Access[86]"}}:::plan
@@ -205,13 +213,13 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,__InputObject7,PgSelect10,Access11,Access12,Object13,Connection14,ApplyInput15,__InputObject17,PgSelect20,Connection22,ApplyInput23,__InputObject25,PgSelect28,Connection30,ApplyInput31,__InputObject33,PgSelect36,Connection38,ApplyInput39,PgSelect45,First46,PgSelectRows47,PgSelectSingle48,PgSelect50,First51,PgSelectRows52,PgSelectSingle53,PgSelect55,First56,PgSelectRows57,PgSelectSingle58,PgSelect60,First61,PgSelectRows62,PgSelectSingle63,ConnectionItems65,ConnectionItems68,ConnectionItems71,ConnectionItems74,First85,Access86,First88,Access89,First91,Access92,First94,Access95,Last97,Last99,Last101,Last103 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo41 bucket1
+    class Bucket1,PageInfo41,Access105,Access109 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo42 bucket2
+    class Bucket2,PageInfo42,Access106,Access110 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PageInfo43 bucket3
+    class Bucket3,PageInfo43,Access107,Access111 bucket3
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PageInfo44 bucket4
+    class Bucket4,PageInfo44,Access108,Access112 bucket4
     classDef bucket9 stroke:#ff0000
     class Bucket9,__Item77,Edge78,PgCursor114 bucket9
     classDef bucket10 stroke:#ffff00

--- a/postgraphile/postgraphile/__tests__/queries/v4/pg11.types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/pg11.types.mermaid
@@ -38,7 +38,7 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     ConnectionItems14[["ConnectionItems[14∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[12]"]]:::plan
     PgSelect19[["PgSelect[19∈0] ➊<br />ᐸtypes(aggregate)ᐳ"]]:::plan
@@ -58,6 +58,8 @@ graph TD
     Access81{{"Access[81∈0] ➊<br />ᐸ8.m.joinDetailsFor58ᐳ"}}:::plan
     PgSelect8 --> Access81
     PageInfo24{{"PageInfo[24∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access28{{"Access[28∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access29{{"Access[29∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     __Item25[/"__Item[25∈4]<br />ᐸ14ᐳ<br />More deps:<br />- ConnectionItems[14]"\]:::itemplan
     PgSelectSingle26{{"PgSelectSingle[26∈4]<br />ᐸtypesᐳ"}}:::plan
     __Item25 --> PgSelectSingle26
@@ -136,7 +138,7 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,ConnectionItems14,PgSelect19,First20,PgSelectRows21,PgSelectSingle22,First30,Access31,Last33,PgSelectInlineApply76,Access77,PgSelectInlineApply80,Access81 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo24 bucket1
+    class Bucket1,PageInfo24,Access28,Access29 bucket1
     classDef bucket4 stroke:#0000ff
     class Bucket4,__Item25,PgSelectSingle26,Edge27 bucket4
     classDef bucket5 stroke:#7fff00

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
@@ -383,6 +383,18 @@ graph TD
     PgSelectSingle158 --> PgClassExpression223
     PgClassExpression224{{"PgClassExpression[224∈24]<br />ᐸ__post_com....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle158 --> PgClassExpression224
+    Access212{{"Access[212∈25]<br />ᐸ160.secondsᐳ"}}:::plan
+    __Item160 --> Access212
+    Access214{{"Access[214∈25]<br />ᐸ160.minutesᐳ"}}:::plan
+    __Item160 --> Access214
+    Access216{{"Access[216∈25]<br />ᐸ160.hoursᐳ"}}:::plan
+    __Item160 --> Access216
+    Access218{{"Access[218∈25]<br />ᐸ160.daysᐳ"}}:::plan
+    __Item160 --> Access218
+    Access220{{"Access[220∈25]<br />ᐸ160.monthsᐳ"}}:::plan
+    __Item160 --> Access220
+    Access222{{"Access[222∈25]<br />ᐸ160.yearsᐳ"}}:::plan
+    __Item160 --> Access222
     PgClassExpression225{{"PgClassExpression[225∈29]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle167 --> PgClassExpression225
     PgClassExpression229{{"PgClassExpression[229∈29]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -437,6 +449,30 @@ graph TD
     ConnectionItems264[["ConnectionItems[264∈35]"]]:::plan
     Connection257 --> ConnectionItems264
     List316 --> Lambda317
+    Access242{{"Access[242∈36]<br />ᐸ209.secondsᐳ"}}:::plan
+    PgClassExpression209 --> Access242
+    Access248{{"Access[248∈36]<br />ᐸ209.minutesᐳ"}}:::plan
+    PgClassExpression209 --> Access248
+    Access258{{"Access[258∈36]<br />ᐸ209.hoursᐳ"}}:::plan
+    PgClassExpression209 --> Access258
+    Access260{{"Access[260∈36]<br />ᐸ209.daysᐳ"}}:::plan
+    PgClassExpression209 --> Access260
+    Access261{{"Access[261∈36]<br />ᐸ209.monthsᐳ"}}:::plan
+    PgClassExpression209 --> Access261
+    Access262{{"Access[262∈36]<br />ᐸ209.yearsᐳ"}}:::plan
+    PgClassExpression209 --> Access262
+    Access245{{"Access[245∈38]<br />ᐸ223.secondsᐳ"}}:::plan
+    PgClassExpression223 --> Access245
+    Access251{{"Access[251∈38]<br />ᐸ223.minutesᐳ"}}:::plan
+    PgClassExpression223 --> Access251
+    Access259{{"Access[259∈38]<br />ᐸ223.hoursᐳ"}}:::plan
+    PgClassExpression223 --> Access259
+    Access263{{"Access[263∈39]<br />ᐸ209.secondsᐳ"}}:::plan
+    PgClassExpression209 --> Access263
+    Access267{{"Access[267∈39]<br />ᐸ209.minutesᐳ"}}:::plan
+    PgClassExpression209 --> Access267
+    Access268{{"Access[268∈39]<br />ᐸ209.hoursᐳ"}}:::plan
+    PgClassExpression209 --> Access268
     __Item269[/"__Item[269∈41]<br />ᐸ264ᐳ"\]:::itemplan
     ConnectionItems264 ==> __Item269
     PgSelectSingle270{{"PgSelectSingle[270∈41]<br />ᐸperson_friendsᐳ"}}:::plan
@@ -490,7 +526,7 @@ graph TD
     classDef bucket24 stroke:#808000
     class Bucket24,PgClassExpression211,PgClassExpression213,PgClassExpression215,PgClassExpression217,PgClassExpression219,PgClassExpression221,PgClassExpression223,PgClassExpression224 bucket24
     classDef bucket25 stroke:#dda0dd
-    class Bucket25 bucket25
+    class Bucket25,Access212,Access214,Access216,Access218,Access220,Access222 bucket25
     classDef bucket29 stroke:#4169e1
     class Bucket29,PgClassExpression225,PgClassExpression229,PgClassExpression234 bucket29
     classDef bucket30 stroke:#3cb371
@@ -506,13 +542,13 @@ graph TD
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression241,PgClassExpression247,Connection257,ConnectionItems264,List316,Lambda317 bucket35
     classDef bucket36 stroke:#7f007f
-    class Bucket36 bucket36
+    class Bucket36,Access242,Access248,Access258,Access260,Access261,Access262 bucket36
     classDef bucket37 stroke:#ffa500
     class Bucket37 bucket37
     classDef bucket38 stroke:#0000ff
-    class Bucket38 bucket38
+    class Bucket38,Access245,Access251,Access259 bucket38
     classDef bucket39 stroke:#7fff00
-    class Bucket39 bucket39
+    class Bucket39,Access263,Access267,Access268 bucket39
     classDef bucket41 stroke:#808000
     class Bucket41,__Item269,PgSelectSingle270 bucket41
     classDef bucket42 stroke:#dda0dd

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
@@ -191,7 +191,7 @@ graph TD
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Lambda231{{"Lambda[231∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyJuYXR1cmFsIiwxXQ=='ᐳ[710]"}}:::plan
     Object10 & Lambda231 --> PgSelect232
-    Connection234[["Connection[234∈0] ➊<br />ᐸ232ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ1ᐳ[687]"]]:::plan
+    Connection234[["Connection[234∈0] ➊<br />ᐸ232ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ1ᐳ[687]"]]:::plan
     PgSelect232 & Lambda231 --> Connection234
     PgFromExpression76{{"PgFromExpression[76∈0] ➊<br />More deps:<br />- Constantᐸ1ᐳ[687]<br />- Constantᐸundefinedᐳ[56]<br />- Constantᐸ7ᐳ[691]"}}:::plan
     PgFromExpression84{{"PgFromExpression[84∈0] ➊<br />More deps:<br />- Constantᐸ1ᐳ[687]<br />- Constantᐸ8ᐳ[692]<br />- Constantᐸ7ᐳ[691]"}}:::plan
@@ -203,46 +203,46 @@ graph TD
     Lambda193{{"Lambda[193∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyJuYXR1cmFsIiw1XQ=='ᐳ[705]"}}:::plan
     Lambda194{{"Lambda[194∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyJuYXR1cmFsIiwzXQ=='ᐳ[706]"}}:::plan
     Object10 & Lambda193 & Lambda194 --> PgSelect190
-    Connection192[["Connection[192∈0] ➊<br />ᐸ190ᐳ<br />Dependents: 2"]]:::plan
+    Connection192[["Connection[192∈0] ➊<br />ᐸ190ᐳ<br />Dependents: 4"]]:::plan
     PgSelect190 & Lambda193 & Lambda194 --> Connection192
-    Connection197[["Connection[197∈0] ➊<br />ᐸ190ᐳ<br />Dependents: 2"]]:::plan
+    Connection197[["Connection[197∈0] ➊<br />ᐸ190ᐳ<br />Dependents: 4"]]:::plan
     PgSelect190 & Lambda193 & Lambda194 --> Connection197
     PgSelect200[["PgSelect[200∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Object10 & Lambda193 --> PgSelect200
-    Connection202[["Connection[202∈0] ➊<br />ᐸ200ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection202[["Connection[202∈0] ➊<br />ᐸ200ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect200 & Lambda193 --> Connection202
     PgSelect204[["PgSelect[204∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Object10 & Lambda193 --> PgSelect204
-    Connection206[["Connection[206∈0] ➊<br />ᐸ204ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection206[["Connection[206∈0] ➊<br />ᐸ204ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect204 & Lambda193 --> Connection206
     PgSelect208[["PgSelect[208∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Object10 & Lambda194 --> PgSelect208
-    Connection210[["Connection[210∈0] ➊<br />ᐸ208ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection210[["Connection[210∈0] ➊<br />ᐸ208ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect208 & Lambda194 --> Connection210
     PgSelect212[["PgSelect[212∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Object10 --> PgSelect212
-    Connection214[["Connection[214∈0] ➊<br />ᐸ212ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection214[["Connection[214∈0] ➊<br />ᐸ212ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect212 --> Connection214
     PgSelect216[["PgSelect[216∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ4ᐳ[707]"]]:::plan
     Object10 --> PgSelect216
-    Connection218[["Connection[218∈0] ➊<br />ᐸ216ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ4ᐳ[707]"]]:::plan
+    Connection218[["Connection[218∈0] ➊<br />ᐸ216ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ4ᐳ[707]"]]:::plan
     PgSelect216 --> Connection218
     PgSelect220[["PgSelect[220∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ0ᐳ[708]"]]:::plan
     Object10 --> PgSelect220
-    Connection222[["Connection[222∈0] ➊<br />ᐸ220ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ0ᐳ[708]"]]:::plan
+    Connection222[["Connection[222∈0] ➊<br />ᐸ220ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]<br />- Constantᐸ0ᐳ[708]"]]:::plan
     PgSelect220 --> Connection222
     PgSelect224[["PgSelect[224∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ6ᐳ[709]<br />- Constantᐸ0ᐳ[708]"]]:::plan
     Object10 --> PgSelect224
-    Connection226[["Connection[226∈0] ➊<br />ᐸ224ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ6ᐳ[709]<br />- Constantᐸ0ᐳ[708]"]]:::plan
+    Connection226[["Connection[226∈0] ➊<br />ᐸ224ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ6ᐳ[709]<br />- Constantᐸ0ᐳ[708]"]]:::plan
     PgSelect224 --> Connection226
     PgSelect228[["PgSelect[228∈0] ➊<br />ᐸtable_set_query+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Object10 & Lambda231 --> PgSelect228
-    Connection230[["Connection[230∈0] ➊<br />ᐸ228ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection230[["Connection[230∈0] ➊<br />ᐸ228ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect228 & Lambda231 --> Connection230
     PgSelect240[["PgSelect[240∈0] ➊<br />ᐸtable_set_query_plpgsql+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Lambda243{{"Lambda[243∈0] ➊<br />ᐸparseCursorᐳ<br />More deps:<br />- Constantᐸ'WyJuYXR1cmFsIiwyXQ=='ᐳ[711]"}}:::plan
     Object10 & Lambda243 --> PgSelect240
-    Connection242[["Connection[242∈0] ➊<br />ᐸ240ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection242[["Connection[242∈0] ➊<br />ᐸ240ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect240 & Lambda243 --> Connection242
     PgFromExpression246{{"PgFromExpression[246∈0] ➊<br />More deps:<br />- Constantᐸ5ᐳ[689]<br />- Constantᐸundefinedᐳ[56]<br />- Constantᐸ6ᐳ[709]"}}:::plan
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸjson_identityᐳ"]]:::plan
@@ -296,7 +296,7 @@ graph TD
     Object10 & PgFromExpression155 --> PgSelect153
     PgSelect159[["PgSelect[159∈0] ➊<br />ᐸcompound_type_set_query+1ᐳ<br />More deps:<br />- Constantᐸ5ᐳ[689]"]]:::plan
     Object10 --> PgSelect159
-    Connection161[["Connection[161∈0] ➊<br />ᐸ159ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ5ᐳ[689]"]]:::plan
+    Connection161[["Connection[161∈0] ➊<br />ᐸ159ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ5ᐳ[689]"]]:::plan
     PgSelect159 --> Connection161
     PgSelect165[["PgSelect[165∈0] ➊<br />ᐸcompound_type_array_queryᐳ"]]:::plan
     PgFromExpression167{{"PgFromExpression[167∈0] ➊"}}:::plan
@@ -310,7 +310,7 @@ graph TD
     Object10 & ApplyInput187 --> PgSelect184
     PgSelect236[["PgSelect[236∈0] ➊<br />ᐸtable_set_query_plpgsql+1ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     Object10 --> PgSelect236
-    Connection238[["Connection[238∈0] ➊<br />ᐸ236ᐳ<br />Dependents: 2<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
+    Connection238[["Connection[238∈0] ➊<br />ᐸ236ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[688]"]]:::plan
     PgSelect236 --> Connection238
     PgSelect244[["PgSelect[244∈0] ➊<br />ᐸint_set_queryᐳ"]]:::plan
     Object10 & PgFromExpression246 --> PgSelect244
@@ -438,13 +438,13 @@ graph TD
     First171 --> PgSelectSingle173
     PgSelect174[["PgSelect[174∈0] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
     Object10 --> PgSelect174
-    Connection176[["Connection[176∈0] ➊<br />ᐸ174ᐳ<br />Dependents: 2"]]:::plan
+    Connection176[["Connection[176∈0] ➊<br />ᐸ174ᐳ<br />Dependents: 4"]]:::plan
     PgSelect174 --> Connection176
     PgSelect178[["PgSelect[178∈0] ➊<br />ᐸtable_set_query+1ᐳ"]]:::plan
     Object10 --> PgSelect178
-    Connection180[["Connection[180∈0] ➊<br />ᐸ178ᐳ<br />Dependents: 2"]]:::plan
+    Connection180[["Connection[180∈0] ➊<br />ᐸ178ᐳ<br />Dependents: 4"]]:::plan
     PgSelect178 --> Connection180
-    Connection186[["Connection[186∈0] ➊<br />ᐸ184ᐳ<br />Dependents: 2"]]:::plan
+    Connection186[["Connection[186∈0] ➊<br />ᐸ184ᐳ<br />Dependents: 4"]]:::plan
     PgSelect184 --> Connection186
     __InputObject182 --> ApplyInput187
     Connection247[["Connection[247∈0] ➊<br />ᐸ244ᐳ"]]:::plan
@@ -624,6 +624,8 @@ graph TD
     PgClassExpression393{{"PgClassExpression[393∈1] ➊<br />ᐸ__compound....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle158 --> PgClassExpression393
     PageInfo352{{"PageInfo[352∈2] ➊<br />More deps:<br />- Connection[161]"}}:::plan
+    Access545{{"Access[545∈2] ➊<br />ᐸ161.hasNextPageᐳ<br />More deps:<br />- Connection[161]"}}:::plan
+    Access563{{"Access[563∈2] ➊<br />ᐸ161.hasPreviousPageᐳ<br />More deps:<br />- Connection[161]"}}:::plan
     List292{{"List[292∈3] ➊<br />ᐸ290,291ᐳ<br />More deps:<br />- Constantᐸ'posts'ᐳ[290]"}}:::plan
     PgClassExpression291{{"PgClassExpression[291∈3] ➊<br />ᐸ__table_query__.”id”ᐳ"}}:::plan
     PgClassExpression291 --> List292
@@ -635,21 +637,53 @@ graph TD
     PgClassExpression389{{"PgClassExpression[389∈3] ➊<br />ᐸ__table_qu...author_id”ᐳ"}}:::plan
     PgSelectSingle173 --> PgClassExpression389
     PageInfo353{{"PageInfo[353∈4] ➊<br />More deps:<br />- Connection[176]"}}:::plan
+    Access546{{"Access[546∈4] ➊<br />ᐸ176.hasNextPageᐳ<br />More deps:<br />- Connection[176]"}}:::plan
+    Access564{{"Access[564∈4] ➊<br />ᐸ176.hasPreviousPageᐳ<br />More deps:<br />- Connection[176]"}}:::plan
     PageInfo354{{"PageInfo[354∈5] ➊<br />More deps:<br />- Connection[180]"}}:::plan
+    Access547{{"Access[547∈5] ➊<br />ᐸ180.hasNextPageᐳ<br />More deps:<br />- Connection[180]"}}:::plan
+    Access565{{"Access[565∈5] ➊<br />ᐸ180.hasPreviousPageᐳ<br />More deps:<br />- Connection[180]"}}:::plan
     PageInfo355{{"PageInfo[355∈6] ➊<br />More deps:<br />- Connection[186]"}}:::plan
+    Access548{{"Access[548∈6] ➊<br />ᐸ186.hasNextPageᐳ<br />More deps:<br />- Connection[186]"}}:::plan
+    Access566{{"Access[566∈6] ➊<br />ᐸ186.hasPreviousPageᐳ<br />More deps:<br />- Connection[186]"}}:::plan
     PageInfo356{{"PageInfo[356∈7] ➊<br />More deps:<br />- Connection[192]"}}:::plan
+    Access549{{"Access[549∈7] ➊<br />ᐸ192.hasNextPageᐳ<br />More deps:<br />- Connection[192]"}}:::plan
+    Access567{{"Access[567∈7] ➊<br />ᐸ192.hasPreviousPageᐳ<br />More deps:<br />- Connection[192]"}}:::plan
     PageInfo357{{"PageInfo[357∈8] ➊<br />More deps:<br />- Connection[197]"}}:::plan
+    Access550{{"Access[550∈8] ➊<br />ᐸ197.hasNextPageᐳ<br />More deps:<br />- Connection[197]"}}:::plan
+    Access568{{"Access[568∈8] ➊<br />ᐸ197.hasPreviousPageᐳ<br />More deps:<br />- Connection[197]"}}:::plan
     PageInfo358{{"PageInfo[358∈9] ➊<br />More deps:<br />- Connection[202]"}}:::plan
+    Access551{{"Access[551∈9] ➊<br />ᐸ202.hasNextPageᐳ<br />More deps:<br />- Connection[202]"}}:::plan
+    Access569{{"Access[569∈9] ➊<br />ᐸ202.hasPreviousPageᐳ<br />More deps:<br />- Connection[202]"}}:::plan
     PageInfo359{{"PageInfo[359∈10] ➊<br />More deps:<br />- Connection[206]"}}:::plan
+    Access552{{"Access[552∈10] ➊<br />ᐸ206.hasNextPageᐳ<br />More deps:<br />- Connection[206]"}}:::plan
+    Access570{{"Access[570∈10] ➊<br />ᐸ206.hasPreviousPageᐳ<br />More deps:<br />- Connection[206]"}}:::plan
     PageInfo360{{"PageInfo[360∈11] ➊<br />More deps:<br />- Connection[210]"}}:::plan
+    Access553{{"Access[553∈11] ➊<br />ᐸ210.hasNextPageᐳ<br />More deps:<br />- Connection[210]"}}:::plan
+    Access571{{"Access[571∈11] ➊<br />ᐸ210.hasPreviousPageᐳ<br />More deps:<br />- Connection[210]"}}:::plan
     PageInfo361{{"PageInfo[361∈12] ➊<br />More deps:<br />- Connection[214]"}}:::plan
+    Access554{{"Access[554∈12] ➊<br />ᐸ214.hasNextPageᐳ<br />More deps:<br />- Connection[214]"}}:::plan
+    Access572{{"Access[572∈12] ➊<br />ᐸ214.hasPreviousPageᐳ<br />More deps:<br />- Connection[214]"}}:::plan
     PageInfo362{{"PageInfo[362∈13] ➊<br />More deps:<br />- Connection[218]"}}:::plan
+    Access555{{"Access[555∈13] ➊<br />ᐸ218.hasNextPageᐳ<br />More deps:<br />- Connection[218]"}}:::plan
+    Access573{{"Access[573∈13] ➊<br />ᐸ218.hasPreviousPageᐳ<br />More deps:<br />- Connection[218]"}}:::plan
     PageInfo363{{"PageInfo[363∈14] ➊<br />More deps:<br />- Connection[222]"}}:::plan
+    Access556{{"Access[556∈14] ➊<br />ᐸ222.hasNextPageᐳ<br />More deps:<br />- Connection[222]"}}:::plan
+    Access574{{"Access[574∈14] ➊<br />ᐸ222.hasPreviousPageᐳ<br />More deps:<br />- Connection[222]"}}:::plan
     PageInfo364{{"PageInfo[364∈15] ➊<br />More deps:<br />- Connection[226]"}}:::plan
+    Access557{{"Access[557∈15] ➊<br />ᐸ226.hasNextPageᐳ<br />More deps:<br />- Connection[226]"}}:::plan
+    Access575{{"Access[575∈15] ➊<br />ᐸ226.hasPreviousPageᐳ<br />More deps:<br />- Connection[226]"}}:::plan
     PageInfo365{{"PageInfo[365∈16] ➊<br />More deps:<br />- Connection[230]"}}:::plan
+    Access558{{"Access[558∈16] ➊<br />ᐸ230.hasNextPageᐳ<br />More deps:<br />- Connection[230]"}}:::plan
+    Access576{{"Access[576∈16] ➊<br />ᐸ230.hasPreviousPageᐳ<br />More deps:<br />- Connection[230]"}}:::plan
     PageInfo366{{"PageInfo[366∈17] ➊<br />More deps:<br />- Connection[234]"}}:::plan
+    Access559{{"Access[559∈17] ➊<br />ᐸ234.hasNextPageᐳ<br />More deps:<br />- Connection[234]"}}:::plan
+    Access577{{"Access[577∈17] ➊<br />ᐸ234.hasPreviousPageᐳ<br />More deps:<br />- Connection[234]"}}:::plan
     PageInfo367{{"PageInfo[367∈18] ➊<br />More deps:<br />- Connection[238]"}}:::plan
+    Access560{{"Access[560∈18] ➊<br />ᐸ238.hasNextPageᐳ<br />More deps:<br />- Connection[238]"}}:::plan
+    Access578{{"Access[578∈18] ➊<br />ᐸ238.hasPreviousPageᐳ<br />More deps:<br />- Connection[238]"}}:::plan
     PageInfo368{{"PageInfo[368∈19] ➊<br />More deps:<br />- Connection[242]"}}:::plan
+    Access561{{"Access[561∈19] ➊<br />ᐸ242.hasNextPageᐳ<br />More deps:<br />- Connection[242]"}}:::plan
+    Access579{{"Access[579∈19] ➊<br />ᐸ242.hasPreviousPageᐳ<br />More deps:<br />- Connection[242]"}}:::plan
     __Item280[/"__Item[280∈23]<br />ᐸ278ᐳ"\]:::itemplan
     PgSelectRows278 ==> __Item280
     PgSelectSingle281{{"PgSelectSingle[281∈23]<br />ᐸcompound_type_array_queryᐳ"}}:::plan
@@ -694,6 +728,24 @@ graph TD
     PgSelectSingle283 --> PgClassExpression455
     PgClassExpression457{{"PgClassExpression[457∈28]<br />ᐸ__query_co....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle283 --> PgClassExpression457
+    Access438{{"Access[438∈29]<br />ᐸ285.secondsᐳ"}}:::plan
+    __Item285 --> Access438
+    Access441{{"Access[441∈29]<br />ᐸ285.minutesᐳ"}}:::plan
+    __Item285 --> Access441
+    Access444{{"Access[444∈29]<br />ᐸ285.hoursᐳ"}}:::plan
+    __Item285 --> Access444
+    Access447{{"Access[447∈29]<br />ᐸ285.daysᐳ"}}:::plan
+    __Item285 --> Access447
+    Access450{{"Access[450∈29]<br />ᐸ285.monthsᐳ"}}:::plan
+    __Item285 --> Access450
+    Access453{{"Access[453∈29]<br />ᐸ285.yearsᐳ"}}:::plan
+    __Item285 --> Access453
+    Access509{{"Access[509∈51] ➊<br />ᐸ392.hoursᐳ"}}:::plan
+    PgClassExpression392 --> Access509
+    Access544{{"Access[544∈51] ➊<br />ᐸ392.minutesᐳ"}}:::plan
+    PgClassExpression392 --> Access544
+    Access562{{"Access[562∈51] ➊<br />ᐸ392.secondsᐳ"}}:::plan
+    PgClassExpression392 --> Access562
     Edge395{{"Edge[395∈52]"}}:::plan
     __Item394[/"__Item[394∈52]<br />ᐸ287ᐳ<br />More deps:<br />- ConnectionItems[287]"\]:::itemplan
     PgCursor581{{"PgCursor[581∈52]<br />More deps:<br />- Access[459]"}}:::plan
@@ -841,6 +893,36 @@ graph TD
     __Item430 --> PgSelectSingle616
     PgClassExpression617{{"PgClassExpression[617∈90]<br />ᐸ__static_b...nteger__.vᐳ"}}:::plan
     PgSelectSingle616 --> PgClassExpression617
+    Access618{{"Access[618∈91]<br />ᐸ434.secondsᐳ"}}:::plan
+    PgClassExpression434 --> Access618
+    Access642{{"Access[642∈91]<br />ᐸ434.minutesᐳ"}}:::plan
+    PgClassExpression434 --> Access642
+    Access647{{"Access[647∈91]<br />ᐸ434.hoursᐳ"}}:::plan
+    PgClassExpression434 --> Access647
+    Access650{{"Access[650∈91]<br />ᐸ434.daysᐳ"}}:::plan
+    PgClassExpression434 --> Access650
+    Access651{{"Access[651∈91]<br />ᐸ434.monthsᐳ"}}:::plan
+    PgClassExpression434 --> Access651
+    Access652{{"Access[652∈91]<br />ᐸ434.yearsᐳ"}}:::plan
+    PgClassExpression434 --> Access652
+    Access621{{"Access[621∈93]<br />ᐸ454.hoursᐳ"}}:::plan
+    PgClassExpression454 --> Access621
+    Access645{{"Access[645∈93]<br />ᐸ454.minutesᐳ"}}:::plan
+    PgClassExpression454 --> Access645
+    Access648{{"Access[648∈93]<br />ᐸ454.secondsᐳ"}}:::plan
+    PgClassExpression454 --> Access648
+    Access622{{"Access[622∈94]<br />ᐸ455.secondsᐳ"}}:::plan
+    PgClassExpression455 --> Access622
+    Access646{{"Access[646∈94]<br />ᐸ455.minutesᐳ"}}:::plan
+    PgClassExpression455 --> Access646
+    Access649{{"Access[649∈94]<br />ᐸ455.hoursᐳ"}}:::plan
+    PgClassExpression455 --> Access649
+    Access653{{"Access[653∈95]<br />ᐸ434.secondsᐳ"}}:::plan
+    PgClassExpression434 --> Access653
+    Access671{{"Access[671∈95]<br />ᐸ434.minutesᐳ"}}:::plan
+    PgClassExpression434 --> Access671
+    Access673{{"Access[673∈95]<br />ᐸ434.hoursᐳ"}}:::plan
+    PgClassExpression434 --> Access673
     PgClassExpression654{{"PgClassExpression[654∈96]<br />ᐸ__compound...uery__.”a”ᐳ"}}:::plan
     PgSelectSingle623 --> PgClassExpression654
     PgClassExpression672{{"PgClassExpression[672∈96]<br />ᐸ__compound...uery__.”b”ᐳ"}}:::plan
@@ -889,6 +971,12 @@ graph TD
     PgSelectSingle638 --> PgClassExpression669
     PgClassExpression670{{"PgClassExpression[670∈112]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle639 --> PgClassExpression670
+    Access680{{"Access[680∈113]<br />ᐸ678.hoursᐳ"}}:::plan
+    PgClassExpression678 --> Access680
+    Access681{{"Access[681∈113]<br />ᐸ678.minutesᐳ"}}:::plan
+    PgClassExpression678 --> Access681
+    Access682{{"Access[682∈113]<br />ᐸ678.secondsᐳ"}}:::plan
+    PgClassExpression678 --> Access682
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -896,41 +984,41 @@ graph TD
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression286,PgClassExpression351,PgClassExpression381,PgClassExpression388,PgClassExpression390,PgClassExpression391,PgClassExpression392,PgClassExpression393 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PageInfo352 bucket2
+    class Bucket2,PageInfo352,Access545,Access563 bucket2
     classDef bucket3 stroke:#ffa500
     class Bucket3,PgClassExpression291,List292,Lambda293,PgClassExpression382,PgClassExpression389 bucket3
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PageInfo353 bucket4
+    class Bucket4,PageInfo353,Access546,Access564 bucket4
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PageInfo354 bucket5
+    class Bucket5,PageInfo354,Access547,Access565 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PageInfo355 bucket6
+    class Bucket6,PageInfo355,Access548,Access566 bucket6
     classDef bucket7 stroke:#808000
-    class Bucket7,PageInfo356 bucket7
+    class Bucket7,PageInfo356,Access549,Access567 bucket7
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PageInfo357 bucket8
+    class Bucket8,PageInfo357,Access550,Access568 bucket8
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PageInfo358 bucket9
+    class Bucket9,PageInfo358,Access551,Access569 bucket9
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PageInfo359 bucket10
+    class Bucket10,PageInfo359,Access552,Access570 bucket10
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PageInfo360 bucket11
+    class Bucket11,PageInfo360,Access553,Access571 bucket11
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PageInfo361 bucket12
+    class Bucket12,PageInfo361,Access554,Access572 bucket12
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PageInfo362 bucket13
+    class Bucket13,PageInfo362,Access555,Access573 bucket13
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PageInfo363 bucket14
+    class Bucket14,PageInfo363,Access556,Access574 bucket14
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PageInfo364 bucket15
+    class Bucket15,PageInfo364,Access557,Access575 bucket15
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PageInfo365 bucket16
+    class Bucket16,PageInfo365,Access558,Access576 bucket16
     classDef bucket17 stroke:#696969
-    class Bucket17,PageInfo366 bucket17
+    class Bucket17,PageInfo366,Access559,Access577 bucket17
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PageInfo367 bucket18
+    class Bucket18,PageInfo367,Access560,Access578 bucket18
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PageInfo368 bucket19
+    class Bucket19,PageInfo368,Access561,Access579 bucket19
     classDef bucket20 stroke:#ffa500
     class Bucket20 bucket20
     classDef bucket21 stroke:#0000ff
@@ -950,9 +1038,9 @@ graph TD
     classDef bucket28 stroke:#00ffff
     class Bucket28,PgClassExpression437,PgClassExpression440,PgClassExpression443,PgClassExpression446,PgClassExpression449,PgClassExpression452,PgClassExpression455,PgClassExpression457 bucket28
     classDef bucket29 stroke:#4169e1
-    class Bucket29 bucket29
+    class Bucket29,Access438,Access441,Access444,Access447,Access450,Access453 bucket29
     classDef bucket51 stroke:#696969
-    class Bucket51 bucket51
+    class Bucket51,Access509,Access544,Access562 bucket51
     classDef bucket52 stroke:#00bfff
     class Bucket52,__Item394,Edge395,PgCursor581 bucket52
     classDef bucket53 stroke:#7f007f
@@ -1032,15 +1120,15 @@ graph TD
     classDef bucket90 stroke:#7fff00
     class Bucket90,PgSelectSingle616,PgClassExpression617 bucket90
     classDef bucket91 stroke:#ff1493
-    class Bucket91 bucket91
+    class Bucket91,Access618,Access642,Access647,Access650,Access651,Access652 bucket91
     classDef bucket92 stroke:#808000
     class Bucket92 bucket92
     classDef bucket93 stroke:#dda0dd
-    class Bucket93 bucket93
+    class Bucket93,Access621,Access645,Access648 bucket93
     classDef bucket94 stroke:#ff0000
-    class Bucket94 bucket94
+    class Bucket94,Access622,Access646,Access649 bucket94
     classDef bucket95 stroke:#ffff00
-    class Bucket95 bucket95
+    class Bucket95,Access653,Access671,Access673 bucket95
     classDef bucket96 stroke:#00ffff
     class Bucket96,PgClassExpression654,PgClassExpression672,PgClassExpression674,PgClassExpression675,PgClassExpression676,PgClassExpression677,PgClassExpression678,PgClassExpression679 bucket96
     classDef bucket97 stroke:#4169e1
@@ -1076,5 +1164,5 @@ graph TD
     classDef bucket112 stroke:#ffff00
     class Bucket112,PgClassExpression670 bucket112
     classDef bucket113 stroke:#00ffff
-    class Bucket113 bucket113
+    class Bucket113,Access680,Access681,Access682 bucket113
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-computed-fields.mermaid
@@ -626,6 +626,10 @@ graph TD
     __Item201 --> PgSelectSingle202
     PgClassExpression203{{"PgClassExpression[203∈34]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle202 --> PgClassExpression203
+    Access313{{"Access[313∈35]<br />ᐸ200.secondsᐳ"}}:::plan
+    PgClassExpression200 --> Access313
+    Access314{{"Access[314∈36]<br />ᐸ203.secondsᐳ"}}:::plan
+    PgClassExpression203 --> Access314
     __Item204[/"__Item[204∈37]<br />ᐸ186ᐳ"\]:::itemplan
     ConnectionItems186 ==> __Item204
     PgSelectSingle205{{"PgSelectSingle[205∈37]<br />ᐸpostᐳ"}}:::plan
@@ -734,6 +738,18 @@ graph TD
     __Item310 --> PgSelectSingle311
     PgClassExpression312{{"PgClassExpression[312∈52]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle311 --> PgClassExpression312
+    Access384{{"Access[384∈53]<br />ᐸ297.secondsᐳ"}}:::plan
+    PgClassExpression297 --> Access384
+    Access385{{"Access[385∈54]<br />ᐸ300.secondsᐳ"}}:::plan
+    PgClassExpression300 --> Access385
+    Access386{{"Access[386∈55]<br />ᐸ303.secondsᐳ"}}:::plan
+    PgClassExpression303 --> Access386
+    Access387{{"Access[387∈56]<br />ᐸ306.secondsᐳ"}}:::plan
+    PgClassExpression306 --> Access387
+    Access388{{"Access[388∈57]<br />ᐸ309.secondsᐳ"}}:::plan
+    PgClassExpression309 --> Access388
+    Access389{{"Access[389∈58]<br />ᐸ312.secondsᐳ"}}:::plan
+    PgClassExpression312 --> Access389
     __Item364[/"__Item[364∈64]<br />ᐸ319ᐳ"\]:::itemplan
     ConnectionItems319 ==> __Item364
     PgSelectSingle365{{"PgSelectSingle[365∈64]<br />ᐸperson_friendsᐳ"}}:::plan
@@ -778,6 +794,18 @@ graph TD
     PgSelectSingle365 --> PgClassExpression402
     PgClassExpression410{{"PgClassExpression[410∈71]<br />ᐸ”c”.”perso...friends__)ᐳ"}}:::plan
     PgSelectSingle365 --> PgClassExpression410
+    Access403{{"Access[403∈72]<br />ᐸ368.secondsᐳ"}}:::plan
+    PgClassExpression368 --> Access403
+    Access404{{"Access[404∈73]<br />ᐸ371.secondsᐳ"}}:::plan
+    PgClassExpression371 --> Access404
+    Access405{{"Access[405∈74]<br />ᐸ374.secondsᐳ"}}:::plan
+    PgClassExpression374 --> Access405
+    Access406{{"Access[406∈75]<br />ᐸ377.secondsᐳ"}}:::plan
+    PgClassExpression377 --> Access406
+    Access407{{"Access[407∈76]<br />ᐸ380.secondsᐳ"}}:::plan
+    PgClassExpression380 --> Access407
+    Access408{{"Access[408∈77]<br />ᐸ383.secondsᐳ"}}:::plan
+    PgClassExpression383 --> Access408
     __Item396[/"__Item[396∈80]<br />ᐸ390ᐳ"\]:::itemplan
     ConnectionItems390 ==> __Item396
     PgSelectSingle397{{"PgSelectSingle[397∈80]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
@@ -790,6 +818,10 @@ graph TD
     __Item399 --> PgSelectSingle400
     PgClassExpression401{{"PgClassExpression[401∈81]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle400 --> PgClassExpression401
+    Access411{{"Access[411∈82]<br />ᐸ398.secondsᐳ"}}:::plan
+    PgClassExpression398 --> Access411
+    Access412{{"Access[412∈83]<br />ᐸ401.secondsᐳ"}}:::plan
+    PgClassExpression401 --> Access412
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -843,9 +875,9 @@ graph TD
     classDef bucket34 stroke:#696969
     class Bucket34,__Item201,PgSelectSingle202,PgClassExpression203 bucket34
     classDef bucket35 stroke:#00bfff
-    class Bucket35 bucket35
+    class Bucket35,Access313 bucket35
     classDef bucket36 stroke:#7f007f
-    class Bucket36 bucket36
+    class Bucket36,Access314 bucket36
     classDef bucket37 stroke:#ffa500
     class Bucket37,__Item204,PgSelectSingle205,Access486,Access490 bucket37
     classDef bucket38 stroke:#0000ff
@@ -875,17 +907,17 @@ graph TD
     classDef bucket52 stroke:#00bfff
     class Bucket52,__Item310,PgSelectSingle311,PgClassExpression312 bucket52
     classDef bucket53 stroke:#7f007f
-    class Bucket53 bucket53
+    class Bucket53,Access384 bucket53
     classDef bucket54 stroke:#ffa500
-    class Bucket54 bucket54
+    class Bucket54,Access385 bucket54
     classDef bucket55 stroke:#0000ff
-    class Bucket55 bucket55
+    class Bucket55,Access386 bucket55
     classDef bucket56 stroke:#7fff00
-    class Bucket56 bucket56
+    class Bucket56,Access387 bucket56
     classDef bucket57 stroke:#ff1493
-    class Bucket57 bucket57
+    class Bucket57,Access388 bucket57
     classDef bucket58 stroke:#808000
-    class Bucket58 bucket58
+    class Bucket58,Access389 bucket58
     classDef bucket64 stroke:#3cb371
     class Bucket64,__Item364,PgSelectSingle365 bucket64
     classDef bucket65 stroke:#a52a2a
@@ -903,23 +935,23 @@ graph TD
     classDef bucket71 stroke:#ffa500
     class Bucket71,PgClassExpression402,PgClassExpression410 bucket71
     classDef bucket72 stroke:#0000ff
-    class Bucket72 bucket72
+    class Bucket72,Access403 bucket72
     classDef bucket73 stroke:#7fff00
-    class Bucket73 bucket73
+    class Bucket73,Access404 bucket73
     classDef bucket74 stroke:#ff1493
-    class Bucket74 bucket74
+    class Bucket74,Access405 bucket74
     classDef bucket75 stroke:#808000
-    class Bucket75 bucket75
+    class Bucket75,Access406 bucket75
     classDef bucket76 stroke:#dda0dd
-    class Bucket76 bucket76
+    class Bucket76,Access407 bucket76
     classDef bucket77 stroke:#ff0000
-    class Bucket77 bucket77
+    class Bucket77,Access408 bucket77
     classDef bucket80 stroke:#4169e1
     class Bucket80,__Item396,PgSelectSingle397,PgClassExpression398 bucket80
     classDef bucket81 stroke:#3cb371
     class Bucket81,__Item399,PgSelectSingle400,PgClassExpression401 bucket81
     classDef bucket82 stroke:#a52a2a
-    class Bucket82 bucket82
+    class Bucket82,Access411 bucket82
     classDef bucket83 stroke:#ff00ff
-    class Bucket83 bucket83
+    class Bucket83,Access412 bucket83
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/simple-procedure-query.mermaid
@@ -134,12 +134,34 @@ graph TD
     PgSelectSingle38 --> PgClassExpression53
     PgClassExpression54{{"PgClassExpression[54∈10]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
     PgSelectSingle40 --> PgClassExpression54
+    Access55{{"Access[55∈11]<br />ᐸ49.secondsᐳ"}}:::plan
+    PgClassExpression49 --> Access55
+    Access58{{"Access[58∈11]<br />ᐸ49.minutesᐳ"}}:::plan
+    PgClassExpression49 --> Access58
+    Access66{{"Access[66∈11]<br />ᐸ49.hoursᐳ"}}:::plan
+    PgClassExpression49 --> Access66
+    Access68{{"Access[68∈11]<br />ᐸ49.daysᐳ"}}:::plan
+    PgClassExpression49 --> Access68
+    Access70{{"Access[70∈11]<br />ᐸ49.monthsᐳ"}}:::plan
+    PgClassExpression49 --> Access70
+    Access72{{"Access[72∈11]<br />ᐸ49.yearsᐳ"}}:::plan
+    PgClassExpression49 --> Access72
+    Access78{{"Access[78∈12]<br />ᐸ73.hoursᐳ"}}:::plan
+    PgClassExpression73 --> Access78
+    Access79{{"Access[79∈12]<br />ᐸ73.minutesᐳ"}}:::plan
+    PgClassExpression73 --> Access79
+    Access80{{"Access[80∈12]<br />ᐸ73.secondsᐳ"}}:::plan
+    PgClassExpression73 --> Access80
     __Item75[/"__Item[75∈13]<br />ᐸ74ᐳ"\]:::itemplan
     PgSelectRows74 ==> __Item75
     PgSelectSingle76{{"PgSelectSingle[76∈13]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item75 --> PgSelectSingle76
     PgClassExpression77{{"PgClassExpression[77∈13]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle76 --> PgClassExpression77
+    Access81{{"Access[81∈14]<br />ᐸ77.secondsᐳ"}}:::plan
+    PgClassExpression77 --> Access81
+    Access82{{"Access[82∈14]<br />ᐸ77.minutesᐳ"}}:::plan
+    PgClassExpression77 --> Access82
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -165,11 +187,11 @@ graph TD
     classDef bucket10 stroke:#ffff00
     class Bucket10,PgClassExpression54 bucket10
     classDef bucket11 stroke:#00ffff
-    class Bucket11 bucket11
+    class Bucket11,Access55,Access58,Access66,Access68,Access70,Access72 bucket11
     classDef bucket12 stroke:#4169e1
-    class Bucket12 bucket12
+    class Bucket12,Access78,Access79,Access80 bucket12
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item75,PgSelectSingle76,PgClassExpression77 bucket13
     classDef bucket14 stroke:#a52a2a
-    class Bucket14 bucket14
+    class Bucket14,Access81,Access82 bucket14
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
@@ -13,8 +13,8 @@ graph TD
     Bucket3("Bucket 3 (listItem)<br /><br />ROOT __Item{3}ᐸ14ᐳ[17]"):::bucket
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 18<br /><br />ROOT PgSelectSingle{3}ᐸspacecraftᐳ[18]"):::bucket
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 27<br /><br />ROOT PgClassExpression{4}ᐸ(1/0) /* E...ferred! */ᐳ[27]"):::bucket
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 28, 27<br /><br />ROOT Access{5}ᐸ27.startᐳ[28]"):::bucket
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 29, 27<br /><br />ROOT Access{5}ᐸ27.endᐳ[29]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 27, 28<br /><br />ROOT Access{5}ᐸ27.startᐳ[28]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 27, 29<br /><br />ROOT Access{5}ᐸ27.endᐳ[29]"):::bucket
     end
     Bucket0 --> Bucket1
     Bucket1 --> Bucket3
@@ -55,6 +55,14 @@ graph TD
     PgClassExpression27 --> Access28
     Access29{{"Access[29∈5]<br />ᐸ27.endᐳ"}}:::plan
     PgClassExpression27 --> Access29
+    Access30{{"Access[30∈6]<br />ᐸ27.start.valueᐳ"}}:::plan
+    PgClassExpression27 --> Access30
+    Access32{{"Access[32∈6]<br />ᐸ27.start.inclusiveᐳ"}}:::plan
+    PgClassExpression27 --> Access32
+    Access31{{"Access[31∈7]<br />ᐸ27.end.valueᐳ"}}:::plan
+    PgClassExpression27 --> Access31
+    Access33{{"Access[33∈7]<br />ᐸ27.end.inclusiveᐳ"}}:::plan
+    PgClassExpression27 --> Access33
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -68,7 +76,7 @@ graph TD
     classDef bucket5 stroke:#7fff00
     class Bucket5,Access28,Access29 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6 bucket6
+    class Bucket6,Access30,Access32 bucket6
     classDef bucket7 stroke:#808000
-    class Bucket7 bucket7
+    class Bucket7,Access31,Access33 bucket7
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/ts.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/ts.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 18, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: First[11], PgSelectSingle[13]"):::bucket
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[13]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14<br /><br />ROOT PgClassExpression{1}ᐸ__range_test__.”ts”ᐳ[14]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 14<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 16, 17<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
     end
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
@@ -37,6 +37,10 @@ graph TD
     PgSelectSingle13 --> PgClassExpression14
     Access15{{"Access[15∈2] ➊<br />ᐸ14.startᐳ"}}:::plan
     PgClassExpression14 --> Access15
+    Access16{{"Access[16∈2] ➊<br />ᐸ14.start.valueᐳ"}}:::plan
+    PgClassExpression14 --> Access16
+    Access17{{"Access[17∈2] ➊<br />ᐸ14.start.inclusiveᐳ"}}:::plan
+    PgClassExpression14 --> Access17
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -44,7 +48,7 @@ graph TD
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access15 bucket2
+    class Bucket2,Access15,Access16,Access17 bucket2
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/tstz.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/tstz.mermaid
@@ -11,7 +11,7 @@ graph TD
     Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 18, 10<br />2: PgSelect[7]<br />3: PgSelectRows[12]<br />ᐳ: First[11], PgSelectSingle[13]"):::bucket
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸrange_testᐳ[13]"):::bucket
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 14<br /><br />ROOT PgClassExpression{1}ᐸ__range_test__.”tstz”ᐳ[14]"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 14<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 15, 16, 17<br /><br />ROOT Access{2}ᐸ14.startᐳ[15]"):::bucket
     end
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
@@ -37,6 +37,10 @@ graph TD
     PgSelectSingle13 --> PgClassExpression14
     Access15{{"Access[15∈2] ➊<br />ᐸ14.startᐳ"}}:::plan
     PgClassExpression14 --> Access15
+    Access16{{"Access[16∈2] ➊<br />ᐸ14.start.valueᐳ"}}:::plan
+    PgClassExpression14 --> Access16
+    Access17{{"Access[17∈2] ➊<br />ᐸ14.start.inclusiveᐳ"}}:::plan
+    PgClassExpression14 --> Access17
 
     %% define steps
     classDef bucket0 stroke:#696969
@@ -44,7 +48,7 @@ graph TD
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression14 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,Access15 bucket2
+    class Bucket2,Access15,Access16,Access17 bucket2
     classDef bucket3 stroke:#ffa500
     class Bucket3 bucket3
 

--- a/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
@@ -10,14 +10,14 @@ graph TD
     subgraph "Buckets for queries/v4/types"
     Bucket0("Bucket 0 (root)<br /><br />1: 3809, 3813, 3817, 3821, 3825, 3833, 3837, 3841, 3849, 3853, 3857, 3861, 3865, 3873, 3877, 3881, 3889, 3893, 3897, 3901, 3905, 3913, 3917, 3921, 3929, 3933, 3937, 3941, 3945, 3953, 3957, 3961, 3969, 3973, 3977, 3981, 3985, 3993, 3997, 4001, 4009, 4013, 4017, 4021, 4025, 4033, 4037, 4041, 4049, 4053, 4057, 4061, 4065, 4073, 4077, 4081, 4089, 4093, 4097, 4105, 4109, 4113, 4121, 4125, 4129, 4137, 4141, 4145, 4153, 4157, 4161, 4165, 4169, 4177, 4181, 4185, 4198, 4202, 4206, 4210, 4214, 4222, 4226, 4230, 4243, 4247, 4251, 4259, 4263, 4267, 4275, 4279, 4283, 4291, 4295, 4299, 4313, 4317, 4321, 4325, 4329, 4333, 4341, 4345, 4349, 4361, 4365, 4369, 4373, 4377, 4385, 4389, 4393, 4401, 4405, 4409, 4413, 4417, 4425, 4429, 4433, 4445<br />ᐳ: 9, 10, 4238, 4307, 4489, 4492, 4493, 11, 23, 24, 33, 55, 56, 4193<br />2: 284, 292, 3829, 3845, 3869, 3885, 3909, 3925, 3949, 3965, 3989, 4005, 4029, 4045, 4069, 4085, 4101, 4117, 4133, 4149, 4173, 4189, 4218, 4234, 4255, 4271, 4287, 4303, 4337, 4353, 4381, 4397, 4421, 4437<br />3: 8, 14, 17, 26, 31, 37, 39, 286, 294, 4194, 4239, 4308, 4357, 4441<br />ᐳ: 285, 287, 288, 293, 295, 296, 999, 1002, 3810, 3814, 3818, 3830, 3834, 3846, 3850, 3854, 3858, 3870, 3874, 3886, 3890, 3894, 3898, 3910, 3914, 3926, 3930, 3934, 3938, 3950, 3954, 3966, 3970, 3974, 3978, 3990, 3994, 4006, 4010, 4014, 4018, 4030, 4034, 4046, 4050, 4054, 4058, 4070, 4074, 4086, 4090, 4102, 4106, 4118, 4122, 4134, 4138, 4150<br />4: 12, 20, 29, 35, 41, 43, 48, 53, 54<br />ᐳ: 19, 21, 28, 30, 34, 36, 4195, 4240, 4309, 4314, 4358, 4442, 4446<br />5: 46, 51, 254, 260<br />ᐳ: 45, 47, 50, 52, 998, 1000, 1001, 1003, 1027, 1028, 1029, 1030, 4241, 4242, 4310, 4311, 4315, 4316, 4443, 4444, 4447, 4448"):::bucket
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 12, 254, 3810, 3814, 3818, 3830, 3834, 3846, 3850, 3854, 3858, 3870, 3874, 3886, 288, 1000, 1028<br /><br />ROOT Connectionᐸ8ᐳ[12]"):::bucket
-    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 3930, 3934, 3938, 3950, 3954, 3966<br /><br />ROOT PgSelectSingleᐸtypesᐳ[21]<br />1: <br />ᐳ: 257, 275, 289, 310, 318, 321, 324, 327, 330, 333, 336, 339, 342, 345, 348, 351, 354, 357, 360, 363, 366, 369, 372, 375, 378, 381, 462, 465, 468, 471, 474, 477, 480, 483, 486, 489, 492, 495, 498, 501, 504, 507, 510, 543, 546, 3931, 3935, 3939, 3951, 3955, 3967, 842, 845, 848, 925, 928, 931, 3932, 3936, 3940, 3952, 3956, 3968, 3942, 3946, 3958, 3962<br />2: 390, 412, 430, 448, 516, 531<br />ᐳ: 389, 391, 411, 413, 429, 431, 447, 449, 515, 517, 530, 532, 854, 937, 1012, 1015, 1035, 1046, 1057, 1065, 3943, 3944, 3947, 3948<br />3: PgSelectRows[861], PgSelectRows[944]<br />ᐳ: 860, 862, 943, 945"):::bucket
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 30, 3970, 3974, 3978, 3990, 3994, 4006<br /><br />ROOT PgSelectSingleᐸtypesᐳ[30]<br />1: <br />ᐳ: 258, 276, 290, 311, 319, 322, 325, 328, 331, 334, 337, 340, 343, 346, 349, 352, 355, 358, 361, 364, 367, 370, 373, 376, 379, 382, 463, 466, 469, 472, 475, 478, 481, 484, 487, 490, 493, 496, 499, 502, 505, 508, 511, 544, 547, 3971, 3975, 3979, 3991, 3995, 4007, 843, 846, 849, 926, 929, 932, 3972, 3976, 3980, 3992, 3996, 4008, 3982, 3986, 3998, 4002<br />2: 398, 418, 436, 454, 521, 536<br />ᐳ: 397, 399, 417, 419, 435, 437, 453, 455, 520, 522, 535, 537, 855, 938, 1013, 1016, 1036, 1047, 1058, 1066, 3983, 3984, 3987, 3988<br />3: PgSelectRows[867], PgSelectRows[950]<br />ᐳ: 866, 868, 949, 951"):::bucket
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 36, 4010, 4014, 4018, 4030, 4034, 4046<br /><br />ROOT PgSelectSingleᐸtype_functionᐳ[36]<br />1: <br />ᐳ: 259, 277, 291, 312, 320, 323, 326, 329, 332, 335, 338, 341, 344, 347, 350, 353, 356, 359, 362, 365, 368, 371, 374, 377, 380, 383, 464, 467, 470, 473, 476, 479, 482, 485, 488, 491, 494, 497, 500, 503, 506, 509, 512, 545, 548, 4011, 4015, 4019, 4031, 4035, 4047, 844, 847, 850, 927, 930, 933, 4012, 4016, 4020, 4032, 4036, 4048, 4022, 4026, 4038, 4042<br />2: 406, 424, 442, 460, 526, 541<br />ᐳ: 405, 407, 423, 425, 441, 443, 459, 461, 525, 527, 540, 542, 856, 939, 1014, 1017, 1037, 1048, 1059, 1067, 4023, 4024, 4027, 4028<br />3: PgSelectRows[873], PgSelectRows[956]<br />ᐳ: 872, 874, 955, 957"):::bucket
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 3930, 3934, 3938, 3950, 3954, 3966<br /><br />ROOT PgSelectSingleᐸtypesᐳ[21]<br />1: <br />ᐳ: 257, 275, 289, 310, 318, 321, 324, 327, 330, 333, 336, 339, 342, 345, 348, 351, 354, 357, 360, 363, 366, 369, 372, 375, 378, 381, 462, 465, 468, 471, 474, 477, 480, 483, 486, 489, 492, 495, 498, 501, 504, 507, 510, 543, 546, 3931, 3935, 3939, 3951, 3955, 3967, 842, 845, 848, 851, 902, 925, 928, 931, 934, 979, 1009, 1032, 1043, 1054, 1712, 1715, 1718, 1730, 1733, 1736, 1801, 1804, 1807, 1819, 1822, 1825, 3932, 3936, 3940, 3952, 3956, 3968, 3942, 3946, 3958, 3962<br />2: 390, 412, 430, 448, 516, 531<br />ᐳ: 389, 391, 411, 413, 429, 431, 447, 449, 515, 517, 530, 532, 854, 937, 1012, 1015, 1035, 1046, 1057, 1065, 3943, 3944, 3947, 3948<br />3: PgSelectRows[861], PgSelectRows[944]<br />ᐳ: 860, 862, 943, 945"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 30, 3970, 3974, 3978, 3990, 3994, 4006<br /><br />ROOT PgSelectSingleᐸtypesᐳ[30]<br />1: <br />ᐳ: 258, 276, 290, 311, 319, 322, 325, 328, 331, 334, 337, 340, 343, 346, 349, 352, 355, 358, 361, 364, 367, 370, 373, 376, 379, 382, 463, 466, 469, 472, 475, 478, 481, 484, 487, 490, 493, 496, 499, 502, 505, 508, 511, 544, 547, 3971, 3975, 3979, 3991, 3995, 4007, 843, 846, 849, 852, 903, 926, 929, 932, 935, 980, 1010, 1033, 1044, 1055, 1713, 1716, 1719, 1731, 1734, 1737, 1802, 1805, 1808, 1820, 1823, 1826, 3972, 3976, 3980, 3992, 3996, 4008, 3982, 3986, 3998, 4002<br />2: 398, 418, 436, 454, 521, 536<br />ᐳ: 397, 399, 417, 419, 435, 437, 453, 455, 520, 522, 535, 537, 855, 938, 1013, 1016, 1036, 1047, 1058, 1066, 3983, 3984, 3987, 3988<br />3: PgSelectRows[867], PgSelectRows[950]<br />ᐳ: 866, 868, 949, 951"):::bucket
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 36, 4010, 4014, 4018, 4030, 4034, 4046<br /><br />ROOT PgSelectSingleᐸtype_functionᐳ[36]<br />1: <br />ᐳ: 259, 277, 291, 312, 320, 323, 326, 329, 332, 335, 338, 341, 344, 347, 350, 353, 356, 359, 362, 365, 368, 371, 374, 377, 380, 383, 464, 467, 470, 473, 476, 479, 482, 485, 488, 491, 494, 497, 500, 503, 506, 509, 512, 545, 548, 4011, 4015, 4019, 4031, 4035, 4047, 844, 847, 850, 853, 904, 927, 930, 933, 936, 981, 1011, 1034, 1045, 1056, 1714, 1717, 1720, 1732, 1735, 1738, 1803, 1806, 1809, 1821, 1824, 1827, 4012, 4016, 4020, 4032, 4036, 4048, 4022, 4026, 4038, 4042<br />2: 406, 424, 442, 460, 526, 541<br />ᐳ: 405, 407, 423, 425, 441, 443, 459, 461, 525, 527, 540, 542, 856, 939, 1014, 1017, 1037, 1048, 1059, 1067, 4023, 4024, 4027, 4028<br />3: PgSelectRows[873], PgSelectRows[956]<br />ᐳ: 872, 874, 955, 957"):::bucket
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 41, 260, 11, 4090, 4102, 4106, 4118, 4122, 4134, 4138, 4150, 296, 1003, 1030<br /><br />ROOT Connectionᐸ39ᐳ[41]"):::bucket
-    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 4311, 4242, 4316, 4195, 47, 11<br /><br />ROOT PgSelectSingleᐸpersonᐳ[47]<br />1: 300, 549, 994<br />ᐳ: 1896, 4196, 4199, 4203, 4207, 4219, 4223, 4235, 4244, 4256, 4260, 4272, 4276, 4288, 4292, 4304, 993, 995, 996, 1025, 4197, 4154, 4158, 4162, 4174, 4178, 4190<br />2: PgSelectRows[270], ConnectionItems[830]<br />ᐳ: 269, 271, 1895, 1897, 1924, 1925"):::bucket
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 52, 4444, 4448, 4358<br /><br />ROOT PgSelectSingleᐸpostᐳ[52]<br />1: Connection[316], PgSelectRows[1006]<br />ᐳ: 272, 283, 1899, 4359, 4362, 4366, 4370, 4382, 4386, 4398, 4402, 4406, 4410, 4422, 4426, 4438, 1005, 1007, 1008, 1031, 4360, 4318, 4322, 4326, 4338, 4342, 4354<br />2: PgSelectRows[306], ConnectionItems[836]<br />ᐳ: 305, 307, 1898, 1900, 1926, 1927"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 4311, 4242, 4316, 4195, 47, 11<br /><br />ROOT PgSelectSingleᐸpersonᐳ[47]<br />1: 300, 549, 994<br />ᐳ: 1896, 4196, 4199, 4203, 4207, 4219, 4223, 4235, 4244, 4256, 4260, 4272, 4276, 4288, 4292, 4304, 993, 995, 996, 1025, 1745, 1834, 4197, 4154, 4158, 4162, 4174, 4178, 4190<br />2: PgSelectRows[270], ConnectionItems[830]<br />ᐳ: 269, 271, 1895, 1897, 1924, 1925"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 52, 4444, 4448, 4358<br /><br />ROOT PgSelectSingleᐸpostᐳ[52]<br />1: Connection[316], PgSelectRows[1006]<br />ᐳ: 272, 283, 1899, 4359, 4362, 4366, 4370, 4382, 4386, 4398, 4402, 4406, 4410, 4422, 4426, 4438, 1005, 1007, 1008, 1031, 1746, 1835, 4360, 4318, 4322, 4326, 4338, 4342, 4354<br />2: PgSelectRows[306], ConnectionItems[836]<br />ᐳ: 305, 307, 1898, 1900, 1926, 1927"):::bucket
     Bucket8("Bucket 8 (polymorphic)<br />__typename: Lambda[56]<br />Deps: 55, 56, 11, 4"):::bucket
-    Bucket9("Bucket 9 (listItem)<br />Deps: 3890, 3894, 3898, 3910, 3914, 3926<br /><br />ROOT __Item{9}ᐸ53ᐳ[250]<br />1: <br />ᐳ: 251, 660, 662, 664, 666, 668, 670, 672, 674, 676, 678, 680, 682, 684, 686, 688, 690, 692, 694, 696, 698, 700, 702, 704, 706, 708, 710, 764, 766, 768, 770, 772, 774, 776, 778, 780, 782, 784, 786, 788, 790, 792, 794, 796, 818, 820, 1327, 1329, 1331, 1383, 1385, 1387, 3891, 3892, 3895, 3896, 3899, 3900, 3911, 3912, 3915, 3916, 3927, 3928, 3902, 3906<br />2: 718, 732, 744, 756, 801, 811<br />ᐳ: 717, 719, 731, 733, 743, 745, 755, 757, 800, 802, 810, 812, 1335, 1391, 1435, 1437, 1451, 1463, 1475, 1482, 3903, 3904, 3907, 3908<br />3: PgSelectRows[1341], PgSelectRows[1397]<br />ᐳ: 1340, 1342, 1396, 1398"):::bucket
+    Bucket9("Bucket 9 (listItem)<br />Deps: 3890, 3894, 3898, 3910, 3914, 3926<br /><br />ROOT __Item{9}ᐸ53ᐳ[250]<br />1: <br />ᐳ: 251, 660, 662, 664, 666, 668, 670, 672, 674, 676, 678, 680, 682, 684, 686, 688, 690, 692, 694, 696, 698, 700, 702, 704, 706, 708, 710, 764, 766, 768, 770, 772, 774, 776, 778, 780, 782, 784, 786, 788, 790, 792, 794, 796, 818, 820, 1327, 1329, 1331, 1333, 1367, 1383, 1385, 1387, 1389, 1419, 1433, 1449, 1461, 1473, 3891, 3892, 3895, 3896, 3899, 3900, 3911, 3912, 3915, 3916, 3927, 3928, 3902, 3906<br />2: 718, 732, 744, 756, 801, 811<br />ᐳ: 717, 719, 731, 733, 743, 745, 755, 757, 800, 802, 810, 812, 1335, 1391, 1435, 1437, 1451, 1463, 1475, 1482, 3903, 3904, 3907, 3908<br />3: PgSelectRows[1341], PgSelectRows[1397]<br />ᐳ: 1340, 1342, 1396, 1398"):::bucket
     Bucket10("Bucket 10 (listItem)<br />Deps: 4050, 4054, 4058, 4070, 4074, 4086<br /><br />ROOT __Item{10}ᐸ54ᐳ[252]"):::bucket
     Bucket11("Bucket 11 (polymorphicPartition)<br />|Query<br />Deps: 4<br />ᐳQuery"):::bucket
     Bucket12("Bucket 12 (polymorphicPartition)<br />|Input<br />Deps: 11, 4490<br />ᐳInput<br /><br />1: PgSelect[61]<br />2: PgSelectRows[66]<br />ᐳ: First[65], PgSelectSingle[67]"):::bucket
@@ -29,7 +29,7 @@ graph TD
     Bucket18("Bucket 18 (polymorphicPartition)<br />|CompoundKey<br />Deps: 11, 4490, 55<br />ᐳCompoundKey<br /><br />1: Access[4491]<br />2: PgSelect[123]<br />3: PgSelectRows[128]<br />ᐳ: First[127], PgSelectSingle[129]"):::bucket
     Bucket19("Bucket 19 (polymorphicPartition)<br />|Person<br />Deps: 11, 4490<br />ᐳPerson<br /><br />1: PgSelect[133]<br />2: PgSelectRows[138]<br />ᐳ: First[137], PgSelectSingle[139]"):::bucket
     Bucket20("Bucket 20 (polymorphicPartition)<br />|Post<br />Deps: 11, 4490<br />ᐳPost<br /><br />1: PgSelect[143]<br />2: PgSelectRows[148]<br />ᐳ: First[147], PgSelectSingle[149]"):::bucket
-    Bucket21("Bucket 21 (polymorphicPartition)<br />|Type<br />Deps: 11, 4490<br />ᐳType<br /><br />1: 4449, 4453, 4457, 4461, 4465, 4473, 4477, 4481<br />2: 4469, 4485<br />3: PgSelect[153]<br />ᐳ: 4450, 4454, 4458, 4470, 4474, 4486<br />4: PgSelectRows[158]<br />ᐳ: 157, 159, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 629, 630, 1234, 1235, 1236, 1259, 1260, 1261, 4451, 4452, 4455, 4456, 4459, 4460, 4471, 4472, 4475, 4476, 4487, 4488, 4462, 4466, 4478, 4482<br />5: 582, 588, 594, 600, 622, 627<br />ᐳ: 581, 583, 587, 589, 593, 595, 599, 601, 621, 623, 626, 628, 1238, 1263, 1282, 1283, 1287, 1290, 1293, 1295, 4463, 4464, 4467, 4468<br />6: PgSelectRows[1243], PgSelectRows[1268]<br />ᐳ: 1242, 1244, 1267, 1269"):::bucket
+    Bucket21("Bucket 21 (polymorphicPartition)<br />|Type<br />Deps: 11, 4490<br />ᐳType<br /><br />1: 4449, 4453, 4457, 4461, 4465, 4473, 4477, 4481<br />2: 4469, 4485<br />3: PgSelect[153]<br />ᐳ: 4450, 4454, 4458, 4470, 4474, 4486<br />4: PgSelectRows[158]<br />ᐳ: 157, 159, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 629, 630, 1234, 1235, 1236, 1237, 1254, 1259, 1260, 1261, 1262, 1277, 1281, 1286, 1289, 1292, 2012, 2013, 2014, 2018, 2019, 2020, 2026, 2027, 2028, 2032, 2033, 2034, 4451, 4452, 4455, 4456, 4459, 4460, 4471, 4472, 4475, 4476, 4487, 4488, 4462, 4466, 4478, 4482<br />5: 582, 588, 594, 600, 622, 627<br />ᐳ: 581, 583, 587, 589, 593, 595, 599, 601, 621, 623, 626, 628, 1238, 1263, 1282, 1283, 1287, 1290, 1293, 1295, 4463, 4464, 4467, 4468<br />6: PgSelectRows[1243], PgSelectRows[1268]<br />ᐳ: 1242, 1244, 1267, 1269"):::bucket
     Bucket22("Bucket 22 (polymorphicPartition)<br />|PersonSecret<br />Deps: 11, 4490<br />ᐳPersonSecret<br /><br />1: PgSelect[163]<br />2: PgSelectRows[168]<br />ᐳ: First[167], PgSelectSingle[169]"):::bucket
     Bucket23("Bucket 23 (polymorphicPartition)<br />|LeftArm<br />Deps: 11, 4490<br />ᐳLeftArm<br /><br />1: PgSelect[173]<br />2: PgSelectRows[178]<br />ᐳ: First[177], PgSelectSingle[179]"):::bucket
     Bucket24("Bucket 24 (polymorphicPartition)<br />|MyTable<br />Deps: 11, 4490<br />ᐳMyTable<br /><br />1: PgSelect[183]<br />2: PgSelectRows[188]<br />ᐳ: First[187], PgSelectSingle[189]"):::bucket
@@ -39,9 +39,9 @@ graph TD
     Bucket28("Bucket 28 (polymorphicPartition)<br />|NullTestRecord<br />Deps: 11, 4490<br />ᐳNullTestRecord<br /><br />1: PgSelect[223]<br />2: PgSelectRows[228]<br />ᐳ: First[227], PgSelectSingle[229]"):::bucket
     Bucket29("Bucket 29 (polymorphicPartition)<br />|Issue756<br />Deps: 11, 4490<br />ᐳIssue756<br /><br />1: PgSelect[233]<br />2: PgSelectRows[238]<br />ᐳ: First[237], PgSelectSingle[239]"):::bucket
     Bucket30("Bucket 30 (polymorphicPartition)<br />|List<br />Deps: 11, 4490<br />ᐳList<br /><br />1: PgSelect[243]<br />2: PgSelectRows[248]<br />ᐳ: First[247], PgSelectSingle[249]"):::bucket
-    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 253, 4050, 4054, 4058, 4070, 4074, 4086<br /><br />ROOT PgSelectSingle{10}ᐸtype_function_listᐳ[253]<br />1: <br />ᐳ: 661, 663, 665, 667, 669, 671, 673, 675, 677, 679, 681, 683, 685, 687, 689, 691, 693, 695, 697, 699, 701, 703, 705, 707, 709, 711, 765, 767, 769, 771, 773, 775, 777, 779, 781, 783, 785, 787, 789, 791, 793, 795, 797, 819, 821, 4051, 4055, 4059, 4071, 4075, 4087, 1328, 1330, 1332, 1384, 1386, 1388, 4052, 4056, 4060, 4072, 4076, 4088, 4062, 4066<br />2: 726, 738, 750, 762, 806, 816<br />ᐳ: 725, 727, 737, 739, 749, 751, 761, 763, 805, 807, 815, 817, 1336, 1392, 1436, 1438, 1452, 1464, 1476, 1483, 4063, 4064, 4067, 4068<br />3: PgSelectRows[1347], PgSelectRows[1403]<br />ᐳ: 1346, 1348, 1402, 1404"):::bucket
-    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 271, 4154, 4158, 4162, 4174, 4178, 4190<br /><br />ROOT PgSelectSingle{6}ᐸperson_type_functionᐳ[271]<br />1: <br />ᐳ: 829, 914, 991, 1024, 1041, 1052, 1063, 1071, 1073, 1075, 1077, 1079, 1081, 1083, 1085, 1087, 1089, 1091, 1093, 1095, 1097, 1099, 1101, 1103, 1105, 1107, 1161, 1163, 1165, 1167, 1169, 1171, 1173, 1175, 1177, 1179, 1181, 1183, 1185, 1187, 1189, 1191, 1193, 1215, 1217, 4155, 4159, 4163, 4175, 4179, 4191, 1749, 1751, 1753, 1838, 1840, 1842, 4156, 4160, 4164, 4176, 4180, 4192, 4166, 4170, 4182, 4186<br />2: 1115, 1129, 1141, 1153, 1198, 1208<br />ᐳ: 1114, 1116, 1128, 1130, 1140, 1142, 1152, 1154, 1197, 1199, 1207, 1209, 1757, 1846, 1903, 1905, 1930, 1949, 1968, 1984, 4167, 4168, 4171, 4172<br />3: PgSelectRows[1763], PgSelectRows[1852]<br />ᐳ: 1762, 1764, 1851, 1853"):::bucket
-    Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 307, 4318, 4322, 4326, 4338, 4342, 4354<br /><br />ROOT PgSelectSingle{7}ᐸtypesᐳ[307]<br />1: <br />ᐳ: 833, 917, 997, 1026, 1042, 1053, 1064, 1072, 1074, 1076, 1078, 1080, 1082, 1084, 1086, 1088, 1090, 1092, 1094, 1096, 1098, 1100, 1102, 1104, 1106, 1108, 1162, 1164, 1166, 1168, 1170, 1172, 1174, 1176, 1178, 1180, 1182, 1184, 1186, 1188, 1190, 1192, 1194, 1216, 1218, 4319, 4323, 4327, 4339, 4343, 4355, 1750, 1752, 1754, 1839, 1841, 1843, 4320, 4324, 4328, 4340, 4344, 4356, 4330, 4334, 4346, 4350<br />2: 1123, 1135, 1147, 1159, 1203, 1213<br />ᐳ: 1122, 1124, 1134, 1136, 1146, 1148, 1158, 1160, 1202, 1204, 1212, 1214, 1758, 1847, 1904, 1906, 1931, 1950, 1969, 1985, 4331, 4332, 4335, 4336<br />3: PgSelectRows[1769], PgSelectRows[1858]<br />ᐳ: 1768, 1770, 1857, 1859"):::bucket
+    Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 253, 4050, 4054, 4058, 4070, 4074, 4086<br /><br />ROOT PgSelectSingle{10}ᐸtype_function_listᐳ[253]<br />1: <br />ᐳ: 661, 663, 665, 667, 669, 671, 673, 675, 677, 679, 681, 683, 685, 687, 689, 691, 693, 695, 697, 699, 701, 703, 705, 707, 709, 711, 765, 767, 769, 771, 773, 775, 777, 779, 781, 783, 785, 787, 789, 791, 793, 795, 797, 819, 821, 4051, 4055, 4059, 4071, 4075, 4087, 1328, 1330, 1332, 1334, 1368, 1384, 1386, 1388, 1390, 1420, 1434, 1450, 1462, 1474, 4052, 4056, 4060, 4072, 4076, 4088, 4062, 4066<br />2: 726, 738, 750, 762, 806, 816<br />ᐳ: 725, 727, 737, 739, 749, 751, 761, 763, 805, 807, 815, 817, 1336, 1392, 1436, 1438, 1452, 1464, 1476, 1483, 4063, 4064, 4067, 4068<br />3: PgSelectRows[1347], PgSelectRows[1403]<br />ᐳ: 1346, 1348, 1402, 1404"):::bucket
+    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 271, 4154, 4158, 4162, 4174, 4178, 4190<br /><br />ROOT PgSelectSingle{6}ᐸperson_type_functionᐳ[271]<br />1: <br />ᐳ: 829, 914, 991, 1024, 1041, 1052, 1063, 1071, 1073, 1075, 1077, 1079, 1081, 1083, 1085, 1087, 1089, 1091, 1093, 1095, 1097, 1099, 1101, 1103, 1105, 1107, 1161, 1163, 1165, 1167, 1169, 1171, 1173, 1175, 1177, 1179, 1181, 1183, 1185, 1187, 1189, 1191, 1193, 1215, 1217, 4155, 4159, 4163, 4175, 4179, 4191, 1749, 1751, 1753, 1755, 1789, 1838, 1840, 1842, 1844, 1874, 1901, 1928, 1947, 1966, 2685, 2687, 2689, 2697, 2699, 2701, 2709, 2711, 2713, 2721, 2723, 2725, 4156, 4160, 4164, 4176, 4180, 4192, 4166, 4170, 4182, 4186<br />2: 1115, 1129, 1141, 1153, 1198, 1208<br />ᐳ: 1114, 1116, 1128, 1130, 1140, 1142, 1152, 1154, 1197, 1199, 1207, 1209, 1757, 1846, 1903, 1905, 1930, 1949, 1968, 1984, 4167, 4168, 4171, 4172<br />3: PgSelectRows[1763], PgSelectRows[1852]<br />ᐳ: 1762, 1764, 1851, 1853"):::bucket
+    Bucket37("Bucket 37 (nullableBoundary)<br />Deps: 307, 4318, 4322, 4326, 4338, 4342, 4354<br /><br />ROOT PgSelectSingle{7}ᐸtypesᐳ[307]<br />1: <br />ᐳ: 833, 917, 997, 1026, 1042, 1053, 1064, 1072, 1074, 1076, 1078, 1080, 1082, 1084, 1086, 1088, 1090, 1092, 1094, 1096, 1098, 1100, 1102, 1104, 1106, 1108, 1162, 1164, 1166, 1168, 1170, 1172, 1174, 1176, 1178, 1180, 1182, 1184, 1186, 1188, 1190, 1192, 1194, 1216, 1218, 4319, 4323, 4327, 4339, 4343, 4355, 1750, 1752, 1754, 1756, 1790, 1839, 1841, 1843, 1845, 1875, 1902, 1929, 1948, 1967, 2686, 2688, 2690, 2698, 2700, 2702, 2710, 2712, 2714, 2722, 2724, 2726, 4320, 4324, 4328, 4340, 4344, 4356, 4330, 4334, 4346, 4350<br />2: 1123, 1135, 1147, 1159, 1203, 1213<br />ᐳ: 1122, 1124, 1134, 1136, 1146, 1148, 1158, 1160, 1202, 1204, 1212, 1214, 1758, 1847, 1904, 1906, 1931, 1950, 1969, 1985, 4331, 4332, 4335, 4336<br />3: PgSelectRows[1769], PgSelectRows[1858]<br />ᐳ: 1768, 1770, 1857, 1859"):::bucket
     Bucket38("Bucket 38 (nullableBoundary)<br />Deps: 348<br /><br />ROOT PgClassExpression{2}ᐸ__types__....ble_range”ᐳ[348]"):::bucket
     Bucket39("Bucket 39 (nullableBoundary)<br />Deps: 349<br /><br />ROOT PgClassExpression{3}ᐸ__types__....ble_range”ᐳ[349]"):::bucket
     Bucket40("Bucket 40 (nullableBoundary)<br />Deps: 350<br /><br />ROOT PgClassExpression{4}ᐸ__type_fun...ble_range”ᐳ[350]"):::bucket
@@ -90,11 +90,11 @@ graph TD
     Bucket83("Bucket 83 (nullableBoundary)<br />Deps: 603<br /><br />ROOT PgClassExpression{21}ᐸ__types__....ablePoint”ᐳ[603]"):::bucket
     Bucket84("Bucket 84 (nullableBoundary)<br />Deps: 623<br /><br />ROOT PgSelectSingle{21}ᐸpostᐳ[623]"):::bucket
     Bucket85("Bucket 85 (nullableBoundary)<br />Deps: 628<br /><br />ROOT PgSelectSingle{21}ᐸpostᐳ[628]"):::bucket
-    Bucket86("Bucket 86 (nullableBoundary)<br />Deps: 632, 3810, 3814, 3818, 3830, 3834, 3846<br /><br />ROOT PgSelectSingle{56}ᐸtypesᐳ[632]<br />1: <br />ᐳ: 1317, 1375, 1427, 1443, 1455, 1467, 1479, 1486, 1489, 1492, 1495, 1498, 1501, 1504, 1507, 1510, 1513, 1516, 1519, 1522, 1525, 1528, 1531, 1534, 1537, 1540, 1621, 1624, 1627, 1630, 1633, 1636, 1639, 1642, 1645, 1648, 1651, 1654, 1657, 1660, 1663, 1666, 1669, 1702, 1705, 3811, 3815, 3819, 3831, 3835, 3847, 2100, 2103, 2106, 2205, 2208, 2211, 3812, 3816, 3820, 3832, 3836, 3848, 3822, 3826<br />2: 1549, 1571, 1589, 1607, 1675, 1690<br />ᐳ: 1548, 1550, 1570, 1572, 1588, 1590, 1606, 1608, 1674, 1676, 1689, 1691, 2112, 2217, 2288, 2291, 2317, 2340, 2363, 2381, 3823, 3824, 3827, 3828<br />3: PgSelectRows[2119], PgSelectRows[2224]<br />ᐳ: 2118, 2120, 2223, 2225"):::bucket
-    Bucket87("Bucket 87 (nullableBoundary)<br />Deps: 634, 11, 4090, 4102, 4106, 4118<br /><br />ROOT PgSelectSingle{57}ᐸtype_function_connectionᐳ[634]<br />1: <br />ᐳ: 1318, 1376, 1428, 1444, 1456, 1468, 1480, 1487, 1490, 1493, 1496, 1499, 1502, 1505, 1508, 1511, 1514, 1517, 1520, 1523, 1526, 1529, 1532, 1535, 1538, 1541, 1622, 1625, 1628, 1631, 1634, 1637, 1640, 1643, 1646, 1649, 1652, 1655, 1658, 1661, 1664, 1667, 1670, 1703, 1706, 4091, 4103, 4107, 4119, 2101, 2104, 2107, 2206, 2209, 2212, 4092, 4104, 4108, 4120, 4094, 4098<br />2: 1557, 1577, 1595, 1613, 1677, 1692<br />ᐳ: 1556, 1558, 1576, 1578, 1594, 1596, 1612, 1614, 2113, 2218, 2289, 2292, 2318, 2341, 2364, 2382, 4095, 4096, 4099, 4100<br />3: 1680, 1695, 2125, 2230<br />ᐳ: 1679, 1681, 1694, 1696, 2124, 2126, 2229, 2231"):::bucket
+    Bucket86("Bucket 86 (nullableBoundary)<br />Deps: 632, 3810, 3814, 3818, 3830, 3834, 3846<br /><br />ROOT PgSelectSingle{56}ᐸtypesᐳ[632]<br />1: <br />ᐳ: 1317, 1375, 1427, 1443, 1455, 1467, 1479, 1486, 1489, 1492, 1495, 1498, 1501, 1504, 1507, 1510, 1513, 1516, 1519, 1522, 1525, 1528, 1531, 1534, 1537, 1540, 1621, 1624, 1627, 1630, 1633, 1636, 1639, 1642, 1645, 1648, 1651, 1654, 1657, 1660, 1663, 1666, 1669, 1702, 1705, 3811, 3815, 3819, 3831, 3835, 3847, 2100, 2103, 2106, 2109, 2160, 2205, 2208, 2211, 2214, 2259, 2285, 2314, 2337, 2360, 3812, 3816, 3820, 3832, 3836, 3848, 3822, 3826<br />2: 1549, 1571, 1589, 1607, 1675, 1690<br />ᐳ: 1548, 1550, 1570, 1572, 1588, 1590, 1606, 1608, 1674, 1676, 1689, 1691, 2112, 2217, 2288, 2291, 2317, 2340, 2363, 2381, 3823, 3824, 3827, 3828<br />3: PgSelectRows[2119], PgSelectRows[2224]<br />ᐳ: 2118, 2120, 2223, 2225"):::bucket
+    Bucket87("Bucket 87 (nullableBoundary)<br />Deps: 634, 11, 4090, 4102, 4106, 4118<br /><br />ROOT PgSelectSingle{57}ᐸtype_function_connectionᐳ[634]<br />1: <br />ᐳ: 1318, 1376, 1428, 1444, 1456, 1468, 1480, 1487, 1490, 1493, 1496, 1499, 1502, 1505, 1508, 1511, 1514, 1517, 1520, 1523, 1526, 1529, 1532, 1535, 1538, 1541, 1622, 1625, 1628, 1631, 1634, 1637, 1640, 1643, 1646, 1649, 1652, 1655, 1658, 1661, 1664, 1667, 1670, 1703, 1706, 4091, 4103, 4107, 4119, 2101, 2104, 2107, 2110, 2161, 2206, 2209, 2212, 2215, 2260, 2286, 2315, 2338, 2361, 4092, 4104, 4108, 4120, 4094, 4098<br />2: 1557, 1577, 1595, 1613, 1677, 1692<br />ᐳ: 1556, 1558, 1576, 1578, 1594, 1596, 1612, 1614, 2113, 2218, 2289, 2292, 2318, 2341, 2364, 2382, 4095, 4096, 4099, 4100<br />3: 1680, 1695, 2125, 2230<br />ᐳ: 1679, 1681, 1694, 1696, 2124, 2126, 2229, 2231"):::bucket
     Bucket88("Bucket 88 (nullableBoundary)<br />Deps: 635, 632, 3850, 3854, 3858, 3870, 3874, 3886<br /><br />ROOT Edge{56}[635]"):::bucket
     Bucket89("Bucket 89 (nullableBoundary)<br />Deps: 636, 634, 11, 4122, 4134, 4138, 4150<br /><br />ROOT Edge{57}[636]"):::bucket
-    Bucket90("Bucket 90 (nullableBoundary)<br />Deps: 638, 4199, 4203, 4207, 4219, 4223, 4235<br /><br />ROOT PgSelectSingle{58}ᐸperson_type_function_listᐳ[638]<br />1: <br />ᐳ: 1321, 1377, 1429, 1445, 1457, 1469, 1481, 1488, 1491, 1494, 1497, 1500, 1503, 1506, 1509, 1512, 1515, 1518, 1521, 1524, 1527, 1530, 1533, 1536, 1539, 1542, 1623, 1626, 1629, 1632, 1635, 1638, 1641, 1644, 1647, 1650, 1653, 1656, 1659, 1662, 1665, 1668, 1671, 1704, 1707, 4200, 4204, 4208, 4220, 4224, 4236, 2102, 2105, 2108, 2207, 2210, 2213, 4201, 4205, 4209, 4221, 4225, 4237, 4211, 4215<br />2: 1565, 1583, 1601, 1619, 1685, 1700<br />ᐳ: 1564, 1566, 1582, 1584, 1600, 1602, 1618, 1620, 1684, 1686, 1699, 1701, 2114, 2219, 2290, 2293, 2319, 2342, 2365, 2383, 4212, 4213, 4216, 4217<br />3: PgSelectRows[2131], PgSelectRows[2236]<br />ᐳ: 2130, 2132, 2235, 2237"):::bucket
+    Bucket90("Bucket 90 (nullableBoundary)<br />Deps: 638, 4199, 4203, 4207, 4219, 4223, 4235<br /><br />ROOT PgSelectSingle{58}ᐸperson_type_function_listᐳ[638]<br />1: <br />ᐳ: 1321, 1377, 1429, 1445, 1457, 1469, 1481, 1488, 1491, 1494, 1497, 1500, 1503, 1506, 1509, 1512, 1515, 1518, 1521, 1524, 1527, 1530, 1533, 1536, 1539, 1542, 1623, 1626, 1629, 1632, 1635, 1638, 1641, 1644, 1647, 1650, 1653, 1656, 1659, 1662, 1665, 1668, 1671, 1704, 1707, 4200, 4204, 4208, 4220, 4224, 4236, 2102, 2105, 2108, 2111, 2162, 2207, 2210, 2213, 2216, 2261, 2287, 2316, 2339, 2362, 4201, 4205, 4209, 4221, 4225, 4237, 4211, 4215<br />2: 1565, 1583, 1601, 1619, 1685, 1700<br />ᐳ: 1564, 1566, 1582, 1584, 1600, 1602, 1618, 1620, 1684, 1686, 1699, 1701, 2114, 2219, 2290, 2293, 2319, 2342, 2365, 2383, 4212, 4213, 4216, 4217<br />3: PgSelectRows[2131], PgSelectRows[2236]<br />ᐳ: 2130, 2132, 2235, 2237"):::bucket
     Bucket91("Bucket 91 (nullableBoundary)<br />Deps: 645<br /><br />ROOT __Item{65}ᐸ378ᐳ[645]"):::bucket
     Bucket92("Bucket 92 (nullableBoundary)<br />Deps: 646<br /><br />ROOT __Item{66}ᐸ379ᐳ[646]"):::bucket
     Bucket93("Bucket 93 (nullableBoundary)<br />Deps: 647<br /><br />ROOT __Item{67}ᐸ380ᐳ[647]"):::bucket
@@ -132,36 +132,36 @@ graph TD
     Bucket129("Bucket 129 (listItem)<br /><br />ROOT __Item{129}ᐸ797ᐳ[1230]"):::bucket
     Bucket130("Bucket 130 (listItem)<br /><br />ROOT __Item{130}ᐸ820ᐳ[1231]"):::bucket
     Bucket131("Bucket 131 (listItem)<br /><br />ROOT __Item{131}ᐸ821ᐳ[1232]"):::bucket
-    Bucket132("Bucket 132 (nullableBoundary)<br />Deps: 839, 348<br /><br />ROOT Access{38}ᐸ348.startᐳ[839]"):::bucket
-    Bucket133("Bucket 133 (nullableBoundary)<br />Deps: 840, 349<br /><br />ROOT Access{39}ᐸ349.startᐳ[840]"):::bucket
-    Bucket134("Bucket 134 (nullableBoundary)<br />Deps: 841, 350<br /><br />ROOT Access{40}ᐸ350.startᐳ[841]"):::bucket
-    Bucket135("Bucket 135 (nullableBoundary)<br />Deps: 842, 351<br /><br />ROOT Access{2}ᐸ351.startᐳ[842]"):::bucket
-    Bucket136("Bucket 136 (nullableBoundary)<br />Deps: 843, 352<br /><br />ROOT Access{3}ᐸ352.startᐳ[843]"):::bucket
-    Bucket137("Bucket 137 (nullableBoundary)<br />Deps: 844, 353<br /><br />ROOT Access{4}ᐸ353.startᐳ[844]"):::bucket
-    Bucket138("Bucket 138 (nullableBoundary)<br />Deps: 845, 354<br /><br />ROOT Access{2}ᐸ354.startᐳ[845]"):::bucket
-    Bucket139("Bucket 139 (nullableBoundary)<br />Deps: 846, 355<br /><br />ROOT Access{3}ᐸ355.startᐳ[846]"):::bucket
-    Bucket140("Bucket 140 (nullableBoundary)<br />Deps: 847, 356<br /><br />ROOT Access{4}ᐸ356.startᐳ[847]"):::bucket
-    Bucket141("Bucket 141 (nullableBoundary)<br />Deps: 848, 357<br /><br />ROOT Access{2}ᐸ357.startᐳ[848]"):::bucket
-    Bucket142("Bucket 142 (nullableBoundary)<br />Deps: 849, 358<br /><br />ROOT Access{3}ᐸ358.startᐳ[849]"):::bucket
-    Bucket143("Bucket 143 (nullableBoundary)<br />Deps: 850, 359<br /><br />ROOT Access{4}ᐸ359.startᐳ[850]"):::bucket
+    Bucket132("Bucket 132 (nullableBoundary)<br />Deps: 839, 1709, 1798<br /><br />ROOT Access{38}ᐸ348.startᐳ[839]"):::bucket
+    Bucket133("Bucket 133 (nullableBoundary)<br />Deps: 840, 1710, 1799<br /><br />ROOT Access{39}ᐸ349.startᐳ[840]"):::bucket
+    Bucket134("Bucket 134 (nullableBoundary)<br />Deps: 841, 1711, 1800<br /><br />ROOT Access{40}ᐸ350.startᐳ[841]"):::bucket
+    Bucket135("Bucket 135 (nullableBoundary)<br />Deps: 842, 1712, 1801<br /><br />ROOT Access{2}ᐸ351.startᐳ[842]"):::bucket
+    Bucket136("Bucket 136 (nullableBoundary)<br />Deps: 843, 1713, 1802<br /><br />ROOT Access{3}ᐸ352.startᐳ[843]"):::bucket
+    Bucket137("Bucket 137 (nullableBoundary)<br />Deps: 844, 1714, 1803<br /><br />ROOT Access{4}ᐸ353.startᐳ[844]"):::bucket
+    Bucket138("Bucket 138 (nullableBoundary)<br />Deps: 845, 1715, 1804<br /><br />ROOT Access{2}ᐸ354.startᐳ[845]"):::bucket
+    Bucket139("Bucket 139 (nullableBoundary)<br />Deps: 846, 1716, 1805<br /><br />ROOT Access{3}ᐸ355.startᐳ[846]"):::bucket
+    Bucket140("Bucket 140 (nullableBoundary)<br />Deps: 847, 1717, 1806<br /><br />ROOT Access{4}ᐸ356.startᐳ[847]"):::bucket
+    Bucket141("Bucket 141 (nullableBoundary)<br />Deps: 848, 1718, 1807<br /><br />ROOT Access{2}ᐸ357.startᐳ[848]"):::bucket
+    Bucket142("Bucket 142 (nullableBoundary)<br />Deps: 849, 1719, 1808<br /><br />ROOT Access{3}ᐸ358.startᐳ[849]"):::bucket
+    Bucket143("Bucket 143 (nullableBoundary)<br />Deps: 850, 1720, 1809<br /><br />ROOT Access{4}ᐸ359.startᐳ[850]"):::bucket
     Bucket144("Bucket 144 (nullableBoundary)<br />Deps: 862<br /><br />ROOT PgSelectSingle{2}ᐸfrmcdc_compoundTypeᐳ[862]"):::bucket
     Bucket145("Bucket 145 (nullableBoundary)<br />Deps: 868<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_compoundTypeᐳ[868]"):::bucket
     Bucket146("Bucket 146 (nullableBoundary)<br />Deps: 874<br /><br />ROOT PgSelectSingle{4}ᐸfrmcdc_compoundTypeᐳ[874]"):::bucket
     Bucket147("Bucket 147 (nullableBoundary)<br />Deps: 885<br /><br />ROOT PgSelectSingle{44}ᐸfrmcdc_compoundTypeᐳ[885]"):::bucket
     Bucket148("Bucket 148 (nullableBoundary)<br />Deps: 893<br /><br />ROOT PgSelectSingle{45}ᐸfrmcdc_compoundTypeᐳ[893]"):::bucket
     Bucket149("Bucket 149 (nullableBoundary)<br />Deps: 901<br /><br />ROOT PgSelectSingle{46}ᐸfrmcdc_compoundTypeᐳ[901]"):::bucket
-    Bucket150("Bucket 150 (nullableBoundary)<br />Deps: 922, 348<br /><br />ROOT Access{38}ᐸ348.endᐳ[922]"):::bucket
-    Bucket151("Bucket 151 (nullableBoundary)<br />Deps: 923, 349<br /><br />ROOT Access{39}ᐸ349.endᐳ[923]"):::bucket
-    Bucket152("Bucket 152 (nullableBoundary)<br />Deps: 924, 350<br /><br />ROOT Access{40}ᐸ350.endᐳ[924]"):::bucket
-    Bucket153("Bucket 153 (nullableBoundary)<br />Deps: 925, 351<br /><br />ROOT Access{2}ᐸ351.endᐳ[925]"):::bucket
-    Bucket154("Bucket 154 (nullableBoundary)<br />Deps: 926, 352<br /><br />ROOT Access{3}ᐸ352.endᐳ[926]"):::bucket
-    Bucket155("Bucket 155 (nullableBoundary)<br />Deps: 927, 353<br /><br />ROOT Access{4}ᐸ353.endᐳ[927]"):::bucket
-    Bucket156("Bucket 156 (nullableBoundary)<br />Deps: 928, 354<br /><br />ROOT Access{2}ᐸ354.endᐳ[928]"):::bucket
-    Bucket157("Bucket 157 (nullableBoundary)<br />Deps: 929, 355<br /><br />ROOT Access{3}ᐸ355.endᐳ[929]"):::bucket
-    Bucket158("Bucket 158 (nullableBoundary)<br />Deps: 930, 356<br /><br />ROOT Access{4}ᐸ356.endᐳ[930]"):::bucket
-    Bucket159("Bucket 159 (nullableBoundary)<br />Deps: 931, 357<br /><br />ROOT Access{2}ᐸ357.endᐳ[931]"):::bucket
-    Bucket160("Bucket 160 (nullableBoundary)<br />Deps: 932, 358<br /><br />ROOT Access{3}ᐸ358.endᐳ[932]"):::bucket
-    Bucket161("Bucket 161 (nullableBoundary)<br />Deps: 933, 359<br /><br />ROOT Access{4}ᐸ359.endᐳ[933]"):::bucket
+    Bucket150("Bucket 150 (nullableBoundary)<br />Deps: 922, 1727, 1816<br /><br />ROOT Access{38}ᐸ348.endᐳ[922]"):::bucket
+    Bucket151("Bucket 151 (nullableBoundary)<br />Deps: 923, 1728, 1817<br /><br />ROOT Access{39}ᐸ349.endᐳ[923]"):::bucket
+    Bucket152("Bucket 152 (nullableBoundary)<br />Deps: 924, 1729, 1818<br /><br />ROOT Access{40}ᐸ350.endᐳ[924]"):::bucket
+    Bucket153("Bucket 153 (nullableBoundary)<br />Deps: 925, 1730, 1819<br /><br />ROOT Access{2}ᐸ351.endᐳ[925]"):::bucket
+    Bucket154("Bucket 154 (nullableBoundary)<br />Deps: 926, 1731, 1820<br /><br />ROOT Access{3}ᐸ352.endᐳ[926]"):::bucket
+    Bucket155("Bucket 155 (nullableBoundary)<br />Deps: 927, 1732, 1821<br /><br />ROOT Access{4}ᐸ353.endᐳ[927]"):::bucket
+    Bucket156("Bucket 156 (nullableBoundary)<br />Deps: 928, 1733, 1822<br /><br />ROOT Access{2}ᐸ354.endᐳ[928]"):::bucket
+    Bucket157("Bucket 157 (nullableBoundary)<br />Deps: 929, 1734, 1823<br /><br />ROOT Access{3}ᐸ355.endᐳ[929]"):::bucket
+    Bucket158("Bucket 158 (nullableBoundary)<br />Deps: 930, 1735, 1824<br /><br />ROOT Access{4}ᐸ356.endᐳ[930]"):::bucket
+    Bucket159("Bucket 159 (nullableBoundary)<br />Deps: 931, 1736, 1825<br /><br />ROOT Access{2}ᐸ357.endᐳ[931]"):::bucket
+    Bucket160("Bucket 160 (nullableBoundary)<br />Deps: 932, 1737, 1826<br /><br />ROOT Access{3}ᐸ358.endᐳ[932]"):::bucket
+    Bucket161("Bucket 161 (nullableBoundary)<br />Deps: 933, 1738, 1827<br /><br />ROOT Access{4}ᐸ359.endᐳ[933]"):::bucket
     Bucket162("Bucket 162 (nullableBoundary)<br />Deps: 945<br /><br />ROOT PgSelectSingle{2}ᐸfrmcdc_compoundTypeᐳ[945]"):::bucket
     Bucket163("Bucket 163 (nullableBoundary)<br />Deps: 951<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_compoundTypeᐳ[951]"):::bucket
     Bucket164("Bucket 164 (nullableBoundary)<br />Deps: 957<br /><br />ROOT PgSelectSingle{4}ᐸfrmcdc_compoundTypeᐳ[957]"):::bucket
@@ -198,46 +198,46 @@ graph TD
     Bucket195("Bucket 195 (listItem)<br /><br />ROOT __Item{195}ᐸ1194ᐳ[1314]"):::bucket
     Bucket196("Bucket 196 (listItem)<br /><br />ROOT __Item{196}ᐸ1217ᐳ[1315]"):::bucket
     Bucket197("Bucket 197 (listItem)<br /><br />ROOT __Item{197}ᐸ1218ᐳ[1316]"):::bucket
-    Bucket198("Bucket 198 (nullableBoundary)<br />Deps: 1233, 564<br /><br />ROOT Access{80}ᐸ564.startᐳ[1233]"):::bucket
-    Bucket199("Bucket 199 (nullableBoundary)<br />Deps: 1234, 565<br /><br />ROOT Access{21}ᐸ565.startᐳ[1234]"):::bucket
-    Bucket200("Bucket 200 (nullableBoundary)<br />Deps: 1235, 566<br /><br />ROOT Access{21}ᐸ566.startᐳ[1235]"):::bucket
-    Bucket201("Bucket 201 (nullableBoundary)<br />Deps: 1236, 567<br /><br />ROOT Access{21}ᐸ567.startᐳ[1236]"):::bucket
+    Bucket198("Bucket 198 (nullableBoundary)<br />Deps: 1233, 2011, 2025<br /><br />ROOT Access{80}ᐸ564.startᐳ[1233]"):::bucket
+    Bucket199("Bucket 199 (nullableBoundary)<br />Deps: 1234, 2012, 2026<br /><br />ROOT Access{21}ᐸ565.startᐳ[1234]"):::bucket
+    Bucket200("Bucket 200 (nullableBoundary)<br />Deps: 1235, 2013, 2027<br /><br />ROOT Access{21}ᐸ566.startᐳ[1235]"):::bucket
+    Bucket201("Bucket 201 (nullableBoundary)<br />Deps: 1236, 2014, 2028<br /><br />ROOT Access{21}ᐸ567.startᐳ[1236]"):::bucket
     Bucket202("Bucket 202 (nullableBoundary)<br />Deps: 1244<br /><br />ROOT PgSelectSingle{21}ᐸfrmcdc_compoundTypeᐳ[1244]"):::bucket
     Bucket203("Bucket 203 (nullableBoundary)<br />Deps: 1253<br /><br />ROOT PgSelectSingle{82}ᐸfrmcdc_compoundTypeᐳ[1253]"):::bucket
-    Bucket204("Bucket 204 (nullableBoundary)<br />Deps: 1258, 564<br /><br />ROOT Access{80}ᐸ564.endᐳ[1258]"):::bucket
-    Bucket205("Bucket 205 (nullableBoundary)<br />Deps: 1259, 565<br /><br />ROOT Access{21}ᐸ565.endᐳ[1259]"):::bucket
-    Bucket206("Bucket 206 (nullableBoundary)<br />Deps: 1260, 566<br /><br />ROOT Access{21}ᐸ566.endᐳ[1260]"):::bucket
-    Bucket207("Bucket 207 (nullableBoundary)<br />Deps: 1261, 567<br /><br />ROOT Access{21}ᐸ567.endᐳ[1261]"):::bucket
+    Bucket204("Bucket 204 (nullableBoundary)<br />Deps: 1258, 2017, 2031<br /><br />ROOT Access{80}ᐸ564.endᐳ[1258]"):::bucket
+    Bucket205("Bucket 205 (nullableBoundary)<br />Deps: 1259, 2018, 2032<br /><br />ROOT Access{21}ᐸ565.endᐳ[1259]"):::bucket
+    Bucket206("Bucket 206 (nullableBoundary)<br />Deps: 1260, 2019, 2033<br /><br />ROOT Access{21}ᐸ566.endᐳ[1260]"):::bucket
+    Bucket207("Bucket 207 (nullableBoundary)<br />Deps: 1261, 2020, 2034<br /><br />ROOT Access{21}ᐸ567.endᐳ[1261]"):::bucket
     Bucket208("Bucket 208 (nullableBoundary)<br />Deps: 1269<br /><br />ROOT PgSelectSingle{21}ᐸfrmcdc_compoundTypeᐳ[1269]"):::bucket
     Bucket209("Bucket 209 (nullableBoundary)<br />Deps: 1276<br /><br />ROOT PgSelectSingle{82}ᐸfrmcdc_compoundTypeᐳ[1276]"):::bucket
-    Bucket210("Bucket 210 (nullableBoundary)<br />Deps: 1298, 11, 4244, 4256, 4260, 4272<br /><br />ROOT PgSelectSingle{182}ᐸperson_type_function_connectionᐳ[1298]<br />1: <br />ᐳ: 2065, 2172, 2271, 2300, 2323, 2346, 2369, 2387, 2391, 2395, 2399, 2403, 2407, 2411, 2415, 2419, 2423, 2427, 2431, 2435, 2439, 2443, 2447, 2451, 2455, 2459, 2567, 2571, 2575, 2579, 2583, 2587, 2591, 2595, 2599, 2603, 2607, 2611, 2615, 2619, 2623, 2627, 2631, 2675, 2679, 4245, 4257, 4261, 4273, 2859, 2863, 2867, 2997, 3001, 3005, 4246, 4258, 4262, 4274, 4248, 4252<br />2: 2469, 2499, 2523, 2547, 2635, 2655<br />ᐳ: 2468, 2470, 2498, 2500, 2522, 2524, 2546, 2548, 2875, 3013, 3103, 3107, 3137, 3163, 3189, 3211, 4249, 4250, 4253, 4254<br />3: 2638, 2658, 2883, 3021<br />ᐳ: 2637, 2639, 2657, 2659, 2882, 2884, 3020, 3022"):::bucket
-    Bucket211("Bucket 211 (nullableBoundary)<br />Deps: 1300, 4362, 4366, 4370, 4382, 4386, 4398<br /><br />ROOT PgSelectSingle{183}ᐸtypesᐳ[1300]<br />1: <br />ᐳ: 2066, 2173, 2272, 2301, 2324, 2347, 2370, 2388, 2392, 2396, 2400, 2404, 2408, 2412, 2416, 2420, 2424, 2428, 2432, 2436, 2440, 2444, 2448, 2452, 2456, 2460, 2568, 2572, 2576, 2580, 2584, 2588, 2592, 2596, 2600, 2604, 2608, 2612, 2616, 2620, 2624, 2628, 2632, 2676, 2680, 4363, 4367, 4371, 4383, 4387, 4399, 2860, 2864, 2868, 2998, 3002, 3006, 4364, 4368, 4372, 4384, 4388, 4400, 4374, 4378<br />2: 2477, 2505, 2529, 2553, 2643, 2663<br />ᐳ: 2476, 2478, 2504, 2506, 2528, 2530, 2552, 2554, 2642, 2644, 2662, 2664, 2876, 3014, 3104, 3108, 3138, 3164, 3190, 3212, 4375, 4376, 4379, 4380<br />3: PgSelectRows[2889], PgSelectRows[3027]<br />ᐳ: 2888, 2890, 3026, 3028"):::bucket
+    Bucket210("Bucket 210 (nullableBoundary)<br />Deps: 1298, 11, 4244, 4256, 4260, 4272<br /><br />ROOT PgSelectSingle{182}ᐸperson_type_function_connectionᐳ[1298]<br />1: <br />ᐳ: 2065, 2172, 2271, 2300, 2323, 2346, 2369, 2387, 2391, 2395, 2399, 2403, 2407, 2411, 2415, 2419, 2423, 2427, 2431, 2435, 2439, 2443, 2447, 2451, 2455, 2459, 2567, 2571, 2575, 2579, 2583, 2587, 2591, 2595, 2599, 2603, 2607, 2611, 2615, 2619, 2623, 2627, 2631, 2675, 2679, 4245, 4257, 4261, 4273, 2859, 2863, 2867, 2871, 2939, 2997, 3001, 3005, 3009, 3069, 3099, 3133, 3159, 3185, 4246, 4258, 4262, 4274, 4248, 4252<br />2: 2469, 2499, 2523, 2547, 2635, 2655<br />ᐳ: 2468, 2470, 2498, 2500, 2522, 2524, 2546, 2548, 2875, 3013, 3103, 3107, 3137, 3163, 3189, 3211, 4249, 4250, 4253, 4254<br />3: 2638, 2658, 2883, 3021<br />ᐳ: 2637, 2639, 2657, 2659, 2882, 2884, 3020, 3022"):::bucket
+    Bucket211("Bucket 211 (nullableBoundary)<br />Deps: 1300, 4362, 4366, 4370, 4382, 4386, 4398<br /><br />ROOT PgSelectSingle{183}ᐸtypesᐳ[1300]<br />1: <br />ᐳ: 2066, 2173, 2272, 2301, 2324, 2347, 2370, 2388, 2392, 2396, 2400, 2404, 2408, 2412, 2416, 2420, 2424, 2428, 2432, 2436, 2440, 2444, 2448, 2452, 2456, 2460, 2568, 2572, 2576, 2580, 2584, 2588, 2592, 2596, 2600, 2604, 2608, 2612, 2616, 2620, 2624, 2628, 2632, 2676, 2680, 4363, 4367, 4371, 4383, 4387, 4399, 2860, 2864, 2868, 2872, 2940, 2998, 3002, 3006, 3010, 3070, 3100, 3134, 3160, 3186, 4364, 4368, 4372, 4384, 4388, 4400, 4374, 4378<br />2: 2477, 2505, 2529, 2553, 2643, 2663<br />ᐳ: 2476, 2478, 2504, 2506, 2528, 2530, 2552, 2554, 2642, 2644, 2662, 2664, 2876, 3014, 3104, 3108, 3138, 3164, 3190, 3212, 4375, 4376, 4379, 4380<br />3: PgSelectRows[2889], PgSelectRows[3027]<br />ᐳ: 2888, 2890, 3026, 3028"):::bucket
     Bucket212("Bucket 212 (nullableBoundary)<br />Deps: 1301, 1298, 11, 4276, 4288, 4292, 4304<br /><br />ROOT Edge{182}[1301]"):::bucket
     Bucket213("Bucket 213 (nullableBoundary)<br />Deps: 1302, 1300, 4402, 4406, 4410, 4422, 4426, 4438<br /><br />ROOT Edge{183}[1302]"):::bucket
     Bucket214("Bucket 214 (nullableBoundary)<br />Deps: 1307<br /><br />ROOT __Item{188}ᐸ1105ᐳ[1307]"):::bucket
     Bucket215("Bucket 215 (nullableBoundary)<br />Deps: 1308<br /><br />ROOT __Item{189}ᐸ1106ᐳ[1308]"):::bucket
-    Bucket216("Bucket 216 (nullableBoundary)<br />Deps: 632, 3850, 3854, 3858, 3870, 3874, 3886<br /><br />ROOT PgSelectSingle{56}ᐸtypesᐳ[632]<br />1: <br />ᐳ: 2071, 2176, 2275, 2304, 2327, 2350, 2371, 2389, 2393, 2397, 2401, 2405, 2409, 2413, 2417, 2421, 2425, 2429, 2433, 2437, 2441, 2445, 2449, 2453, 2457, 2461, 2569, 2573, 2577, 2581, 2585, 2589, 2593, 2597, 2601, 2605, 2609, 2613, 2617, 2621, 2625, 2629, 2633, 2677, 2681, 3851, 3855, 3859, 3871, 3875, 3887, 2861, 2865, 2869, 2999, 3003, 3007, 3852, 3856, 3860, 3872, 3876, 3888, 3862, 3866<br />2: 2485, 2511, 2535, 2559, 2648, 2668<br />ᐳ: 2484, 2486, 2510, 2512, 2534, 2536, 2558, 2560, 2647, 2649, 2667, 2669, 2877, 3015, 3105, 3109, 3139, 3165, 3191, 3213, 3863, 3864, 3867, 3868<br />3: PgSelectRows[2895], PgSelectRows[3033]<br />ᐳ: 2894, 2896, 3032, 3034"):::bucket
-    Bucket217("Bucket 217 (nullableBoundary)<br />Deps: 634, 11, 4122, 4134, 4138, 4150<br /><br />ROOT PgSelectSingle{57}ᐸtype_function_connectionᐳ[634]<br />1: <br />ᐳ: 2072, 2177, 2276, 2305, 2328, 2351, 2372, 2390, 2394, 2398, 2402, 2406, 2410, 2414, 2418, 2422, 2426, 2430, 2434, 2438, 2442, 2446, 2450, 2454, 2458, 2462, 2570, 2574, 2578, 2582, 2586, 2590, 2594, 2598, 2602, 2606, 2610, 2614, 2618, 2622, 2626, 2630, 2634, 2678, 2682, 4123, 4135, 4139, 4151, 2862, 2866, 2870, 3000, 3004, 3008, 4124, 4136, 4140, 4152, 4126, 4130<br />2: 2493, 2517, 2541, 2565, 2650, 2670<br />ᐳ: 2492, 2494, 2516, 2518, 2540, 2542, 2564, 2566, 2878, 3016, 3106, 3110, 3140, 3166, 3192, 3214, 4127, 4128, 4131, 4132<br />3: 2653, 2673, 2901, 3039<br />ᐳ: 2652, 2654, 2672, 2674, 2900, 2902, 3038, 3040"):::bucket
-    Bucket218("Bucket 218 (nullableBoundary)<br />Deps: 1325, 688<br /><br />ROOT Access{101}ᐸ688.startᐳ[1325]"):::bucket
-    Bucket219("Bucket 219 (nullableBoundary)<br />Deps: 1326, 689<br /><br />ROOT Access{102}ᐸ689.startᐳ[1326]"):::bucket
-    Bucket220("Bucket 220 (nullableBoundary)<br />Deps: 1327, 690<br /><br />ROOT Access{9}ᐸ690.startᐳ[1327]"):::bucket
-    Bucket221("Bucket 221 (nullableBoundary)<br />Deps: 1328, 691<br /><br />ROOT Access{31}ᐸ691.startᐳ[1328]"):::bucket
-    Bucket222("Bucket 222 (nullableBoundary)<br />Deps: 1329, 692<br /><br />ROOT Access{9}ᐸ692.startᐳ[1329]"):::bucket
-    Bucket223("Bucket 223 (nullableBoundary)<br />Deps: 1330, 693<br /><br />ROOT Access{31}ᐸ693.startᐳ[1330]"):::bucket
-    Bucket224("Bucket 224 (nullableBoundary)<br />Deps: 1331, 694<br /><br />ROOT Access{9}ᐸ694.startᐳ[1331]"):::bucket
-    Bucket225("Bucket 225 (nullableBoundary)<br />Deps: 1332, 695<br /><br />ROOT Access{31}ᐸ695.startᐳ[1332]"):::bucket
+    Bucket216("Bucket 216 (nullableBoundary)<br />Deps: 632, 3850, 3854, 3858, 3870, 3874, 3886<br /><br />ROOT PgSelectSingle{56}ᐸtypesᐳ[632]<br />1: <br />ᐳ: 2071, 2176, 2275, 2304, 2327, 2350, 2371, 2389, 2393, 2397, 2401, 2405, 2409, 2413, 2417, 2421, 2425, 2429, 2433, 2437, 2441, 2445, 2449, 2453, 2457, 2461, 2569, 2573, 2577, 2581, 2585, 2589, 2593, 2597, 2601, 2605, 2609, 2613, 2617, 2621, 2625, 2629, 2633, 2677, 2681, 3851, 3855, 3859, 3871, 3875, 3887, 2861, 2865, 2869, 2873, 2941, 2999, 3003, 3007, 3011, 3071, 3101, 3135, 3161, 3187, 3852, 3856, 3860, 3872, 3876, 3888, 3862, 3866<br />2: 2485, 2511, 2535, 2559, 2648, 2668<br />ᐳ: 2484, 2486, 2510, 2512, 2534, 2536, 2558, 2560, 2647, 2649, 2667, 2669, 2877, 3015, 3105, 3109, 3139, 3165, 3191, 3213, 3863, 3864, 3867, 3868<br />3: PgSelectRows[2895], PgSelectRows[3033]<br />ᐳ: 2894, 2896, 3032, 3034"):::bucket
+    Bucket217("Bucket 217 (nullableBoundary)<br />Deps: 634, 11, 4122, 4134, 4138, 4150<br /><br />ROOT PgSelectSingle{57}ᐸtype_function_connectionᐳ[634]<br />1: <br />ᐳ: 2072, 2177, 2276, 2305, 2328, 2351, 2372, 2390, 2394, 2398, 2402, 2406, 2410, 2414, 2418, 2422, 2426, 2430, 2434, 2438, 2442, 2446, 2450, 2454, 2458, 2462, 2570, 2574, 2578, 2582, 2586, 2590, 2594, 2598, 2602, 2606, 2610, 2614, 2618, 2622, 2626, 2630, 2634, 2678, 2682, 4123, 4135, 4139, 4151, 2862, 2866, 2870, 2874, 2942, 3000, 3004, 3008, 3012, 3072, 3102, 3136, 3162, 3188, 4124, 4136, 4140, 4152, 4126, 4130<br />2: 2493, 2517, 2541, 2565, 2650, 2670<br />ᐳ: 2492, 2494, 2516, 2518, 2540, 2542, 2564, 2566, 2878, 3016, 3106, 3110, 3140, 3166, 3192, 3214, 4127, 4128, 4131, 4132<br />3: 2653, 2673, 2901, 3039<br />ᐳ: 2652, 2654, 2672, 2674, 2900, 2902, 3038, 3040"):::bucket
+    Bucket218("Bucket 218 (nullableBoundary)<br />Deps: 688, 1325<br /><br />ROOT Access{101}ᐸ688.startᐳ[1325]"):::bucket
+    Bucket219("Bucket 219 (nullableBoundary)<br />Deps: 689, 1326<br /><br />ROOT Access{102}ᐸ689.startᐳ[1326]"):::bucket
+    Bucket220("Bucket 220 (nullableBoundary)<br />Deps: 690, 1327<br /><br />ROOT Access{9}ᐸ690.startᐳ[1327]"):::bucket
+    Bucket221("Bucket 221 (nullableBoundary)<br />Deps: 691, 1328<br /><br />ROOT Access{31}ᐸ691.startᐳ[1328]"):::bucket
+    Bucket222("Bucket 222 (nullableBoundary)<br />Deps: 692, 1329<br /><br />ROOT Access{9}ᐸ692.startᐳ[1329]"):::bucket
+    Bucket223("Bucket 223 (nullableBoundary)<br />Deps: 693, 1330<br /><br />ROOT Access{31}ᐸ693.startᐳ[1330]"):::bucket
+    Bucket224("Bucket 224 (nullableBoundary)<br />Deps: 694, 1331<br /><br />ROOT Access{9}ᐸ694.startᐳ[1331]"):::bucket
+    Bucket225("Bucket 225 (nullableBoundary)<br />Deps: 695, 1332<br /><br />ROOT Access{31}ᐸ695.startᐳ[1332]"):::bucket
     Bucket226("Bucket 226 (nullableBoundary)<br />Deps: 1342<br /><br />ROOT PgSelectSingle{9}ᐸfrmcdc_compoundTypeᐳ[1342]"):::bucket
     Bucket227("Bucket 227 (nullableBoundary)<br />Deps: 1348<br /><br />ROOT PgSelectSingle{31}ᐸfrmcdc_compoundTypeᐳ[1348]"):::bucket
     Bucket228("Bucket 228 (nullableBoundary)<br />Deps: 1358<br /><br />ROOT PgSelectSingle{105}ᐸfrmcdc_compoundTypeᐳ[1358]"):::bucket
     Bucket229("Bucket 229 (nullableBoundary)<br />Deps: 1366<br /><br />ROOT PgSelectSingle{106}ᐸfrmcdc_compoundTypeᐳ[1366]"):::bucket
-    Bucket230("Bucket 230 (nullableBoundary)<br />Deps: 1381, 688<br /><br />ROOT Access{101}ᐸ688.endᐳ[1381]"):::bucket
-    Bucket231("Bucket 231 (nullableBoundary)<br />Deps: 1382, 689<br /><br />ROOT Access{102}ᐸ689.endᐳ[1382]"):::bucket
-    Bucket232("Bucket 232 (nullableBoundary)<br />Deps: 1383, 690<br /><br />ROOT Access{9}ᐸ690.endᐳ[1383]"):::bucket
-    Bucket233("Bucket 233 (nullableBoundary)<br />Deps: 1384, 691<br /><br />ROOT Access{31}ᐸ691.endᐳ[1384]"):::bucket
-    Bucket234("Bucket 234 (nullableBoundary)<br />Deps: 1385, 692<br /><br />ROOT Access{9}ᐸ692.endᐳ[1385]"):::bucket
-    Bucket235("Bucket 235 (nullableBoundary)<br />Deps: 1386, 693<br /><br />ROOT Access{31}ᐸ693.endᐳ[1386]"):::bucket
-    Bucket236("Bucket 236 (nullableBoundary)<br />Deps: 1387, 694<br /><br />ROOT Access{9}ᐸ694.endᐳ[1387]"):::bucket
-    Bucket237("Bucket 237 (nullableBoundary)<br />Deps: 1388, 695<br /><br />ROOT Access{31}ᐸ695.endᐳ[1388]"):::bucket
+    Bucket230("Bucket 230 (nullableBoundary)<br />Deps: 688, 1381<br /><br />ROOT Access{101}ᐸ688.endᐳ[1381]"):::bucket
+    Bucket231("Bucket 231 (nullableBoundary)<br />Deps: 689, 1382<br /><br />ROOT Access{102}ᐸ689.endᐳ[1382]"):::bucket
+    Bucket232("Bucket 232 (nullableBoundary)<br />Deps: 690, 1383<br /><br />ROOT Access{9}ᐸ690.endᐳ[1383]"):::bucket
+    Bucket233("Bucket 233 (nullableBoundary)<br />Deps: 691, 1384<br /><br />ROOT Access{31}ᐸ691.endᐳ[1384]"):::bucket
+    Bucket234("Bucket 234 (nullableBoundary)<br />Deps: 692, 1385<br /><br />ROOT Access{9}ᐸ692.endᐳ[1385]"):::bucket
+    Bucket235("Bucket 235 (nullableBoundary)<br />Deps: 693, 1386<br /><br />ROOT Access{31}ᐸ693.endᐳ[1386]"):::bucket
+    Bucket236("Bucket 236 (nullableBoundary)<br />Deps: 694, 1387<br /><br />ROOT Access{9}ᐸ694.endᐳ[1387]"):::bucket
+    Bucket237("Bucket 237 (nullableBoundary)<br />Deps: 695, 1388<br /><br />ROOT Access{31}ᐸ695.endᐳ[1388]"):::bucket
     Bucket238("Bucket 238 (nullableBoundary)<br />Deps: 1398<br /><br />ROOT PgSelectSingle{9}ᐸfrmcdc_compoundTypeᐳ[1398]"):::bucket
     Bucket239("Bucket 239 (nullableBoundary)<br />Deps: 1404<br /><br />ROOT PgSelectSingle{31}ᐸfrmcdc_compoundTypeᐳ[1404]"):::bucket
     Bucket240("Bucket 240 (nullableBoundary)<br />Deps: 1412<br /><br />ROOT PgSelectSingle{105}ᐸfrmcdc_compoundTypeᐳ[1412]"):::bucket
@@ -281,26 +281,26 @@ graph TD
     Bucket278("Bucket 278 (listItem)<br /><br />ROOT __Item{278}ᐸ1705ᐳ[2006]"):::bucket
     Bucket279("Bucket 279 (listItem)<br /><br />ROOT __Item{279}ᐸ1706ᐳ[2007]"):::bucket
     Bucket280("Bucket 280 (listItem)<br /><br />ROOT __Item{280}ᐸ1707ᐳ[2008]"):::bucket
-    Bucket281("Bucket 281 (nullableBoundary)<br />Deps: 1747, 1085<br /><br />ROOT Access{168}ᐸ1085.startᐳ[1747]"):::bucket
-    Bucket282("Bucket 282 (nullableBoundary)<br />Deps: 1748, 1086<br /><br />ROOT Access{169}ᐸ1086.startᐳ[1748]"):::bucket
-    Bucket283("Bucket 283 (nullableBoundary)<br />Deps: 1749, 1087<br /><br />ROOT Access{36}ᐸ1087.startᐳ[1749]"):::bucket
-    Bucket284("Bucket 284 (nullableBoundary)<br />Deps: 1750, 1088<br /><br />ROOT Access{37}ᐸ1088.startᐳ[1750]"):::bucket
-    Bucket285("Bucket 285 (nullableBoundary)<br />Deps: 1751, 1089<br /><br />ROOT Access{36}ᐸ1089.startᐳ[1751]"):::bucket
-    Bucket286("Bucket 286 (nullableBoundary)<br />Deps: 1752, 1090<br /><br />ROOT Access{37}ᐸ1090.startᐳ[1752]"):::bucket
-    Bucket287("Bucket 287 (nullableBoundary)<br />Deps: 1753, 1091<br /><br />ROOT Access{36}ᐸ1091.startᐳ[1753]"):::bucket
-    Bucket288("Bucket 288 (nullableBoundary)<br />Deps: 1754, 1092<br /><br />ROOT Access{37}ᐸ1092.startᐳ[1754]"):::bucket
+    Bucket281("Bucket 281 (nullableBoundary)<br />Deps: 1747, 2683, 2707<br /><br />ROOT Access{168}ᐸ1085.startᐳ[1747]"):::bucket
+    Bucket282("Bucket 282 (nullableBoundary)<br />Deps: 1748, 2684, 2708<br /><br />ROOT Access{169}ᐸ1086.startᐳ[1748]"):::bucket
+    Bucket283("Bucket 283 (nullableBoundary)<br />Deps: 1749, 2685, 2709<br /><br />ROOT Access{36}ᐸ1087.startᐳ[1749]"):::bucket
+    Bucket284("Bucket 284 (nullableBoundary)<br />Deps: 1750, 2686, 2710<br /><br />ROOT Access{37}ᐸ1088.startᐳ[1750]"):::bucket
+    Bucket285("Bucket 285 (nullableBoundary)<br />Deps: 1751, 2687, 2711<br /><br />ROOT Access{36}ᐸ1089.startᐳ[1751]"):::bucket
+    Bucket286("Bucket 286 (nullableBoundary)<br />Deps: 1752, 2688, 2712<br /><br />ROOT Access{37}ᐸ1090.startᐳ[1752]"):::bucket
+    Bucket287("Bucket 287 (nullableBoundary)<br />Deps: 1753, 2689, 2713<br /><br />ROOT Access{36}ᐸ1091.startᐳ[1753]"):::bucket
+    Bucket288("Bucket 288 (nullableBoundary)<br />Deps: 1754, 2690, 2714<br /><br />ROOT Access{37}ᐸ1092.startᐳ[1754]"):::bucket
     Bucket289("Bucket 289 (nullableBoundary)<br />Deps: 1764<br /><br />ROOT PgSelectSingle{36}ᐸfrmcdc_compoundTypeᐳ[1764]"):::bucket
     Bucket290("Bucket 290 (nullableBoundary)<br />Deps: 1770<br /><br />ROOT PgSelectSingle{37}ᐸfrmcdc_compoundTypeᐳ[1770]"):::bucket
     Bucket291("Bucket 291 (nullableBoundary)<br />Deps: 1780<br /><br />ROOT PgSelectSingle{172}ᐸfrmcdc_compoundTypeᐳ[1780]"):::bucket
     Bucket292("Bucket 292 (nullableBoundary)<br />Deps: 1788<br /><br />ROOT PgSelectSingle{173}ᐸfrmcdc_compoundTypeᐳ[1788]"):::bucket
-    Bucket293("Bucket 293 (nullableBoundary)<br />Deps: 1836, 1085<br /><br />ROOT Access{168}ᐸ1085.endᐳ[1836]"):::bucket
-    Bucket294("Bucket 294 (nullableBoundary)<br />Deps: 1837, 1086<br /><br />ROOT Access{169}ᐸ1086.endᐳ[1837]"):::bucket
-    Bucket295("Bucket 295 (nullableBoundary)<br />Deps: 1838, 1087<br /><br />ROOT Access{36}ᐸ1087.endᐳ[1838]"):::bucket
-    Bucket296("Bucket 296 (nullableBoundary)<br />Deps: 1839, 1088<br /><br />ROOT Access{37}ᐸ1088.endᐳ[1839]"):::bucket
-    Bucket297("Bucket 297 (nullableBoundary)<br />Deps: 1840, 1089<br /><br />ROOT Access{36}ᐸ1089.endᐳ[1840]"):::bucket
-    Bucket298("Bucket 298 (nullableBoundary)<br />Deps: 1841, 1090<br /><br />ROOT Access{37}ᐸ1090.endᐳ[1841]"):::bucket
-    Bucket299("Bucket 299 (nullableBoundary)<br />Deps: 1842, 1091<br /><br />ROOT Access{36}ᐸ1091.endᐳ[1842]"):::bucket
-    Bucket300("Bucket 300 (nullableBoundary)<br />Deps: 1843, 1092<br /><br />ROOT Access{37}ᐸ1092.endᐳ[1843]"):::bucket
+    Bucket293("Bucket 293 (nullableBoundary)<br />Deps: 1836, 2695, 2719<br /><br />ROOT Access{168}ᐸ1085.endᐳ[1836]"):::bucket
+    Bucket294("Bucket 294 (nullableBoundary)<br />Deps: 1837, 2696, 2720<br /><br />ROOT Access{169}ᐸ1086.endᐳ[1837]"):::bucket
+    Bucket295("Bucket 295 (nullableBoundary)<br />Deps: 1838, 2697, 2721<br /><br />ROOT Access{36}ᐸ1087.endᐳ[1838]"):::bucket
+    Bucket296("Bucket 296 (nullableBoundary)<br />Deps: 1839, 2698, 2722<br /><br />ROOT Access{37}ᐸ1088.endᐳ[1839]"):::bucket
+    Bucket297("Bucket 297 (nullableBoundary)<br />Deps: 1840, 2699, 2723<br /><br />ROOT Access{36}ᐸ1089.endᐳ[1840]"):::bucket
+    Bucket298("Bucket 298 (nullableBoundary)<br />Deps: 1841, 2700, 2724<br /><br />ROOT Access{37}ᐸ1090.endᐳ[1841]"):::bucket
+    Bucket299("Bucket 299 (nullableBoundary)<br />Deps: 1842, 2701, 2725<br /><br />ROOT Access{36}ᐸ1091.endᐳ[1842]"):::bucket
+    Bucket300("Bucket 300 (nullableBoundary)<br />Deps: 1843, 2702, 2726<br /><br />ROOT Access{37}ᐸ1092.endᐳ[1843]"):::bucket
     Bucket301("Bucket 301 (nullableBoundary)<br />Deps: 1853<br /><br />ROOT PgSelectSingle{36}ᐸfrmcdc_compoundTypeᐳ[1853]"):::bucket
     Bucket302("Bucket 302 (nullableBoundary)<br />Deps: 1859<br /><br />ROOT PgSelectSingle{37}ᐸfrmcdc_compoundTypeᐳ[1859]"):::bucket
     Bucket303("Bucket 303 (nullableBoundary)<br />Deps: 1867<br /><br />ROOT PgSelectSingle{172}ᐸfrmcdc_compoundTypeᐳ[1867]"):::bucket
@@ -308,38 +308,38 @@ graph TD
     Bucket305("Bucket 305 (nullableBoundary)<br />Deps: 1994<br /><br />ROOT __Item{266}ᐸ1537ᐳ[1994]"):::bucket
     Bucket306("Bucket 306 (nullableBoundary)<br />Deps: 1995<br /><br />ROOT __Item{267}ᐸ1538ᐳ[1995]"):::bucket
     Bucket307("Bucket 307 (nullableBoundary)<br />Deps: 1996<br /><br />ROOT __Item{268}ᐸ1539ᐳ[1996]"):::bucket
-    Bucket308("Bucket 308 (nullableBoundary)<br />Deps: 1298, 11, 4276, 4288, 4292, 4304<br /><br />ROOT PgSelectSingle{182}ᐸperson_type_function_connectionᐳ[1298]<br />1: <br />ᐳ: 2817, 2955, 3085, 3119, 3145, 3171, 3197, 3219, 3221, 3223, 3225, 3227, 3229, 3231, 3233, 3235, 3237, 3239, 3241, 3243, 3245, 3247, 3249, 3251, 3253, 3255, 3309, 3311, 3313, 3315, 3317, 3319, 3321, 3323, 3325, 3327, 3329, 3331, 3333, 3335, 3337, 3339, 3341, 3363, 3365, 4277, 4289, 4293, 4305, 3455, 3457, 3459, 3553, 3555, 3557, 4278, 4290, 4294, 4306, 4280, 4284<br />2: 3263, 3277, 3289, 3301, 3343, 3353<br />ᐳ: 3262, 3264, 3276, 3278, 3288, 3290, 3300, 3302, 3463, 3561, 3615, 3617, 3641, 3663, 3685, 3705, 4281, 4282, 4285, 4286<br />3: 3346, 3356, 3469, 3567<br />ᐳ: 3345, 3347, 3355, 3357, 3468, 3470, 3566, 3568"):::bucket
-    Bucket309("Bucket 309 (nullableBoundary)<br />Deps: 1300, 4402, 4406, 4410, 4422, 4426, 4438<br /><br />ROOT PgSelectSingle{183}ᐸtypesᐳ[1300]<br />1: <br />ᐳ: 2818, 2956, 3086, 3120, 3146, 3172, 3198, 3220, 3222, 3224, 3226, 3228, 3230, 3232, 3234, 3236, 3238, 3240, 3242, 3244, 3246, 3248, 3250, 3252, 3254, 3256, 3310, 3312, 3314, 3316, 3318, 3320, 3322, 3324, 3326, 3328, 3330, 3332, 3334, 3336, 3338, 3340, 3342, 3364, 3366, 4403, 4407, 4411, 4423, 4427, 4439, 3456, 3458, 3460, 3554, 3556, 3558, 4404, 4408, 4412, 4424, 4428, 4440, 4414, 4418<br />2: 3271, 3283, 3295, 3307, 3351, 3361<br />ᐳ: 3270, 3272, 3282, 3284, 3294, 3296, 3306, 3308, 3350, 3352, 3360, 3362, 3464, 3562, 3616, 3618, 3642, 3664, 3686, 3706, 4415, 4416, 4419, 4420<br />3: PgSelectRows[3475], PgSelectRows[3573]<br />ᐳ: 3474, 3476, 3572, 3574"):::bucket
-    Bucket310("Bucket 310 (nullableBoundary)<br />Deps: 2097, 1507<br /><br />ROOT Access{242}ᐸ1507.startᐳ[2097]"):::bucket
-    Bucket311("Bucket 311 (nullableBoundary)<br />Deps: 2098, 1508<br /><br />ROOT Access{243}ᐸ1508.startᐳ[2098]"):::bucket
-    Bucket312("Bucket 312 (nullableBoundary)<br />Deps: 2099, 1509<br /><br />ROOT Access{244}ᐸ1509.startᐳ[2099]"):::bucket
-    Bucket313("Bucket 313 (nullableBoundary)<br />Deps: 2100, 1510<br /><br />ROOT Access{86}ᐸ1510.startᐳ[2100]"):::bucket
-    Bucket314("Bucket 314 (nullableBoundary)<br />Deps: 2101, 1511<br /><br />ROOT Access{87}ᐸ1511.startᐳ[2101]"):::bucket
-    Bucket315("Bucket 315 (nullableBoundary)<br />Deps: 2102, 1512<br /><br />ROOT Access{90}ᐸ1512.startᐳ[2102]"):::bucket
-    Bucket316("Bucket 316 (nullableBoundary)<br />Deps: 2103, 1513<br /><br />ROOT Access{86}ᐸ1513.startᐳ[2103]"):::bucket
-    Bucket317("Bucket 317 (nullableBoundary)<br />Deps: 2104, 1514<br /><br />ROOT Access{87}ᐸ1514.startᐳ[2104]"):::bucket
-    Bucket318("Bucket 318 (nullableBoundary)<br />Deps: 2105, 1515<br /><br />ROOT Access{90}ᐸ1515.startᐳ[2105]"):::bucket
-    Bucket319("Bucket 319 (nullableBoundary)<br />Deps: 2106, 1516<br /><br />ROOT Access{86}ᐸ1516.startᐳ[2106]"):::bucket
-    Bucket320("Bucket 320 (nullableBoundary)<br />Deps: 2107, 1517<br /><br />ROOT Access{87}ᐸ1517.startᐳ[2107]"):::bucket
-    Bucket321("Bucket 321 (nullableBoundary)<br />Deps: 2108, 1518<br /><br />ROOT Access{90}ᐸ1518.startᐳ[2108]"):::bucket
+    Bucket308("Bucket 308 (nullableBoundary)<br />Deps: 1298, 11, 4276, 4288, 4292, 4304<br /><br />ROOT PgSelectSingle{182}ᐸperson_type_function_connectionᐳ[1298]<br />1: <br />ᐳ: 2817, 2955, 3085, 3119, 3145, 3171, 3197, 3219, 3221, 3223, 3225, 3227, 3229, 3231, 3233, 3235, 3237, 3239, 3241, 3243, 3245, 3247, 3249, 3251, 3253, 3255, 3309, 3311, 3313, 3315, 3317, 3319, 3321, 3323, 3325, 3327, 3329, 3331, 3333, 3335, 3337, 3339, 3341, 3363, 3365, 4277, 4289, 4293, 4305, 3455, 3457, 3459, 3461, 3495, 3553, 3555, 3557, 3559, 3589, 3613, 3639, 3661, 3683, 4278, 4290, 4294, 4306, 4280, 4284<br />2: 3263, 3277, 3289, 3301, 3343, 3353<br />ᐳ: 3262, 3264, 3276, 3278, 3288, 3290, 3300, 3302, 3463, 3561, 3615, 3617, 3641, 3663, 3685, 3705, 4281, 4282, 4285, 4286<br />3: 3346, 3356, 3469, 3567<br />ᐳ: 3345, 3347, 3355, 3357, 3468, 3470, 3566, 3568"):::bucket
+    Bucket309("Bucket 309 (nullableBoundary)<br />Deps: 1300, 4402, 4406, 4410, 4422, 4426, 4438<br /><br />ROOT PgSelectSingle{183}ᐸtypesᐳ[1300]<br />1: <br />ᐳ: 2818, 2956, 3086, 3120, 3146, 3172, 3198, 3220, 3222, 3224, 3226, 3228, 3230, 3232, 3234, 3236, 3238, 3240, 3242, 3244, 3246, 3248, 3250, 3252, 3254, 3256, 3310, 3312, 3314, 3316, 3318, 3320, 3322, 3324, 3326, 3328, 3330, 3332, 3334, 3336, 3338, 3340, 3342, 3364, 3366, 4403, 4407, 4411, 4423, 4427, 4439, 3456, 3458, 3460, 3462, 3496, 3554, 3556, 3558, 3560, 3590, 3614, 3640, 3662, 3684, 4404, 4408, 4412, 4424, 4428, 4440, 4414, 4418<br />2: 3271, 3283, 3295, 3307, 3351, 3361<br />ᐳ: 3270, 3272, 3282, 3284, 3294, 3296, 3306, 3308, 3350, 3352, 3360, 3362, 3464, 3562, 3616, 3618, 3642, 3664, 3686, 3706, 4415, 4416, 4419, 4420<br />3: PgSelectRows[3475], PgSelectRows[3573]<br />ᐳ: 3474, 3476, 3572, 3574"):::bucket
+    Bucket310("Bucket 310 (nullableBoundary)<br />Deps: 1507, 2097<br /><br />ROOT Access{242}ᐸ1507.startᐳ[2097]"):::bucket
+    Bucket311("Bucket 311 (nullableBoundary)<br />Deps: 1508, 2098<br /><br />ROOT Access{243}ᐸ1508.startᐳ[2098]"):::bucket
+    Bucket312("Bucket 312 (nullableBoundary)<br />Deps: 1509, 2099<br /><br />ROOT Access{244}ᐸ1509.startᐳ[2099]"):::bucket
+    Bucket313("Bucket 313 (nullableBoundary)<br />Deps: 1510, 2100<br /><br />ROOT Access{86}ᐸ1510.startᐳ[2100]"):::bucket
+    Bucket314("Bucket 314 (nullableBoundary)<br />Deps: 1511, 2101<br /><br />ROOT Access{87}ᐸ1511.startᐳ[2101]"):::bucket
+    Bucket315("Bucket 315 (nullableBoundary)<br />Deps: 1512, 2102<br /><br />ROOT Access{90}ᐸ1512.startᐳ[2102]"):::bucket
+    Bucket316("Bucket 316 (nullableBoundary)<br />Deps: 1513, 2103<br /><br />ROOT Access{86}ᐸ1513.startᐳ[2103]"):::bucket
+    Bucket317("Bucket 317 (nullableBoundary)<br />Deps: 1514, 2104<br /><br />ROOT Access{87}ᐸ1514.startᐳ[2104]"):::bucket
+    Bucket318("Bucket 318 (nullableBoundary)<br />Deps: 1515, 2105<br /><br />ROOT Access{90}ᐸ1515.startᐳ[2105]"):::bucket
+    Bucket319("Bucket 319 (nullableBoundary)<br />Deps: 1516, 2106<br /><br />ROOT Access{86}ᐸ1516.startᐳ[2106]"):::bucket
+    Bucket320("Bucket 320 (nullableBoundary)<br />Deps: 1517, 2107<br /><br />ROOT Access{87}ᐸ1517.startᐳ[2107]"):::bucket
+    Bucket321("Bucket 321 (nullableBoundary)<br />Deps: 1518, 2108<br /><br />ROOT Access{90}ᐸ1518.startᐳ[2108]"):::bucket
     Bucket322("Bucket 322 (nullableBoundary)<br />Deps: 2120<br /><br />ROOT PgSelectSingle{86}ᐸfrmcdc_compoundTypeᐳ[2120]"):::bucket
     Bucket323("Bucket 323 (nullableBoundary)<br />Deps: 2126<br /><br />ROOT PgSelectSingle{87}ᐸfrmcdc_compoundTypeᐳ[2126]"):::bucket
     Bucket324("Bucket 324 (nullableBoundary)<br />Deps: 2132<br /><br />ROOT PgSelectSingle{90}ᐸfrmcdc_compoundTypeᐳ[2132]"):::bucket
     Bucket325("Bucket 325 (nullableBoundary)<br />Deps: 2143<br /><br />ROOT PgSelectSingle{248}ᐸfrmcdc_compoundTypeᐳ[2143]"):::bucket
     Bucket326("Bucket 326 (nullableBoundary)<br />Deps: 2151<br /><br />ROOT PgSelectSingle{249}ᐸfrmcdc_compoundTypeᐳ[2151]"):::bucket
     Bucket327("Bucket 327 (nullableBoundary)<br />Deps: 2159<br /><br />ROOT PgSelectSingle{250}ᐸfrmcdc_compoundTypeᐳ[2159]"):::bucket
-    Bucket328("Bucket 328 (nullableBoundary)<br />Deps: 2202, 1507<br /><br />ROOT Access{242}ᐸ1507.endᐳ[2202]"):::bucket
-    Bucket329("Bucket 329 (nullableBoundary)<br />Deps: 2203, 1508<br /><br />ROOT Access{243}ᐸ1508.endᐳ[2203]"):::bucket
-    Bucket330("Bucket 330 (nullableBoundary)<br />Deps: 2204, 1509<br /><br />ROOT Access{244}ᐸ1509.endᐳ[2204]"):::bucket
-    Bucket331("Bucket 331 (nullableBoundary)<br />Deps: 2205, 1510<br /><br />ROOT Access{86}ᐸ1510.endᐳ[2205]"):::bucket
-    Bucket332("Bucket 332 (nullableBoundary)<br />Deps: 2206, 1511<br /><br />ROOT Access{87}ᐸ1511.endᐳ[2206]"):::bucket
-    Bucket333("Bucket 333 (nullableBoundary)<br />Deps: 2207, 1512<br /><br />ROOT Access{90}ᐸ1512.endᐳ[2207]"):::bucket
-    Bucket334("Bucket 334 (nullableBoundary)<br />Deps: 2208, 1513<br /><br />ROOT Access{86}ᐸ1513.endᐳ[2208]"):::bucket
-    Bucket335("Bucket 335 (nullableBoundary)<br />Deps: 2209, 1514<br /><br />ROOT Access{87}ᐸ1514.endᐳ[2209]"):::bucket
-    Bucket336("Bucket 336 (nullableBoundary)<br />Deps: 2210, 1515<br /><br />ROOT Access{90}ᐸ1515.endᐳ[2210]"):::bucket
-    Bucket337("Bucket 337 (nullableBoundary)<br />Deps: 2211, 1516<br /><br />ROOT Access{86}ᐸ1516.endᐳ[2211]"):::bucket
-    Bucket338("Bucket 338 (nullableBoundary)<br />Deps: 2212, 1517<br /><br />ROOT Access{87}ᐸ1517.endᐳ[2212]"):::bucket
-    Bucket339("Bucket 339 (nullableBoundary)<br />Deps: 2213, 1518<br /><br />ROOT Access{90}ᐸ1518.endᐳ[2213]"):::bucket
+    Bucket328("Bucket 328 (nullableBoundary)<br />Deps: 1507, 2202<br /><br />ROOT Access{242}ᐸ1507.endᐳ[2202]"):::bucket
+    Bucket329("Bucket 329 (nullableBoundary)<br />Deps: 1508, 2203<br /><br />ROOT Access{243}ᐸ1508.endᐳ[2203]"):::bucket
+    Bucket330("Bucket 330 (nullableBoundary)<br />Deps: 1509, 2204<br /><br />ROOT Access{244}ᐸ1509.endᐳ[2204]"):::bucket
+    Bucket331("Bucket 331 (nullableBoundary)<br />Deps: 1510, 2205<br /><br />ROOT Access{86}ᐸ1510.endᐳ[2205]"):::bucket
+    Bucket332("Bucket 332 (nullableBoundary)<br />Deps: 1511, 2206<br /><br />ROOT Access{87}ᐸ1511.endᐳ[2206]"):::bucket
+    Bucket333("Bucket 333 (nullableBoundary)<br />Deps: 1512, 2207<br /><br />ROOT Access{90}ᐸ1512.endᐳ[2207]"):::bucket
+    Bucket334("Bucket 334 (nullableBoundary)<br />Deps: 1513, 2208<br /><br />ROOT Access{86}ᐸ1513.endᐳ[2208]"):::bucket
+    Bucket335("Bucket 335 (nullableBoundary)<br />Deps: 1514, 2209<br /><br />ROOT Access{87}ᐸ1514.endᐳ[2209]"):::bucket
+    Bucket336("Bucket 336 (nullableBoundary)<br />Deps: 1515, 2210<br /><br />ROOT Access{90}ᐸ1515.endᐳ[2210]"):::bucket
+    Bucket337("Bucket 337 (nullableBoundary)<br />Deps: 1516, 2211<br /><br />ROOT Access{86}ᐸ1516.endᐳ[2211]"):::bucket
+    Bucket338("Bucket 338 (nullableBoundary)<br />Deps: 1517, 2212<br /><br />ROOT Access{87}ᐸ1517.endᐳ[2212]"):::bucket
+    Bucket339("Bucket 339 (nullableBoundary)<br />Deps: 1518, 2213<br /><br />ROOT Access{90}ᐸ1518.endᐳ[2213]"):::bucket
     Bucket340("Bucket 340 (nullableBoundary)<br />Deps: 2225<br /><br />ROOT PgSelectSingle{86}ᐸfrmcdc_compoundTypeᐳ[2225]"):::bucket
     Bucket341("Bucket 341 (nullableBoundary)<br />Deps: 2231<br /><br />ROOT PgSelectSingle{87}ᐸfrmcdc_compoundTypeᐳ[2231]"):::bucket
     Bucket342("Bucket 342 (nullableBoundary)<br />Deps: 2237<br /><br />ROOT PgSelectSingle{90}ᐸfrmcdc_compoundTypeᐳ[2237]"):::bucket
@@ -402,22 +402,22 @@ graph TD
     Bucket399("Bucket 399 (nullableBoundary)<br />Deps: 2780<br /><br />ROOT __Item{379}ᐸ2456ᐳ[2780]"):::bucket
     Bucket400("Bucket 400 (nullableBoundary)<br />Deps: 2781<br /><br />ROOT __Item{380}ᐸ2457ᐳ[2781]"):::bucket
     Bucket401("Bucket 401 (nullableBoundary)<br />Deps: 2782<br /><br />ROOT __Item{381}ᐸ2458ᐳ[2782]"):::bucket
-    Bucket402("Bucket 402 (nullableBoundary)<br />Deps: 2855, 2415<br /><br />ROOT Access{346}ᐸ2415.startᐳ[2855]"):::bucket
-    Bucket403("Bucket 403 (nullableBoundary)<br />Deps: 2856, 2416<br /><br />ROOT Access{347}ᐸ2416.startᐳ[2856]"):::bucket
-    Bucket404("Bucket 404 (nullableBoundary)<br />Deps: 2857, 2417<br /><br />ROOT Access{348}ᐸ2417.startᐳ[2857]"):::bucket
-    Bucket405("Bucket 405 (nullableBoundary)<br />Deps: 2858, 2418<br /><br />ROOT Access{349}ᐸ2418.startᐳ[2858]"):::bucket
-    Bucket406("Bucket 406 (nullableBoundary)<br />Deps: 2859, 2419<br /><br />ROOT Access{210}ᐸ2419.startᐳ[2859]"):::bucket
-    Bucket407("Bucket 407 (nullableBoundary)<br />Deps: 2860, 2420<br /><br />ROOT Access{211}ᐸ2420.startᐳ[2860]"):::bucket
-    Bucket408("Bucket 408 (nullableBoundary)<br />Deps: 2861, 2421<br /><br />ROOT Access{216}ᐸ2421.startᐳ[2861]"):::bucket
-    Bucket409("Bucket 409 (nullableBoundary)<br />Deps: 2862, 2422<br /><br />ROOT Access{217}ᐸ2422.startᐳ[2862]"):::bucket
-    Bucket410("Bucket 410 (nullableBoundary)<br />Deps: 2863, 2423<br /><br />ROOT Access{210}ᐸ2423.startᐳ[2863]"):::bucket
-    Bucket411("Bucket 411 (nullableBoundary)<br />Deps: 2864, 2424<br /><br />ROOT Access{211}ᐸ2424.startᐳ[2864]"):::bucket
-    Bucket412("Bucket 412 (nullableBoundary)<br />Deps: 2865, 2425<br /><br />ROOT Access{216}ᐸ2425.startᐳ[2865]"):::bucket
-    Bucket413("Bucket 413 (nullableBoundary)<br />Deps: 2866, 2426<br /><br />ROOT Access{217}ᐸ2426.startᐳ[2866]"):::bucket
-    Bucket414("Bucket 414 (nullableBoundary)<br />Deps: 2867, 2427<br /><br />ROOT Access{210}ᐸ2427.startᐳ[2867]"):::bucket
-    Bucket415("Bucket 415 (nullableBoundary)<br />Deps: 2868, 2428<br /><br />ROOT Access{211}ᐸ2428.startᐳ[2868]"):::bucket
-    Bucket416("Bucket 416 (nullableBoundary)<br />Deps: 2869, 2429<br /><br />ROOT Access{216}ᐸ2429.startᐳ[2869]"):::bucket
-    Bucket417("Bucket 417 (nullableBoundary)<br />Deps: 2870, 2430<br /><br />ROOT Access{217}ᐸ2430.startᐳ[2870]"):::bucket
+    Bucket402("Bucket 402 (nullableBoundary)<br />Deps: 2415, 2855<br /><br />ROOT Access{346}ᐸ2415.startᐳ[2855]"):::bucket
+    Bucket403("Bucket 403 (nullableBoundary)<br />Deps: 2416, 2856<br /><br />ROOT Access{347}ᐸ2416.startᐳ[2856]"):::bucket
+    Bucket404("Bucket 404 (nullableBoundary)<br />Deps: 2417, 2857<br /><br />ROOT Access{348}ᐸ2417.startᐳ[2857]"):::bucket
+    Bucket405("Bucket 405 (nullableBoundary)<br />Deps: 2418, 2858<br /><br />ROOT Access{349}ᐸ2418.startᐳ[2858]"):::bucket
+    Bucket406("Bucket 406 (nullableBoundary)<br />Deps: 2419, 2859<br /><br />ROOT Access{210}ᐸ2419.startᐳ[2859]"):::bucket
+    Bucket407("Bucket 407 (nullableBoundary)<br />Deps: 2420, 2860<br /><br />ROOT Access{211}ᐸ2420.startᐳ[2860]"):::bucket
+    Bucket408("Bucket 408 (nullableBoundary)<br />Deps: 2421, 2861<br /><br />ROOT Access{216}ᐸ2421.startᐳ[2861]"):::bucket
+    Bucket409("Bucket 409 (nullableBoundary)<br />Deps: 2422, 2862<br /><br />ROOT Access{217}ᐸ2422.startᐳ[2862]"):::bucket
+    Bucket410("Bucket 410 (nullableBoundary)<br />Deps: 2423, 2863<br /><br />ROOT Access{210}ᐸ2423.startᐳ[2863]"):::bucket
+    Bucket411("Bucket 411 (nullableBoundary)<br />Deps: 2424, 2864<br /><br />ROOT Access{211}ᐸ2424.startᐳ[2864]"):::bucket
+    Bucket412("Bucket 412 (nullableBoundary)<br />Deps: 2425, 2865<br /><br />ROOT Access{216}ᐸ2425.startᐳ[2865]"):::bucket
+    Bucket413("Bucket 413 (nullableBoundary)<br />Deps: 2426, 2866<br /><br />ROOT Access{217}ᐸ2426.startᐳ[2866]"):::bucket
+    Bucket414("Bucket 414 (nullableBoundary)<br />Deps: 2427, 2867<br /><br />ROOT Access{210}ᐸ2427.startᐳ[2867]"):::bucket
+    Bucket415("Bucket 415 (nullableBoundary)<br />Deps: 2428, 2868<br /><br />ROOT Access{211}ᐸ2428.startᐳ[2868]"):::bucket
+    Bucket416("Bucket 416 (nullableBoundary)<br />Deps: 2429, 2869<br /><br />ROOT Access{216}ᐸ2429.startᐳ[2869]"):::bucket
+    Bucket417("Bucket 417 (nullableBoundary)<br />Deps: 2430, 2870<br /><br />ROOT Access{217}ᐸ2430.startᐳ[2870]"):::bucket
     Bucket418("Bucket 418 (nullableBoundary)<br />Deps: 2884<br /><br />ROOT PgSelectSingle{210}ᐸfrmcdc_compoundTypeᐳ[2884]"):::bucket
     Bucket419("Bucket 419 (nullableBoundary)<br />Deps: 2890<br /><br />ROOT PgSelectSingle{211}ᐸfrmcdc_compoundTypeᐳ[2890]"):::bucket
     Bucket420("Bucket 420 (nullableBoundary)<br />Deps: 2896<br /><br />ROOT PgSelectSingle{216}ᐸfrmcdc_compoundTypeᐳ[2896]"):::bucket
@@ -426,22 +426,22 @@ graph TD
     Bucket423("Bucket 423 (nullableBoundary)<br />Deps: 2922<br /><br />ROOT PgSelectSingle{355}ᐸfrmcdc_compoundTypeᐳ[2922]"):::bucket
     Bucket424("Bucket 424 (nullableBoundary)<br />Deps: 2930<br /><br />ROOT PgSelectSingle{356}ᐸfrmcdc_compoundTypeᐳ[2930]"):::bucket
     Bucket425("Bucket 425 (nullableBoundary)<br />Deps: 2938<br /><br />ROOT PgSelectSingle{357}ᐸfrmcdc_compoundTypeᐳ[2938]"):::bucket
-    Bucket426("Bucket 426 (nullableBoundary)<br />Deps: 2993, 2415<br /><br />ROOT Access{346}ᐸ2415.endᐳ[2993]"):::bucket
-    Bucket427("Bucket 427 (nullableBoundary)<br />Deps: 2994, 2416<br /><br />ROOT Access{347}ᐸ2416.endᐳ[2994]"):::bucket
-    Bucket428("Bucket 428 (nullableBoundary)<br />Deps: 2995, 2417<br /><br />ROOT Access{348}ᐸ2417.endᐳ[2995]"):::bucket
-    Bucket429("Bucket 429 (nullableBoundary)<br />Deps: 2996, 2418<br /><br />ROOT Access{349}ᐸ2418.endᐳ[2996]"):::bucket
-    Bucket430("Bucket 430 (nullableBoundary)<br />Deps: 2997, 2419<br /><br />ROOT Access{210}ᐸ2419.endᐳ[2997]"):::bucket
-    Bucket431("Bucket 431 (nullableBoundary)<br />Deps: 2998, 2420<br /><br />ROOT Access{211}ᐸ2420.endᐳ[2998]"):::bucket
-    Bucket432("Bucket 432 (nullableBoundary)<br />Deps: 2999, 2421<br /><br />ROOT Access{216}ᐸ2421.endᐳ[2999]"):::bucket
-    Bucket433("Bucket 433 (nullableBoundary)<br />Deps: 3000, 2422<br /><br />ROOT Access{217}ᐸ2422.endᐳ[3000]"):::bucket
-    Bucket434("Bucket 434 (nullableBoundary)<br />Deps: 3001, 2423<br /><br />ROOT Access{210}ᐸ2423.endᐳ[3001]"):::bucket
-    Bucket435("Bucket 435 (nullableBoundary)<br />Deps: 3002, 2424<br /><br />ROOT Access{211}ᐸ2424.endᐳ[3002]"):::bucket
-    Bucket436("Bucket 436 (nullableBoundary)<br />Deps: 3003, 2425<br /><br />ROOT Access{216}ᐸ2425.endᐳ[3003]"):::bucket
-    Bucket437("Bucket 437 (nullableBoundary)<br />Deps: 3004, 2426<br /><br />ROOT Access{217}ᐸ2426.endᐳ[3004]"):::bucket
-    Bucket438("Bucket 438 (nullableBoundary)<br />Deps: 3005, 2427<br /><br />ROOT Access{210}ᐸ2427.endᐳ[3005]"):::bucket
-    Bucket439("Bucket 439 (nullableBoundary)<br />Deps: 3006, 2428<br /><br />ROOT Access{211}ᐸ2428.endᐳ[3006]"):::bucket
-    Bucket440("Bucket 440 (nullableBoundary)<br />Deps: 3007, 2429<br /><br />ROOT Access{216}ᐸ2429.endᐳ[3007]"):::bucket
-    Bucket441("Bucket 441 (nullableBoundary)<br />Deps: 3008, 2430<br /><br />ROOT Access{217}ᐸ2430.endᐳ[3008]"):::bucket
+    Bucket426("Bucket 426 (nullableBoundary)<br />Deps: 2415, 2993<br /><br />ROOT Access{346}ᐸ2415.endᐳ[2993]"):::bucket
+    Bucket427("Bucket 427 (nullableBoundary)<br />Deps: 2416, 2994<br /><br />ROOT Access{347}ᐸ2416.endᐳ[2994]"):::bucket
+    Bucket428("Bucket 428 (nullableBoundary)<br />Deps: 2417, 2995<br /><br />ROOT Access{348}ᐸ2417.endᐳ[2995]"):::bucket
+    Bucket429("Bucket 429 (nullableBoundary)<br />Deps: 2418, 2996<br /><br />ROOT Access{349}ᐸ2418.endᐳ[2996]"):::bucket
+    Bucket430("Bucket 430 (nullableBoundary)<br />Deps: 2419, 2997<br /><br />ROOT Access{210}ᐸ2419.endᐳ[2997]"):::bucket
+    Bucket431("Bucket 431 (nullableBoundary)<br />Deps: 2420, 2998<br /><br />ROOT Access{211}ᐸ2420.endᐳ[2998]"):::bucket
+    Bucket432("Bucket 432 (nullableBoundary)<br />Deps: 2421, 2999<br /><br />ROOT Access{216}ᐸ2421.endᐳ[2999]"):::bucket
+    Bucket433("Bucket 433 (nullableBoundary)<br />Deps: 2422, 3000<br /><br />ROOT Access{217}ᐸ2422.endᐳ[3000]"):::bucket
+    Bucket434("Bucket 434 (nullableBoundary)<br />Deps: 2423, 3001<br /><br />ROOT Access{210}ᐸ2423.endᐳ[3001]"):::bucket
+    Bucket435("Bucket 435 (nullableBoundary)<br />Deps: 2424, 3002<br /><br />ROOT Access{211}ᐸ2424.endᐳ[3002]"):::bucket
+    Bucket436("Bucket 436 (nullableBoundary)<br />Deps: 2425, 3003<br /><br />ROOT Access{216}ᐸ2425.endᐳ[3003]"):::bucket
+    Bucket437("Bucket 437 (nullableBoundary)<br />Deps: 2426, 3004<br /><br />ROOT Access{217}ᐸ2426.endᐳ[3004]"):::bucket
+    Bucket438("Bucket 438 (nullableBoundary)<br />Deps: 2427, 3005<br /><br />ROOT Access{210}ᐸ2427.endᐳ[3005]"):::bucket
+    Bucket439("Bucket 439 (nullableBoundary)<br />Deps: 2428, 3006<br /><br />ROOT Access{211}ᐸ2428.endᐳ[3006]"):::bucket
+    Bucket440("Bucket 440 (nullableBoundary)<br />Deps: 2429, 3007<br /><br />ROOT Access{216}ᐸ2429.endᐳ[3007]"):::bucket
+    Bucket441("Bucket 441 (nullableBoundary)<br />Deps: 2430, 3008<br /><br />ROOT Access{217}ᐸ2430.endᐳ[3008]"):::bucket
     Bucket442("Bucket 442 (nullableBoundary)<br />Deps: 3022<br /><br />ROOT PgSelectSingle{210}ᐸfrmcdc_compoundTypeᐳ[3022]"):::bucket
     Bucket443("Bucket 443 (nullableBoundary)<br />Deps: 3028<br /><br />ROOT PgSelectSingle{211}ᐸfrmcdc_compoundTypeᐳ[3028]"):::bucket
     Bucket444("Bucket 444 (nullableBoundary)<br />Deps: 3034<br /><br />ROOT PgSelectSingle{216}ᐸfrmcdc_compoundTypeᐳ[3034]"):::bucket
@@ -478,26 +478,26 @@ graph TD
     Bucket475("Bucket 475 (listItem)<br /><br />ROOT __Item{475}ᐸ3366ᐳ[3380]"):::bucket
     Bucket476("Bucket 476 (nullableBoundary)<br />Deps: 3371<br /><br />ROOT __Item{466}ᐸ3253ᐳ[3371]"):::bucket
     Bucket477("Bucket 477 (nullableBoundary)<br />Deps: 3372<br /><br />ROOT __Item{467}ᐸ3254ᐳ[3372]"):::bucket
-    Bucket478("Bucket 478 (nullableBoundary)<br />Deps: 3453, 3233<br /><br />ROOT Access{450}ᐸ3233.startᐳ[3453]"):::bucket
-    Bucket479("Bucket 479 (nullableBoundary)<br />Deps: 3454, 3234<br /><br />ROOT Access{451}ᐸ3234.startᐳ[3454]"):::bucket
-    Bucket480("Bucket 480 (nullableBoundary)<br />Deps: 3455, 3235<br /><br />ROOT Access{308}ᐸ3235.startᐳ[3455]"):::bucket
-    Bucket481("Bucket 481 (nullableBoundary)<br />Deps: 3456, 3236<br /><br />ROOT Access{309}ᐸ3236.startᐳ[3456]"):::bucket
-    Bucket482("Bucket 482 (nullableBoundary)<br />Deps: 3457, 3237<br /><br />ROOT Access{308}ᐸ3237.startᐳ[3457]"):::bucket
-    Bucket483("Bucket 483 (nullableBoundary)<br />Deps: 3458, 3238<br /><br />ROOT Access{309}ᐸ3238.startᐳ[3458]"):::bucket
-    Bucket484("Bucket 484 (nullableBoundary)<br />Deps: 3459, 3239<br /><br />ROOT Access{308}ᐸ3239.startᐳ[3459]"):::bucket
-    Bucket485("Bucket 485 (nullableBoundary)<br />Deps: 3460, 3240<br /><br />ROOT Access{309}ᐸ3240.startᐳ[3460]"):::bucket
+    Bucket478("Bucket 478 (nullableBoundary)<br />Deps: 3233, 3453<br /><br />ROOT Access{450}ᐸ3233.startᐳ[3453]"):::bucket
+    Bucket479("Bucket 479 (nullableBoundary)<br />Deps: 3234, 3454<br /><br />ROOT Access{451}ᐸ3234.startᐳ[3454]"):::bucket
+    Bucket480("Bucket 480 (nullableBoundary)<br />Deps: 3235, 3455<br /><br />ROOT Access{308}ᐸ3235.startᐳ[3455]"):::bucket
+    Bucket481("Bucket 481 (nullableBoundary)<br />Deps: 3236, 3456<br /><br />ROOT Access{309}ᐸ3236.startᐳ[3456]"):::bucket
+    Bucket482("Bucket 482 (nullableBoundary)<br />Deps: 3237, 3457<br /><br />ROOT Access{308}ᐸ3237.startᐳ[3457]"):::bucket
+    Bucket483("Bucket 483 (nullableBoundary)<br />Deps: 3238, 3458<br /><br />ROOT Access{309}ᐸ3238.startᐳ[3458]"):::bucket
+    Bucket484("Bucket 484 (nullableBoundary)<br />Deps: 3239, 3459<br /><br />ROOT Access{308}ᐸ3239.startᐳ[3459]"):::bucket
+    Bucket485("Bucket 485 (nullableBoundary)<br />Deps: 3240, 3460<br /><br />ROOT Access{309}ᐸ3240.startᐳ[3460]"):::bucket
     Bucket486("Bucket 486 (nullableBoundary)<br />Deps: 3470<br /><br />ROOT PgSelectSingle{308}ᐸfrmcdc_compoundTypeᐳ[3470]"):::bucket
     Bucket487("Bucket 487 (nullableBoundary)<br />Deps: 3476<br /><br />ROOT PgSelectSingle{309}ᐸfrmcdc_compoundTypeᐳ[3476]"):::bucket
     Bucket488("Bucket 488 (nullableBoundary)<br />Deps: 3486<br /><br />ROOT PgSelectSingle{454}ᐸfrmcdc_compoundTypeᐳ[3486]"):::bucket
     Bucket489("Bucket 489 (nullableBoundary)<br />Deps: 3494<br /><br />ROOT PgSelectSingle{455}ᐸfrmcdc_compoundTypeᐳ[3494]"):::bucket
-    Bucket490("Bucket 490 (nullableBoundary)<br />Deps: 3551, 3233<br /><br />ROOT Access{450}ᐸ3233.endᐳ[3551]"):::bucket
-    Bucket491("Bucket 491 (nullableBoundary)<br />Deps: 3552, 3234<br /><br />ROOT Access{451}ᐸ3234.endᐳ[3552]"):::bucket
-    Bucket492("Bucket 492 (nullableBoundary)<br />Deps: 3553, 3235<br /><br />ROOT Access{308}ᐸ3235.endᐳ[3553]"):::bucket
-    Bucket493("Bucket 493 (nullableBoundary)<br />Deps: 3554, 3236<br /><br />ROOT Access{309}ᐸ3236.endᐳ[3554]"):::bucket
-    Bucket494("Bucket 494 (nullableBoundary)<br />Deps: 3555, 3237<br /><br />ROOT Access{308}ᐸ3237.endᐳ[3555]"):::bucket
-    Bucket495("Bucket 495 (nullableBoundary)<br />Deps: 3556, 3238<br /><br />ROOT Access{309}ᐸ3238.endᐳ[3556]"):::bucket
-    Bucket496("Bucket 496 (nullableBoundary)<br />Deps: 3557, 3239<br /><br />ROOT Access{308}ᐸ3239.endᐳ[3557]"):::bucket
-    Bucket497("Bucket 497 (nullableBoundary)<br />Deps: 3558, 3240<br /><br />ROOT Access{309}ᐸ3240.endᐳ[3558]"):::bucket
+    Bucket490("Bucket 490 (nullableBoundary)<br />Deps: 3233, 3551<br /><br />ROOT Access{450}ᐸ3233.endᐳ[3551]"):::bucket
+    Bucket491("Bucket 491 (nullableBoundary)<br />Deps: 3234, 3552<br /><br />ROOT Access{451}ᐸ3234.endᐳ[3552]"):::bucket
+    Bucket492("Bucket 492 (nullableBoundary)<br />Deps: 3235, 3553<br /><br />ROOT Access{308}ᐸ3235.endᐳ[3553]"):::bucket
+    Bucket493("Bucket 493 (nullableBoundary)<br />Deps: 3236, 3554<br /><br />ROOT Access{309}ᐸ3236.endᐳ[3554]"):::bucket
+    Bucket494("Bucket 494 (nullableBoundary)<br />Deps: 3237, 3555<br /><br />ROOT Access{308}ᐸ3237.endᐳ[3555]"):::bucket
+    Bucket495("Bucket 495 (nullableBoundary)<br />Deps: 3238, 3556<br /><br />ROOT Access{309}ᐸ3238.endᐳ[3556]"):::bucket
+    Bucket496("Bucket 496 (nullableBoundary)<br />Deps: 3239, 3557<br /><br />ROOT Access{308}ᐸ3239.endᐳ[3557]"):::bucket
+    Bucket497("Bucket 497 (nullableBoundary)<br />Deps: 3240, 3558<br /><br />ROOT Access{309}ᐸ3240.endᐳ[3558]"):::bucket
     Bucket498("Bucket 498 (nullableBoundary)<br />Deps: 3568<br /><br />ROOT PgSelectSingle{308}ᐸfrmcdc_compoundTypeᐳ[3568]"):::bucket
     Bucket499("Bucket 499 (nullableBoundary)<br />Deps: 3574<br /><br />ROOT PgSelectSingle{309}ᐸfrmcdc_compoundTypeᐳ[3574]"):::bucket
     Bucket500("Bucket 500 (nullableBoundary)<br />Deps: 3582<br /><br />ROOT PgSelectSingle{454}ᐸfrmcdc_compoundTypeᐳ[3582]"):::bucket
@@ -834,7 +834,7 @@ graph TD
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access9
     __Value2 --> Access10
-    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 2"]]:::plan
+    Connection12[["Connection[12∈0] ➊<br />ᐸ8ᐳ<br />Dependents: 4"]]:::plan
     PgSelect8 --> Connection12
     First19{{"First[19∈0] ➊"}}:::plan
     PgSelectRows20[["PgSelectRows[20∈0] ➊"]]:::plan
@@ -856,7 +856,7 @@ graph TD
     PgSelect31 --> PgSelectRows35
     PgSelectSingle36{{"PgSelectSingle[36∈0] ➊<br />ᐸtype_functionᐳ"}}:::plan
     First34 --> PgSelectSingle36
-    Connection41[["Connection[41∈0] ➊<br />ᐸ39ᐳ<br />Dependents: 2"]]:::plan
+    Connection41[["Connection[41∈0] ➊<br />ᐸ39ᐳ<br />Dependents: 4"]]:::plan
     PgSelect39 --> Connection41
     PgSelectRows46[["PgSelectRows[46∈0] ➊"]]:::plan
     PgSelectRows46 --> First45
@@ -1017,6 +1017,8 @@ graph TD
     Lambda4448{{"Lambda[4448∈0] ➊<br />ᐸpgInlineViaSubqueryTransformᐳ"}}:::plan
     List4447 --> Lambda4448
     PageInfo309{{"PageInfo[309∈1] ➊<br />More deps:<br />- Connection[12]"}}:::plan
+    Access834{{"Access[834∈1] ➊<br />ᐸ12.hasNextPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
+    Access918{{"Access[918∈1] ➊<br />ᐸ12.hasPreviousPageᐳ<br />More deps:<br />- Connection[12]"}}:::plan
     List3931{{"List[3931∈2] ➊<br />ᐸ3930,21ᐳ"}}:::plan
     Access3930 & PgSelectSingle21 --> List3931
     List3935{{"List[3935∈2] ➊<br />ᐸ3934,21ᐳ"}}:::plan
@@ -1173,6 +1175,8 @@ graph TD
     PgClassExpression354 --> Access845
     Access848{{"Access[848∈2] ➊<br />ᐸ357.startᐳ"}}:::plan
     PgClassExpression357 --> Access848
+    Access851{{"Access[851∈2] ➊<br />ᐸ375.yearsᐳ"}}:::plan
+    PgClassExpression375 --> Access851
     PgClassExpression854{{"PgClassExpression[854∈2] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression854
     First860{{"First[860∈2] ➊"}}:::plan
@@ -1182,12 +1186,16 @@ graph TD
     Lambda3944 --> PgSelectRows861
     PgSelectSingle862{{"PgSelectSingle[862∈2] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First860 --> PgSelectSingle862
+    Access902{{"Access[902∈2] ➊<br />ᐸ462.xᐳ"}}:::plan
+    PgClassExpression462 --> Access902
     Access925{{"Access[925∈2] ➊<br />ᐸ351.endᐳ"}}:::plan
     PgClassExpression351 --> Access925
     Access928{{"Access[928∈2] ➊<br />ᐸ354.endᐳ"}}:::plan
     PgClassExpression354 --> Access928
     Access931{{"Access[931∈2] ➊<br />ᐸ357.endᐳ"}}:::plan
     PgClassExpression357 --> Access931
+    Access934{{"Access[934∈2] ➊<br />ᐸ375.monthsᐳ"}}:::plan
+    PgClassExpression375 --> Access934
     PgClassExpression937{{"PgClassExpression[937∈2] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression937
     First943{{"First[943∈2] ➊"}}:::plan
@@ -1197,18 +1205,52 @@ graph TD
     Lambda3948 --> PgSelectRows944
     PgSelectSingle945{{"PgSelectSingle[945∈2] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First943 --> PgSelectSingle945
+    Access979{{"Access[979∈2] ➊<br />ᐸ462.yᐳ"}}:::plan
+    PgClassExpression462 --> Access979
+    Access1009{{"Access[1009∈2] ➊<br />ᐸ375.daysᐳ"}}:::plan
+    PgClassExpression375 --> Access1009
     PgClassExpression1012{{"PgClassExpression[1012∈2] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression1012
     PgClassExpression1015{{"PgClassExpression[1015∈2] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle413 --> PgClassExpression1015
+    Access1032{{"Access[1032∈2] ➊<br />ᐸ375.hoursᐳ"}}:::plan
+    PgClassExpression375 --> Access1032
     PgClassExpression1035{{"PgClassExpression[1035∈2] ➊<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression1035
+    Access1043{{"Access[1043∈2] ➊<br />ᐸ375.minutesᐳ"}}:::plan
+    PgClassExpression375 --> Access1043
     PgClassExpression1046{{"PgClassExpression[1046∈2] ➊<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression1046
+    Access1054{{"Access[1054∈2] ➊<br />ᐸ375.secondsᐳ"}}:::plan
+    PgClassExpression375 --> Access1054
     PgClassExpression1057{{"PgClassExpression[1057∈2] ➊<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression1057
     PgClassExpression1065{{"PgClassExpression[1065∈2] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle391 --> PgClassExpression1065
+    Access1712{{"Access[1712∈2] ➊<br />ᐸ351.start.valueᐳ"}}:::plan
+    PgClassExpression351 --> Access1712
+    Access1715{{"Access[1715∈2] ➊<br />ᐸ354.start.valueᐳ"}}:::plan
+    PgClassExpression354 --> Access1715
+    Access1718{{"Access[1718∈2] ➊<br />ᐸ357.start.valueᐳ"}}:::plan
+    PgClassExpression357 --> Access1718
+    Access1730{{"Access[1730∈2] ➊<br />ᐸ351.end.valueᐳ"}}:::plan
+    PgClassExpression351 --> Access1730
+    Access1733{{"Access[1733∈2] ➊<br />ᐸ354.end.valueᐳ"}}:::plan
+    PgClassExpression354 --> Access1733
+    Access1736{{"Access[1736∈2] ➊<br />ᐸ357.end.valueᐳ"}}:::plan
+    PgClassExpression357 --> Access1736
+    Access1801{{"Access[1801∈2] ➊<br />ᐸ351.start.inclusiveᐳ"}}:::plan
+    PgClassExpression351 --> Access1801
+    Access1804{{"Access[1804∈2] ➊<br />ᐸ354.start.inclusiveᐳ"}}:::plan
+    PgClassExpression354 --> Access1804
+    Access1807{{"Access[1807∈2] ➊<br />ᐸ357.start.inclusiveᐳ"}}:::plan
+    PgClassExpression357 --> Access1807
+    Access1819{{"Access[1819∈2] ➊<br />ᐸ351.end.inclusiveᐳ"}}:::plan
+    PgClassExpression351 --> Access1819
+    Access1822{{"Access[1822∈2] ➊<br />ᐸ354.end.inclusiveᐳ"}}:::plan
+    PgClassExpression354 --> Access1822
+    Access1825{{"Access[1825∈2] ➊<br />ᐸ357.end.inclusiveᐳ"}}:::plan
+    PgClassExpression357 --> Access1825
     List3931 --> Lambda3932
     List3935 --> Lambda3936
     List3939 --> Lambda3940
@@ -1379,6 +1421,8 @@ graph TD
     PgClassExpression355 --> Access846
     Access849{{"Access[849∈3] ➊<br />ᐸ358.startᐳ"}}:::plan
     PgClassExpression358 --> Access849
+    Access852{{"Access[852∈3] ➊<br />ᐸ376.yearsᐳ"}}:::plan
+    PgClassExpression376 --> Access852
     PgClassExpression855{{"PgClassExpression[855∈3] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression855
     First866{{"First[866∈3] ➊"}}:::plan
@@ -1388,12 +1432,16 @@ graph TD
     Lambda3984 --> PgSelectRows867
     PgSelectSingle868{{"PgSelectSingle[868∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First866 --> PgSelectSingle868
+    Access903{{"Access[903∈3] ➊<br />ᐸ463.xᐳ"}}:::plan
+    PgClassExpression463 --> Access903
     Access926{{"Access[926∈3] ➊<br />ᐸ352.endᐳ"}}:::plan
     PgClassExpression352 --> Access926
     Access929{{"Access[929∈3] ➊<br />ᐸ355.endᐳ"}}:::plan
     PgClassExpression355 --> Access929
     Access932{{"Access[932∈3] ➊<br />ᐸ358.endᐳ"}}:::plan
     PgClassExpression358 --> Access932
+    Access935{{"Access[935∈3] ➊<br />ᐸ376.monthsᐳ"}}:::plan
+    PgClassExpression376 --> Access935
     PgClassExpression938{{"PgClassExpression[938∈3] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression938
     First949{{"First[949∈3] ➊"}}:::plan
@@ -1403,18 +1451,52 @@ graph TD
     Lambda3988 --> PgSelectRows950
     PgSelectSingle951{{"PgSelectSingle[951∈3] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First949 --> PgSelectSingle951
+    Access980{{"Access[980∈3] ➊<br />ᐸ463.yᐳ"}}:::plan
+    PgClassExpression463 --> Access980
+    Access1010{{"Access[1010∈3] ➊<br />ᐸ376.daysᐳ"}}:::plan
+    PgClassExpression376 --> Access1010
     PgClassExpression1013{{"PgClassExpression[1013∈3] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression1013
     PgClassExpression1016{{"PgClassExpression[1016∈3] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle419 --> PgClassExpression1016
+    Access1033{{"Access[1033∈3] ➊<br />ᐸ376.hoursᐳ"}}:::plan
+    PgClassExpression376 --> Access1033
     PgClassExpression1036{{"PgClassExpression[1036∈3] ➊<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression1036
+    Access1044{{"Access[1044∈3] ➊<br />ᐸ376.minutesᐳ"}}:::plan
+    PgClassExpression376 --> Access1044
     PgClassExpression1047{{"PgClassExpression[1047∈3] ➊<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression1047
+    Access1055{{"Access[1055∈3] ➊<br />ᐸ376.secondsᐳ"}}:::plan
+    PgClassExpression376 --> Access1055
     PgClassExpression1058{{"PgClassExpression[1058∈3] ➊<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression1058
     PgClassExpression1066{{"PgClassExpression[1066∈3] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle399 --> PgClassExpression1066
+    Access1713{{"Access[1713∈3] ➊<br />ᐸ352.start.valueᐳ"}}:::plan
+    PgClassExpression352 --> Access1713
+    Access1716{{"Access[1716∈3] ➊<br />ᐸ355.start.valueᐳ"}}:::plan
+    PgClassExpression355 --> Access1716
+    Access1719{{"Access[1719∈3] ➊<br />ᐸ358.start.valueᐳ"}}:::plan
+    PgClassExpression358 --> Access1719
+    Access1731{{"Access[1731∈3] ➊<br />ᐸ352.end.valueᐳ"}}:::plan
+    PgClassExpression352 --> Access1731
+    Access1734{{"Access[1734∈3] ➊<br />ᐸ355.end.valueᐳ"}}:::plan
+    PgClassExpression355 --> Access1734
+    Access1737{{"Access[1737∈3] ➊<br />ᐸ358.end.valueᐳ"}}:::plan
+    PgClassExpression358 --> Access1737
+    Access1802{{"Access[1802∈3] ➊<br />ᐸ352.start.inclusiveᐳ"}}:::plan
+    PgClassExpression352 --> Access1802
+    Access1805{{"Access[1805∈3] ➊<br />ᐸ355.start.inclusiveᐳ"}}:::plan
+    PgClassExpression355 --> Access1805
+    Access1808{{"Access[1808∈3] ➊<br />ᐸ358.start.inclusiveᐳ"}}:::plan
+    PgClassExpression358 --> Access1808
+    Access1820{{"Access[1820∈3] ➊<br />ᐸ352.end.inclusiveᐳ"}}:::plan
+    PgClassExpression352 --> Access1820
+    Access1823{{"Access[1823∈3] ➊<br />ᐸ355.end.inclusiveᐳ"}}:::plan
+    PgClassExpression355 --> Access1823
+    Access1826{{"Access[1826∈3] ➊<br />ᐸ358.end.inclusiveᐳ"}}:::plan
+    PgClassExpression358 --> Access1826
     List3971 --> Lambda3972
     List3975 --> Lambda3976
     List3979 --> Lambda3980
@@ -1585,6 +1667,8 @@ graph TD
     PgClassExpression356 --> Access847
     Access850{{"Access[850∈4] ➊<br />ᐸ359.startᐳ"}}:::plan
     PgClassExpression359 --> Access850
+    Access853{{"Access[853∈4] ➊<br />ᐸ377.yearsᐳ"}}:::plan
+    PgClassExpression377 --> Access853
     PgClassExpression856{{"PgClassExpression[856∈4] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression856
     First872{{"First[872∈4] ➊"}}:::plan
@@ -1594,12 +1678,16 @@ graph TD
     Lambda4024 --> PgSelectRows873
     PgSelectSingle874{{"PgSelectSingle[874∈4] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First872 --> PgSelectSingle874
+    Access904{{"Access[904∈4] ➊<br />ᐸ464.xᐳ"}}:::plan
+    PgClassExpression464 --> Access904
     Access927{{"Access[927∈4] ➊<br />ᐸ353.endᐳ"}}:::plan
     PgClassExpression353 --> Access927
     Access930{{"Access[930∈4] ➊<br />ᐸ356.endᐳ"}}:::plan
     PgClassExpression356 --> Access930
     Access933{{"Access[933∈4] ➊<br />ᐸ359.endᐳ"}}:::plan
     PgClassExpression359 --> Access933
+    Access936{{"Access[936∈4] ➊<br />ᐸ377.monthsᐳ"}}:::plan
+    PgClassExpression377 --> Access936
     PgClassExpression939{{"PgClassExpression[939∈4] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression939
     First955{{"First[955∈4] ➊"}}:::plan
@@ -1609,18 +1697,52 @@ graph TD
     Lambda4028 --> PgSelectRows956
     PgSelectSingle957{{"PgSelectSingle[957∈4] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First955 --> PgSelectSingle957
+    Access981{{"Access[981∈4] ➊<br />ᐸ464.yᐳ"}}:::plan
+    PgClassExpression464 --> Access981
+    Access1011{{"Access[1011∈4] ➊<br />ᐸ377.daysᐳ"}}:::plan
+    PgClassExpression377 --> Access1011
     PgClassExpression1014{{"PgClassExpression[1014∈4] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression1014
     PgClassExpression1017{{"PgClassExpression[1017∈4] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle425 --> PgClassExpression1017
+    Access1034{{"Access[1034∈4] ➊<br />ᐸ377.hoursᐳ"}}:::plan
+    PgClassExpression377 --> Access1034
     PgClassExpression1037{{"PgClassExpression[1037∈4] ➊<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression1037
+    Access1045{{"Access[1045∈4] ➊<br />ᐸ377.minutesᐳ"}}:::plan
+    PgClassExpression377 --> Access1045
     PgClassExpression1048{{"PgClassExpression[1048∈4] ➊<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression1048
+    Access1056{{"Access[1056∈4] ➊<br />ᐸ377.secondsᐳ"}}:::plan
+    PgClassExpression377 --> Access1056
     PgClassExpression1059{{"PgClassExpression[1059∈4] ➊<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression1059
     PgClassExpression1067{{"PgClassExpression[1067∈4] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle407 --> PgClassExpression1067
+    Access1714{{"Access[1714∈4] ➊<br />ᐸ353.start.valueᐳ"}}:::plan
+    PgClassExpression353 --> Access1714
+    Access1717{{"Access[1717∈4] ➊<br />ᐸ356.start.valueᐳ"}}:::plan
+    PgClassExpression356 --> Access1717
+    Access1720{{"Access[1720∈4] ➊<br />ᐸ359.start.valueᐳ"}}:::plan
+    PgClassExpression359 --> Access1720
+    Access1732{{"Access[1732∈4] ➊<br />ᐸ353.end.valueᐳ"}}:::plan
+    PgClassExpression353 --> Access1732
+    Access1735{{"Access[1735∈4] ➊<br />ᐸ356.end.valueᐳ"}}:::plan
+    PgClassExpression356 --> Access1735
+    Access1738{{"Access[1738∈4] ➊<br />ᐸ359.end.valueᐳ"}}:::plan
+    PgClassExpression359 --> Access1738
+    Access1803{{"Access[1803∈4] ➊<br />ᐸ353.start.inclusiveᐳ"}}:::plan
+    PgClassExpression353 --> Access1803
+    Access1806{{"Access[1806∈4] ➊<br />ᐸ356.start.inclusiveᐳ"}}:::plan
+    PgClassExpression356 --> Access1806
+    Access1809{{"Access[1809∈4] ➊<br />ᐸ359.start.inclusiveᐳ"}}:::plan
+    PgClassExpression359 --> Access1809
+    Access1821{{"Access[1821∈4] ➊<br />ᐸ353.end.inclusiveᐳ"}}:::plan
+    PgClassExpression353 --> Access1821
+    Access1824{{"Access[1824∈4] ➊<br />ᐸ356.end.inclusiveᐳ"}}:::plan
+    PgClassExpression356 --> Access1824
+    Access1827{{"Access[1827∈4] ➊<br />ᐸ359.end.inclusiveᐳ"}}:::plan
+    PgClassExpression359 --> Access1827
     List4011 --> Lambda4012
     List4015 --> Lambda4016
     List4019 --> Lambda4020
@@ -1636,6 +1758,8 @@ graph TD
     Lambda4048 --> Access4042
     List4047 --> Lambda4048
     PageInfo313{{"PageInfo[313∈5] ➊<br />More deps:<br />- Connection[41]"}}:::plan
+    Access835{{"Access[835∈5] ➊<br />ᐸ41.hasNextPageᐳ<br />More deps:<br />- Connection[41]"}}:::plan
+    Access919{{"Access[919∈5] ➊<br />ᐸ41.hasPreviousPageᐳ<br />More deps:<br />- Connection[41]"}}:::plan
     PgCursor1897{{"PgCursor[1897∈6] ➊"}}:::plan
     First1895{{"First[1895∈6] ➊"}}:::plan
     Access1896{{"Access[1896∈6] ➊<br />ᐸ4311.cursorDetailsᐳ"}}:::plan
@@ -1668,6 +1792,10 @@ graph TD
     PgSelectSingle995 --> PgClassExpression996
     PageInfo1025{{"PageInfo[1025∈6] ➊"}}:::plan
     Connection300 --> PageInfo1025
+    Access1745{{"Access[1745∈6] ➊<br />ᐸ300.hasNextPageᐳ"}}:::plan
+    Connection300 --> Access1745
+    Access1834{{"Access[1834∈6] ➊<br />ᐸ300.hasPreviousPageᐳ"}}:::plan
+    Connection300 --> Access1834
     ConnectionItems830 --> First1895
     Lambda4311 --> Access1896
     ConnectionItems830 --> Last1924
@@ -1746,6 +1874,10 @@ graph TD
     PgSelectSingle1007 --> PgClassExpression1008
     PageInfo1031{{"PageInfo[1031∈7] ➊"}}:::plan
     Connection316 --> PageInfo1031
+    Access1746{{"Access[1746∈7] ➊<br />ᐸ316.hasNextPageᐳ"}}:::plan
+    Connection316 --> Access1746
+    Access1835{{"Access[1835∈7] ➊<br />ᐸ316.hasPreviousPageᐳ"}}:::plan
+    Connection316 --> Access1835
     ConnectionItems836 --> First1898
     Lambda4444 --> Access1899
     ConnectionItems836 --> Last1926
@@ -1947,6 +2079,8 @@ graph TD
     PgClassExpression692 --> Access1329
     Access1331{{"Access[1331∈9]<br />ᐸ694.startᐳ"}}:::plan
     PgClassExpression694 --> Access1331
+    Access1333{{"Access[1333∈9]<br />ᐸ706.yearsᐳ"}}:::plan
+    PgClassExpression706 --> Access1333
     PgClassExpression1335{{"PgClassExpression[1335∈9]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle719 --> PgClassExpression1335
     First1340{{"First[1340∈9]"}}:::plan
@@ -1956,12 +2090,16 @@ graph TD
     Lambda3904 --> PgSelectRows1341
     PgSelectSingle1342{{"PgSelectSingle[1342∈9]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1340 --> PgSelectSingle1342
+    Access1367{{"Access[1367∈9]<br />ᐸ764.xᐳ"}}:::plan
+    PgClassExpression764 --> Access1367
     Access1383{{"Access[1383∈9]<br />ᐸ690.endᐳ"}}:::plan
     PgClassExpression690 --> Access1383
     Access1385{{"Access[1385∈9]<br />ᐸ692.endᐳ"}}:::plan
     PgClassExpression692 --> Access1385
     Access1387{{"Access[1387∈9]<br />ᐸ694.endᐳ"}}:::plan
     PgClassExpression694 --> Access1387
+    Access1389{{"Access[1389∈9]<br />ᐸ706.monthsᐳ"}}:::plan
+    PgClassExpression706 --> Access1389
     PgClassExpression1391{{"PgClassExpression[1391∈9]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle719 --> PgClassExpression1391
     First1396{{"First[1396∈9]"}}:::plan
@@ -1971,14 +2109,24 @@ graph TD
     Lambda3908 --> PgSelectRows1397
     PgSelectSingle1398{{"PgSelectSingle[1398∈9]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1396 --> PgSelectSingle1398
+    Access1419{{"Access[1419∈9]<br />ᐸ764.yᐳ"}}:::plan
+    PgClassExpression764 --> Access1419
+    Access1433{{"Access[1433∈9]<br />ᐸ706.daysᐳ"}}:::plan
+    PgClassExpression706 --> Access1433
     PgClassExpression1435{{"PgClassExpression[1435∈9]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle719 --> PgClassExpression1435
     PgClassExpression1437{{"PgClassExpression[1437∈9]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle733 --> PgClassExpression1437
+    Access1449{{"Access[1449∈9]<br />ᐸ706.hoursᐳ"}}:::plan
+    PgClassExpression706 --> Access1449
     PgClassExpression1451{{"PgClassExpression[1451∈9]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle719 --> PgClassExpression1451
+    Access1461{{"Access[1461∈9]<br />ᐸ706.minutesᐳ"}}:::plan
+    PgClassExpression706 --> Access1461
     PgClassExpression1463{{"PgClassExpression[1463∈9]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle719 --> PgClassExpression1463
+    Access1473{{"Access[1473∈9]<br />ᐸ706.secondsᐳ"}}:::plan
+    PgClassExpression706 --> Access1473
     PgClassExpression1475{{"PgClassExpression[1475∈9]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle719 --> PgClassExpression1475
     PgClassExpression1482{{"PgClassExpression[1482∈9]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -2254,6 +2402,8 @@ graph TD
     PgClassExpression566 --> Access1235
     Access1236{{"Access[1236∈21] ➊^<br />ᐸ567.startᐳ"}}:::plan
     PgClassExpression567 --> Access1236
+    Access1237{{"Access[1237∈21] ➊^<br />ᐸ573.yearsᐳ"}}:::plan
+    PgClassExpression573 --> Access1237
     PgClassExpression1238{{"PgClassExpression[1238∈21] ➊^<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1238
     First1242{{"First[1242∈21] ➊^"}}:::plan
@@ -2263,12 +2413,16 @@ graph TD
     Lambda4464 --> PgSelectRows1243
     PgSelectSingle1244{{"PgSelectSingle[1244∈21] ➊^<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1242 --> PgSelectSingle1244
+    Access1254{{"Access[1254∈21] ➊^<br />ᐸ602.xᐳ"}}:::plan
+    PgClassExpression602 --> Access1254
     Access1259{{"Access[1259∈21] ➊^<br />ᐸ565.endᐳ"}}:::plan
     PgClassExpression565 --> Access1259
     Access1260{{"Access[1260∈21] ➊^<br />ᐸ566.endᐳ"}}:::plan
     PgClassExpression566 --> Access1260
     Access1261{{"Access[1261∈21] ➊^<br />ᐸ567.endᐳ"}}:::plan
     PgClassExpression567 --> Access1261
+    Access1262{{"Access[1262∈21] ➊^<br />ᐸ573.monthsᐳ"}}:::plan
+    PgClassExpression573 --> Access1262
     PgClassExpression1263{{"PgClassExpression[1263∈21] ➊^<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1263
     First1267{{"First[1267∈21] ➊^"}}:::plan
@@ -2278,18 +2432,52 @@ graph TD
     Lambda4468 --> PgSelectRows1268
     PgSelectSingle1269{{"PgSelectSingle[1269∈21] ➊^<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1267 --> PgSelectSingle1269
+    Access1277{{"Access[1277∈21] ➊^<br />ᐸ602.yᐳ"}}:::plan
+    PgClassExpression602 --> Access1277
+    Access1281{{"Access[1281∈21] ➊^<br />ᐸ573.daysᐳ"}}:::plan
+    PgClassExpression573 --> Access1281
     PgClassExpression1282{{"PgClassExpression[1282∈21] ➊^<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1282
     PgClassExpression1283{{"PgClassExpression[1283∈21] ➊^<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle589 --> PgClassExpression1283
+    Access1286{{"Access[1286∈21] ➊^<br />ᐸ573.hoursᐳ"}}:::plan
+    PgClassExpression573 --> Access1286
     PgClassExpression1287{{"PgClassExpression[1287∈21] ➊^<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1287
+    Access1289{{"Access[1289∈21] ➊^<br />ᐸ573.minutesᐳ"}}:::plan
+    PgClassExpression573 --> Access1289
     PgClassExpression1290{{"PgClassExpression[1290∈21] ➊^<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1290
+    Access1292{{"Access[1292∈21] ➊^<br />ᐸ573.secondsᐳ"}}:::plan
+    PgClassExpression573 --> Access1292
     PgClassExpression1293{{"PgClassExpression[1293∈21] ➊^<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1293
     PgClassExpression1295{{"PgClassExpression[1295∈21] ➊^<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle583 --> PgClassExpression1295
+    Access2012{{"Access[2012∈21] ➊^<br />ᐸ565.start.valueᐳ"}}:::plan
+    PgClassExpression565 --> Access2012
+    Access2013{{"Access[2013∈21] ➊^<br />ᐸ566.start.valueᐳ"}}:::plan
+    PgClassExpression566 --> Access2013
+    Access2014{{"Access[2014∈21] ➊^<br />ᐸ567.start.valueᐳ"}}:::plan
+    PgClassExpression567 --> Access2014
+    Access2018{{"Access[2018∈21] ➊^<br />ᐸ565.end.valueᐳ"}}:::plan
+    PgClassExpression565 --> Access2018
+    Access2019{{"Access[2019∈21] ➊^<br />ᐸ566.end.valueᐳ"}}:::plan
+    PgClassExpression566 --> Access2019
+    Access2020{{"Access[2020∈21] ➊^<br />ᐸ567.end.valueᐳ"}}:::plan
+    PgClassExpression567 --> Access2020
+    Access2026{{"Access[2026∈21] ➊^<br />ᐸ565.start.inclusiveᐳ"}}:::plan
+    PgClassExpression565 --> Access2026
+    Access2027{{"Access[2027∈21] ➊^<br />ᐸ566.start.inclusiveᐳ"}}:::plan
+    PgClassExpression566 --> Access2027
+    Access2028{{"Access[2028∈21] ➊^<br />ᐸ567.start.inclusiveᐳ"}}:::plan
+    PgClassExpression567 --> Access2028
+    Access2032{{"Access[2032∈21] ➊^<br />ᐸ565.end.inclusiveᐳ"}}:::plan
+    PgClassExpression565 --> Access2032
+    Access2033{{"Access[2033∈21] ➊^<br />ᐸ566.end.inclusiveᐳ"}}:::plan
+    PgClassExpression566 --> Access2033
+    Access2034{{"Access[2034∈21] ➊^<br />ᐸ567.end.inclusiveᐳ"}}:::plan
+    PgClassExpression567 --> Access2034
     PgSelect153 --> Access4450
     List4451 --> Lambda4452
     PgSelect153 --> Access4454
@@ -2538,6 +2726,8 @@ graph TD
     PgClassExpression693 --> Access1330
     Access1332{{"Access[1332∈31]<br />ᐸ695.startᐳ"}}:::plan
     PgClassExpression695 --> Access1332
+    Access1334{{"Access[1334∈31]<br />ᐸ707.yearsᐳ"}}:::plan
+    PgClassExpression707 --> Access1334
     PgClassExpression1336{{"PgClassExpression[1336∈31]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle727 --> PgClassExpression1336
     First1346{{"First[1346∈31]"}}:::plan
@@ -2547,12 +2737,16 @@ graph TD
     Lambda4064 --> PgSelectRows1347
     PgSelectSingle1348{{"PgSelectSingle[1348∈31]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1346 --> PgSelectSingle1348
+    Access1368{{"Access[1368∈31]<br />ᐸ765.xᐳ"}}:::plan
+    PgClassExpression765 --> Access1368
     Access1384{{"Access[1384∈31]<br />ᐸ691.endᐳ"}}:::plan
     PgClassExpression691 --> Access1384
     Access1386{{"Access[1386∈31]<br />ᐸ693.endᐳ"}}:::plan
     PgClassExpression693 --> Access1386
     Access1388{{"Access[1388∈31]<br />ᐸ695.endᐳ"}}:::plan
     PgClassExpression695 --> Access1388
+    Access1390{{"Access[1390∈31]<br />ᐸ707.monthsᐳ"}}:::plan
+    PgClassExpression707 --> Access1390
     PgClassExpression1392{{"PgClassExpression[1392∈31]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle727 --> PgClassExpression1392
     First1402{{"First[1402∈31]"}}:::plan
@@ -2562,14 +2756,24 @@ graph TD
     Lambda4068 --> PgSelectRows1403
     PgSelectSingle1404{{"PgSelectSingle[1404∈31]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1402 --> PgSelectSingle1404
+    Access1420{{"Access[1420∈31]<br />ᐸ765.yᐳ"}}:::plan
+    PgClassExpression765 --> Access1420
+    Access1434{{"Access[1434∈31]<br />ᐸ707.daysᐳ"}}:::plan
+    PgClassExpression707 --> Access1434
     PgClassExpression1436{{"PgClassExpression[1436∈31]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle727 --> PgClassExpression1436
     PgClassExpression1438{{"PgClassExpression[1438∈31]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle739 --> PgClassExpression1438
+    Access1450{{"Access[1450∈31]<br />ᐸ707.hoursᐳ"}}:::plan
+    PgClassExpression707 --> Access1450
     PgClassExpression1452{{"PgClassExpression[1452∈31]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle727 --> PgClassExpression1452
+    Access1462{{"Access[1462∈31]<br />ᐸ707.minutesᐳ"}}:::plan
+    PgClassExpression707 --> Access1462
     PgClassExpression1464{{"PgClassExpression[1464∈31]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle727 --> PgClassExpression1464
+    Access1474{{"Access[1474∈31]<br />ᐸ707.secondsᐳ"}}:::plan
+    PgClassExpression707 --> Access1474
     PgClassExpression1476{{"PgClassExpression[1476∈31]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle727 --> PgClassExpression1476
     PgClassExpression1483{{"PgClassExpression[1483∈31]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -2740,6 +2944,8 @@ graph TD
     PgClassExpression1089 --> Access1751
     Access1753{{"Access[1753∈36] ➊<br />ᐸ1091.startᐳ"}}:::plan
     PgClassExpression1091 --> Access1753
+    Access1755{{"Access[1755∈36] ➊<br />ᐸ1103.yearsᐳ"}}:::plan
+    PgClassExpression1103 --> Access1755
     PgClassExpression1757{{"PgClassExpression[1757∈36] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1757
     First1762{{"First[1762∈36] ➊"}}:::plan
@@ -2749,12 +2955,16 @@ graph TD
     Lambda4168 --> PgSelectRows1763
     PgSelectSingle1764{{"PgSelectSingle[1764∈36] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1762 --> PgSelectSingle1764
+    Access1789{{"Access[1789∈36] ➊<br />ᐸ1161.xᐳ"}}:::plan
+    PgClassExpression1161 --> Access1789
     Access1838{{"Access[1838∈36] ➊<br />ᐸ1087.endᐳ"}}:::plan
     PgClassExpression1087 --> Access1838
     Access1840{{"Access[1840∈36] ➊<br />ᐸ1089.endᐳ"}}:::plan
     PgClassExpression1089 --> Access1840
     Access1842{{"Access[1842∈36] ➊<br />ᐸ1091.endᐳ"}}:::plan
     PgClassExpression1091 --> Access1842
+    Access1844{{"Access[1844∈36] ➊<br />ᐸ1103.monthsᐳ"}}:::plan
+    PgClassExpression1103 --> Access1844
     PgClassExpression1846{{"PgClassExpression[1846∈36] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1846
     First1851{{"First[1851∈36] ➊"}}:::plan
@@ -2764,18 +2974,52 @@ graph TD
     Lambda4172 --> PgSelectRows1852
     PgSelectSingle1853{{"PgSelectSingle[1853∈36] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1851 --> PgSelectSingle1853
+    Access1874{{"Access[1874∈36] ➊<br />ᐸ1161.yᐳ"}}:::plan
+    PgClassExpression1161 --> Access1874
+    Access1901{{"Access[1901∈36] ➊<br />ᐸ1103.daysᐳ"}}:::plan
+    PgClassExpression1103 --> Access1901
     PgClassExpression1903{{"PgClassExpression[1903∈36] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1903
     PgClassExpression1905{{"PgClassExpression[1905∈36] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1130 --> PgClassExpression1905
+    Access1928{{"Access[1928∈36] ➊<br />ᐸ1103.hoursᐳ"}}:::plan
+    PgClassExpression1103 --> Access1928
     PgClassExpression1930{{"PgClassExpression[1930∈36] ➊<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1930
+    Access1947{{"Access[1947∈36] ➊<br />ᐸ1103.minutesᐳ"}}:::plan
+    PgClassExpression1103 --> Access1947
     PgClassExpression1949{{"PgClassExpression[1949∈36] ➊<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1949
+    Access1966{{"Access[1966∈36] ➊<br />ᐸ1103.secondsᐳ"}}:::plan
+    PgClassExpression1103 --> Access1966
     PgClassExpression1968{{"PgClassExpression[1968∈36] ➊<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1968
     PgClassExpression1984{{"PgClassExpression[1984∈36] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1116 --> PgClassExpression1984
+    Access2685{{"Access[2685∈36] ➊<br />ᐸ1087.start.valueᐳ"}}:::plan
+    PgClassExpression1087 --> Access2685
+    Access2687{{"Access[2687∈36] ➊<br />ᐸ1089.start.valueᐳ"}}:::plan
+    PgClassExpression1089 --> Access2687
+    Access2689{{"Access[2689∈36] ➊<br />ᐸ1091.start.valueᐳ"}}:::plan
+    PgClassExpression1091 --> Access2689
+    Access2697{{"Access[2697∈36] ➊<br />ᐸ1087.end.valueᐳ"}}:::plan
+    PgClassExpression1087 --> Access2697
+    Access2699{{"Access[2699∈36] ➊<br />ᐸ1089.end.valueᐳ"}}:::plan
+    PgClassExpression1089 --> Access2699
+    Access2701{{"Access[2701∈36] ➊<br />ᐸ1091.end.valueᐳ"}}:::plan
+    PgClassExpression1091 --> Access2701
+    Access2709{{"Access[2709∈36] ➊<br />ᐸ1087.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1087 --> Access2709
+    Access2711{{"Access[2711∈36] ➊<br />ᐸ1089.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1089 --> Access2711
+    Access2713{{"Access[2713∈36] ➊<br />ᐸ1091.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1091 --> Access2713
+    Access2721{{"Access[2721∈36] ➊<br />ᐸ1087.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1087 --> Access2721
+    Access2723{{"Access[2723∈36] ➊<br />ᐸ1089.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1089 --> Access2723
+    Access2725{{"Access[2725∈36] ➊<br />ᐸ1091.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1091 --> Access2725
     List4155 --> Lambda4156
     List4159 --> Lambda4160
     List4163 --> Lambda4164
@@ -2946,6 +3190,8 @@ graph TD
     PgClassExpression1090 --> Access1752
     Access1754{{"Access[1754∈37] ➊<br />ᐸ1092.startᐳ"}}:::plan
     PgClassExpression1092 --> Access1754
+    Access1756{{"Access[1756∈37] ➊<br />ᐸ1104.yearsᐳ"}}:::plan
+    PgClassExpression1104 --> Access1756
     PgClassExpression1758{{"PgClassExpression[1758∈37] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1758
     First1768{{"First[1768∈37] ➊"}}:::plan
@@ -2955,12 +3201,16 @@ graph TD
     Lambda4332 --> PgSelectRows1769
     PgSelectSingle1770{{"PgSelectSingle[1770∈37] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1768 --> PgSelectSingle1770
+    Access1790{{"Access[1790∈37] ➊<br />ᐸ1162.xᐳ"}}:::plan
+    PgClassExpression1162 --> Access1790
     Access1839{{"Access[1839∈37] ➊<br />ᐸ1088.endᐳ"}}:::plan
     PgClassExpression1088 --> Access1839
     Access1841{{"Access[1841∈37] ➊<br />ᐸ1090.endᐳ"}}:::plan
     PgClassExpression1090 --> Access1841
     Access1843{{"Access[1843∈37] ➊<br />ᐸ1092.endᐳ"}}:::plan
     PgClassExpression1092 --> Access1843
+    Access1845{{"Access[1845∈37] ➊<br />ᐸ1104.monthsᐳ"}}:::plan
+    PgClassExpression1104 --> Access1845
     PgClassExpression1847{{"PgClassExpression[1847∈37] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1847
     First1857{{"First[1857∈37] ➊"}}:::plan
@@ -2970,18 +3220,52 @@ graph TD
     Lambda4336 --> PgSelectRows1858
     PgSelectSingle1859{{"PgSelectSingle[1859∈37] ➊<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First1857 --> PgSelectSingle1859
+    Access1875{{"Access[1875∈37] ➊<br />ᐸ1162.yᐳ"}}:::plan
+    PgClassExpression1162 --> Access1875
+    Access1902{{"Access[1902∈37] ➊<br />ᐸ1104.daysᐳ"}}:::plan
+    PgClassExpression1104 --> Access1902
     PgClassExpression1904{{"PgClassExpression[1904∈37] ➊<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1904
     PgClassExpression1906{{"PgClassExpression[1906∈37] ➊<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1136 --> PgClassExpression1906
+    Access1929{{"Access[1929∈37] ➊<br />ᐸ1104.hoursᐳ"}}:::plan
+    PgClassExpression1104 --> Access1929
     PgClassExpression1931{{"PgClassExpression[1931∈37] ➊<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1931
+    Access1948{{"Access[1948∈37] ➊<br />ᐸ1104.minutesᐳ"}}:::plan
+    PgClassExpression1104 --> Access1948
     PgClassExpression1950{{"PgClassExpression[1950∈37] ➊<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1950
+    Access1967{{"Access[1967∈37] ➊<br />ᐸ1104.secondsᐳ"}}:::plan
+    PgClassExpression1104 --> Access1967
     PgClassExpression1969{{"PgClassExpression[1969∈37] ➊<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1969
     PgClassExpression1985{{"PgClassExpression[1985∈37] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1124 --> PgClassExpression1985
+    Access2686{{"Access[2686∈37] ➊<br />ᐸ1088.start.valueᐳ"}}:::plan
+    PgClassExpression1088 --> Access2686
+    Access2688{{"Access[2688∈37] ➊<br />ᐸ1090.start.valueᐳ"}}:::plan
+    PgClassExpression1090 --> Access2688
+    Access2690{{"Access[2690∈37] ➊<br />ᐸ1092.start.valueᐳ"}}:::plan
+    PgClassExpression1092 --> Access2690
+    Access2698{{"Access[2698∈37] ➊<br />ᐸ1088.end.valueᐳ"}}:::plan
+    PgClassExpression1088 --> Access2698
+    Access2700{{"Access[2700∈37] ➊<br />ᐸ1090.end.valueᐳ"}}:::plan
+    PgClassExpression1090 --> Access2700
+    Access2702{{"Access[2702∈37] ➊<br />ᐸ1092.end.valueᐳ"}}:::plan
+    PgClassExpression1092 --> Access2702
+    Access2710{{"Access[2710∈37] ➊<br />ᐸ1088.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1088 --> Access2710
+    Access2712{{"Access[2712∈37] ➊<br />ᐸ1090.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1090 --> Access2712
+    Access2714{{"Access[2714∈37] ➊<br />ᐸ1092.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1092 --> Access2714
+    Access2722{{"Access[2722∈37] ➊<br />ᐸ1088.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1088 --> Access2722
+    Access2724{{"Access[2724∈37] ➊<br />ᐸ1090.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1090 --> Access2724
+    Access2726{{"Access[2726∈37] ➊<br />ᐸ1092.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1092 --> Access2726
     List4319 --> Lambda4320
     List4323 --> Lambda4324
     List4327 --> Lambda4328
@@ -3000,14 +3284,38 @@ graph TD
     PgClassExpression348 --> Access839
     Access922{{"Access[922∈38] ➊<br />ᐸ348.endᐳ"}}:::plan
     PgClassExpression348 --> Access922
+    Access1709{{"Access[1709∈38] ➊<br />ᐸ348.start.valueᐳ"}}:::plan
+    PgClassExpression348 --> Access1709
+    Access1727{{"Access[1727∈38] ➊<br />ᐸ348.end.valueᐳ"}}:::plan
+    PgClassExpression348 --> Access1727
+    Access1798{{"Access[1798∈38] ➊<br />ᐸ348.start.inclusiveᐳ"}}:::plan
+    PgClassExpression348 --> Access1798
+    Access1816{{"Access[1816∈38] ➊<br />ᐸ348.end.inclusiveᐳ"}}:::plan
+    PgClassExpression348 --> Access1816
     Access840{{"Access[840∈39] ➊<br />ᐸ349.startᐳ"}}:::plan
     PgClassExpression349 --> Access840
     Access923{{"Access[923∈39] ➊<br />ᐸ349.endᐳ"}}:::plan
     PgClassExpression349 --> Access923
+    Access1710{{"Access[1710∈39] ➊<br />ᐸ349.start.valueᐳ"}}:::plan
+    PgClassExpression349 --> Access1710
+    Access1728{{"Access[1728∈39] ➊<br />ᐸ349.end.valueᐳ"}}:::plan
+    PgClassExpression349 --> Access1728
+    Access1799{{"Access[1799∈39] ➊<br />ᐸ349.start.inclusiveᐳ"}}:::plan
+    PgClassExpression349 --> Access1799
+    Access1817{{"Access[1817∈39] ➊<br />ᐸ349.end.inclusiveᐳ"}}:::plan
+    PgClassExpression349 --> Access1817
     Access841{{"Access[841∈40] ➊<br />ᐸ350.startᐳ"}}:::plan
     PgClassExpression350 --> Access841
     Access924{{"Access[924∈40] ➊<br />ᐸ350.endᐳ"}}:::plan
     PgClassExpression350 --> Access924
+    Access1711{{"Access[1711∈40] ➊<br />ᐸ350.start.valueᐳ"}}:::plan
+    PgClassExpression350 --> Access1711
+    Access1729{{"Access[1729∈40] ➊<br />ᐸ350.end.valueᐳ"}}:::plan
+    PgClassExpression350 --> Access1729
+    Access1800{{"Access[1800∈40] ➊<br />ᐸ350.start.inclusiveᐳ"}}:::plan
+    PgClassExpression350 --> Access1800
+    Access1818{{"Access[1818∈40] ➊<br />ᐸ350.end.inclusiveᐳ"}}:::plan
+    PgClassExpression350 --> Access1818
     PgClassExpression875{{"PgClassExpression[875∈41] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle431 --> PgClassExpression875
     PgClassExpression958{{"PgClassExpression[958∈41] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -3116,6 +3424,18 @@ graph TD
     PgSelectSingle461 --> PgClassExpression1023
     List4039 --> Lambda4040
     List4043 --> Lambda4044
+    Access905{{"Access[905∈47] ➊<br />ᐸ465.xᐳ"}}:::plan
+    PgClassExpression465 --> Access905
+    Access982{{"Access[982∈47] ➊<br />ᐸ465.yᐳ"}}:::plan
+    PgClassExpression465 --> Access982
+    Access906{{"Access[906∈48] ➊<br />ᐸ466.xᐳ"}}:::plan
+    PgClassExpression466 --> Access906
+    Access983{{"Access[983∈48] ➊<br />ᐸ466.yᐳ"}}:::plan
+    PgClassExpression466 --> Access983
+    Access907{{"Access[907∈49] ➊<br />ᐸ467.xᐳ"}}:::plan
+    PgClassExpression467 --> Access907
+    Access984{{"Access[984∈49] ➊<br />ᐸ467.yᐳ"}}:::plan
+    PgClassExpression467 --> Access984
     PgClassExpression908{{"PgClassExpression[908∈50] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle517 --> PgClassExpression908
     PgClassExpression985{{"PgClassExpression[985∈50] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -3200,6 +3520,14 @@ graph TD
     PgClassExpression564 --> Access1233
     Access1258{{"Access[1258∈80] ➊<br />ᐸ564.endᐳ<br />ᐳType"}}:::plan
     PgClassExpression564 --> Access1258
+    Access2011{{"Access[2011∈80] ➊<br />ᐸ564.start.valueᐳ<br />ᐳType"}}:::plan
+    PgClassExpression564 --> Access2011
+    Access2017{{"Access[2017∈80] ➊<br />ᐸ564.end.valueᐳ<br />ᐳType"}}:::plan
+    PgClassExpression564 --> Access2017
+    Access2025{{"Access[2025∈80] ➊<br />ᐸ564.start.inclusiveᐳ<br />ᐳType"}}:::plan
+    PgClassExpression564 --> Access2025
+    Access2031{{"Access[2031∈80] ➊<br />ᐸ564.end.inclusiveᐳ<br />ᐳType"}}:::plan
+    PgClassExpression564 --> Access2031
     PgClassExpression1245{{"PgClassExpression[1245∈81] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ<br />ᐳType"}}:::plan
     PgSelectSingle595 --> PgClassExpression1245
     PgClassExpression1270{{"PgClassExpression[1270∈81] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ<br />ᐳType"}}:::plan
@@ -3236,6 +3564,10 @@ graph TD
     PgSelectSingle601 --> PgClassExpression1285
     List4479 --> Lambda4480
     List4483 --> Lambda4484
+    Access1255{{"Access[1255∈83] ➊<br />ᐸ603.xᐳ<br />ᐳType"}}:::plan
+    PgClassExpression603 --> Access1255
+    Access1278{{"Access[1278∈83] ➊<br />ᐸ603.yᐳ<br />ᐳType"}}:::plan
+    PgClassExpression603 --> Access1278
     PgClassExpression1256{{"PgClassExpression[1256∈84] ➊<br />ᐸ__post__.”id”ᐳ<br />ᐳType"}}:::plan
     PgSelectSingle623 --> PgClassExpression1256
     PgClassExpression1279{{"PgClassExpression[1279∈84] ➊<br />ᐸ__post__.”headline”ᐳ<br />ᐳType"}}:::plan
@@ -3400,6 +3732,8 @@ graph TD
     PgClassExpression1513 --> Access2103
     Access2106{{"Access[2106∈86]<br />ᐸ1516.startᐳ"}}:::plan
     PgClassExpression1516 --> Access2106
+    Access2109{{"Access[2109∈86]<br />ᐸ1534.yearsᐳ"}}:::plan
+    PgClassExpression1534 --> Access2109
     PgClassExpression2112{{"PgClassExpression[2112∈86]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1550 --> PgClassExpression2112
     First2118{{"First[2118∈86]"}}:::plan
@@ -3409,12 +3743,16 @@ graph TD
     Lambda3824 --> PgSelectRows2119
     PgSelectSingle2120{{"PgSelectSingle[2120∈86]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2118 --> PgSelectSingle2120
+    Access2160{{"Access[2160∈86]<br />ᐸ1621.xᐳ"}}:::plan
+    PgClassExpression1621 --> Access2160
     Access2205{{"Access[2205∈86]<br />ᐸ1510.endᐳ"}}:::plan
     PgClassExpression1510 --> Access2205
     Access2208{{"Access[2208∈86]<br />ᐸ1513.endᐳ"}}:::plan
     PgClassExpression1513 --> Access2208
     Access2211{{"Access[2211∈86]<br />ᐸ1516.endᐳ"}}:::plan
     PgClassExpression1516 --> Access2211
+    Access2214{{"Access[2214∈86]<br />ᐸ1534.monthsᐳ"}}:::plan
+    PgClassExpression1534 --> Access2214
     PgClassExpression2217{{"PgClassExpression[2217∈86]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle1550 --> PgClassExpression2217
     First2223{{"First[2223∈86]"}}:::plan
@@ -3424,14 +3762,24 @@ graph TD
     Lambda3828 --> PgSelectRows2224
     PgSelectSingle2225{{"PgSelectSingle[2225∈86]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2223 --> PgSelectSingle2225
+    Access2259{{"Access[2259∈86]<br />ᐸ1621.yᐳ"}}:::plan
+    PgClassExpression1621 --> Access2259
+    Access2285{{"Access[2285∈86]<br />ᐸ1534.daysᐳ"}}:::plan
+    PgClassExpression1534 --> Access2285
     PgClassExpression2288{{"PgClassExpression[2288∈86]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle1550 --> PgClassExpression2288
     PgClassExpression2291{{"PgClassExpression[2291∈86]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1572 --> PgClassExpression2291
+    Access2314{{"Access[2314∈86]<br />ᐸ1534.hoursᐳ"}}:::plan
+    PgClassExpression1534 --> Access2314
     PgClassExpression2317{{"PgClassExpression[2317∈86]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle1550 --> PgClassExpression2317
+    Access2337{{"Access[2337∈86]<br />ᐸ1534.minutesᐳ"}}:::plan
+    PgClassExpression1534 --> Access2337
     PgClassExpression2340{{"PgClassExpression[2340∈86]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle1550 --> PgClassExpression2340
+    Access2360{{"Access[2360∈86]<br />ᐸ1534.secondsᐳ"}}:::plan
+    PgClassExpression1534 --> Access2360
     PgClassExpression2363{{"PgClassExpression[2363∈86]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle1550 --> PgClassExpression2363
     PgClassExpression2381{{"PgClassExpression[2381∈86]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -3600,6 +3948,8 @@ graph TD
     PgClassExpression1514 --> Access2104
     Access2107{{"Access[2107∈87]<br />ᐸ1517.startᐳ"}}:::plan
     PgClassExpression1517 --> Access2107
+    Access2110{{"Access[2110∈87]<br />ᐸ1535.yearsᐳ"}}:::plan
+    PgClassExpression1535 --> Access2110
     PgClassExpression2113{{"PgClassExpression[2113∈87]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1558 --> PgClassExpression2113
     First2124{{"First[2124∈87]"}}:::plan
@@ -3609,12 +3959,16 @@ graph TD
     Lambda4096 --> PgSelectRows2125
     PgSelectSingle2126{{"PgSelectSingle[2126∈87]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2124 --> PgSelectSingle2126
+    Access2161{{"Access[2161∈87]<br />ᐸ1622.xᐳ"}}:::plan
+    PgClassExpression1622 --> Access2161
     Access2206{{"Access[2206∈87]<br />ᐸ1511.endᐳ"}}:::plan
     PgClassExpression1511 --> Access2206
     Access2209{{"Access[2209∈87]<br />ᐸ1514.endᐳ"}}:::plan
     PgClassExpression1514 --> Access2209
     Access2212{{"Access[2212∈87]<br />ᐸ1517.endᐳ"}}:::plan
     PgClassExpression1517 --> Access2212
+    Access2215{{"Access[2215∈87]<br />ᐸ1535.monthsᐳ"}}:::plan
+    PgClassExpression1535 --> Access2215
     PgClassExpression2218{{"PgClassExpression[2218∈87]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle1558 --> PgClassExpression2218
     First2229{{"First[2229∈87]"}}:::plan
@@ -3624,14 +3978,24 @@ graph TD
     Lambda4100 --> PgSelectRows2230
     PgSelectSingle2231{{"PgSelectSingle[2231∈87]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2229 --> PgSelectSingle2231
+    Access2260{{"Access[2260∈87]<br />ᐸ1622.yᐳ"}}:::plan
+    PgClassExpression1622 --> Access2260
+    Access2286{{"Access[2286∈87]<br />ᐸ1535.daysᐳ"}}:::plan
+    PgClassExpression1535 --> Access2286
     PgClassExpression2289{{"PgClassExpression[2289∈87]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle1558 --> PgClassExpression2289
     PgClassExpression2292{{"PgClassExpression[2292∈87]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1578 --> PgClassExpression2292
+    Access2315{{"Access[2315∈87]<br />ᐸ1535.hoursᐳ"}}:::plan
+    PgClassExpression1535 --> Access2315
     PgClassExpression2318{{"PgClassExpression[2318∈87]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle1558 --> PgClassExpression2318
+    Access2338{{"Access[2338∈87]<br />ᐸ1535.minutesᐳ"}}:::plan
+    PgClassExpression1535 --> Access2338
     PgClassExpression2341{{"PgClassExpression[2341∈87]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle1558 --> PgClassExpression2341
+    Access2361{{"Access[2361∈87]<br />ᐸ1535.secondsᐳ"}}:::plan
+    PgClassExpression1535 --> Access2361
     PgClassExpression2364{{"PgClassExpression[2364∈87]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle1558 --> PgClassExpression2364
     PgClassExpression2382{{"PgClassExpression[2382∈87]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -3800,6 +4164,8 @@ graph TD
     PgClassExpression1515 --> Access2105
     Access2108{{"Access[2108∈90]<br />ᐸ1518.startᐳ"}}:::plan
     PgClassExpression1518 --> Access2108
+    Access2111{{"Access[2111∈90]<br />ᐸ1536.yearsᐳ"}}:::plan
+    PgClassExpression1536 --> Access2111
     PgClassExpression2114{{"PgClassExpression[2114∈90]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1566 --> PgClassExpression2114
     First2130{{"First[2130∈90]"}}:::plan
@@ -3809,12 +4175,16 @@ graph TD
     Lambda4213 --> PgSelectRows2131
     PgSelectSingle2132{{"PgSelectSingle[2132∈90]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2130 --> PgSelectSingle2132
+    Access2162{{"Access[2162∈90]<br />ᐸ1623.xᐳ"}}:::plan
+    PgClassExpression1623 --> Access2162
     Access2207{{"Access[2207∈90]<br />ᐸ1512.endᐳ"}}:::plan
     PgClassExpression1512 --> Access2207
     Access2210{{"Access[2210∈90]<br />ᐸ1515.endᐳ"}}:::plan
     PgClassExpression1515 --> Access2210
     Access2213{{"Access[2213∈90]<br />ᐸ1518.endᐳ"}}:::plan
     PgClassExpression1518 --> Access2213
+    Access2216{{"Access[2216∈90]<br />ᐸ1536.monthsᐳ"}}:::plan
+    PgClassExpression1536 --> Access2216
     PgClassExpression2219{{"PgClassExpression[2219∈90]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle1566 --> PgClassExpression2219
     First2235{{"First[2235∈90]"}}:::plan
@@ -3824,14 +4194,24 @@ graph TD
     Lambda4217 --> PgSelectRows2236
     PgSelectSingle2237{{"PgSelectSingle[2237∈90]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2235 --> PgSelectSingle2237
+    Access2261{{"Access[2261∈90]<br />ᐸ1623.yᐳ"}}:::plan
+    PgClassExpression1623 --> Access2261
+    Access2287{{"Access[2287∈90]<br />ᐸ1536.daysᐳ"}}:::plan
+    PgClassExpression1536 --> Access2287
     PgClassExpression2290{{"PgClassExpression[2290∈90]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle1566 --> PgClassExpression2290
     PgClassExpression2293{{"PgClassExpression[2293∈90]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle1584 --> PgClassExpression2293
+    Access2316{{"Access[2316∈90]<br />ᐸ1536.hoursᐳ"}}:::plan
+    PgClassExpression1536 --> Access2316
     PgClassExpression2319{{"PgClassExpression[2319∈90]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle1566 --> PgClassExpression2319
+    Access2339{{"Access[2339∈90]<br />ᐸ1536.minutesᐳ"}}:::plan
+    PgClassExpression1536 --> Access2339
     PgClassExpression2342{{"PgClassExpression[2342∈90]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle1566 --> PgClassExpression2342
+    Access2362{{"Access[2362∈90]<br />ᐸ1536.secondsᐳ"}}:::plan
+    PgClassExpression1536 --> Access2362
     PgClassExpression2365{{"PgClassExpression[2365∈90]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle1566 --> PgClassExpression2365
     PgClassExpression2383{{"PgClassExpression[2383∈90]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -3846,6 +4226,42 @@ graph TD
     List4220 --> Lambda4221
     List4224 --> Lambda4225
     List4236 --> Lambda4237
+    Access1322{{"Access[1322∈91]<br />ᐸ645.yearsᐳ"}}:::plan
+    __Item645 --> Access1322
+    Access1378{{"Access[1378∈91]<br />ᐸ645.monthsᐳ"}}:::plan
+    __Item645 --> Access1378
+    Access1430{{"Access[1430∈91]<br />ᐸ645.daysᐳ"}}:::plan
+    __Item645 --> Access1430
+    Access1446{{"Access[1446∈91]<br />ᐸ645.hoursᐳ"}}:::plan
+    __Item645 --> Access1446
+    Access1458{{"Access[1458∈91]<br />ᐸ645.minutesᐳ"}}:::plan
+    __Item645 --> Access1458
+    Access1470{{"Access[1470∈91]<br />ᐸ645.secondsᐳ"}}:::plan
+    __Item645 --> Access1470
+    Access1323{{"Access[1323∈92]<br />ᐸ646.yearsᐳ"}}:::plan
+    __Item646 --> Access1323
+    Access1379{{"Access[1379∈92]<br />ᐸ646.monthsᐳ"}}:::plan
+    __Item646 --> Access1379
+    Access1431{{"Access[1431∈92]<br />ᐸ646.daysᐳ"}}:::plan
+    __Item646 --> Access1431
+    Access1447{{"Access[1447∈92]<br />ᐸ646.hoursᐳ"}}:::plan
+    __Item646 --> Access1447
+    Access1459{{"Access[1459∈92]<br />ᐸ646.minutesᐳ"}}:::plan
+    __Item646 --> Access1459
+    Access1471{{"Access[1471∈92]<br />ᐸ646.secondsᐳ"}}:::plan
+    __Item646 --> Access1471
+    Access1324{{"Access[1324∈93]<br />ᐸ647.yearsᐳ"}}:::plan
+    __Item647 --> Access1324
+    Access1380{{"Access[1380∈93]<br />ᐸ647.monthsᐳ"}}:::plan
+    __Item647 --> Access1380
+    Access1432{{"Access[1432∈93]<br />ᐸ647.daysᐳ"}}:::plan
+    __Item647 --> Access1432
+    Access1448{{"Access[1448∈93]<br />ᐸ647.hoursᐳ"}}:::plan
+    __Item647 --> Access1448
+    Access1460{{"Access[1460∈93]<br />ᐸ647.minutesᐳ"}}:::plan
+    __Item647 --> Access1460
+    Access1472{{"Access[1472∈93]<br />ᐸ647.secondsᐳ"}}:::plan
+    __Item647 --> Access1472
     __Item822[/"__Item[822∈94]<br />ᐸ558ᐳ<br />ᐳType"\]:::itemplan
     PgClassExpression558 ==> __Item822
     __Item823[/"__Item[823∈95]<br />ᐸ561ᐳ<br />ᐳType"\]:::itemplan
@@ -3948,6 +4364,14 @@ graph TD
     List4079 --> Lambda4080
     Lambda4088 --> Access4082
     List4083 --> Lambda4084
+    Access1369{{"Access[1369∈107]<br />ᐸ766.xᐳ"}}:::plan
+    PgClassExpression766 --> Access1369
+    Access1421{{"Access[1421∈107]<br />ᐸ766.yᐳ"}}:::plan
+    PgClassExpression766 --> Access1421
+    Access1370{{"Access[1370∈108]<br />ᐸ767.xᐳ"}}:::plan
+    PgClassExpression767 --> Access1370
+    Access1422{{"Access[1422∈108]<br />ᐸ767.yᐳ"}}:::plan
+    PgClassExpression767 --> Access1422
     PgClassExpression1371{{"PgClassExpression[1371∈109]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle802 --> PgClassExpression1371
     PgClassExpression1423{{"PgClassExpression[1423∈109]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -3964,6 +4388,18 @@ graph TD
     PgSelectSingle817 --> PgClassExpression1374
     PgClassExpression1426{{"PgClassExpression[1426∈112]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle817 --> PgClassExpression1426
+    Access1708{{"Access[1708∈117]<br />ᐸ824.yearsᐳ<br />ᐳType"}}:::plan
+    __Item824 --> Access1708
+    Access1797{{"Access[1797∈117]<br />ᐸ824.monthsᐳ<br />ᐳType"}}:::plan
+    __Item824 --> Access1797
+    Access1882{{"Access[1882∈117]<br />ᐸ824.daysᐳ<br />ᐳType"}}:::plan
+    __Item824 --> Access1882
+    Access1911{{"Access[1911∈117]<br />ᐸ824.hoursᐳ<br />ᐳType"}}:::plan
+    __Item824 --> Access1911
+    Access1934{{"Access[1934∈117]<br />ᐸ824.minutesᐳ<br />ᐳType"}}:::plan
+    __Item824 --> Access1934
+    Access1953{{"Access[1953∈117]<br />ᐸ824.secondsᐳ<br />ᐳType"}}:::plan
+    __Item824 --> Access1953
     __Item1219[/"__Item[1219∈118]<br />ᐸ676ᐳ"\]:::itemplan
     PgClassExpression676 ==> __Item1219
     __Item1220[/"__Item[1220∈119]<br />ᐸ677ᐳ"\]:::itemplan
@@ -4164,10 +4600,26 @@ graph TD
     PgClassExpression1085 --> Access1747
     Access1836{{"Access[1836∈168] ➊<br />ᐸ1085.endᐳ"}}:::plan
     PgClassExpression1085 --> Access1836
+    Access2683{{"Access[2683∈168] ➊<br />ᐸ1085.start.valueᐳ"}}:::plan
+    PgClassExpression1085 --> Access2683
+    Access2695{{"Access[2695∈168] ➊<br />ᐸ1085.end.valueᐳ"}}:::plan
+    PgClassExpression1085 --> Access2695
+    Access2707{{"Access[2707∈168] ➊<br />ᐸ1085.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1085 --> Access2707
+    Access2719{{"Access[2719∈168] ➊<br />ᐸ1085.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1085 --> Access2719
     Access1748{{"Access[1748∈169] ➊<br />ᐸ1086.startᐳ"}}:::plan
     PgClassExpression1086 --> Access1748
     Access1837{{"Access[1837∈169] ➊<br />ᐸ1086.endᐳ"}}:::plan
     PgClassExpression1086 --> Access1837
+    Access2684{{"Access[2684∈169] ➊<br />ᐸ1086.start.valueᐳ"}}:::plan
+    PgClassExpression1086 --> Access2684
+    Access2696{{"Access[2696∈169] ➊<br />ᐸ1086.end.valueᐳ"}}:::plan
+    PgClassExpression1086 --> Access2696
+    Access2708{{"Access[2708∈169] ➊<br />ᐸ1086.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1086 --> Access2708
+    Access2720{{"Access[2720∈169] ➊<br />ᐸ1086.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1086 --> Access2720
     PgClassExpression1771{{"PgClassExpression[1771∈170] ➊<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1142 --> PgClassExpression1771
     PgClassExpression1860{{"PgClassExpression[1860∈170] ➊<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -4240,6 +4692,14 @@ graph TD
     PgSelectSingle1160 --> PgClassExpression1910
     List4347 --> Lambda4348
     List4351 --> Lambda4352
+    Access1791{{"Access[1791∈174] ➊<br />ᐸ1163.xᐳ"}}:::plan
+    PgClassExpression1163 --> Access1791
+    Access1876{{"Access[1876∈174] ➊<br />ᐸ1163.yᐳ"}}:::plan
+    PgClassExpression1163 --> Access1876
+    Access1792{{"Access[1792∈175] ➊<br />ᐸ1164.xᐳ"}}:::plan
+    PgClassExpression1164 --> Access1792
+    Access1877{{"Access[1877∈175] ➊<br />ᐸ1164.yᐳ"}}:::plan
+    PgClassExpression1164 --> Access1877
     PgClassExpression1793{{"PgClassExpression[1793∈176] ➊<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle1199 --> PgClassExpression1793
     PgClassExpression1878{{"PgClassExpression[1878∈176] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -4256,6 +4716,30 @@ graph TD
     PgSelectSingle1214 --> PgClassExpression1796
     PgClassExpression1881{{"PgClassExpression[1881∈179] ➊<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle1214 --> PgClassExpression1881
+    Access2009{{"Access[2009∈180]<br />ᐸ1223.yearsᐳ"}}:::plan
+    __Item1223 --> Access2009
+    Access2023{{"Access[2023∈180]<br />ᐸ1223.monthsᐳ"}}:::plan
+    __Item1223 --> Access2023
+    Access2037{{"Access[2037∈180]<br />ᐸ1223.daysᐳ"}}:::plan
+    __Item1223 --> Access2037
+    Access2043{{"Access[2043∈180]<br />ᐸ1223.hoursᐳ"}}:::plan
+    __Item1223 --> Access2043
+    Access2049{{"Access[2049∈180]<br />ᐸ1223.minutesᐳ"}}:::plan
+    __Item1223 --> Access2049
+    Access2055{{"Access[2055∈180]<br />ᐸ1223.secondsᐳ"}}:::plan
+    __Item1223 --> Access2055
+    Access2010{{"Access[2010∈181]<br />ᐸ1224.yearsᐳ"}}:::plan
+    __Item1224 --> Access2010
+    Access2024{{"Access[2024∈181]<br />ᐸ1224.monthsᐳ"}}:::plan
+    __Item1224 --> Access2024
+    Access2038{{"Access[2038∈181]<br />ᐸ1224.daysᐳ"}}:::plan
+    __Item1224 --> Access2038
+    Access2044{{"Access[2044∈181]<br />ᐸ1224.hoursᐳ"}}:::plan
+    __Item1224 --> Access2044
+    Access2050{{"Access[2050∈181]<br />ᐸ1224.minutesᐳ"}}:::plan
+    __Item1224 --> Access2050
+    Access2056{{"Access[2056∈181]<br />ᐸ1224.secondsᐳ"}}:::plan
+    __Item1224 --> Access2056
     __Item1297[/"__Item[1297∈182]<br />ᐸ830ᐳ"\]:::itemplan
     ConnectionItems830 ==> __Item1297
     PgSelectSingle1298{{"PgSelectSingle[1298∈182]<br />ᐸperson_type_function_connectionᐳ"}}:::plan
@@ -4506,6 +4990,8 @@ graph TD
     PgClassExpression2423 --> Access2863
     Access2867{{"Access[2867∈210]<br />ᐸ2427.startᐳ"}}:::plan
     PgClassExpression2427 --> Access2867
+    Access2871{{"Access[2871∈210]<br />ᐸ2451.yearsᐳ"}}:::plan
+    PgClassExpression2451 --> Access2871
     PgClassExpression2875{{"PgClassExpression[2875∈210]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2470 --> PgClassExpression2875
     First2882{{"First[2882∈210]"}}:::plan
@@ -4515,12 +5001,16 @@ graph TD
     Lambda4250 --> PgSelectRows2883
     PgSelectSingle2884{{"PgSelectSingle[2884∈210]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2882 --> PgSelectSingle2884
+    Access2939{{"Access[2939∈210]<br />ᐸ2567.xᐳ"}}:::plan
+    PgClassExpression2567 --> Access2939
     Access2997{{"Access[2997∈210]<br />ᐸ2419.endᐳ"}}:::plan
     PgClassExpression2419 --> Access2997
     Access3001{{"Access[3001∈210]<br />ᐸ2423.endᐳ"}}:::plan
     PgClassExpression2423 --> Access3001
     Access3005{{"Access[3005∈210]<br />ᐸ2427.endᐳ"}}:::plan
     PgClassExpression2427 --> Access3005
+    Access3009{{"Access[3009∈210]<br />ᐸ2451.monthsᐳ"}}:::plan
+    PgClassExpression2451 --> Access3009
     PgClassExpression3013{{"PgClassExpression[3013∈210]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle2470 --> PgClassExpression3013
     First3020{{"First[3020∈210]"}}:::plan
@@ -4530,14 +5020,24 @@ graph TD
     Lambda4254 --> PgSelectRows3021
     PgSelectSingle3022{{"PgSelectSingle[3022∈210]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3020 --> PgSelectSingle3022
+    Access3069{{"Access[3069∈210]<br />ᐸ2567.yᐳ"}}:::plan
+    PgClassExpression2567 --> Access3069
+    Access3099{{"Access[3099∈210]<br />ᐸ2451.daysᐳ"}}:::plan
+    PgClassExpression2451 --> Access3099
     PgClassExpression3103{{"PgClassExpression[3103∈210]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle2470 --> PgClassExpression3103
     PgClassExpression3107{{"PgClassExpression[3107∈210]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2500 --> PgClassExpression3107
+    Access3133{{"Access[3133∈210]<br />ᐸ2451.hoursᐳ"}}:::plan
+    PgClassExpression2451 --> Access3133
     PgClassExpression3137{{"PgClassExpression[3137∈210]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle2470 --> PgClassExpression3137
+    Access3159{{"Access[3159∈210]<br />ᐸ2451.minutesᐳ"}}:::plan
+    PgClassExpression2451 --> Access3159
     PgClassExpression3163{{"PgClassExpression[3163∈210]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle2470 --> PgClassExpression3163
+    Access3185{{"Access[3185∈210]<br />ᐸ2451.secondsᐳ"}}:::plan
+    PgClassExpression2451 --> Access3185
     PgClassExpression3189{{"PgClassExpression[3189∈210]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle2470 --> PgClassExpression3189
     PgClassExpression3211{{"PgClassExpression[3211∈210]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -4706,6 +5206,8 @@ graph TD
     PgClassExpression2424 --> Access2864
     Access2868{{"Access[2868∈211]<br />ᐸ2428.startᐳ"}}:::plan
     PgClassExpression2428 --> Access2868
+    Access2872{{"Access[2872∈211]<br />ᐸ2452.yearsᐳ"}}:::plan
+    PgClassExpression2452 --> Access2872
     PgClassExpression2876{{"PgClassExpression[2876∈211]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2478 --> PgClassExpression2876
     First2888{{"First[2888∈211]"}}:::plan
@@ -4715,12 +5217,16 @@ graph TD
     Lambda4376 --> PgSelectRows2889
     PgSelectSingle2890{{"PgSelectSingle[2890∈211]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2888 --> PgSelectSingle2890
+    Access2940{{"Access[2940∈211]<br />ᐸ2568.xᐳ"}}:::plan
+    PgClassExpression2568 --> Access2940
     Access2998{{"Access[2998∈211]<br />ᐸ2420.endᐳ"}}:::plan
     PgClassExpression2420 --> Access2998
     Access3002{{"Access[3002∈211]<br />ᐸ2424.endᐳ"}}:::plan
     PgClassExpression2424 --> Access3002
     Access3006{{"Access[3006∈211]<br />ᐸ2428.endᐳ"}}:::plan
     PgClassExpression2428 --> Access3006
+    Access3010{{"Access[3010∈211]<br />ᐸ2452.monthsᐳ"}}:::plan
+    PgClassExpression2452 --> Access3010
     PgClassExpression3014{{"PgClassExpression[3014∈211]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle2478 --> PgClassExpression3014
     First3026{{"First[3026∈211]"}}:::plan
@@ -4730,14 +5236,24 @@ graph TD
     Lambda4380 --> PgSelectRows3027
     PgSelectSingle3028{{"PgSelectSingle[3028∈211]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3026 --> PgSelectSingle3028
+    Access3070{{"Access[3070∈211]<br />ᐸ2568.yᐳ"}}:::plan
+    PgClassExpression2568 --> Access3070
+    Access3100{{"Access[3100∈211]<br />ᐸ2452.daysᐳ"}}:::plan
+    PgClassExpression2452 --> Access3100
     PgClassExpression3104{{"PgClassExpression[3104∈211]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle2478 --> PgClassExpression3104
     PgClassExpression3108{{"PgClassExpression[3108∈211]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2506 --> PgClassExpression3108
+    Access3134{{"Access[3134∈211]<br />ᐸ2452.hoursᐳ"}}:::plan
+    PgClassExpression2452 --> Access3134
     PgClassExpression3138{{"PgClassExpression[3138∈211]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle2478 --> PgClassExpression3138
+    Access3160{{"Access[3160∈211]<br />ᐸ2452.minutesᐳ"}}:::plan
+    PgClassExpression2452 --> Access3160
     PgClassExpression3164{{"PgClassExpression[3164∈211]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle2478 --> PgClassExpression3164
+    Access3186{{"Access[3186∈211]<br />ᐸ2452.secondsᐳ"}}:::plan
+    PgClassExpression2452 --> Access3186
     PgClassExpression3190{{"PgClassExpression[3190∈211]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle2478 --> PgClassExpression3190
     PgClassExpression3212{{"PgClassExpression[3212∈211]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -4752,6 +5268,30 @@ graph TD
     List4383 --> Lambda4384
     List4387 --> Lambda4388
     List4399 --> Lambda4400
+    Access2069{{"Access[2069∈214]<br />ᐸ1307.yearsᐳ"}}:::plan
+    __Item1307 --> Access2069
+    Access2174{{"Access[2174∈214]<br />ᐸ1307.monthsᐳ"}}:::plan
+    __Item1307 --> Access2174
+    Access2273{{"Access[2273∈214]<br />ᐸ1307.daysᐳ"}}:::plan
+    __Item1307 --> Access2273
+    Access2302{{"Access[2302∈214]<br />ᐸ1307.hoursᐳ"}}:::plan
+    __Item1307 --> Access2302
+    Access2325{{"Access[2325∈214]<br />ᐸ1307.minutesᐳ"}}:::plan
+    __Item1307 --> Access2325
+    Access2348{{"Access[2348∈214]<br />ᐸ1307.secondsᐳ"}}:::plan
+    __Item1307 --> Access2348
+    Access2070{{"Access[2070∈215]<br />ᐸ1308.yearsᐳ"}}:::plan
+    __Item1308 --> Access2070
+    Access2175{{"Access[2175∈215]<br />ᐸ1308.monthsᐳ"}}:::plan
+    __Item1308 --> Access2175
+    Access2274{{"Access[2274∈215]<br />ᐸ1308.daysᐳ"}}:::plan
+    __Item1308 --> Access2274
+    Access2303{{"Access[2303∈215]<br />ᐸ1308.hoursᐳ"}}:::plan
+    __Item1308 --> Access2303
+    Access2326{{"Access[2326∈215]<br />ᐸ1308.minutesᐳ"}}:::plan
+    __Item1308 --> Access2326
+    Access2349{{"Access[2349∈215]<br />ᐸ1308.secondsᐳ"}}:::plan
+    __Item1308 --> Access2349
     List3851{{"List[3851∈216]<br />ᐸ3850,632ᐳ"}}:::plan
     Access3850 & PgSelectSingle632 --> List3851
     List3855{{"List[3855∈216]<br />ᐸ3854,632ᐳ"}}:::plan
@@ -4908,6 +5448,8 @@ graph TD
     PgClassExpression2425 --> Access2865
     Access2869{{"Access[2869∈216]<br />ᐸ2429.startᐳ"}}:::plan
     PgClassExpression2429 --> Access2869
+    Access2873{{"Access[2873∈216]<br />ᐸ2453.yearsᐳ"}}:::plan
+    PgClassExpression2453 --> Access2873
     PgClassExpression2877{{"PgClassExpression[2877∈216]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2486 --> PgClassExpression2877
     First2894{{"First[2894∈216]"}}:::plan
@@ -4917,12 +5459,16 @@ graph TD
     Lambda3864 --> PgSelectRows2895
     PgSelectSingle2896{{"PgSelectSingle[2896∈216]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2894 --> PgSelectSingle2896
+    Access2941{{"Access[2941∈216]<br />ᐸ2569.xᐳ"}}:::plan
+    PgClassExpression2569 --> Access2941
     Access2999{{"Access[2999∈216]<br />ᐸ2421.endᐳ"}}:::plan
     PgClassExpression2421 --> Access2999
     Access3003{{"Access[3003∈216]<br />ᐸ2425.endᐳ"}}:::plan
     PgClassExpression2425 --> Access3003
     Access3007{{"Access[3007∈216]<br />ᐸ2429.endᐳ"}}:::plan
     PgClassExpression2429 --> Access3007
+    Access3011{{"Access[3011∈216]<br />ᐸ2453.monthsᐳ"}}:::plan
+    PgClassExpression2453 --> Access3011
     PgClassExpression3015{{"PgClassExpression[3015∈216]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle2486 --> PgClassExpression3015
     First3032{{"First[3032∈216]"}}:::plan
@@ -4932,14 +5478,24 @@ graph TD
     Lambda3868 --> PgSelectRows3033
     PgSelectSingle3034{{"PgSelectSingle[3034∈216]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3032 --> PgSelectSingle3034
+    Access3071{{"Access[3071∈216]<br />ᐸ2569.yᐳ"}}:::plan
+    PgClassExpression2569 --> Access3071
+    Access3101{{"Access[3101∈216]<br />ᐸ2453.daysᐳ"}}:::plan
+    PgClassExpression2453 --> Access3101
     PgClassExpression3105{{"PgClassExpression[3105∈216]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle2486 --> PgClassExpression3105
     PgClassExpression3109{{"PgClassExpression[3109∈216]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2512 --> PgClassExpression3109
+    Access3135{{"Access[3135∈216]<br />ᐸ2453.hoursᐳ"}}:::plan
+    PgClassExpression2453 --> Access3135
     PgClassExpression3139{{"PgClassExpression[3139∈216]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle2486 --> PgClassExpression3139
+    Access3161{{"Access[3161∈216]<br />ᐸ2453.minutesᐳ"}}:::plan
+    PgClassExpression2453 --> Access3161
     PgClassExpression3165{{"PgClassExpression[3165∈216]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle2486 --> PgClassExpression3165
+    Access3187{{"Access[3187∈216]<br />ᐸ2453.secondsᐳ"}}:::plan
+    PgClassExpression2453 --> Access3187
     PgClassExpression3191{{"PgClassExpression[3191∈216]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle2486 --> PgClassExpression3191
     PgClassExpression3213{{"PgClassExpression[3213∈216]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -5108,6 +5664,8 @@ graph TD
     PgClassExpression2426 --> Access2866
     Access2870{{"Access[2870∈217]<br />ᐸ2430.startᐳ"}}:::plan
     PgClassExpression2430 --> Access2870
+    Access2874{{"Access[2874∈217]<br />ᐸ2454.yearsᐳ"}}:::plan
+    PgClassExpression2454 --> Access2874
     PgClassExpression2878{{"PgClassExpression[2878∈217]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2494 --> PgClassExpression2878
     First2900{{"First[2900∈217]"}}:::plan
@@ -5117,12 +5675,16 @@ graph TD
     Lambda4128 --> PgSelectRows2901
     PgSelectSingle2902{{"PgSelectSingle[2902∈217]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First2900 --> PgSelectSingle2902
+    Access2942{{"Access[2942∈217]<br />ᐸ2570.xᐳ"}}:::plan
+    PgClassExpression2570 --> Access2942
     Access3000{{"Access[3000∈217]<br />ᐸ2422.endᐳ"}}:::plan
     PgClassExpression2422 --> Access3000
     Access3004{{"Access[3004∈217]<br />ᐸ2426.endᐳ"}}:::plan
     PgClassExpression2426 --> Access3004
     Access3008{{"Access[3008∈217]<br />ᐸ2430.endᐳ"}}:::plan
     PgClassExpression2430 --> Access3008
+    Access3012{{"Access[3012∈217]<br />ᐸ2454.monthsᐳ"}}:::plan
+    PgClassExpression2454 --> Access3012
     PgClassExpression3016{{"PgClassExpression[3016∈217]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle2494 --> PgClassExpression3016
     First3038{{"First[3038∈217]"}}:::plan
@@ -5132,14 +5694,24 @@ graph TD
     Lambda4132 --> PgSelectRows3039
     PgSelectSingle3040{{"PgSelectSingle[3040∈217]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3038 --> PgSelectSingle3040
+    Access3072{{"Access[3072∈217]<br />ᐸ2570.yᐳ"}}:::plan
+    PgClassExpression2570 --> Access3072
+    Access3102{{"Access[3102∈217]<br />ᐸ2454.daysᐳ"}}:::plan
+    PgClassExpression2454 --> Access3102
     PgClassExpression3106{{"PgClassExpression[3106∈217]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle2494 --> PgClassExpression3106
     PgClassExpression3110{{"PgClassExpression[3110∈217]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle2518 --> PgClassExpression3110
+    Access3136{{"Access[3136∈217]<br />ᐸ2454.hoursᐳ"}}:::plan
+    PgClassExpression2454 --> Access3136
     PgClassExpression3140{{"PgClassExpression[3140∈217]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle2494 --> PgClassExpression3140
+    Access3162{{"Access[3162∈217]<br />ᐸ2454.minutesᐳ"}}:::plan
+    PgClassExpression2454 --> Access3162
     PgClassExpression3166{{"PgClassExpression[3166∈217]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle2494 --> PgClassExpression3166
+    Access3188{{"Access[3188∈217]<br />ᐸ2454.secondsᐳ"}}:::plan
+    PgClassExpression2454 --> Access3188
     PgClassExpression3192{{"PgClassExpression[3192∈217]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle2494 --> PgClassExpression3192
     PgClassExpression3214{{"PgClassExpression[3214∈217]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -5152,6 +5724,38 @@ graph TD
     List4135 --> Lambda4136
     List4139 --> Lambda4140
     List4151 --> Lambda4152
+    Access2073{{"Access[2073∈218]<br />ᐸ688.start.valueᐳ"}}:::plan
+    PgClassExpression688 --> Access2073
+    Access2178{{"Access[2178∈218]<br />ᐸ688.start.inclusiveᐳ"}}:::plan
+    PgClassExpression688 --> Access2178
+    Access2074{{"Access[2074∈219]<br />ᐸ689.start.valueᐳ"}}:::plan
+    PgClassExpression689 --> Access2074
+    Access2179{{"Access[2179∈219]<br />ᐸ689.start.inclusiveᐳ"}}:::plan
+    PgClassExpression689 --> Access2179
+    Access2075{{"Access[2075∈220]<br />ᐸ690.start.valueᐳ"}}:::plan
+    PgClassExpression690 --> Access2075
+    Access2180{{"Access[2180∈220]<br />ᐸ690.start.inclusiveᐳ"}}:::plan
+    PgClassExpression690 --> Access2180
+    Access2076{{"Access[2076∈221]<br />ᐸ691.start.valueᐳ"}}:::plan
+    PgClassExpression691 --> Access2076
+    Access2181{{"Access[2181∈221]<br />ᐸ691.start.inclusiveᐳ"}}:::plan
+    PgClassExpression691 --> Access2181
+    Access2077{{"Access[2077∈222]<br />ᐸ692.start.valueᐳ"}}:::plan
+    PgClassExpression692 --> Access2077
+    Access2182{{"Access[2182∈222]<br />ᐸ692.start.inclusiveᐳ"}}:::plan
+    PgClassExpression692 --> Access2182
+    Access2078{{"Access[2078∈223]<br />ᐸ693.start.valueᐳ"}}:::plan
+    PgClassExpression693 --> Access2078
+    Access2183{{"Access[2183∈223]<br />ᐸ693.start.inclusiveᐳ"}}:::plan
+    PgClassExpression693 --> Access2183
+    Access2079{{"Access[2079∈224]<br />ᐸ694.start.valueᐳ"}}:::plan
+    PgClassExpression694 --> Access2079
+    Access2184{{"Access[2184∈224]<br />ᐸ694.start.inclusiveᐳ"}}:::plan
+    PgClassExpression694 --> Access2184
+    Access2080{{"Access[2080∈225]<br />ᐸ695.start.valueᐳ"}}:::plan
+    PgClassExpression695 --> Access2080
+    Access2185{{"Access[2185∈225]<br />ᐸ695.start.inclusiveᐳ"}}:::plan
+    PgClassExpression695 --> Access2185
     PgClassExpression2081{{"PgClassExpression[2081∈226]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1342 --> PgClassExpression2081
     PgClassExpression2186{{"PgClassExpression[2186∈226]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5208,6 +5812,38 @@ graph TD
     PgSelectSingle1366 --> PgClassExpression2355
     PgClassExpression2376{{"PgClassExpression[2376∈229]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1366 --> PgClassExpression2376
+    Access2085{{"Access[2085∈230]<br />ᐸ688.end.valueᐳ"}}:::plan
+    PgClassExpression688 --> Access2085
+    Access2190{{"Access[2190∈230]<br />ᐸ688.end.inclusiveᐳ"}}:::plan
+    PgClassExpression688 --> Access2190
+    Access2086{{"Access[2086∈231]<br />ᐸ689.end.valueᐳ"}}:::plan
+    PgClassExpression689 --> Access2086
+    Access2191{{"Access[2191∈231]<br />ᐸ689.end.inclusiveᐳ"}}:::plan
+    PgClassExpression689 --> Access2191
+    Access2087{{"Access[2087∈232]<br />ᐸ690.end.valueᐳ"}}:::plan
+    PgClassExpression690 --> Access2087
+    Access2192{{"Access[2192∈232]<br />ᐸ690.end.inclusiveᐳ"}}:::plan
+    PgClassExpression690 --> Access2192
+    Access2088{{"Access[2088∈233]<br />ᐸ691.end.valueᐳ"}}:::plan
+    PgClassExpression691 --> Access2088
+    Access2193{{"Access[2193∈233]<br />ᐸ691.end.inclusiveᐳ"}}:::plan
+    PgClassExpression691 --> Access2193
+    Access2089{{"Access[2089∈234]<br />ᐸ692.end.valueᐳ"}}:::plan
+    PgClassExpression692 --> Access2089
+    Access2194{{"Access[2194∈234]<br />ᐸ692.end.inclusiveᐳ"}}:::plan
+    PgClassExpression692 --> Access2194
+    Access2090{{"Access[2090∈235]<br />ᐸ693.end.valueᐳ"}}:::plan
+    PgClassExpression693 --> Access2090
+    Access2195{{"Access[2195∈235]<br />ᐸ693.end.inclusiveᐳ"}}:::plan
+    PgClassExpression693 --> Access2195
+    Access2091{{"Access[2091∈236]<br />ᐸ694.end.valueᐳ"}}:::plan
+    PgClassExpression694 --> Access2091
+    Access2196{{"Access[2196∈236]<br />ᐸ694.end.inclusiveᐳ"}}:::plan
+    PgClassExpression694 --> Access2196
+    Access2092{{"Access[2092∈237]<br />ᐸ695.end.valueᐳ"}}:::plan
+    PgClassExpression695 --> Access2092
+    Access2197{{"Access[2197∈237]<br />ᐸ695.end.inclusiveᐳ"}}:::plan
+    PgClassExpression695 --> Access2197
     PgClassExpression2093{{"PgClassExpression[2093∈238]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle1398 --> PgClassExpression2093
     PgClassExpression2198{{"PgClassExpression[2198∈238]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -5396,6 +6032,18 @@ graph TD
     List4228 --> Lambda4229
     Lambda4237 --> Access4231
     List4232 --> Lambda4233
+    Access2163{{"Access[2163∈251]<br />ᐸ1624.xᐳ"}}:::plan
+    PgClassExpression1624 --> Access2163
+    Access2262{{"Access[2262∈251]<br />ᐸ1624.yᐳ"}}:::plan
+    PgClassExpression1624 --> Access2262
+    Access2164{{"Access[2164∈252]<br />ᐸ1625.xᐳ"}}:::plan
+    PgClassExpression1625 --> Access2164
+    Access2263{{"Access[2263∈252]<br />ᐸ1625.yᐳ"}}:::plan
+    PgClassExpression1625 --> Access2263
+    Access2165{{"Access[2165∈253]<br />ᐸ1626.xᐳ"}}:::plan
+    PgClassExpression1626 --> Access2165
+    Access2264{{"Access[2264∈253]<br />ᐸ1626.yᐳ"}}:::plan
+    PgClassExpression1626 --> Access2264
     PgClassExpression2166{{"PgClassExpression[2166∈254]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle1676 --> PgClassExpression2166
     PgClassExpression2265{{"PgClassExpression[2265∈254]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -5574,6 +6222,42 @@ graph TD
     PgSelectSingle1873 --> PgClassExpression2762
     PgClassExpression2770{{"PgClassExpression[2770∈304] ➊<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle1873 --> PgClassExpression2770
+    Access2799{{"Access[2799∈305]<br />ᐸ1994.yearsᐳ"}}:::plan
+    __Item1994 --> Access2799
+    Access2802{{"Access[2802∈305]<br />ᐸ1994.monthsᐳ"}}:::plan
+    __Item1994 --> Access2802
+    Access2805{{"Access[2805∈305]<br />ᐸ1994.daysᐳ"}}:::plan
+    __Item1994 --> Access2805
+    Access2808{{"Access[2808∈305]<br />ᐸ1994.hoursᐳ"}}:::plan
+    __Item1994 --> Access2808
+    Access2811{{"Access[2811∈305]<br />ᐸ1994.minutesᐳ"}}:::plan
+    __Item1994 --> Access2811
+    Access2814{{"Access[2814∈305]<br />ᐸ1994.secondsᐳ"}}:::plan
+    __Item1994 --> Access2814
+    Access2800{{"Access[2800∈306]<br />ᐸ1995.yearsᐳ"}}:::plan
+    __Item1995 --> Access2800
+    Access2803{{"Access[2803∈306]<br />ᐸ1995.monthsᐳ"}}:::plan
+    __Item1995 --> Access2803
+    Access2806{{"Access[2806∈306]<br />ᐸ1995.daysᐳ"}}:::plan
+    __Item1995 --> Access2806
+    Access2809{{"Access[2809∈306]<br />ᐸ1995.hoursᐳ"}}:::plan
+    __Item1995 --> Access2809
+    Access2812{{"Access[2812∈306]<br />ᐸ1995.minutesᐳ"}}:::plan
+    __Item1995 --> Access2812
+    Access2815{{"Access[2815∈306]<br />ᐸ1995.secondsᐳ"}}:::plan
+    __Item1995 --> Access2815
+    Access2801{{"Access[2801∈307]<br />ᐸ1996.yearsᐳ"}}:::plan
+    __Item1996 --> Access2801
+    Access2804{{"Access[2804∈307]<br />ᐸ1996.monthsᐳ"}}:::plan
+    __Item1996 --> Access2804
+    Access2807{{"Access[2807∈307]<br />ᐸ1996.daysᐳ"}}:::plan
+    __Item1996 --> Access2807
+    Access2810{{"Access[2810∈307]<br />ᐸ1996.hoursᐳ"}}:::plan
+    __Item1996 --> Access2810
+    Access2813{{"Access[2813∈307]<br />ᐸ1996.minutesᐳ"}}:::plan
+    __Item1996 --> Access2813
+    Access2816{{"Access[2816∈307]<br />ᐸ1996.secondsᐳ"}}:::plan
+    __Item1996 --> Access2816
     PgSelect3343[["PgSelect[3343∈308]<br />ᐸpostᐳ<br />More deps:<br />- Object[11]"]]:::plan
     PgClassExpression2955{{"PgClassExpression[2955∈308]<br />ᐸ__person_t...”smallint”ᐳ"}}:::plan
     PgClassExpression2955 --> PgSelect3343
@@ -5728,6 +6412,8 @@ graph TD
     PgClassExpression3237 --> Access3457
     Access3459{{"Access[3459∈308]<br />ᐸ3239.startᐳ"}}:::plan
     PgClassExpression3239 --> Access3459
+    Access3461{{"Access[3461∈308]<br />ᐸ3251.yearsᐳ"}}:::plan
+    PgClassExpression3251 --> Access3461
     PgClassExpression3463{{"PgClassExpression[3463∈308]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3463
     First3468{{"First[3468∈308]"}}:::plan
@@ -5737,12 +6423,16 @@ graph TD
     Lambda4282 --> PgSelectRows3469
     PgSelectSingle3470{{"PgSelectSingle[3470∈308]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3468 --> PgSelectSingle3470
+    Access3495{{"Access[3495∈308]<br />ᐸ3309.xᐳ"}}:::plan
+    PgClassExpression3309 --> Access3495
     Access3553{{"Access[3553∈308]<br />ᐸ3235.endᐳ"}}:::plan
     PgClassExpression3235 --> Access3553
     Access3555{{"Access[3555∈308]<br />ᐸ3237.endᐳ"}}:::plan
     PgClassExpression3237 --> Access3555
     Access3557{{"Access[3557∈308]<br />ᐸ3239.endᐳ"}}:::plan
     PgClassExpression3239 --> Access3557
+    Access3559{{"Access[3559∈308]<br />ᐸ3251.monthsᐳ"}}:::plan
+    PgClassExpression3251 --> Access3559
     PgClassExpression3561{{"PgClassExpression[3561∈308]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3561
     First3566{{"First[3566∈308]"}}:::plan
@@ -5752,14 +6442,24 @@ graph TD
     Lambda4286 --> PgSelectRows3567
     PgSelectSingle3568{{"PgSelectSingle[3568∈308]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3566 --> PgSelectSingle3568
+    Access3589{{"Access[3589∈308]<br />ᐸ3309.yᐳ"}}:::plan
+    PgClassExpression3309 --> Access3589
+    Access3613{{"Access[3613∈308]<br />ᐸ3251.daysᐳ"}}:::plan
+    PgClassExpression3251 --> Access3613
     PgClassExpression3615{{"PgClassExpression[3615∈308]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3615
     PgClassExpression3617{{"PgClassExpression[3617∈308]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3278 --> PgClassExpression3617
+    Access3639{{"Access[3639∈308]<br />ᐸ3251.hoursᐳ"}}:::plan
+    PgClassExpression3251 --> Access3639
     PgClassExpression3641{{"PgClassExpression[3641∈308]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3641
+    Access3661{{"Access[3661∈308]<br />ᐸ3251.minutesᐳ"}}:::plan
+    PgClassExpression3251 --> Access3661
     PgClassExpression3663{{"PgClassExpression[3663∈308]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3663
+    Access3683{{"Access[3683∈308]<br />ᐸ3251.secondsᐳ"}}:::plan
+    PgClassExpression3251 --> Access3683
     PgClassExpression3685{{"PgClassExpression[3685∈308]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle3264 --> PgClassExpression3685
     PgClassExpression3705{{"PgClassExpression[3705∈308]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -5928,6 +6628,8 @@ graph TD
     PgClassExpression3238 --> Access3458
     Access3460{{"Access[3460∈309]<br />ᐸ3240.startᐳ"}}:::plan
     PgClassExpression3240 --> Access3460
+    Access3462{{"Access[3462∈309]<br />ᐸ3252.yearsᐳ"}}:::plan
+    PgClassExpression3252 --> Access3462
     PgClassExpression3464{{"PgClassExpression[3464∈309]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3272 --> PgClassExpression3464
     First3474{{"First[3474∈309]"}}:::plan
@@ -5937,12 +6639,16 @@ graph TD
     Lambda4416 --> PgSelectRows3475
     PgSelectSingle3476{{"PgSelectSingle[3476∈309]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3474 --> PgSelectSingle3476
+    Access3496{{"Access[3496∈309]<br />ᐸ3310.xᐳ"}}:::plan
+    PgClassExpression3310 --> Access3496
     Access3554{{"Access[3554∈309]<br />ᐸ3236.endᐳ"}}:::plan
     PgClassExpression3236 --> Access3554
     Access3556{{"Access[3556∈309]<br />ᐸ3238.endᐳ"}}:::plan
     PgClassExpression3238 --> Access3556
     Access3558{{"Access[3558∈309]<br />ᐸ3240.endᐳ"}}:::plan
     PgClassExpression3240 --> Access3558
+    Access3560{{"Access[3560∈309]<br />ᐸ3252.monthsᐳ"}}:::plan
+    PgClassExpression3252 --> Access3560
     PgClassExpression3562{{"PgClassExpression[3562∈309]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
     PgSelectSingle3272 --> PgClassExpression3562
     First3572{{"First[3572∈309]"}}:::plan
@@ -5952,14 +6658,24 @@ graph TD
     Lambda4420 --> PgSelectRows3573
     PgSelectSingle3574{{"PgSelectSingle[3574∈309]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     First3572 --> PgSelectSingle3574
+    Access3590{{"Access[3590∈309]<br />ᐸ3310.yᐳ"}}:::plan
+    PgClassExpression3310 --> Access3590
+    Access3614{{"Access[3614∈309]<br />ᐸ3252.daysᐳ"}}:::plan
+    PgClassExpression3252 --> Access3614
     PgClassExpression3616{{"PgClassExpression[3616∈309]<br />ᐸ__frmcdc_c...type__.”c”ᐳ"}}:::plan
     PgSelectSingle3272 --> PgClassExpression3616
     PgClassExpression3618{{"PgClassExpression[3618∈309]<br />ᐸ__frmcdc_n....”baz_buz”ᐳ"}}:::plan
     PgSelectSingle3284 --> PgClassExpression3618
+    Access3640{{"Access[3640∈309]<br />ᐸ3252.hoursᐳ"}}:::plan
+    PgClassExpression3252 --> Access3640
     PgClassExpression3642{{"PgClassExpression[3642∈309]<br />ᐸ__frmcdc_c...type__.”d”ᐳ"}}:::plan
     PgSelectSingle3272 --> PgClassExpression3642
+    Access3662{{"Access[3662∈309]<br />ᐸ3252.minutesᐳ"}}:::plan
+    PgClassExpression3252 --> Access3662
     PgClassExpression3664{{"PgClassExpression[3664∈309]<br />ᐸ__frmcdc_c...type__.”e”ᐳ"}}:::plan
     PgSelectSingle3272 --> PgClassExpression3664
+    Access3684{{"Access[3684∈309]<br />ᐸ3252.secondsᐳ"}}:::plan
+    PgClassExpression3252 --> Access3684
     PgClassExpression3686{{"PgClassExpression[3686∈309]<br />ᐸ__frmcdc_c...type__.”f”ᐳ"}}:::plan
     PgSelectSingle3272 --> PgClassExpression3686
     PgClassExpression3706{{"PgClassExpression[3706∈309]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -5974,6 +6690,54 @@ graph TD
     List4423 --> Lambda4424
     List4427 --> Lambda4428
     List4439 --> Lambda4440
+    Access2819{{"Access[2819∈310]<br />ᐸ1507.start.valueᐳ"}}:::plan
+    PgClassExpression1507 --> Access2819
+    Access2957{{"Access[2957∈310]<br />ᐸ1507.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1507 --> Access2957
+    Access2820{{"Access[2820∈311]<br />ᐸ1508.start.valueᐳ"}}:::plan
+    PgClassExpression1508 --> Access2820
+    Access2958{{"Access[2958∈311]<br />ᐸ1508.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1508 --> Access2958
+    Access2821{{"Access[2821∈312]<br />ᐸ1509.start.valueᐳ"}}:::plan
+    PgClassExpression1509 --> Access2821
+    Access2959{{"Access[2959∈312]<br />ᐸ1509.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1509 --> Access2959
+    Access2822{{"Access[2822∈313]<br />ᐸ1510.start.valueᐳ"}}:::plan
+    PgClassExpression1510 --> Access2822
+    Access2960{{"Access[2960∈313]<br />ᐸ1510.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1510 --> Access2960
+    Access2823{{"Access[2823∈314]<br />ᐸ1511.start.valueᐳ"}}:::plan
+    PgClassExpression1511 --> Access2823
+    Access2961{{"Access[2961∈314]<br />ᐸ1511.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1511 --> Access2961
+    Access2824{{"Access[2824∈315]<br />ᐸ1512.start.valueᐳ"}}:::plan
+    PgClassExpression1512 --> Access2824
+    Access2962{{"Access[2962∈315]<br />ᐸ1512.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1512 --> Access2962
+    Access2825{{"Access[2825∈316]<br />ᐸ1513.start.valueᐳ"}}:::plan
+    PgClassExpression1513 --> Access2825
+    Access2963{{"Access[2963∈316]<br />ᐸ1513.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1513 --> Access2963
+    Access2826{{"Access[2826∈317]<br />ᐸ1514.start.valueᐳ"}}:::plan
+    PgClassExpression1514 --> Access2826
+    Access2964{{"Access[2964∈317]<br />ᐸ1514.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1514 --> Access2964
+    Access2827{{"Access[2827∈318]<br />ᐸ1515.start.valueᐳ"}}:::plan
+    PgClassExpression1515 --> Access2827
+    Access2965{{"Access[2965∈318]<br />ᐸ1515.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1515 --> Access2965
+    Access2828{{"Access[2828∈319]<br />ᐸ1516.start.valueᐳ"}}:::plan
+    PgClassExpression1516 --> Access2828
+    Access2966{{"Access[2966∈319]<br />ᐸ1516.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1516 --> Access2966
+    Access2829{{"Access[2829∈320]<br />ᐸ1517.start.valueᐳ"}}:::plan
+    PgClassExpression1517 --> Access2829
+    Access2967{{"Access[2967∈320]<br />ᐸ1517.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1517 --> Access2967
+    Access2830{{"Access[2830∈321]<br />ᐸ1518.start.valueᐳ"}}:::plan
+    PgClassExpression1518 --> Access2830
+    Access2968{{"Access[2968∈321]<br />ᐸ1518.start.inclusiveᐳ"}}:::plan
+    PgClassExpression1518 --> Access2968
     PgClassExpression2831{{"PgClassExpression[2831∈322]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2120 --> PgClassExpression2831
     PgClassExpression2969{{"PgClassExpression[2969∈322]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6058,6 +6822,54 @@ graph TD
     PgSelectSingle2159 --> PgClassExpression3178
     PgClassExpression3204{{"PgClassExpression[3204∈327]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle2159 --> PgClassExpression3204
+    Access2837{{"Access[2837∈328]<br />ᐸ1507.end.valueᐳ"}}:::plan
+    PgClassExpression1507 --> Access2837
+    Access2975{{"Access[2975∈328]<br />ᐸ1507.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1507 --> Access2975
+    Access2838{{"Access[2838∈329]<br />ᐸ1508.end.valueᐳ"}}:::plan
+    PgClassExpression1508 --> Access2838
+    Access2976{{"Access[2976∈329]<br />ᐸ1508.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1508 --> Access2976
+    Access2839{{"Access[2839∈330]<br />ᐸ1509.end.valueᐳ"}}:::plan
+    PgClassExpression1509 --> Access2839
+    Access2977{{"Access[2977∈330]<br />ᐸ1509.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1509 --> Access2977
+    Access2840{{"Access[2840∈331]<br />ᐸ1510.end.valueᐳ"}}:::plan
+    PgClassExpression1510 --> Access2840
+    Access2978{{"Access[2978∈331]<br />ᐸ1510.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1510 --> Access2978
+    Access2841{{"Access[2841∈332]<br />ᐸ1511.end.valueᐳ"}}:::plan
+    PgClassExpression1511 --> Access2841
+    Access2979{{"Access[2979∈332]<br />ᐸ1511.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1511 --> Access2979
+    Access2842{{"Access[2842∈333]<br />ᐸ1512.end.valueᐳ"}}:::plan
+    PgClassExpression1512 --> Access2842
+    Access2980{{"Access[2980∈333]<br />ᐸ1512.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1512 --> Access2980
+    Access2843{{"Access[2843∈334]<br />ᐸ1513.end.valueᐳ"}}:::plan
+    PgClassExpression1513 --> Access2843
+    Access2981{{"Access[2981∈334]<br />ᐸ1513.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1513 --> Access2981
+    Access2844{{"Access[2844∈335]<br />ᐸ1514.end.valueᐳ"}}:::plan
+    PgClassExpression1514 --> Access2844
+    Access2982{{"Access[2982∈335]<br />ᐸ1514.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1514 --> Access2982
+    Access2845{{"Access[2845∈336]<br />ᐸ1515.end.valueᐳ"}}:::plan
+    PgClassExpression1515 --> Access2845
+    Access2983{{"Access[2983∈336]<br />ᐸ1515.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1515 --> Access2983
+    Access2846{{"Access[2846∈337]<br />ᐸ1516.end.valueᐳ"}}:::plan
+    PgClassExpression1516 --> Access2846
+    Access2984{{"Access[2984∈337]<br />ᐸ1516.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1516 --> Access2984
+    Access2847{{"Access[2847∈338]<br />ᐸ1517.end.valueᐳ"}}:::plan
+    PgClassExpression1517 --> Access2847
+    Access2985{{"Access[2985∈338]<br />ᐸ1517.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1517 --> Access2985
+    Access2848{{"Access[2848∈339]<br />ᐸ1518.end.valueᐳ"}}:::plan
+    PgClassExpression1518 --> Access2848
+    Access2986{{"Access[2986∈339]<br />ᐸ1518.end.inclusiveᐳ"}}:::plan
+    PgClassExpression1518 --> Access2986
     PgClassExpression2849{{"PgClassExpression[2849∈340]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2225 --> PgClassExpression2849
     PgClassExpression2987{{"PgClassExpression[2987∈340]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6318,6 +7130,22 @@ graph TD
     List4143 --> Lambda4144
     Lambda4152 --> Access4146
     List4147 --> Lambda4148
+    Access2943{{"Access[2943∈358]<br />ᐸ2571.xᐳ"}}:::plan
+    PgClassExpression2571 --> Access2943
+    Access3073{{"Access[3073∈358]<br />ᐸ2571.yᐳ"}}:::plan
+    PgClassExpression2571 --> Access3073
+    Access2944{{"Access[2944∈359]<br />ᐸ2572.xᐳ"}}:::plan
+    PgClassExpression2572 --> Access2944
+    Access3074{{"Access[3074∈359]<br />ᐸ2572.yᐳ"}}:::plan
+    PgClassExpression2572 --> Access3074
+    Access2945{{"Access[2945∈360]<br />ᐸ2573.xᐳ"}}:::plan
+    PgClassExpression2573 --> Access2945
+    Access3075{{"Access[3075∈360]<br />ᐸ2573.yᐳ"}}:::plan
+    PgClassExpression2573 --> Access3075
+    Access2946{{"Access[2946∈361]<br />ᐸ2574.xᐳ"}}:::plan
+    PgClassExpression2574 --> Access2946
+    Access3076{{"Access[3076∈361]<br />ᐸ2574.yᐳ"}}:::plan
+    PgClassExpression2574 --> Access3076
     PgClassExpression2947{{"PgClassExpression[2947∈362]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle2639 --> PgClassExpression2947
     PgClassExpression3077{{"PgClassExpression[3077∈362]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -6406,6 +7234,118 @@ graph TD
     PgClassExpression2681 ==> __Item2797
     __Item2798[/"__Item[2798∈397]<br />ᐸ2682ᐳ"\]:::itemplan
     PgClassExpression2682 ==> __Item2798
+    Access3381{{"Access[3381∈398]<br />ᐸ2779.yearsᐳ"}}:::plan
+    __Item2779 --> Access3381
+    Access3385{{"Access[3385∈398]<br />ᐸ2779.monthsᐳ"}}:::plan
+    __Item2779 --> Access3385
+    Access3389{{"Access[3389∈398]<br />ᐸ2779.daysᐳ"}}:::plan
+    __Item2779 --> Access3389
+    Access3393{{"Access[3393∈398]<br />ᐸ2779.hoursᐳ"}}:::plan
+    __Item2779 --> Access3393
+    Access3397{{"Access[3397∈398]<br />ᐸ2779.minutesᐳ"}}:::plan
+    __Item2779 --> Access3397
+    Access3401{{"Access[3401∈398]<br />ᐸ2779.secondsᐳ"}}:::plan
+    __Item2779 --> Access3401
+    Access3382{{"Access[3382∈399]<br />ᐸ2780.yearsᐳ"}}:::plan
+    __Item2780 --> Access3382
+    Access3386{{"Access[3386∈399]<br />ᐸ2780.monthsᐳ"}}:::plan
+    __Item2780 --> Access3386
+    Access3390{{"Access[3390∈399]<br />ᐸ2780.daysᐳ"}}:::plan
+    __Item2780 --> Access3390
+    Access3394{{"Access[3394∈399]<br />ᐸ2780.hoursᐳ"}}:::plan
+    __Item2780 --> Access3394
+    Access3398{{"Access[3398∈399]<br />ᐸ2780.minutesᐳ"}}:::plan
+    __Item2780 --> Access3398
+    Access3402{{"Access[3402∈399]<br />ᐸ2780.secondsᐳ"}}:::plan
+    __Item2780 --> Access3402
+    Access3383{{"Access[3383∈400]<br />ᐸ2781.yearsᐳ"}}:::plan
+    __Item2781 --> Access3383
+    Access3387{{"Access[3387∈400]<br />ᐸ2781.monthsᐳ"}}:::plan
+    __Item2781 --> Access3387
+    Access3391{{"Access[3391∈400]<br />ᐸ2781.daysᐳ"}}:::plan
+    __Item2781 --> Access3391
+    Access3395{{"Access[3395∈400]<br />ᐸ2781.hoursᐳ"}}:::plan
+    __Item2781 --> Access3395
+    Access3399{{"Access[3399∈400]<br />ᐸ2781.minutesᐳ"}}:::plan
+    __Item2781 --> Access3399
+    Access3403{{"Access[3403∈400]<br />ᐸ2781.secondsᐳ"}}:::plan
+    __Item2781 --> Access3403
+    Access3384{{"Access[3384∈401]<br />ᐸ2782.yearsᐳ"}}:::plan
+    __Item2782 --> Access3384
+    Access3388{{"Access[3388∈401]<br />ᐸ2782.monthsᐳ"}}:::plan
+    __Item2782 --> Access3388
+    Access3392{{"Access[3392∈401]<br />ᐸ2782.daysᐳ"}}:::plan
+    __Item2782 --> Access3392
+    Access3396{{"Access[3396∈401]<br />ᐸ2782.hoursᐳ"}}:::plan
+    __Item2782 --> Access3396
+    Access3400{{"Access[3400∈401]<br />ᐸ2782.minutesᐳ"}}:::plan
+    __Item2782 --> Access3400
+    Access3404{{"Access[3404∈401]<br />ᐸ2782.secondsᐳ"}}:::plan
+    __Item2782 --> Access3404
+    Access3405{{"Access[3405∈402]<br />ᐸ2415.start.valueᐳ"}}:::plan
+    PgClassExpression2415 --> Access3405
+    Access3503{{"Access[3503∈402]<br />ᐸ2415.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2415 --> Access3503
+    Access3406{{"Access[3406∈403]<br />ᐸ2416.start.valueᐳ"}}:::plan
+    PgClassExpression2416 --> Access3406
+    Access3504{{"Access[3504∈403]<br />ᐸ2416.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2416 --> Access3504
+    Access3407{{"Access[3407∈404]<br />ᐸ2417.start.valueᐳ"}}:::plan
+    PgClassExpression2417 --> Access3407
+    Access3505{{"Access[3505∈404]<br />ᐸ2417.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2417 --> Access3505
+    Access3408{{"Access[3408∈405]<br />ᐸ2418.start.valueᐳ"}}:::plan
+    PgClassExpression2418 --> Access3408
+    Access3506{{"Access[3506∈405]<br />ᐸ2418.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2418 --> Access3506
+    Access3409{{"Access[3409∈406]<br />ᐸ2419.start.valueᐳ"}}:::plan
+    PgClassExpression2419 --> Access3409
+    Access3507{{"Access[3507∈406]<br />ᐸ2419.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2419 --> Access3507
+    Access3410{{"Access[3410∈407]<br />ᐸ2420.start.valueᐳ"}}:::plan
+    PgClassExpression2420 --> Access3410
+    Access3508{{"Access[3508∈407]<br />ᐸ2420.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2420 --> Access3508
+    Access3411{{"Access[3411∈408]<br />ᐸ2421.start.valueᐳ"}}:::plan
+    PgClassExpression2421 --> Access3411
+    Access3509{{"Access[3509∈408]<br />ᐸ2421.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2421 --> Access3509
+    Access3412{{"Access[3412∈409]<br />ᐸ2422.start.valueᐳ"}}:::plan
+    PgClassExpression2422 --> Access3412
+    Access3510{{"Access[3510∈409]<br />ᐸ2422.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2422 --> Access3510
+    Access3413{{"Access[3413∈410]<br />ᐸ2423.start.valueᐳ"}}:::plan
+    PgClassExpression2423 --> Access3413
+    Access3511{{"Access[3511∈410]<br />ᐸ2423.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2423 --> Access3511
+    Access3414{{"Access[3414∈411]<br />ᐸ2424.start.valueᐳ"}}:::plan
+    PgClassExpression2424 --> Access3414
+    Access3512{{"Access[3512∈411]<br />ᐸ2424.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2424 --> Access3512
+    Access3415{{"Access[3415∈412]<br />ᐸ2425.start.valueᐳ"}}:::plan
+    PgClassExpression2425 --> Access3415
+    Access3513{{"Access[3513∈412]<br />ᐸ2425.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2425 --> Access3513
+    Access3416{{"Access[3416∈413]<br />ᐸ2426.start.valueᐳ"}}:::plan
+    PgClassExpression2426 --> Access3416
+    Access3514{{"Access[3514∈413]<br />ᐸ2426.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2426 --> Access3514
+    Access3417{{"Access[3417∈414]<br />ᐸ2427.start.valueᐳ"}}:::plan
+    PgClassExpression2427 --> Access3417
+    Access3515{{"Access[3515∈414]<br />ᐸ2427.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2427 --> Access3515
+    Access3418{{"Access[3418∈415]<br />ᐸ2428.start.valueᐳ"}}:::plan
+    PgClassExpression2428 --> Access3418
+    Access3516{{"Access[3516∈415]<br />ᐸ2428.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2428 --> Access3516
+    Access3419{{"Access[3419∈416]<br />ᐸ2429.start.valueᐳ"}}:::plan
+    PgClassExpression2429 --> Access3419
+    Access3517{{"Access[3517∈416]<br />ᐸ2429.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2429 --> Access3517
+    Access3420{{"Access[3420∈417]<br />ᐸ2430.start.valueᐳ"}}:::plan
+    PgClassExpression2430 --> Access3420
+    Access3518{{"Access[3518∈417]<br />ᐸ2430.start.inclusiveᐳ"}}:::plan
+    PgClassExpression2430 --> Access3518
     PgClassExpression3421{{"PgClassExpression[3421∈418]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle2884 --> PgClassExpression3421
     PgClassExpression3519{{"PgClassExpression[3519∈418]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6518,6 +7458,70 @@ graph TD
     PgSelectSingle2938 --> PgClassExpression3674
     PgClassExpression3696{{"PgClassExpression[3696∈425]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle2938 --> PgClassExpression3696
+    Access3429{{"Access[3429∈426]<br />ᐸ2415.end.valueᐳ"}}:::plan
+    PgClassExpression2415 --> Access3429
+    Access3527{{"Access[3527∈426]<br />ᐸ2415.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2415 --> Access3527
+    Access3430{{"Access[3430∈427]<br />ᐸ2416.end.valueᐳ"}}:::plan
+    PgClassExpression2416 --> Access3430
+    Access3528{{"Access[3528∈427]<br />ᐸ2416.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2416 --> Access3528
+    Access3431{{"Access[3431∈428]<br />ᐸ2417.end.valueᐳ"}}:::plan
+    PgClassExpression2417 --> Access3431
+    Access3529{{"Access[3529∈428]<br />ᐸ2417.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2417 --> Access3529
+    Access3432{{"Access[3432∈429]<br />ᐸ2418.end.valueᐳ"}}:::plan
+    PgClassExpression2418 --> Access3432
+    Access3530{{"Access[3530∈429]<br />ᐸ2418.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2418 --> Access3530
+    Access3433{{"Access[3433∈430]<br />ᐸ2419.end.valueᐳ"}}:::plan
+    PgClassExpression2419 --> Access3433
+    Access3531{{"Access[3531∈430]<br />ᐸ2419.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2419 --> Access3531
+    Access3434{{"Access[3434∈431]<br />ᐸ2420.end.valueᐳ"}}:::plan
+    PgClassExpression2420 --> Access3434
+    Access3532{{"Access[3532∈431]<br />ᐸ2420.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2420 --> Access3532
+    Access3435{{"Access[3435∈432]<br />ᐸ2421.end.valueᐳ"}}:::plan
+    PgClassExpression2421 --> Access3435
+    Access3533{{"Access[3533∈432]<br />ᐸ2421.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2421 --> Access3533
+    Access3436{{"Access[3436∈433]<br />ᐸ2422.end.valueᐳ"}}:::plan
+    PgClassExpression2422 --> Access3436
+    Access3534{{"Access[3534∈433]<br />ᐸ2422.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2422 --> Access3534
+    Access3437{{"Access[3437∈434]<br />ᐸ2423.end.valueᐳ"}}:::plan
+    PgClassExpression2423 --> Access3437
+    Access3535{{"Access[3535∈434]<br />ᐸ2423.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2423 --> Access3535
+    Access3438{{"Access[3438∈435]<br />ᐸ2424.end.valueᐳ"}}:::plan
+    PgClassExpression2424 --> Access3438
+    Access3536{{"Access[3536∈435]<br />ᐸ2424.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2424 --> Access3536
+    Access3439{{"Access[3439∈436]<br />ᐸ2425.end.valueᐳ"}}:::plan
+    PgClassExpression2425 --> Access3439
+    Access3537{{"Access[3537∈436]<br />ᐸ2425.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2425 --> Access3537
+    Access3440{{"Access[3440∈437]<br />ᐸ2426.end.valueᐳ"}}:::plan
+    PgClassExpression2426 --> Access3440
+    Access3538{{"Access[3538∈437]<br />ᐸ2426.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2426 --> Access3538
+    Access3441{{"Access[3441∈438]<br />ᐸ2427.end.valueᐳ"}}:::plan
+    PgClassExpression2427 --> Access3441
+    Access3539{{"Access[3539∈438]<br />ᐸ2427.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2427 --> Access3539
+    Access3442{{"Access[3442∈439]<br />ᐸ2428.end.valueᐳ"}}:::plan
+    PgClassExpression2428 --> Access3442
+    Access3540{{"Access[3540∈439]<br />ᐸ2428.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2428 --> Access3540
+    Access3443{{"Access[3443∈440]<br />ᐸ2429.end.valueᐳ"}}:::plan
+    PgClassExpression2429 --> Access3443
+    Access3541{{"Access[3541∈440]<br />ᐸ2429.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2429 --> Access3541
+    Access3444{{"Access[3444∈441]<br />ᐸ2430.end.valueᐳ"}}:::plan
+    PgClassExpression2430 --> Access3444
+    Access3542{{"Access[3542∈441]<br />ᐸ2430.end.inclusiveᐳ"}}:::plan
+    PgClassExpression2430 --> Access3542
     PgClassExpression3445{{"PgClassExpression[3445∈442]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3022 --> PgClassExpression3445
     PgClassExpression3543{{"PgClassExpression[3543∈442]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6718,6 +7722,14 @@ graph TD
     List4431 --> Lambda4432
     Lambda4440 --> Access4434
     List4435 --> Lambda4436
+    Access3497{{"Access[3497∈456]<br />ᐸ3311.xᐳ"}}:::plan
+    PgClassExpression3311 --> Access3497
+    Access3591{{"Access[3591∈456]<br />ᐸ3311.yᐳ"}}:::plan
+    PgClassExpression3311 --> Access3591
+    Access3498{{"Access[3498∈457]<br />ᐸ3312.xᐳ"}}:::plan
+    PgClassExpression3312 --> Access3498
+    Access3592{{"Access[3592∈457]<br />ᐸ3312.yᐳ"}}:::plan
+    PgClassExpression3312 --> Access3592
     PgClassExpression3499{{"PgClassExpression[3499∈458]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     PgSelectSingle3347 --> PgClassExpression3499
     PgClassExpression3593{{"PgClassExpression[3593∈458]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
@@ -6762,6 +7774,62 @@ graph TD
     PgClassExpression3365 ==> __Item3379
     __Item3380[/"__Item[3380∈475]<br />ᐸ3366ᐳ"\]:::itemplan
     PgClassExpression3366 ==> __Item3380
+    Access3709{{"Access[3709∈476]<br />ᐸ3371.yearsᐳ"}}:::plan
+    __Item3371 --> Access3709
+    Access3711{{"Access[3711∈476]<br />ᐸ3371.monthsᐳ"}}:::plan
+    __Item3371 --> Access3711
+    Access3713{{"Access[3713∈476]<br />ᐸ3371.daysᐳ"}}:::plan
+    __Item3371 --> Access3713
+    Access3715{{"Access[3715∈476]<br />ᐸ3371.hoursᐳ"}}:::plan
+    __Item3371 --> Access3715
+    Access3717{{"Access[3717∈476]<br />ᐸ3371.minutesᐳ"}}:::plan
+    __Item3371 --> Access3717
+    Access3719{{"Access[3719∈476]<br />ᐸ3371.secondsᐳ"}}:::plan
+    __Item3371 --> Access3719
+    Access3710{{"Access[3710∈477]<br />ᐸ3372.yearsᐳ"}}:::plan
+    __Item3372 --> Access3710
+    Access3712{{"Access[3712∈477]<br />ᐸ3372.monthsᐳ"}}:::plan
+    __Item3372 --> Access3712
+    Access3714{{"Access[3714∈477]<br />ᐸ3372.daysᐳ"}}:::plan
+    __Item3372 --> Access3714
+    Access3716{{"Access[3716∈477]<br />ᐸ3372.hoursᐳ"}}:::plan
+    __Item3372 --> Access3716
+    Access3718{{"Access[3718∈477]<br />ᐸ3372.minutesᐳ"}}:::plan
+    __Item3372 --> Access3718
+    Access3720{{"Access[3720∈477]<br />ᐸ3372.secondsᐳ"}}:::plan
+    __Item3372 --> Access3720
+    Access3721{{"Access[3721∈478]<br />ᐸ3233.start.valueᐳ"}}:::plan
+    PgClassExpression3233 --> Access3721
+    Access3745{{"Access[3745∈478]<br />ᐸ3233.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3233 --> Access3745
+    Access3722{{"Access[3722∈479]<br />ᐸ3234.start.valueᐳ"}}:::plan
+    PgClassExpression3234 --> Access3722
+    Access3746{{"Access[3746∈479]<br />ᐸ3234.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3234 --> Access3746
+    Access3723{{"Access[3723∈480]<br />ᐸ3235.start.valueᐳ"}}:::plan
+    PgClassExpression3235 --> Access3723
+    Access3747{{"Access[3747∈480]<br />ᐸ3235.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3235 --> Access3747
+    Access3724{{"Access[3724∈481]<br />ᐸ3236.start.valueᐳ"}}:::plan
+    PgClassExpression3236 --> Access3724
+    Access3748{{"Access[3748∈481]<br />ᐸ3236.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3236 --> Access3748
+    Access3725{{"Access[3725∈482]<br />ᐸ3237.start.valueᐳ"}}:::plan
+    PgClassExpression3237 --> Access3725
+    Access3749{{"Access[3749∈482]<br />ᐸ3237.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3237 --> Access3749
+    Access3726{{"Access[3726∈483]<br />ᐸ3238.start.valueᐳ"}}:::plan
+    PgClassExpression3238 --> Access3726
+    Access3750{{"Access[3750∈483]<br />ᐸ3238.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3238 --> Access3750
+    Access3727{{"Access[3727∈484]<br />ᐸ3239.start.valueᐳ"}}:::plan
+    PgClassExpression3239 --> Access3727
+    Access3751{{"Access[3751∈484]<br />ᐸ3239.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3239 --> Access3751
+    Access3728{{"Access[3728∈485]<br />ᐸ3240.start.valueᐳ"}}:::plan
+    PgClassExpression3240 --> Access3728
+    Access3752{{"Access[3752∈485]<br />ᐸ3240.start.inclusiveᐳ"}}:::plan
+    PgClassExpression3240 --> Access3752
     PgClassExpression3729{{"PgClassExpression[3729∈486]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3470 --> PgClassExpression3729
     PgClassExpression3753{{"PgClassExpression[3753∈486]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6818,6 +7886,38 @@ graph TD
     PgSelectSingle3494 --> PgClassExpression3796
     PgClassExpression3804{{"PgClassExpression[3804∈489]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
     PgSelectSingle3494 --> PgClassExpression3804
+    Access3733{{"Access[3733∈490]<br />ᐸ3233.end.valueᐳ"}}:::plan
+    PgClassExpression3233 --> Access3733
+    Access3757{{"Access[3757∈490]<br />ᐸ3233.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3233 --> Access3757
+    Access3734{{"Access[3734∈491]<br />ᐸ3234.end.valueᐳ"}}:::plan
+    PgClassExpression3234 --> Access3734
+    Access3758{{"Access[3758∈491]<br />ᐸ3234.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3234 --> Access3758
+    Access3735{{"Access[3735∈492]<br />ᐸ3235.end.valueᐳ"}}:::plan
+    PgClassExpression3235 --> Access3735
+    Access3759{{"Access[3759∈492]<br />ᐸ3235.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3235 --> Access3759
+    Access3736{{"Access[3736∈493]<br />ᐸ3236.end.valueᐳ"}}:::plan
+    PgClassExpression3236 --> Access3736
+    Access3760{{"Access[3760∈493]<br />ᐸ3236.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3236 --> Access3760
+    Access3737{{"Access[3737∈494]<br />ᐸ3237.end.valueᐳ"}}:::plan
+    PgClassExpression3237 --> Access3737
+    Access3761{{"Access[3761∈494]<br />ᐸ3237.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3237 --> Access3761
+    Access3738{{"Access[3738∈495]<br />ᐸ3238.end.valueᐳ"}}:::plan
+    PgClassExpression3238 --> Access3738
+    Access3762{{"Access[3762∈495]<br />ᐸ3238.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3238 --> Access3762
+    Access3739{{"Access[3739∈496]<br />ᐸ3239.end.valueᐳ"}}:::plan
+    PgClassExpression3239 --> Access3739
+    Access3763{{"Access[3763∈496]<br />ᐸ3239.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3239 --> Access3763
+    Access3740{{"Access[3740∈497]<br />ᐸ3240.end.valueᐳ"}}:::plan
+    PgClassExpression3240 --> Access3740
+    Access3764{{"Access[3764∈497]<br />ᐸ3240.end.inclusiveᐳ"}}:::plan
+    PgClassExpression3240 --> Access3764
     PgClassExpression3741{{"PgClassExpression[3741∈498]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle3568 --> PgClassExpression3741
     PgClassExpression3765{{"PgClassExpression[3765∈498]<br />ᐸ__frmcdc_c...type__.”b”ᐳ"}}:::plan
@@ -6879,23 +7979,23 @@ graph TD
     classDef bucket0 stroke:#696969
     class Bucket0,__Value2,PgSelect8,Access9,Access10,Object11,Connection12,PgSelect14,PgSelect17,First19,PgSelectRows20,PgSelectSingle21,Lambda23,Access24,PgSelect26,First28,PgSelectRows29,PgSelectSingle30,PgSelect31,PgFromExpression33,First34,PgSelectRows35,PgSelectSingle36,PgSelect37,PgSelect39,Connection41,PgSelect43,First45,PgSelectRows46,PgSelectSingle47,PgSelect48,First50,PgSelectRows51,PgSelectSingle52,PgSelectRows53,PgSelectRows54,Lambda55,ConnectionItems254,ConnectionItems260,PgSelect284,First285,PgSelectRows286,PgSelectSingle287,PgSelect292,First293,PgSelectRows294,PgSelectSingle295,First998,Access999,First1001,Access1002,Last1027,Last1029,PgSelectInlineApply3809,Access3810,PgSelectInlineApply3813,Access3814,PgSelectInlineApply3817,Access3818,PgSelectInlineApply3821,PgSelectInlineApply3825,PgSelectInlineApply3829,Access3830,PgSelectInlineApply3833,Access3834,PgSelectInlineApply3837,PgSelectInlineApply3841,PgSelectInlineApply3845,Access3846,PgSelectInlineApply3849,Access3850,PgSelectInlineApply3853,Access3854,PgSelectInlineApply3857,Access3858,PgSelectInlineApply3861,PgSelectInlineApply3865,PgSelectInlineApply3869,Access3870,PgSelectInlineApply3873,Access3874,PgSelectInlineApply3877,PgSelectInlineApply3881,PgSelectInlineApply3885,Access3886,PgSelectInlineApply3889,Access3890,PgSelectInlineApply3893,Access3894,PgSelectInlineApply3897,Access3898,PgSelectInlineApply3901,PgSelectInlineApply3905,PgSelectInlineApply3909,Access3910,PgSelectInlineApply3913,Access3914,PgSelectInlineApply3917,PgSelectInlineApply3921,PgSelectInlineApply3925,Access3926,PgSelectInlineApply3929,Access3930,PgSelectInlineApply3933,Access3934,PgSelectInlineApply3937,Access3938,PgSelectInlineApply3941,PgSelectInlineApply3945,PgSelectInlineApply3949,Access3950,PgSelectInlineApply3953,Access3954,PgSelectInlineApply3957,PgSelectInlineApply3961,PgSelectInlineApply3965,Access3966,PgSelectInlineApply3969,Access3970,PgSelectInlineApply3973,Access3974,PgSelectInlineApply3977,Access3978,PgSelectInlineApply3981,PgSelectInlineApply3985,PgSelectInlineApply3989,Access3990,PgSelectInlineApply3993,Access3994,PgSelectInlineApply3997,PgSelectInlineApply4001,PgSelectInlineApply4005,Access4006,PgSelectInlineApply4009,Access4010,PgSelectInlineApply4013,Access4014,PgSelectInlineApply4017,Access4018,PgSelectInlineApply4021,PgSelectInlineApply4025,PgSelectInlineApply4029,Access4030,PgSelectInlineApply4033,Access4034,PgSelectInlineApply4037,PgSelectInlineApply4041,PgSelectInlineApply4045,Access4046,PgSelectInlineApply4049,Access4050,PgSelectInlineApply4053,Access4054,PgSelectInlineApply4057,Access4058,PgSelectInlineApply4061,PgSelectInlineApply4065,PgSelectInlineApply4069,Access4070,PgSelectInlineApply4073,Access4074,PgSelectInlineApply4077,PgSelectInlineApply4081,PgSelectInlineApply4085,Access4086,PgSelectInlineApply4089,Access4090,PgSelectInlineApply4093,PgSelectInlineApply4097,PgSelectInlineApply4101,Access4102,PgSelectInlineApply4105,Access4106,PgSelectInlineApply4109,PgSelectInlineApply4113,PgSelectInlineApply4117,Access4118,PgSelectInlineApply4121,Access4122,PgSelectInlineApply4125,PgSelectInlineApply4129,PgSelectInlineApply4133,Access4134,PgSelectInlineApply4137,Access4138,PgSelectInlineApply4141,PgSelectInlineApply4145,PgSelectInlineApply4149,Access4150,PgSelectInlineApply4153,PgSelectInlineApply4157,PgSelectInlineApply4161,PgSelectInlineApply4165,PgSelectInlineApply4169,PgSelectInlineApply4173,PgSelectInlineApply4177,PgSelectInlineApply4181,PgSelectInlineApply4185,PgSelectInlineApply4189,PgFromExpression4193,PgSelectInlineApply4194,Access4195,PgSelectInlineApply4198,PgSelectInlineApply4202,PgSelectInlineApply4206,PgSelectInlineApply4210,PgSelectInlineApply4214,PgSelectInlineApply4218,PgSelectInlineApply4222,PgSelectInlineApply4226,PgSelectInlineApply4230,PgSelectInlineApply4234,PgFromExpression4238,PgSelectInlineApply4239,Access4240,List4241,Lambda4242,PgSelectInlineApply4243,PgSelectInlineApply4247,PgSelectInlineApply4251,PgSelectInlineApply4255,PgSelectInlineApply4259,PgSelectInlineApply4263,PgSelectInlineApply4267,PgSelectInlineApply4271,PgSelectInlineApply4275,PgSelectInlineApply4279,PgSelectInlineApply4283,PgSelectInlineApply4287,PgSelectInlineApply4291,PgSelectInlineApply4295,PgSelectInlineApply4299,PgSelectInlineApply4303,PgFromExpression4307,PgSelectInlineApply4308,Access4309,List4310,Lambda4311,PgSelectInlineApply4313,Access4314,List4315,Lambda4316,PgSelectInlineApply4317,PgSelectInlineApply4321,PgSelectInlineApply4325,PgSelectInlineApply4329,PgSelectInlineApply4333,PgSelectInlineApply4337,PgSelectInlineApply4341,PgSelectInlineApply4345,PgSelectInlineApply4349,PgSelectInlineApply4353,PgSelectInlineApply4357,Access4358,PgSelectInlineApply4361,PgSelectInlineApply4365,PgSelectInlineApply4369,PgSelectInlineApply4373,PgSelectInlineApply4377,PgSelectInlineApply4381,PgSelectInlineApply4385,PgSelectInlineApply4389,PgSelectInlineApply4393,PgSelectInlineApply4397,PgSelectInlineApply4401,PgSelectInlineApply4405,PgSelectInlineApply4409,PgSelectInlineApply4413,PgSelectInlineApply4417,PgSelectInlineApply4421,PgSelectInlineApply4425,PgSelectInlineApply4429,PgSelectInlineApply4433,PgSelectInlineApply4437,PgSelectInlineApply4441,Access4442,List4443,Lambda4444,PgSelectInlineApply4445,Access4446,List4447,Lambda4448 bucket0
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PageInfo309 bucket1
+    class Bucket1,PageInfo309,Access834,Access918 bucket1
     classDef bucket2 stroke:#7f007f
-    class Bucket2,PgClassExpression257,PgClassExpression275,PgClassExpression289,PgClassExpression310,PgClassExpression318,PgClassExpression321,PgClassExpression324,PgClassExpression327,PgClassExpression330,PgClassExpression333,PgClassExpression336,PgClassExpression339,PgClassExpression342,PgClassExpression345,PgClassExpression348,PgClassExpression351,PgClassExpression354,PgClassExpression357,PgClassExpression360,PgClassExpression363,PgClassExpression366,PgClassExpression369,PgClassExpression372,PgClassExpression375,PgClassExpression378,PgClassExpression381,First389,PgSelectRows390,PgSelectSingle391,First411,PgSelectRows412,PgSelectSingle413,First429,PgSelectRows430,PgSelectSingle431,First447,PgSelectRows448,PgSelectSingle449,PgClassExpression462,PgClassExpression465,PgClassExpression468,PgClassExpression471,PgClassExpression474,PgClassExpression477,PgClassExpression480,PgClassExpression483,PgClassExpression486,PgClassExpression489,PgClassExpression492,PgClassExpression495,PgClassExpression498,PgClassExpression501,PgClassExpression504,PgClassExpression507,PgClassExpression510,First515,PgSelectRows516,PgSelectSingle517,First530,PgSelectRows531,PgSelectSingle532,PgClassExpression543,PgClassExpression546,Access842,Access845,Access848,PgClassExpression854,First860,PgSelectRows861,PgSelectSingle862,Access925,Access928,Access931,PgClassExpression937,First943,PgSelectRows944,PgSelectSingle945,PgClassExpression1012,PgClassExpression1015,PgClassExpression1035,PgClassExpression1046,PgClassExpression1057,PgClassExpression1065,List3931,Lambda3932,List3935,Lambda3936,List3939,Lambda3940,Access3942,List3943,Lambda3944,Access3946,List3947,Lambda3948,List3951,Lambda3952,List3955,Lambda3956,Access3958,Access3962,List3967,Lambda3968 bucket2
+    class Bucket2,PgClassExpression257,PgClassExpression275,PgClassExpression289,PgClassExpression310,PgClassExpression318,PgClassExpression321,PgClassExpression324,PgClassExpression327,PgClassExpression330,PgClassExpression333,PgClassExpression336,PgClassExpression339,PgClassExpression342,PgClassExpression345,PgClassExpression348,PgClassExpression351,PgClassExpression354,PgClassExpression357,PgClassExpression360,PgClassExpression363,PgClassExpression366,PgClassExpression369,PgClassExpression372,PgClassExpression375,PgClassExpression378,PgClassExpression381,First389,PgSelectRows390,PgSelectSingle391,First411,PgSelectRows412,PgSelectSingle413,First429,PgSelectRows430,PgSelectSingle431,First447,PgSelectRows448,PgSelectSingle449,PgClassExpression462,PgClassExpression465,PgClassExpression468,PgClassExpression471,PgClassExpression474,PgClassExpression477,PgClassExpression480,PgClassExpression483,PgClassExpression486,PgClassExpression489,PgClassExpression492,PgClassExpression495,PgClassExpression498,PgClassExpression501,PgClassExpression504,PgClassExpression507,PgClassExpression510,First515,PgSelectRows516,PgSelectSingle517,First530,PgSelectRows531,PgSelectSingle532,PgClassExpression543,PgClassExpression546,Access842,Access845,Access848,Access851,PgClassExpression854,First860,PgSelectRows861,PgSelectSingle862,Access902,Access925,Access928,Access931,Access934,PgClassExpression937,First943,PgSelectRows944,PgSelectSingle945,Access979,Access1009,PgClassExpression1012,PgClassExpression1015,Access1032,PgClassExpression1035,Access1043,PgClassExpression1046,Access1054,PgClassExpression1057,PgClassExpression1065,Access1712,Access1715,Access1718,Access1730,Access1733,Access1736,Access1801,Access1804,Access1807,Access1819,Access1822,Access1825,List3931,Lambda3932,List3935,Lambda3936,List3939,Lambda3940,Access3942,List3943,Lambda3944,Access3946,List3947,Lambda3948,List3951,Lambda3952,List3955,Lambda3956,Access3958,Access3962,List3967,Lambda3968 bucket2
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression258,PgClassExpression276,PgClassExpression290,PgClassExpression311,PgClassExpression319,PgClassExpression322,PgClassExpression325,PgClassExpression328,PgClassExpression331,PgClassExpression334,PgClassExpression337,PgClassExpression340,PgClassExpression343,PgClassExpression346,PgClassExpression349,PgClassExpression352,PgClassExpression355,PgClassExpression358,PgClassExpression361,PgClassExpression364,PgClassExpression367,PgClassExpression370,PgClassExpression373,PgClassExpression376,PgClassExpression379,PgClassExpression382,First397,PgSelectRows398,PgSelectSingle399,First417,PgSelectRows418,PgSelectSingle419,First435,PgSelectRows436,PgSelectSingle437,First453,PgSelectRows454,PgSelectSingle455,PgClassExpression463,PgClassExpression466,PgClassExpression469,PgClassExpression472,PgClassExpression475,PgClassExpression478,PgClassExpression481,PgClassExpression484,PgClassExpression487,PgClassExpression490,PgClassExpression493,PgClassExpression496,PgClassExpression499,PgClassExpression502,PgClassExpression505,PgClassExpression508,PgClassExpression511,First520,PgSelectRows521,PgSelectSingle522,First535,PgSelectRows536,PgSelectSingle537,PgClassExpression544,PgClassExpression547,Access843,Access846,Access849,PgClassExpression855,First866,PgSelectRows867,PgSelectSingle868,Access926,Access929,Access932,PgClassExpression938,First949,PgSelectRows950,PgSelectSingle951,PgClassExpression1013,PgClassExpression1016,PgClassExpression1036,PgClassExpression1047,PgClassExpression1058,PgClassExpression1066,List3971,Lambda3972,List3975,Lambda3976,List3979,Lambda3980,Access3982,List3983,Lambda3984,Access3986,List3987,Lambda3988,List3991,Lambda3992,List3995,Lambda3996,Access3998,Access4002,List4007,Lambda4008 bucket3
+    class Bucket3,PgClassExpression258,PgClassExpression276,PgClassExpression290,PgClassExpression311,PgClassExpression319,PgClassExpression322,PgClassExpression325,PgClassExpression328,PgClassExpression331,PgClassExpression334,PgClassExpression337,PgClassExpression340,PgClassExpression343,PgClassExpression346,PgClassExpression349,PgClassExpression352,PgClassExpression355,PgClassExpression358,PgClassExpression361,PgClassExpression364,PgClassExpression367,PgClassExpression370,PgClassExpression373,PgClassExpression376,PgClassExpression379,PgClassExpression382,First397,PgSelectRows398,PgSelectSingle399,First417,PgSelectRows418,PgSelectSingle419,First435,PgSelectRows436,PgSelectSingle437,First453,PgSelectRows454,PgSelectSingle455,PgClassExpression463,PgClassExpression466,PgClassExpression469,PgClassExpression472,PgClassExpression475,PgClassExpression478,PgClassExpression481,PgClassExpression484,PgClassExpression487,PgClassExpression490,PgClassExpression493,PgClassExpression496,PgClassExpression499,PgClassExpression502,PgClassExpression505,PgClassExpression508,PgClassExpression511,First520,PgSelectRows521,PgSelectSingle522,First535,PgSelectRows536,PgSelectSingle537,PgClassExpression544,PgClassExpression547,Access843,Access846,Access849,Access852,PgClassExpression855,First866,PgSelectRows867,PgSelectSingle868,Access903,Access926,Access929,Access932,Access935,PgClassExpression938,First949,PgSelectRows950,PgSelectSingle951,Access980,Access1010,PgClassExpression1013,PgClassExpression1016,Access1033,PgClassExpression1036,Access1044,PgClassExpression1047,Access1055,PgClassExpression1058,PgClassExpression1066,Access1713,Access1716,Access1719,Access1731,Access1734,Access1737,Access1802,Access1805,Access1808,Access1820,Access1823,Access1826,List3971,Lambda3972,List3975,Lambda3976,List3979,Lambda3980,Access3982,List3983,Lambda3984,Access3986,List3987,Lambda3988,List3991,Lambda3992,List3995,Lambda3996,Access3998,Access4002,List4007,Lambda4008 bucket3
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression259,PgClassExpression277,PgClassExpression291,PgClassExpression312,PgClassExpression320,PgClassExpression323,PgClassExpression326,PgClassExpression329,PgClassExpression332,PgClassExpression335,PgClassExpression338,PgClassExpression341,PgClassExpression344,PgClassExpression347,PgClassExpression350,PgClassExpression353,PgClassExpression356,PgClassExpression359,PgClassExpression362,PgClassExpression365,PgClassExpression368,PgClassExpression371,PgClassExpression374,PgClassExpression377,PgClassExpression380,PgClassExpression383,First405,PgSelectRows406,PgSelectSingle407,First423,PgSelectRows424,PgSelectSingle425,First441,PgSelectRows442,PgSelectSingle443,First459,PgSelectRows460,PgSelectSingle461,PgClassExpression464,PgClassExpression467,PgClassExpression470,PgClassExpression473,PgClassExpression476,PgClassExpression479,PgClassExpression482,PgClassExpression485,PgClassExpression488,PgClassExpression491,PgClassExpression494,PgClassExpression497,PgClassExpression500,PgClassExpression503,PgClassExpression506,PgClassExpression509,PgClassExpression512,First525,PgSelectRows526,PgSelectSingle527,First540,PgSelectRows541,PgSelectSingle542,PgClassExpression545,PgClassExpression548,Access844,Access847,Access850,PgClassExpression856,First872,PgSelectRows873,PgSelectSingle874,Access927,Access930,Access933,PgClassExpression939,First955,PgSelectRows956,PgSelectSingle957,PgClassExpression1014,PgClassExpression1017,PgClassExpression1037,PgClassExpression1048,PgClassExpression1059,PgClassExpression1067,List4011,Lambda4012,List4015,Lambda4016,List4019,Lambda4020,Access4022,List4023,Lambda4024,Access4026,List4027,Lambda4028,List4031,Lambda4032,List4035,Lambda4036,Access4038,Access4042,List4047,Lambda4048 bucket4
+    class Bucket4,PgClassExpression259,PgClassExpression277,PgClassExpression291,PgClassExpression312,PgClassExpression320,PgClassExpression323,PgClassExpression326,PgClassExpression329,PgClassExpression332,PgClassExpression335,PgClassExpression338,PgClassExpression341,PgClassExpression344,PgClassExpression347,PgClassExpression350,PgClassExpression353,PgClassExpression356,PgClassExpression359,PgClassExpression362,PgClassExpression365,PgClassExpression368,PgClassExpression371,PgClassExpression374,PgClassExpression377,PgClassExpression380,PgClassExpression383,First405,PgSelectRows406,PgSelectSingle407,First423,PgSelectRows424,PgSelectSingle425,First441,PgSelectRows442,PgSelectSingle443,First459,PgSelectRows460,PgSelectSingle461,PgClassExpression464,PgClassExpression467,PgClassExpression470,PgClassExpression473,PgClassExpression476,PgClassExpression479,PgClassExpression482,PgClassExpression485,PgClassExpression488,PgClassExpression491,PgClassExpression494,PgClassExpression497,PgClassExpression500,PgClassExpression503,PgClassExpression506,PgClassExpression509,PgClassExpression512,First525,PgSelectRows526,PgSelectSingle527,First540,PgSelectRows541,PgSelectSingle542,PgClassExpression545,PgClassExpression548,Access844,Access847,Access850,Access853,PgClassExpression856,First872,PgSelectRows873,PgSelectSingle874,Access904,Access927,Access930,Access933,Access936,PgClassExpression939,First955,PgSelectRows956,PgSelectSingle957,Access981,Access1011,PgClassExpression1014,PgClassExpression1017,Access1034,PgClassExpression1037,Access1045,PgClassExpression1048,Access1056,PgClassExpression1059,PgClassExpression1067,Access1714,Access1717,Access1720,Access1732,Access1735,Access1738,Access1803,Access1806,Access1809,Access1821,Access1824,Access1827,List4011,Lambda4012,List4015,Lambda4016,List4019,Lambda4020,Access4022,List4023,Lambda4024,Access4026,List4027,Lambda4028,List4031,Lambda4032,List4035,Lambda4036,Access4038,Access4042,List4047,Lambda4048 bucket4
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PageInfo313 bucket5
+    class Bucket5,PageInfo313,Access835,Access919 bucket5
     classDef bucket6 stroke:#ff1493
-    class Bucket6,First269,PgSelectRows270,PgSelectSingle271,Connection300,PgSelectRows549,ConnectionItems830,First993,PgSelectRows994,PgSelectSingle995,PgClassExpression996,PageInfo1025,First1895,Access1896,PgCursor1897,Last1924,PgCursor1925,Access4154,Access4158,Access4162,Access4174,Access4178,Access4190,List4196,Lambda4197,Access4199,Access4203,Access4207,Access4219,Access4223,Access4235,Access4244,Access4256,Access4260,Access4272,Access4276,Access4288,Access4292,Access4304 bucket6
+    class Bucket6,First269,PgSelectRows270,PgSelectSingle271,Connection300,PgSelectRows549,ConnectionItems830,First993,PgSelectRows994,PgSelectSingle995,PgClassExpression996,PageInfo1025,Access1745,Access1834,First1895,Access1896,PgCursor1897,Last1924,PgCursor1925,Access4154,Access4158,Access4162,Access4174,Access4178,Access4190,List4196,Lambda4197,Access4199,Access4203,Access4207,Access4219,Access4223,Access4235,Access4244,Access4256,Access4260,Access4272,Access4276,Access4288,Access4292,Access4304 bucket6
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression272,PgClassExpression283,First305,PgSelectRows306,PgSelectSingle307,Connection316,ConnectionItems836,First1005,PgSelectRows1006,PgSelectSingle1007,PgClassExpression1008,PageInfo1031,First1898,Access1899,PgCursor1900,Last1926,PgCursor1927,Access4318,Access4322,Access4326,Access4338,Access4342,Access4354,List4359,Lambda4360,Access4362,Access4366,Access4370,Access4382,Access4386,Access4398,Access4402,Access4406,Access4410,Access4422,Access4426,Access4438 bucket7
+    class Bucket7,PgClassExpression272,PgClassExpression283,First305,PgSelectRows306,PgSelectSingle307,Connection316,ConnectionItems836,First1005,PgSelectRows1006,PgSelectSingle1007,PgClassExpression1008,PageInfo1031,Access1746,Access1835,First1898,Access1899,PgCursor1900,Last1926,PgCursor1927,Access4318,Access4322,Access4326,Access4338,Access4342,Access4354,List4359,Lambda4360,Access4362,Access4366,Access4370,Access4382,Access4386,Access4398,Access4402,Access4406,Access4410,Access4422,Access4426,Access4438 bucket7
     classDef bucket8 stroke:#dda0dd
     class Bucket8,Access4490 bucket8
     classDef bucket9 stroke:#ff0000
-    class Bucket9,__Item250,PgSelectSingle251,PgClassExpression660,PgClassExpression662,PgClassExpression664,PgClassExpression666,PgClassExpression668,PgClassExpression670,PgClassExpression672,PgClassExpression674,PgClassExpression676,PgClassExpression678,PgClassExpression680,PgClassExpression682,PgClassExpression684,PgClassExpression686,PgClassExpression688,PgClassExpression690,PgClassExpression692,PgClassExpression694,PgClassExpression696,PgClassExpression698,PgClassExpression700,PgClassExpression702,PgClassExpression704,PgClassExpression706,PgClassExpression708,PgClassExpression710,First717,PgSelectRows718,PgSelectSingle719,First731,PgSelectRows732,PgSelectSingle733,First743,PgSelectRows744,PgSelectSingle745,First755,PgSelectRows756,PgSelectSingle757,PgClassExpression764,PgClassExpression766,PgClassExpression768,PgClassExpression770,PgClassExpression772,PgClassExpression774,PgClassExpression776,PgClassExpression778,PgClassExpression780,PgClassExpression782,PgClassExpression784,PgClassExpression786,PgClassExpression788,PgClassExpression790,PgClassExpression792,PgClassExpression794,PgClassExpression796,First800,PgSelectRows801,PgSelectSingle802,First810,PgSelectRows811,PgSelectSingle812,PgClassExpression818,PgClassExpression820,Access1327,Access1329,Access1331,PgClassExpression1335,First1340,PgSelectRows1341,PgSelectSingle1342,Access1383,Access1385,Access1387,PgClassExpression1391,First1396,PgSelectRows1397,PgSelectSingle1398,PgClassExpression1435,PgClassExpression1437,PgClassExpression1451,PgClassExpression1463,PgClassExpression1475,PgClassExpression1482,List3891,Lambda3892,List3895,Lambda3896,List3899,Lambda3900,Access3902,List3903,Lambda3904,Access3906,List3907,Lambda3908,List3911,Lambda3912,List3915,Lambda3916,List3927,Lambda3928 bucket9
+    class Bucket9,__Item250,PgSelectSingle251,PgClassExpression660,PgClassExpression662,PgClassExpression664,PgClassExpression666,PgClassExpression668,PgClassExpression670,PgClassExpression672,PgClassExpression674,PgClassExpression676,PgClassExpression678,PgClassExpression680,PgClassExpression682,PgClassExpression684,PgClassExpression686,PgClassExpression688,PgClassExpression690,PgClassExpression692,PgClassExpression694,PgClassExpression696,PgClassExpression698,PgClassExpression700,PgClassExpression702,PgClassExpression704,PgClassExpression706,PgClassExpression708,PgClassExpression710,First717,PgSelectRows718,PgSelectSingle719,First731,PgSelectRows732,PgSelectSingle733,First743,PgSelectRows744,PgSelectSingle745,First755,PgSelectRows756,PgSelectSingle757,PgClassExpression764,PgClassExpression766,PgClassExpression768,PgClassExpression770,PgClassExpression772,PgClassExpression774,PgClassExpression776,PgClassExpression778,PgClassExpression780,PgClassExpression782,PgClassExpression784,PgClassExpression786,PgClassExpression788,PgClassExpression790,PgClassExpression792,PgClassExpression794,PgClassExpression796,First800,PgSelectRows801,PgSelectSingle802,First810,PgSelectRows811,PgSelectSingle812,PgClassExpression818,PgClassExpression820,Access1327,Access1329,Access1331,Access1333,PgClassExpression1335,First1340,PgSelectRows1341,PgSelectSingle1342,Access1367,Access1383,Access1385,Access1387,Access1389,PgClassExpression1391,First1396,PgSelectRows1397,PgSelectSingle1398,Access1419,Access1433,PgClassExpression1435,PgClassExpression1437,Access1449,PgClassExpression1451,Access1461,PgClassExpression1463,Access1473,PgClassExpression1475,PgClassExpression1482,List3891,Lambda3892,List3895,Lambda3896,List3899,Lambda3900,Access3902,List3903,Lambda3904,Access3906,List3907,Lambda3908,List3911,Lambda3912,List3915,Lambda3916,List3927,Lambda3928 bucket9
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item252,PgSelectSingle253 bucket10
     classDef bucket11 stroke:#00ffff
@@ -6919,7 +8019,7 @@ graph TD
     classDef bucket20 stroke:#ffa500
     class Bucket20,PgSelect143,First147,PgSelectRows148,PgSelectSingle149 bucket20
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PgSelect153,First157,PgSelectRows158,PgSelectSingle159,PgClassExpression550,PgClassExpression551,PgClassExpression552,PgClassExpression553,PgClassExpression554,PgClassExpression555,PgClassExpression556,PgClassExpression557,PgClassExpression558,PgClassExpression559,PgClassExpression560,PgClassExpression561,PgClassExpression562,PgClassExpression563,PgClassExpression564,PgClassExpression565,PgClassExpression566,PgClassExpression567,PgClassExpression568,PgClassExpression569,PgClassExpression570,PgClassExpression571,PgClassExpression572,PgClassExpression573,PgClassExpression574,PgClassExpression575,First581,PgSelectRows582,PgSelectSingle583,First587,PgSelectRows588,PgSelectSingle589,First593,PgSelectRows594,PgSelectSingle595,First599,PgSelectRows600,PgSelectSingle601,PgClassExpression602,PgClassExpression603,PgClassExpression604,PgClassExpression605,PgClassExpression606,PgClassExpression607,PgClassExpression608,PgClassExpression609,PgClassExpression610,PgClassExpression611,PgClassExpression612,PgClassExpression613,PgClassExpression614,PgClassExpression615,PgClassExpression616,PgClassExpression617,PgClassExpression618,First621,PgSelectRows622,PgSelectSingle623,First626,PgSelectRows627,PgSelectSingle628,PgClassExpression629,PgClassExpression630,Access1234,Access1235,Access1236,PgClassExpression1238,First1242,PgSelectRows1243,PgSelectSingle1244,Access1259,Access1260,Access1261,PgClassExpression1263,First1267,PgSelectRows1268,PgSelectSingle1269,PgClassExpression1282,PgClassExpression1283,PgClassExpression1287,PgClassExpression1290,PgClassExpression1293,PgClassExpression1295,PgSelectInlineApply4449,Access4450,List4451,Lambda4452,PgSelectInlineApply4453,Access4454,List4455,Lambda4456,PgSelectInlineApply4457,Access4458,List4459,Lambda4460,PgSelectInlineApply4461,Access4462,List4463,Lambda4464,PgSelectInlineApply4465,Access4466,List4467,Lambda4468,PgSelectInlineApply4469,Access4470,List4471,Lambda4472,PgSelectInlineApply4473,Access4474,List4475,Lambda4476,PgSelectInlineApply4477,Access4478,PgSelectInlineApply4481,Access4482,PgSelectInlineApply4485,Access4486,List4487,Lambda4488 bucket21
+    class Bucket21,PgSelect153,First157,PgSelectRows158,PgSelectSingle159,PgClassExpression550,PgClassExpression551,PgClassExpression552,PgClassExpression553,PgClassExpression554,PgClassExpression555,PgClassExpression556,PgClassExpression557,PgClassExpression558,PgClassExpression559,PgClassExpression560,PgClassExpression561,PgClassExpression562,PgClassExpression563,PgClassExpression564,PgClassExpression565,PgClassExpression566,PgClassExpression567,PgClassExpression568,PgClassExpression569,PgClassExpression570,PgClassExpression571,PgClassExpression572,PgClassExpression573,PgClassExpression574,PgClassExpression575,First581,PgSelectRows582,PgSelectSingle583,First587,PgSelectRows588,PgSelectSingle589,First593,PgSelectRows594,PgSelectSingle595,First599,PgSelectRows600,PgSelectSingle601,PgClassExpression602,PgClassExpression603,PgClassExpression604,PgClassExpression605,PgClassExpression606,PgClassExpression607,PgClassExpression608,PgClassExpression609,PgClassExpression610,PgClassExpression611,PgClassExpression612,PgClassExpression613,PgClassExpression614,PgClassExpression615,PgClassExpression616,PgClassExpression617,PgClassExpression618,First621,PgSelectRows622,PgSelectSingle623,First626,PgSelectRows627,PgSelectSingle628,PgClassExpression629,PgClassExpression630,Access1234,Access1235,Access1236,Access1237,PgClassExpression1238,First1242,PgSelectRows1243,PgSelectSingle1244,Access1254,Access1259,Access1260,Access1261,Access1262,PgClassExpression1263,First1267,PgSelectRows1268,PgSelectSingle1269,Access1277,Access1281,PgClassExpression1282,PgClassExpression1283,Access1286,PgClassExpression1287,Access1289,PgClassExpression1290,Access1292,PgClassExpression1293,PgClassExpression1295,Access2012,Access2013,Access2014,Access2018,Access2019,Access2020,Access2026,Access2027,Access2028,Access2032,Access2033,Access2034,PgSelectInlineApply4449,Access4450,List4451,Lambda4452,PgSelectInlineApply4453,Access4454,List4455,Lambda4456,PgSelectInlineApply4457,Access4458,List4459,Lambda4460,PgSelectInlineApply4461,Access4462,List4463,Lambda4464,PgSelectInlineApply4465,Access4466,List4467,Lambda4468,PgSelectInlineApply4469,Access4470,List4471,Lambda4472,PgSelectInlineApply4473,Access4474,List4475,Lambda4476,PgSelectInlineApply4477,Access4478,PgSelectInlineApply4481,Access4482,PgSelectInlineApply4485,Access4486,List4487,Lambda4488 bucket21
     classDef bucket22 stroke:#7fff00
     class Bucket22,PgSelect163,First167,PgSelectRows168,PgSelectSingle169 bucket22
     classDef bucket23 stroke:#ff1493
@@ -6939,17 +8039,17 @@ graph TD
     classDef bucket30 stroke:#3cb371
     class Bucket30,PgSelect243,First247,PgSelectRows248,PgSelectSingle249 bucket30
     classDef bucket31 stroke:#a52a2a
-    class Bucket31,PgClassExpression661,PgClassExpression663,PgClassExpression665,PgClassExpression667,PgClassExpression669,PgClassExpression671,PgClassExpression673,PgClassExpression675,PgClassExpression677,PgClassExpression679,PgClassExpression681,PgClassExpression683,PgClassExpression685,PgClassExpression687,PgClassExpression689,PgClassExpression691,PgClassExpression693,PgClassExpression695,PgClassExpression697,PgClassExpression699,PgClassExpression701,PgClassExpression703,PgClassExpression705,PgClassExpression707,PgClassExpression709,PgClassExpression711,First725,PgSelectRows726,PgSelectSingle727,First737,PgSelectRows738,PgSelectSingle739,First749,PgSelectRows750,PgSelectSingle751,First761,PgSelectRows762,PgSelectSingle763,PgClassExpression765,PgClassExpression767,PgClassExpression769,PgClassExpression771,PgClassExpression773,PgClassExpression775,PgClassExpression777,PgClassExpression779,PgClassExpression781,PgClassExpression783,PgClassExpression785,PgClassExpression787,PgClassExpression789,PgClassExpression791,PgClassExpression793,PgClassExpression795,PgClassExpression797,First805,PgSelectRows806,PgSelectSingle807,First815,PgSelectRows816,PgSelectSingle817,PgClassExpression819,PgClassExpression821,Access1328,Access1330,Access1332,PgClassExpression1336,First1346,PgSelectRows1347,PgSelectSingle1348,Access1384,Access1386,Access1388,PgClassExpression1392,First1402,PgSelectRows1403,PgSelectSingle1404,PgClassExpression1436,PgClassExpression1438,PgClassExpression1452,PgClassExpression1464,PgClassExpression1476,PgClassExpression1483,List4051,Lambda4052,List4055,Lambda4056,List4059,Lambda4060,Access4062,List4063,Lambda4064,Access4066,List4067,Lambda4068,List4071,Lambda4072,List4075,Lambda4076,List4087,Lambda4088 bucket31
+    class Bucket31,PgClassExpression661,PgClassExpression663,PgClassExpression665,PgClassExpression667,PgClassExpression669,PgClassExpression671,PgClassExpression673,PgClassExpression675,PgClassExpression677,PgClassExpression679,PgClassExpression681,PgClassExpression683,PgClassExpression685,PgClassExpression687,PgClassExpression689,PgClassExpression691,PgClassExpression693,PgClassExpression695,PgClassExpression697,PgClassExpression699,PgClassExpression701,PgClassExpression703,PgClassExpression705,PgClassExpression707,PgClassExpression709,PgClassExpression711,First725,PgSelectRows726,PgSelectSingle727,First737,PgSelectRows738,PgSelectSingle739,First749,PgSelectRows750,PgSelectSingle751,First761,PgSelectRows762,PgSelectSingle763,PgClassExpression765,PgClassExpression767,PgClassExpression769,PgClassExpression771,PgClassExpression773,PgClassExpression775,PgClassExpression777,PgClassExpression779,PgClassExpression781,PgClassExpression783,PgClassExpression785,PgClassExpression787,PgClassExpression789,PgClassExpression791,PgClassExpression793,PgClassExpression795,PgClassExpression797,First805,PgSelectRows806,PgSelectSingle807,First815,PgSelectRows816,PgSelectSingle817,PgClassExpression819,PgClassExpression821,Access1328,Access1330,Access1332,Access1334,PgClassExpression1336,First1346,PgSelectRows1347,PgSelectSingle1348,Access1368,Access1384,Access1386,Access1388,Access1390,PgClassExpression1392,First1402,PgSelectRows1403,PgSelectSingle1404,Access1420,Access1434,PgClassExpression1436,PgClassExpression1438,Access1450,PgClassExpression1452,Access1462,PgClassExpression1464,Access1474,PgClassExpression1476,PgClassExpression1483,List4051,Lambda4052,List4055,Lambda4056,List4059,Lambda4060,Access4062,List4063,Lambda4064,Access4066,List4067,Lambda4068,List4071,Lambda4072,List4075,Lambda4076,List4087,Lambda4088 bucket31
     classDef bucket36 stroke:#7f007f
-    class Bucket36,PgClassExpression829,PgClassExpression914,PgClassExpression991,PgClassExpression1024,PgClassExpression1041,PgClassExpression1052,PgClassExpression1063,PgClassExpression1071,PgClassExpression1073,PgClassExpression1075,PgClassExpression1077,PgClassExpression1079,PgClassExpression1081,PgClassExpression1083,PgClassExpression1085,PgClassExpression1087,PgClassExpression1089,PgClassExpression1091,PgClassExpression1093,PgClassExpression1095,PgClassExpression1097,PgClassExpression1099,PgClassExpression1101,PgClassExpression1103,PgClassExpression1105,PgClassExpression1107,First1114,PgSelectRows1115,PgSelectSingle1116,First1128,PgSelectRows1129,PgSelectSingle1130,First1140,PgSelectRows1141,PgSelectSingle1142,First1152,PgSelectRows1153,PgSelectSingle1154,PgClassExpression1161,PgClassExpression1163,PgClassExpression1165,PgClassExpression1167,PgClassExpression1169,PgClassExpression1171,PgClassExpression1173,PgClassExpression1175,PgClassExpression1177,PgClassExpression1179,PgClassExpression1181,PgClassExpression1183,PgClassExpression1185,PgClassExpression1187,PgClassExpression1189,PgClassExpression1191,PgClassExpression1193,First1197,PgSelectRows1198,PgSelectSingle1199,First1207,PgSelectRows1208,PgSelectSingle1209,PgClassExpression1215,PgClassExpression1217,Access1749,Access1751,Access1753,PgClassExpression1757,First1762,PgSelectRows1763,PgSelectSingle1764,Access1838,Access1840,Access1842,PgClassExpression1846,First1851,PgSelectRows1852,PgSelectSingle1853,PgClassExpression1903,PgClassExpression1905,PgClassExpression1930,PgClassExpression1949,PgClassExpression1968,PgClassExpression1984,List4155,Lambda4156,List4159,Lambda4160,List4163,Lambda4164,Access4166,List4167,Lambda4168,Access4170,List4171,Lambda4172,List4175,Lambda4176,List4179,Lambda4180,Access4182,Access4186,List4191,Lambda4192 bucket36
+    class Bucket36,PgClassExpression829,PgClassExpression914,PgClassExpression991,PgClassExpression1024,PgClassExpression1041,PgClassExpression1052,PgClassExpression1063,PgClassExpression1071,PgClassExpression1073,PgClassExpression1075,PgClassExpression1077,PgClassExpression1079,PgClassExpression1081,PgClassExpression1083,PgClassExpression1085,PgClassExpression1087,PgClassExpression1089,PgClassExpression1091,PgClassExpression1093,PgClassExpression1095,PgClassExpression1097,PgClassExpression1099,PgClassExpression1101,PgClassExpression1103,PgClassExpression1105,PgClassExpression1107,First1114,PgSelectRows1115,PgSelectSingle1116,First1128,PgSelectRows1129,PgSelectSingle1130,First1140,PgSelectRows1141,PgSelectSingle1142,First1152,PgSelectRows1153,PgSelectSingle1154,PgClassExpression1161,PgClassExpression1163,PgClassExpression1165,PgClassExpression1167,PgClassExpression1169,PgClassExpression1171,PgClassExpression1173,PgClassExpression1175,PgClassExpression1177,PgClassExpression1179,PgClassExpression1181,PgClassExpression1183,PgClassExpression1185,PgClassExpression1187,PgClassExpression1189,PgClassExpression1191,PgClassExpression1193,First1197,PgSelectRows1198,PgSelectSingle1199,First1207,PgSelectRows1208,PgSelectSingle1209,PgClassExpression1215,PgClassExpression1217,Access1749,Access1751,Access1753,Access1755,PgClassExpression1757,First1762,PgSelectRows1763,PgSelectSingle1764,Access1789,Access1838,Access1840,Access1842,Access1844,PgClassExpression1846,First1851,PgSelectRows1852,PgSelectSingle1853,Access1874,Access1901,PgClassExpression1903,PgClassExpression1905,Access1928,PgClassExpression1930,Access1947,PgClassExpression1949,Access1966,PgClassExpression1968,PgClassExpression1984,Access2685,Access2687,Access2689,Access2697,Access2699,Access2701,Access2709,Access2711,Access2713,Access2721,Access2723,Access2725,List4155,Lambda4156,List4159,Lambda4160,List4163,Lambda4164,Access4166,List4167,Lambda4168,Access4170,List4171,Lambda4172,List4175,Lambda4176,List4179,Lambda4180,Access4182,Access4186,List4191,Lambda4192 bucket36
     classDef bucket37 stroke:#ffa500
-    class Bucket37,PgClassExpression833,PgClassExpression917,PgClassExpression997,PgClassExpression1026,PgClassExpression1042,PgClassExpression1053,PgClassExpression1064,PgClassExpression1072,PgClassExpression1074,PgClassExpression1076,PgClassExpression1078,PgClassExpression1080,PgClassExpression1082,PgClassExpression1084,PgClassExpression1086,PgClassExpression1088,PgClassExpression1090,PgClassExpression1092,PgClassExpression1094,PgClassExpression1096,PgClassExpression1098,PgClassExpression1100,PgClassExpression1102,PgClassExpression1104,PgClassExpression1106,PgClassExpression1108,First1122,PgSelectRows1123,PgSelectSingle1124,First1134,PgSelectRows1135,PgSelectSingle1136,First1146,PgSelectRows1147,PgSelectSingle1148,First1158,PgSelectRows1159,PgSelectSingle1160,PgClassExpression1162,PgClassExpression1164,PgClassExpression1166,PgClassExpression1168,PgClassExpression1170,PgClassExpression1172,PgClassExpression1174,PgClassExpression1176,PgClassExpression1178,PgClassExpression1180,PgClassExpression1182,PgClassExpression1184,PgClassExpression1186,PgClassExpression1188,PgClassExpression1190,PgClassExpression1192,PgClassExpression1194,First1202,PgSelectRows1203,PgSelectSingle1204,First1212,PgSelectRows1213,PgSelectSingle1214,PgClassExpression1216,PgClassExpression1218,Access1750,Access1752,Access1754,PgClassExpression1758,First1768,PgSelectRows1769,PgSelectSingle1770,Access1839,Access1841,Access1843,PgClassExpression1847,First1857,PgSelectRows1858,PgSelectSingle1859,PgClassExpression1904,PgClassExpression1906,PgClassExpression1931,PgClassExpression1950,PgClassExpression1969,PgClassExpression1985,List4319,Lambda4320,List4323,Lambda4324,List4327,Lambda4328,Access4330,List4331,Lambda4332,Access4334,List4335,Lambda4336,List4339,Lambda4340,List4343,Lambda4344,Access4346,Access4350,List4355,Lambda4356 bucket37
+    class Bucket37,PgClassExpression833,PgClassExpression917,PgClassExpression997,PgClassExpression1026,PgClassExpression1042,PgClassExpression1053,PgClassExpression1064,PgClassExpression1072,PgClassExpression1074,PgClassExpression1076,PgClassExpression1078,PgClassExpression1080,PgClassExpression1082,PgClassExpression1084,PgClassExpression1086,PgClassExpression1088,PgClassExpression1090,PgClassExpression1092,PgClassExpression1094,PgClassExpression1096,PgClassExpression1098,PgClassExpression1100,PgClassExpression1102,PgClassExpression1104,PgClassExpression1106,PgClassExpression1108,First1122,PgSelectRows1123,PgSelectSingle1124,First1134,PgSelectRows1135,PgSelectSingle1136,First1146,PgSelectRows1147,PgSelectSingle1148,First1158,PgSelectRows1159,PgSelectSingle1160,PgClassExpression1162,PgClassExpression1164,PgClassExpression1166,PgClassExpression1168,PgClassExpression1170,PgClassExpression1172,PgClassExpression1174,PgClassExpression1176,PgClassExpression1178,PgClassExpression1180,PgClassExpression1182,PgClassExpression1184,PgClassExpression1186,PgClassExpression1188,PgClassExpression1190,PgClassExpression1192,PgClassExpression1194,First1202,PgSelectRows1203,PgSelectSingle1204,First1212,PgSelectRows1213,PgSelectSingle1214,PgClassExpression1216,PgClassExpression1218,Access1750,Access1752,Access1754,Access1756,PgClassExpression1758,First1768,PgSelectRows1769,PgSelectSingle1770,Access1790,Access1839,Access1841,Access1843,Access1845,PgClassExpression1847,First1857,PgSelectRows1858,PgSelectSingle1859,Access1875,Access1902,PgClassExpression1904,PgClassExpression1906,Access1929,PgClassExpression1931,Access1948,PgClassExpression1950,Access1967,PgClassExpression1969,PgClassExpression1985,Access2686,Access2688,Access2690,Access2698,Access2700,Access2702,Access2710,Access2712,Access2714,Access2722,Access2724,Access2726,List4319,Lambda4320,List4323,Lambda4324,List4327,Lambda4328,Access4330,List4331,Lambda4332,Access4334,List4335,Lambda4336,List4339,Lambda4340,List4343,Lambda4344,Access4346,Access4350,List4355,Lambda4356 bucket37
     classDef bucket38 stroke:#0000ff
-    class Bucket38,Access839,Access922 bucket38
+    class Bucket38,Access839,Access922,Access1709,Access1727,Access1798,Access1816 bucket38
     classDef bucket39 stroke:#7fff00
-    class Bucket39,Access840,Access923 bucket39
+    class Bucket39,Access840,Access923,Access1710,Access1728,Access1799,Access1817 bucket39
     classDef bucket40 stroke:#ff1493
-    class Bucket40,Access841,Access924 bucket40
+    class Bucket40,Access841,Access924,Access1711,Access1729,Access1800,Access1818 bucket40
     classDef bucket41 stroke:#808000
     class Bucket41,PgClassExpression875,PgClassExpression958,PgClassExpression1018,PgClassExpression1038,PgClassExpression1049,PgClassExpression1060,PgClassExpression1068 bucket41
     classDef bucket42 stroke:#dda0dd
@@ -6963,11 +8063,11 @@ graph TD
     classDef bucket46 stroke:#4169e1
     class Bucket46,First899,PgSelectRows900,PgSelectSingle901,First976,PgSelectRows977,PgSelectSingle978,PgClassExpression1023,List4039,Lambda4040,List4043,Lambda4044 bucket46
     classDef bucket47 stroke:#3cb371
-    class Bucket47 bucket47
+    class Bucket47,Access905,Access982 bucket47
     classDef bucket48 stroke:#a52a2a
-    class Bucket48 bucket48
+    class Bucket48,Access906,Access983 bucket48
     classDef bucket49 stroke:#ff00ff
-    class Bucket49 bucket49
+    class Bucket49,Access907,Access984 bucket49
     classDef bucket50 stroke:#f5deb3
     class Bucket50,PgClassExpression908,PgClassExpression985 bucket50
     classDef bucket51 stroke:#696969
@@ -7029,33 +8129,33 @@ graph TD
     classDef bucket79 stroke:#00ffff
     class Bucket79,__Item659 bucket79
     classDef bucket80 stroke:#4169e1
-    class Bucket80,Access1233,Access1258 bucket80
+    class Bucket80,Access1233,Access1258,Access2011,Access2017,Access2025,Access2031 bucket80
     classDef bucket81 stroke:#3cb371
     class Bucket81,PgClassExpression1245,PgClassExpression1270,PgClassExpression1284,PgClassExpression1288,PgClassExpression1291,PgClassExpression1294,PgClassExpression1296 bucket81
     classDef bucket82 stroke:#a52a2a
     class Bucket82,First1251,PgSelectRows1252,PgSelectSingle1253,First1274,PgSelectRows1275,PgSelectSingle1276,PgClassExpression1285,List4479,Lambda4480,List4483,Lambda4484 bucket82
     classDef bucket83 stroke:#ff00ff
-    class Bucket83 bucket83
+    class Bucket83,Access1255,Access1278 bucket83
     classDef bucket84 stroke:#f5deb3
     class Bucket84,PgClassExpression1256,PgClassExpression1279 bucket84
     classDef bucket85 stroke:#696969
     class Bucket85,PgClassExpression1257,PgClassExpression1280 bucket85
     classDef bucket86 stroke:#00bfff
-    class Bucket86,PgClassExpression1317,PgClassExpression1375,PgClassExpression1427,PgClassExpression1443,PgClassExpression1455,PgClassExpression1467,PgClassExpression1479,PgClassExpression1486,PgClassExpression1489,PgClassExpression1492,PgClassExpression1495,PgClassExpression1498,PgClassExpression1501,PgClassExpression1504,PgClassExpression1507,PgClassExpression1510,PgClassExpression1513,PgClassExpression1516,PgClassExpression1519,PgClassExpression1522,PgClassExpression1525,PgClassExpression1528,PgClassExpression1531,PgClassExpression1534,PgClassExpression1537,PgClassExpression1540,First1548,PgSelectRows1549,PgSelectSingle1550,First1570,PgSelectRows1571,PgSelectSingle1572,First1588,PgSelectRows1589,PgSelectSingle1590,First1606,PgSelectRows1607,PgSelectSingle1608,PgClassExpression1621,PgClassExpression1624,PgClassExpression1627,PgClassExpression1630,PgClassExpression1633,PgClassExpression1636,PgClassExpression1639,PgClassExpression1642,PgClassExpression1645,PgClassExpression1648,PgClassExpression1651,PgClassExpression1654,PgClassExpression1657,PgClassExpression1660,PgClassExpression1663,PgClassExpression1666,PgClassExpression1669,First1674,PgSelectRows1675,PgSelectSingle1676,First1689,PgSelectRows1690,PgSelectSingle1691,PgClassExpression1702,PgClassExpression1705,Access2100,Access2103,Access2106,PgClassExpression2112,First2118,PgSelectRows2119,PgSelectSingle2120,Access2205,Access2208,Access2211,PgClassExpression2217,First2223,PgSelectRows2224,PgSelectSingle2225,PgClassExpression2288,PgClassExpression2291,PgClassExpression2317,PgClassExpression2340,PgClassExpression2363,PgClassExpression2381,List3811,Lambda3812,List3815,Lambda3816,List3819,Lambda3820,Access3822,List3823,Lambda3824,Access3826,List3827,Lambda3828,List3831,Lambda3832,List3835,Lambda3836,List3847,Lambda3848 bucket86
+    class Bucket86,PgClassExpression1317,PgClassExpression1375,PgClassExpression1427,PgClassExpression1443,PgClassExpression1455,PgClassExpression1467,PgClassExpression1479,PgClassExpression1486,PgClassExpression1489,PgClassExpression1492,PgClassExpression1495,PgClassExpression1498,PgClassExpression1501,PgClassExpression1504,PgClassExpression1507,PgClassExpression1510,PgClassExpression1513,PgClassExpression1516,PgClassExpression1519,PgClassExpression1522,PgClassExpression1525,PgClassExpression1528,PgClassExpression1531,PgClassExpression1534,PgClassExpression1537,PgClassExpression1540,First1548,PgSelectRows1549,PgSelectSingle1550,First1570,PgSelectRows1571,PgSelectSingle1572,First1588,PgSelectRows1589,PgSelectSingle1590,First1606,PgSelectRows1607,PgSelectSingle1608,PgClassExpression1621,PgClassExpression1624,PgClassExpression1627,PgClassExpression1630,PgClassExpression1633,PgClassExpression1636,PgClassExpression1639,PgClassExpression1642,PgClassExpression1645,PgClassExpression1648,PgClassExpression1651,PgClassExpression1654,PgClassExpression1657,PgClassExpression1660,PgClassExpression1663,PgClassExpression1666,PgClassExpression1669,First1674,PgSelectRows1675,PgSelectSingle1676,First1689,PgSelectRows1690,PgSelectSingle1691,PgClassExpression1702,PgClassExpression1705,Access2100,Access2103,Access2106,Access2109,PgClassExpression2112,First2118,PgSelectRows2119,PgSelectSingle2120,Access2160,Access2205,Access2208,Access2211,Access2214,PgClassExpression2217,First2223,PgSelectRows2224,PgSelectSingle2225,Access2259,Access2285,PgClassExpression2288,PgClassExpression2291,Access2314,PgClassExpression2317,Access2337,PgClassExpression2340,Access2360,PgClassExpression2363,PgClassExpression2381,List3811,Lambda3812,List3815,Lambda3816,List3819,Lambda3820,Access3822,List3823,Lambda3824,Access3826,List3827,Lambda3828,List3831,Lambda3832,List3835,Lambda3836,List3847,Lambda3848 bucket86
     classDef bucket87 stroke:#7f007f
-    class Bucket87,PgClassExpression1318,PgClassExpression1376,PgClassExpression1428,PgClassExpression1444,PgClassExpression1456,PgClassExpression1468,PgClassExpression1480,PgClassExpression1487,PgClassExpression1490,PgClassExpression1493,PgClassExpression1496,PgClassExpression1499,PgClassExpression1502,PgClassExpression1505,PgClassExpression1508,PgClassExpression1511,PgClassExpression1514,PgClassExpression1517,PgClassExpression1520,PgClassExpression1523,PgClassExpression1526,PgClassExpression1529,PgClassExpression1532,PgClassExpression1535,PgClassExpression1538,PgClassExpression1541,First1556,PgSelectRows1557,PgSelectSingle1558,First1576,PgSelectRows1577,PgSelectSingle1578,First1594,PgSelectRows1595,PgSelectSingle1596,First1612,PgSelectRows1613,PgSelectSingle1614,PgClassExpression1622,PgClassExpression1625,PgClassExpression1628,PgClassExpression1631,PgClassExpression1634,PgClassExpression1637,PgClassExpression1640,PgClassExpression1643,PgClassExpression1646,PgClassExpression1649,PgClassExpression1652,PgClassExpression1655,PgClassExpression1658,PgClassExpression1661,PgClassExpression1664,PgClassExpression1667,PgClassExpression1670,PgSelect1677,First1679,PgSelectRows1680,PgSelectSingle1681,PgSelect1692,First1694,PgSelectRows1695,PgSelectSingle1696,PgClassExpression1703,PgClassExpression1706,Access2101,Access2104,Access2107,PgClassExpression2113,First2124,PgSelectRows2125,PgSelectSingle2126,Access2206,Access2209,Access2212,PgClassExpression2218,First2229,PgSelectRows2230,PgSelectSingle2231,PgClassExpression2289,PgClassExpression2292,PgClassExpression2318,PgClassExpression2341,PgClassExpression2364,PgClassExpression2382,List4091,Lambda4092,Access4094,List4095,Lambda4096,Access4098,List4099,Lambda4100,List4103,Lambda4104,List4107,Lambda4108,List4119,Lambda4120 bucket87
+    class Bucket87,PgClassExpression1318,PgClassExpression1376,PgClassExpression1428,PgClassExpression1444,PgClassExpression1456,PgClassExpression1468,PgClassExpression1480,PgClassExpression1487,PgClassExpression1490,PgClassExpression1493,PgClassExpression1496,PgClassExpression1499,PgClassExpression1502,PgClassExpression1505,PgClassExpression1508,PgClassExpression1511,PgClassExpression1514,PgClassExpression1517,PgClassExpression1520,PgClassExpression1523,PgClassExpression1526,PgClassExpression1529,PgClassExpression1532,PgClassExpression1535,PgClassExpression1538,PgClassExpression1541,First1556,PgSelectRows1557,PgSelectSingle1558,First1576,PgSelectRows1577,PgSelectSingle1578,First1594,PgSelectRows1595,PgSelectSingle1596,First1612,PgSelectRows1613,PgSelectSingle1614,PgClassExpression1622,PgClassExpression1625,PgClassExpression1628,PgClassExpression1631,PgClassExpression1634,PgClassExpression1637,PgClassExpression1640,PgClassExpression1643,PgClassExpression1646,PgClassExpression1649,PgClassExpression1652,PgClassExpression1655,PgClassExpression1658,PgClassExpression1661,PgClassExpression1664,PgClassExpression1667,PgClassExpression1670,PgSelect1677,First1679,PgSelectRows1680,PgSelectSingle1681,PgSelect1692,First1694,PgSelectRows1695,PgSelectSingle1696,PgClassExpression1703,PgClassExpression1706,Access2101,Access2104,Access2107,Access2110,PgClassExpression2113,First2124,PgSelectRows2125,PgSelectSingle2126,Access2161,Access2206,Access2209,Access2212,Access2215,PgClassExpression2218,First2229,PgSelectRows2230,PgSelectSingle2231,Access2260,Access2286,PgClassExpression2289,PgClassExpression2292,Access2315,PgClassExpression2318,Access2338,PgClassExpression2341,Access2361,PgClassExpression2364,PgClassExpression2382,List4091,Lambda4092,Access4094,List4095,Lambda4096,Access4098,List4099,Lambda4100,List4103,Lambda4104,List4107,Lambda4108,List4119,Lambda4120 bucket87
     classDef bucket88 stroke:#ffa500
     class Bucket88 bucket88
     classDef bucket89 stroke:#0000ff
     class Bucket89 bucket89
     classDef bucket90 stroke:#7fff00
-    class Bucket90,PgClassExpression1321,PgClassExpression1377,PgClassExpression1429,PgClassExpression1445,PgClassExpression1457,PgClassExpression1469,PgClassExpression1481,PgClassExpression1488,PgClassExpression1491,PgClassExpression1494,PgClassExpression1497,PgClassExpression1500,PgClassExpression1503,PgClassExpression1506,PgClassExpression1509,PgClassExpression1512,PgClassExpression1515,PgClassExpression1518,PgClassExpression1521,PgClassExpression1524,PgClassExpression1527,PgClassExpression1530,PgClassExpression1533,PgClassExpression1536,PgClassExpression1539,PgClassExpression1542,First1564,PgSelectRows1565,PgSelectSingle1566,First1582,PgSelectRows1583,PgSelectSingle1584,First1600,PgSelectRows1601,PgSelectSingle1602,First1618,PgSelectRows1619,PgSelectSingle1620,PgClassExpression1623,PgClassExpression1626,PgClassExpression1629,PgClassExpression1632,PgClassExpression1635,PgClassExpression1638,PgClassExpression1641,PgClassExpression1644,PgClassExpression1647,PgClassExpression1650,PgClassExpression1653,PgClassExpression1656,PgClassExpression1659,PgClassExpression1662,PgClassExpression1665,PgClassExpression1668,PgClassExpression1671,First1684,PgSelectRows1685,PgSelectSingle1686,First1699,PgSelectRows1700,PgSelectSingle1701,PgClassExpression1704,PgClassExpression1707,Access2102,Access2105,Access2108,PgClassExpression2114,First2130,PgSelectRows2131,PgSelectSingle2132,Access2207,Access2210,Access2213,PgClassExpression2219,First2235,PgSelectRows2236,PgSelectSingle2237,PgClassExpression2290,PgClassExpression2293,PgClassExpression2319,PgClassExpression2342,PgClassExpression2365,PgClassExpression2383,List4200,Lambda4201,List4204,Lambda4205,List4208,Lambda4209,Access4211,List4212,Lambda4213,Access4215,List4216,Lambda4217,List4220,Lambda4221,List4224,Lambda4225,List4236,Lambda4237 bucket90
+    class Bucket90,PgClassExpression1321,PgClassExpression1377,PgClassExpression1429,PgClassExpression1445,PgClassExpression1457,PgClassExpression1469,PgClassExpression1481,PgClassExpression1488,PgClassExpression1491,PgClassExpression1494,PgClassExpression1497,PgClassExpression1500,PgClassExpression1503,PgClassExpression1506,PgClassExpression1509,PgClassExpression1512,PgClassExpression1515,PgClassExpression1518,PgClassExpression1521,PgClassExpression1524,PgClassExpression1527,PgClassExpression1530,PgClassExpression1533,PgClassExpression1536,PgClassExpression1539,PgClassExpression1542,First1564,PgSelectRows1565,PgSelectSingle1566,First1582,PgSelectRows1583,PgSelectSingle1584,First1600,PgSelectRows1601,PgSelectSingle1602,First1618,PgSelectRows1619,PgSelectSingle1620,PgClassExpression1623,PgClassExpression1626,PgClassExpression1629,PgClassExpression1632,PgClassExpression1635,PgClassExpression1638,PgClassExpression1641,PgClassExpression1644,PgClassExpression1647,PgClassExpression1650,PgClassExpression1653,PgClassExpression1656,PgClassExpression1659,PgClassExpression1662,PgClassExpression1665,PgClassExpression1668,PgClassExpression1671,First1684,PgSelectRows1685,PgSelectSingle1686,First1699,PgSelectRows1700,PgSelectSingle1701,PgClassExpression1704,PgClassExpression1707,Access2102,Access2105,Access2108,Access2111,PgClassExpression2114,First2130,PgSelectRows2131,PgSelectSingle2132,Access2162,Access2207,Access2210,Access2213,Access2216,PgClassExpression2219,First2235,PgSelectRows2236,PgSelectSingle2237,Access2261,Access2287,PgClassExpression2290,PgClassExpression2293,Access2316,PgClassExpression2319,Access2339,PgClassExpression2342,Access2362,PgClassExpression2365,PgClassExpression2383,List4200,Lambda4201,List4204,Lambda4205,List4208,Lambda4209,Access4211,List4212,Lambda4213,Access4215,List4216,Lambda4217,List4220,Lambda4221,List4224,Lambda4225,List4236,Lambda4237 bucket90
     classDef bucket91 stroke:#ff1493
-    class Bucket91 bucket91
+    class Bucket91,Access1322,Access1378,Access1430,Access1446,Access1458,Access1470 bucket91
     classDef bucket92 stroke:#808000
-    class Bucket92 bucket92
+    class Bucket92,Access1323,Access1379,Access1431,Access1447,Access1459,Access1471 bucket92
     classDef bucket93 stroke:#dda0dd
-    class Bucket93 bucket93
+    class Bucket93,Access1324,Access1380,Access1432,Access1448,Access1460,Access1472 bucket93
     classDef bucket94 stroke:#ff0000
     class Bucket94,__Item822 bucket94
     classDef bucket95 stroke:#ffff00
@@ -7083,9 +8183,9 @@ graph TD
     classDef bucket106 stroke:#0000ff
     class Bucket106,First1364,PgSelectRows1365,PgSelectSingle1366,First1416,PgSelectRows1417,PgSelectSingle1418,PgClassExpression1442,Access4078,List4079,Lambda4080,Access4082,List4083,Lambda4084 bucket106
     classDef bucket107 stroke:#7fff00
-    class Bucket107 bucket107
+    class Bucket107,Access1369,Access1421 bucket107
     classDef bucket108 stroke:#ff1493
-    class Bucket108 bucket108
+    class Bucket108,Access1370,Access1422 bucket108
     classDef bucket109 stroke:#808000
     class Bucket109,PgClassExpression1371,PgClassExpression1423 bucket109
     classDef bucket110 stroke:#dda0dd
@@ -7095,7 +8195,7 @@ graph TD
     classDef bucket112 stroke:#ffff00
     class Bucket112,PgClassExpression1374,PgClassExpression1426 bucket112
     classDef bucket117 stroke:#ff00ff
-    class Bucket117 bucket117
+    class Bucket117,Access1708,Access1797,Access1882,Access1911,Access1934,Access1953 bucket117
     classDef bucket118 stroke:#f5deb3
     class Bucket118,__Item1219 bucket118
     classDef bucket119 stroke:#696969
@@ -7197,9 +8297,9 @@ graph TD
     classDef bucket167 stroke:#a52a2a
     class Bucket167,PgClassExpression1744,PgClassExpression1833,PgClassExpression1894,PgClassExpression1923,PgClassExpression1946,PgClassExpression1965,PgClassExpression1983 bucket167
     classDef bucket168 stroke:#ff00ff
-    class Bucket168,Access1747,Access1836 bucket168
+    class Bucket168,Access1747,Access1836,Access2683,Access2695,Access2707,Access2719 bucket168
     classDef bucket169 stroke:#f5deb3
-    class Bucket169,Access1748,Access1837 bucket169
+    class Bucket169,Access1748,Access1837,Access2684,Access2696,Access2708,Access2720 bucket169
     classDef bucket170 stroke:#696969
     class Bucket170,PgClassExpression1771,PgClassExpression1860,PgClassExpression1907,PgClassExpression1932,PgClassExpression1951,PgClassExpression1970,PgClassExpression1986 bucket170
     classDef bucket171 stroke:#00bfff
@@ -7209,9 +8309,9 @@ graph TD
     classDef bucket173 stroke:#ffa500
     class Bucket173,First1786,PgSelectRows1787,PgSelectSingle1788,First1871,PgSelectRows1872,PgSelectSingle1873,PgClassExpression1910,List4347,Lambda4348,List4351,Lambda4352 bucket173
     classDef bucket174 stroke:#0000ff
-    class Bucket174 bucket174
+    class Bucket174,Access1791,Access1876 bucket174
     classDef bucket175 stroke:#7fff00
-    class Bucket175 bucket175
+    class Bucket175,Access1792,Access1877 bucket175
     classDef bucket176 stroke:#ff1493
     class Bucket176,PgClassExpression1793,PgClassExpression1878 bucket176
     classDef bucket177 stroke:#808000
@@ -7221,9 +8321,9 @@ graph TD
     classDef bucket179 stroke:#ff0000
     class Bucket179,PgClassExpression1796,PgClassExpression1881 bucket179
     classDef bucket180 stroke:#ffff00
-    class Bucket180 bucket180
+    class Bucket180,Access2009,Access2023,Access2037,Access2043,Access2049,Access2055 bucket180
     classDef bucket181 stroke:#00ffff
-    class Bucket181 bucket181
+    class Bucket181,Access2010,Access2024,Access2038,Access2044,Access2050,Access2056 bucket181
     classDef bucket182 stroke:#4169e1
     class Bucket182,__Item1297,PgSelectSingle1298,Edge1301 bucket182
     classDef bucket183 stroke:#3cb371
@@ -7281,37 +8381,37 @@ graph TD
     classDef bucket209 stroke:#7fff00
     class Bucket209,PgClassExpression2022,PgClassExpression2036,PgClassExpression2042,PgClassExpression2048,PgClassExpression2054,PgClassExpression2060,PgClassExpression2064 bucket209
     classDef bucket210 stroke:#ff1493
-    class Bucket210,PgClassExpression2065,PgClassExpression2172,PgClassExpression2271,PgClassExpression2300,PgClassExpression2323,PgClassExpression2346,PgClassExpression2369,PgClassExpression2387,PgClassExpression2391,PgClassExpression2395,PgClassExpression2399,PgClassExpression2403,PgClassExpression2407,PgClassExpression2411,PgClassExpression2415,PgClassExpression2419,PgClassExpression2423,PgClassExpression2427,PgClassExpression2431,PgClassExpression2435,PgClassExpression2439,PgClassExpression2443,PgClassExpression2447,PgClassExpression2451,PgClassExpression2455,PgClassExpression2459,First2468,PgSelectRows2469,PgSelectSingle2470,First2498,PgSelectRows2499,PgSelectSingle2500,First2522,PgSelectRows2523,PgSelectSingle2524,First2546,PgSelectRows2547,PgSelectSingle2548,PgClassExpression2567,PgClassExpression2571,PgClassExpression2575,PgClassExpression2579,PgClassExpression2583,PgClassExpression2587,PgClassExpression2591,PgClassExpression2595,PgClassExpression2599,PgClassExpression2603,PgClassExpression2607,PgClassExpression2611,PgClassExpression2615,PgClassExpression2619,PgClassExpression2623,PgClassExpression2627,PgClassExpression2631,PgSelect2635,First2637,PgSelectRows2638,PgSelectSingle2639,PgSelect2655,First2657,PgSelectRows2658,PgSelectSingle2659,PgClassExpression2675,PgClassExpression2679,Access2859,Access2863,Access2867,PgClassExpression2875,First2882,PgSelectRows2883,PgSelectSingle2884,Access2997,Access3001,Access3005,PgClassExpression3013,First3020,PgSelectRows3021,PgSelectSingle3022,PgClassExpression3103,PgClassExpression3107,PgClassExpression3137,PgClassExpression3163,PgClassExpression3189,PgClassExpression3211,List4245,Lambda4246,Access4248,List4249,Lambda4250,Access4252,List4253,Lambda4254,List4257,Lambda4258,List4261,Lambda4262,List4273,Lambda4274 bucket210
+    class Bucket210,PgClassExpression2065,PgClassExpression2172,PgClassExpression2271,PgClassExpression2300,PgClassExpression2323,PgClassExpression2346,PgClassExpression2369,PgClassExpression2387,PgClassExpression2391,PgClassExpression2395,PgClassExpression2399,PgClassExpression2403,PgClassExpression2407,PgClassExpression2411,PgClassExpression2415,PgClassExpression2419,PgClassExpression2423,PgClassExpression2427,PgClassExpression2431,PgClassExpression2435,PgClassExpression2439,PgClassExpression2443,PgClassExpression2447,PgClassExpression2451,PgClassExpression2455,PgClassExpression2459,First2468,PgSelectRows2469,PgSelectSingle2470,First2498,PgSelectRows2499,PgSelectSingle2500,First2522,PgSelectRows2523,PgSelectSingle2524,First2546,PgSelectRows2547,PgSelectSingle2548,PgClassExpression2567,PgClassExpression2571,PgClassExpression2575,PgClassExpression2579,PgClassExpression2583,PgClassExpression2587,PgClassExpression2591,PgClassExpression2595,PgClassExpression2599,PgClassExpression2603,PgClassExpression2607,PgClassExpression2611,PgClassExpression2615,PgClassExpression2619,PgClassExpression2623,PgClassExpression2627,PgClassExpression2631,PgSelect2635,First2637,PgSelectRows2638,PgSelectSingle2639,PgSelect2655,First2657,PgSelectRows2658,PgSelectSingle2659,PgClassExpression2675,PgClassExpression2679,Access2859,Access2863,Access2867,Access2871,PgClassExpression2875,First2882,PgSelectRows2883,PgSelectSingle2884,Access2939,Access2997,Access3001,Access3005,Access3009,PgClassExpression3013,First3020,PgSelectRows3021,PgSelectSingle3022,Access3069,Access3099,PgClassExpression3103,PgClassExpression3107,Access3133,PgClassExpression3137,Access3159,PgClassExpression3163,Access3185,PgClassExpression3189,PgClassExpression3211,List4245,Lambda4246,Access4248,List4249,Lambda4250,Access4252,List4253,Lambda4254,List4257,Lambda4258,List4261,Lambda4262,List4273,Lambda4274 bucket210
     classDef bucket211 stroke:#808000
-    class Bucket211,PgClassExpression2066,PgClassExpression2173,PgClassExpression2272,PgClassExpression2301,PgClassExpression2324,PgClassExpression2347,PgClassExpression2370,PgClassExpression2388,PgClassExpression2392,PgClassExpression2396,PgClassExpression2400,PgClassExpression2404,PgClassExpression2408,PgClassExpression2412,PgClassExpression2416,PgClassExpression2420,PgClassExpression2424,PgClassExpression2428,PgClassExpression2432,PgClassExpression2436,PgClassExpression2440,PgClassExpression2444,PgClassExpression2448,PgClassExpression2452,PgClassExpression2456,PgClassExpression2460,First2476,PgSelectRows2477,PgSelectSingle2478,First2504,PgSelectRows2505,PgSelectSingle2506,First2528,PgSelectRows2529,PgSelectSingle2530,First2552,PgSelectRows2553,PgSelectSingle2554,PgClassExpression2568,PgClassExpression2572,PgClassExpression2576,PgClassExpression2580,PgClassExpression2584,PgClassExpression2588,PgClassExpression2592,PgClassExpression2596,PgClassExpression2600,PgClassExpression2604,PgClassExpression2608,PgClassExpression2612,PgClassExpression2616,PgClassExpression2620,PgClassExpression2624,PgClassExpression2628,PgClassExpression2632,First2642,PgSelectRows2643,PgSelectSingle2644,First2662,PgSelectRows2663,PgSelectSingle2664,PgClassExpression2676,PgClassExpression2680,Access2860,Access2864,Access2868,PgClassExpression2876,First2888,PgSelectRows2889,PgSelectSingle2890,Access2998,Access3002,Access3006,PgClassExpression3014,First3026,PgSelectRows3027,PgSelectSingle3028,PgClassExpression3104,PgClassExpression3108,PgClassExpression3138,PgClassExpression3164,PgClassExpression3190,PgClassExpression3212,List4363,Lambda4364,List4367,Lambda4368,List4371,Lambda4372,Access4374,List4375,Lambda4376,Access4378,List4379,Lambda4380,List4383,Lambda4384,List4387,Lambda4388,List4399,Lambda4400 bucket211
+    class Bucket211,PgClassExpression2066,PgClassExpression2173,PgClassExpression2272,PgClassExpression2301,PgClassExpression2324,PgClassExpression2347,PgClassExpression2370,PgClassExpression2388,PgClassExpression2392,PgClassExpression2396,PgClassExpression2400,PgClassExpression2404,PgClassExpression2408,PgClassExpression2412,PgClassExpression2416,PgClassExpression2420,PgClassExpression2424,PgClassExpression2428,PgClassExpression2432,PgClassExpression2436,PgClassExpression2440,PgClassExpression2444,PgClassExpression2448,PgClassExpression2452,PgClassExpression2456,PgClassExpression2460,First2476,PgSelectRows2477,PgSelectSingle2478,First2504,PgSelectRows2505,PgSelectSingle2506,First2528,PgSelectRows2529,PgSelectSingle2530,First2552,PgSelectRows2553,PgSelectSingle2554,PgClassExpression2568,PgClassExpression2572,PgClassExpression2576,PgClassExpression2580,PgClassExpression2584,PgClassExpression2588,PgClassExpression2592,PgClassExpression2596,PgClassExpression2600,PgClassExpression2604,PgClassExpression2608,PgClassExpression2612,PgClassExpression2616,PgClassExpression2620,PgClassExpression2624,PgClassExpression2628,PgClassExpression2632,First2642,PgSelectRows2643,PgSelectSingle2644,First2662,PgSelectRows2663,PgSelectSingle2664,PgClassExpression2676,PgClassExpression2680,Access2860,Access2864,Access2868,Access2872,PgClassExpression2876,First2888,PgSelectRows2889,PgSelectSingle2890,Access2940,Access2998,Access3002,Access3006,Access3010,PgClassExpression3014,First3026,PgSelectRows3027,PgSelectSingle3028,Access3070,Access3100,PgClassExpression3104,PgClassExpression3108,Access3134,PgClassExpression3138,Access3160,PgClassExpression3164,Access3186,PgClassExpression3190,PgClassExpression3212,List4363,Lambda4364,List4367,Lambda4368,List4371,Lambda4372,Access4374,List4375,Lambda4376,Access4378,List4379,Lambda4380,List4383,Lambda4384,List4387,Lambda4388,List4399,Lambda4400 bucket211
     classDef bucket212 stroke:#dda0dd
     class Bucket212 bucket212
     classDef bucket213 stroke:#ff0000
     class Bucket213 bucket213
     classDef bucket214 stroke:#ffff00
-    class Bucket214 bucket214
+    class Bucket214,Access2069,Access2174,Access2273,Access2302,Access2325,Access2348 bucket214
     classDef bucket215 stroke:#00ffff
-    class Bucket215 bucket215
+    class Bucket215,Access2070,Access2175,Access2274,Access2303,Access2326,Access2349 bucket215
     classDef bucket216 stroke:#4169e1
-    class Bucket216,PgClassExpression2071,PgClassExpression2176,PgClassExpression2275,PgClassExpression2304,PgClassExpression2327,PgClassExpression2350,PgClassExpression2371,PgClassExpression2389,PgClassExpression2393,PgClassExpression2397,PgClassExpression2401,PgClassExpression2405,PgClassExpression2409,PgClassExpression2413,PgClassExpression2417,PgClassExpression2421,PgClassExpression2425,PgClassExpression2429,PgClassExpression2433,PgClassExpression2437,PgClassExpression2441,PgClassExpression2445,PgClassExpression2449,PgClassExpression2453,PgClassExpression2457,PgClassExpression2461,First2484,PgSelectRows2485,PgSelectSingle2486,First2510,PgSelectRows2511,PgSelectSingle2512,First2534,PgSelectRows2535,PgSelectSingle2536,First2558,PgSelectRows2559,PgSelectSingle2560,PgClassExpression2569,PgClassExpression2573,PgClassExpression2577,PgClassExpression2581,PgClassExpression2585,PgClassExpression2589,PgClassExpression2593,PgClassExpression2597,PgClassExpression2601,PgClassExpression2605,PgClassExpression2609,PgClassExpression2613,PgClassExpression2617,PgClassExpression2621,PgClassExpression2625,PgClassExpression2629,PgClassExpression2633,First2647,PgSelectRows2648,PgSelectSingle2649,First2667,PgSelectRows2668,PgSelectSingle2669,PgClassExpression2677,PgClassExpression2681,Access2861,Access2865,Access2869,PgClassExpression2877,First2894,PgSelectRows2895,PgSelectSingle2896,Access2999,Access3003,Access3007,PgClassExpression3015,First3032,PgSelectRows3033,PgSelectSingle3034,PgClassExpression3105,PgClassExpression3109,PgClassExpression3139,PgClassExpression3165,PgClassExpression3191,PgClassExpression3213,List3851,Lambda3852,List3855,Lambda3856,List3859,Lambda3860,Access3862,List3863,Lambda3864,Access3866,List3867,Lambda3868,List3871,Lambda3872,List3875,Lambda3876,List3887,Lambda3888 bucket216
+    class Bucket216,PgClassExpression2071,PgClassExpression2176,PgClassExpression2275,PgClassExpression2304,PgClassExpression2327,PgClassExpression2350,PgClassExpression2371,PgClassExpression2389,PgClassExpression2393,PgClassExpression2397,PgClassExpression2401,PgClassExpression2405,PgClassExpression2409,PgClassExpression2413,PgClassExpression2417,PgClassExpression2421,PgClassExpression2425,PgClassExpression2429,PgClassExpression2433,PgClassExpression2437,PgClassExpression2441,PgClassExpression2445,PgClassExpression2449,PgClassExpression2453,PgClassExpression2457,PgClassExpression2461,First2484,PgSelectRows2485,PgSelectSingle2486,First2510,PgSelectRows2511,PgSelectSingle2512,First2534,PgSelectRows2535,PgSelectSingle2536,First2558,PgSelectRows2559,PgSelectSingle2560,PgClassExpression2569,PgClassExpression2573,PgClassExpression2577,PgClassExpression2581,PgClassExpression2585,PgClassExpression2589,PgClassExpression2593,PgClassExpression2597,PgClassExpression2601,PgClassExpression2605,PgClassExpression2609,PgClassExpression2613,PgClassExpression2617,PgClassExpression2621,PgClassExpression2625,PgClassExpression2629,PgClassExpression2633,First2647,PgSelectRows2648,PgSelectSingle2649,First2667,PgSelectRows2668,PgSelectSingle2669,PgClassExpression2677,PgClassExpression2681,Access2861,Access2865,Access2869,Access2873,PgClassExpression2877,First2894,PgSelectRows2895,PgSelectSingle2896,Access2941,Access2999,Access3003,Access3007,Access3011,PgClassExpression3015,First3032,PgSelectRows3033,PgSelectSingle3034,Access3071,Access3101,PgClassExpression3105,PgClassExpression3109,Access3135,PgClassExpression3139,Access3161,PgClassExpression3165,Access3187,PgClassExpression3191,PgClassExpression3213,List3851,Lambda3852,List3855,Lambda3856,List3859,Lambda3860,Access3862,List3863,Lambda3864,Access3866,List3867,Lambda3868,List3871,Lambda3872,List3875,Lambda3876,List3887,Lambda3888 bucket216
     classDef bucket217 stroke:#3cb371
-    class Bucket217,PgClassExpression2072,PgClassExpression2177,PgClassExpression2276,PgClassExpression2305,PgClassExpression2328,PgClassExpression2351,PgClassExpression2372,PgClassExpression2390,PgClassExpression2394,PgClassExpression2398,PgClassExpression2402,PgClassExpression2406,PgClassExpression2410,PgClassExpression2414,PgClassExpression2418,PgClassExpression2422,PgClassExpression2426,PgClassExpression2430,PgClassExpression2434,PgClassExpression2438,PgClassExpression2442,PgClassExpression2446,PgClassExpression2450,PgClassExpression2454,PgClassExpression2458,PgClassExpression2462,First2492,PgSelectRows2493,PgSelectSingle2494,First2516,PgSelectRows2517,PgSelectSingle2518,First2540,PgSelectRows2541,PgSelectSingle2542,First2564,PgSelectRows2565,PgSelectSingle2566,PgClassExpression2570,PgClassExpression2574,PgClassExpression2578,PgClassExpression2582,PgClassExpression2586,PgClassExpression2590,PgClassExpression2594,PgClassExpression2598,PgClassExpression2602,PgClassExpression2606,PgClassExpression2610,PgClassExpression2614,PgClassExpression2618,PgClassExpression2622,PgClassExpression2626,PgClassExpression2630,PgClassExpression2634,PgSelect2650,First2652,PgSelectRows2653,PgSelectSingle2654,PgSelect2670,First2672,PgSelectRows2673,PgSelectSingle2674,PgClassExpression2678,PgClassExpression2682,Access2862,Access2866,Access2870,PgClassExpression2878,First2900,PgSelectRows2901,PgSelectSingle2902,Access3000,Access3004,Access3008,PgClassExpression3016,First3038,PgSelectRows3039,PgSelectSingle3040,PgClassExpression3106,PgClassExpression3110,PgClassExpression3140,PgClassExpression3166,PgClassExpression3192,PgClassExpression3214,List4123,Lambda4124,Access4126,List4127,Lambda4128,Access4130,List4131,Lambda4132,List4135,Lambda4136,List4139,Lambda4140,List4151,Lambda4152 bucket217
+    class Bucket217,PgClassExpression2072,PgClassExpression2177,PgClassExpression2276,PgClassExpression2305,PgClassExpression2328,PgClassExpression2351,PgClassExpression2372,PgClassExpression2390,PgClassExpression2394,PgClassExpression2398,PgClassExpression2402,PgClassExpression2406,PgClassExpression2410,PgClassExpression2414,PgClassExpression2418,PgClassExpression2422,PgClassExpression2426,PgClassExpression2430,PgClassExpression2434,PgClassExpression2438,PgClassExpression2442,PgClassExpression2446,PgClassExpression2450,PgClassExpression2454,PgClassExpression2458,PgClassExpression2462,First2492,PgSelectRows2493,PgSelectSingle2494,First2516,PgSelectRows2517,PgSelectSingle2518,First2540,PgSelectRows2541,PgSelectSingle2542,First2564,PgSelectRows2565,PgSelectSingle2566,PgClassExpression2570,PgClassExpression2574,PgClassExpression2578,PgClassExpression2582,PgClassExpression2586,PgClassExpression2590,PgClassExpression2594,PgClassExpression2598,PgClassExpression2602,PgClassExpression2606,PgClassExpression2610,PgClassExpression2614,PgClassExpression2618,PgClassExpression2622,PgClassExpression2626,PgClassExpression2630,PgClassExpression2634,PgSelect2650,First2652,PgSelectRows2653,PgSelectSingle2654,PgSelect2670,First2672,PgSelectRows2673,PgSelectSingle2674,PgClassExpression2678,PgClassExpression2682,Access2862,Access2866,Access2870,Access2874,PgClassExpression2878,First2900,PgSelectRows2901,PgSelectSingle2902,Access2942,Access3000,Access3004,Access3008,Access3012,PgClassExpression3016,First3038,PgSelectRows3039,PgSelectSingle3040,Access3072,Access3102,PgClassExpression3106,PgClassExpression3110,Access3136,PgClassExpression3140,Access3162,PgClassExpression3166,Access3188,PgClassExpression3192,PgClassExpression3214,List4123,Lambda4124,Access4126,List4127,Lambda4128,Access4130,List4131,Lambda4132,List4135,Lambda4136,List4139,Lambda4140,List4151,Lambda4152 bucket217
     classDef bucket218 stroke:#a52a2a
-    class Bucket218 bucket218
+    class Bucket218,Access2073,Access2178 bucket218
     classDef bucket219 stroke:#ff00ff
-    class Bucket219 bucket219
+    class Bucket219,Access2074,Access2179 bucket219
     classDef bucket220 stroke:#f5deb3
-    class Bucket220 bucket220
+    class Bucket220,Access2075,Access2180 bucket220
     classDef bucket221 stroke:#696969
-    class Bucket221 bucket221
+    class Bucket221,Access2076,Access2181 bucket221
     classDef bucket222 stroke:#00bfff
-    class Bucket222 bucket222
+    class Bucket222,Access2077,Access2182 bucket222
     classDef bucket223 stroke:#7f007f
-    class Bucket223 bucket223
+    class Bucket223,Access2078,Access2183 bucket223
     classDef bucket224 stroke:#ffa500
-    class Bucket224 bucket224
+    class Bucket224,Access2079,Access2184 bucket224
     classDef bucket225 stroke:#0000ff
-    class Bucket225 bucket225
+    class Bucket225,Access2080,Access2185 bucket225
     classDef bucket226 stroke:#7fff00
     class Bucket226,PgClassExpression2081,PgClassExpression2186,PgClassExpression2277,PgClassExpression2306,PgClassExpression2329,PgClassExpression2352,PgClassExpression2373 bucket226
     classDef bucket227 stroke:#ff1493
@@ -7321,21 +8421,21 @@ graph TD
     classDef bucket229 stroke:#dda0dd
     class Bucket229,PgClassExpression2084,PgClassExpression2189,PgClassExpression2280,PgClassExpression2309,PgClassExpression2332,PgClassExpression2355,PgClassExpression2376 bucket229
     classDef bucket230 stroke:#ff0000
-    class Bucket230 bucket230
+    class Bucket230,Access2085,Access2190 bucket230
     classDef bucket231 stroke:#ffff00
-    class Bucket231 bucket231
+    class Bucket231,Access2086,Access2191 bucket231
     classDef bucket232 stroke:#00ffff
-    class Bucket232 bucket232
+    class Bucket232,Access2087,Access2192 bucket232
     classDef bucket233 stroke:#4169e1
-    class Bucket233 bucket233
+    class Bucket233,Access2088,Access2193 bucket233
     classDef bucket234 stroke:#3cb371
-    class Bucket234 bucket234
+    class Bucket234,Access2089,Access2194 bucket234
     classDef bucket235 stroke:#a52a2a
-    class Bucket235 bucket235
+    class Bucket235,Access2090,Access2195 bucket235
     classDef bucket236 stroke:#ff00ff
-    class Bucket236 bucket236
+    class Bucket236,Access2091,Access2196 bucket236
     classDef bucket237 stroke:#f5deb3
-    class Bucket237 bucket237
+    class Bucket237,Access2092,Access2197 bucket237
     classDef bucket238 stroke:#696969
     class Bucket238,PgClassExpression2093,PgClassExpression2198,PgClassExpression2281,PgClassExpression2310,PgClassExpression2333,PgClassExpression2356,PgClassExpression2377 bucket238
     classDef bucket239 stroke:#00bfff
@@ -7363,11 +8463,11 @@ graph TD
     classDef bucket250 stroke:#4169e1
     class Bucket250,First2157,PgSelectRows2158,PgSelectSingle2159,First2256,PgSelectRows2257,PgSelectSingle2258,PgClassExpression2299,Access4227,List4228,Lambda4229,Access4231,List4232,Lambda4233 bucket250
     classDef bucket251 stroke:#3cb371
-    class Bucket251 bucket251
+    class Bucket251,Access2163,Access2262 bucket251
     classDef bucket252 stroke:#a52a2a
-    class Bucket252 bucket252
+    class Bucket252,Access2164,Access2263 bucket252
     classDef bucket253 stroke:#ff00ff
-    class Bucket253 bucket253
+    class Bucket253,Access2165,Access2264 bucket253
     classDef bucket254 stroke:#f5deb3
     class Bucket254,PgClassExpression2166,PgClassExpression2265 bucket254
     classDef bucket255 stroke:#696969
@@ -7471,39 +8571,39 @@ graph TD
     classDef bucket304 stroke:#ff00ff
     class Bucket304,PgClassExpression2706,PgClassExpression2730,PgClassExpression2738,PgClassExpression2746,PgClassExpression2754,PgClassExpression2762,PgClassExpression2770 bucket304
     classDef bucket305 stroke:#f5deb3
-    class Bucket305 bucket305
+    class Bucket305,Access2799,Access2802,Access2805,Access2808,Access2811,Access2814 bucket305
     classDef bucket306 stroke:#696969
-    class Bucket306 bucket306
+    class Bucket306,Access2800,Access2803,Access2806,Access2809,Access2812,Access2815 bucket306
     classDef bucket307 stroke:#00bfff
-    class Bucket307 bucket307
+    class Bucket307,Access2801,Access2804,Access2807,Access2810,Access2813,Access2816 bucket307
     classDef bucket308 stroke:#7f007f
-    class Bucket308,PgClassExpression2817,PgClassExpression2955,PgClassExpression3085,PgClassExpression3119,PgClassExpression3145,PgClassExpression3171,PgClassExpression3197,PgClassExpression3219,PgClassExpression3221,PgClassExpression3223,PgClassExpression3225,PgClassExpression3227,PgClassExpression3229,PgClassExpression3231,PgClassExpression3233,PgClassExpression3235,PgClassExpression3237,PgClassExpression3239,PgClassExpression3241,PgClassExpression3243,PgClassExpression3245,PgClassExpression3247,PgClassExpression3249,PgClassExpression3251,PgClassExpression3253,PgClassExpression3255,First3262,PgSelectRows3263,PgSelectSingle3264,First3276,PgSelectRows3277,PgSelectSingle3278,First3288,PgSelectRows3289,PgSelectSingle3290,First3300,PgSelectRows3301,PgSelectSingle3302,PgClassExpression3309,PgClassExpression3311,PgClassExpression3313,PgClassExpression3315,PgClassExpression3317,PgClassExpression3319,PgClassExpression3321,PgClassExpression3323,PgClassExpression3325,PgClassExpression3327,PgClassExpression3329,PgClassExpression3331,PgClassExpression3333,PgClassExpression3335,PgClassExpression3337,PgClassExpression3339,PgClassExpression3341,PgSelect3343,First3345,PgSelectRows3346,PgSelectSingle3347,PgSelect3353,First3355,PgSelectRows3356,PgSelectSingle3357,PgClassExpression3363,PgClassExpression3365,Access3455,Access3457,Access3459,PgClassExpression3463,First3468,PgSelectRows3469,PgSelectSingle3470,Access3553,Access3555,Access3557,PgClassExpression3561,First3566,PgSelectRows3567,PgSelectSingle3568,PgClassExpression3615,PgClassExpression3617,PgClassExpression3641,PgClassExpression3663,PgClassExpression3685,PgClassExpression3705,List4277,Lambda4278,Access4280,List4281,Lambda4282,Access4284,List4285,Lambda4286,List4289,Lambda4290,List4293,Lambda4294,List4305,Lambda4306 bucket308
+    class Bucket308,PgClassExpression2817,PgClassExpression2955,PgClassExpression3085,PgClassExpression3119,PgClassExpression3145,PgClassExpression3171,PgClassExpression3197,PgClassExpression3219,PgClassExpression3221,PgClassExpression3223,PgClassExpression3225,PgClassExpression3227,PgClassExpression3229,PgClassExpression3231,PgClassExpression3233,PgClassExpression3235,PgClassExpression3237,PgClassExpression3239,PgClassExpression3241,PgClassExpression3243,PgClassExpression3245,PgClassExpression3247,PgClassExpression3249,PgClassExpression3251,PgClassExpression3253,PgClassExpression3255,First3262,PgSelectRows3263,PgSelectSingle3264,First3276,PgSelectRows3277,PgSelectSingle3278,First3288,PgSelectRows3289,PgSelectSingle3290,First3300,PgSelectRows3301,PgSelectSingle3302,PgClassExpression3309,PgClassExpression3311,PgClassExpression3313,PgClassExpression3315,PgClassExpression3317,PgClassExpression3319,PgClassExpression3321,PgClassExpression3323,PgClassExpression3325,PgClassExpression3327,PgClassExpression3329,PgClassExpression3331,PgClassExpression3333,PgClassExpression3335,PgClassExpression3337,PgClassExpression3339,PgClassExpression3341,PgSelect3343,First3345,PgSelectRows3346,PgSelectSingle3347,PgSelect3353,First3355,PgSelectRows3356,PgSelectSingle3357,PgClassExpression3363,PgClassExpression3365,Access3455,Access3457,Access3459,Access3461,PgClassExpression3463,First3468,PgSelectRows3469,PgSelectSingle3470,Access3495,Access3553,Access3555,Access3557,Access3559,PgClassExpression3561,First3566,PgSelectRows3567,PgSelectSingle3568,Access3589,Access3613,PgClassExpression3615,PgClassExpression3617,Access3639,PgClassExpression3641,Access3661,PgClassExpression3663,Access3683,PgClassExpression3685,PgClassExpression3705,List4277,Lambda4278,Access4280,List4281,Lambda4282,Access4284,List4285,Lambda4286,List4289,Lambda4290,List4293,Lambda4294,List4305,Lambda4306 bucket308
     classDef bucket309 stroke:#ffa500
-    class Bucket309,PgClassExpression2818,PgClassExpression2956,PgClassExpression3086,PgClassExpression3120,PgClassExpression3146,PgClassExpression3172,PgClassExpression3198,PgClassExpression3220,PgClassExpression3222,PgClassExpression3224,PgClassExpression3226,PgClassExpression3228,PgClassExpression3230,PgClassExpression3232,PgClassExpression3234,PgClassExpression3236,PgClassExpression3238,PgClassExpression3240,PgClassExpression3242,PgClassExpression3244,PgClassExpression3246,PgClassExpression3248,PgClassExpression3250,PgClassExpression3252,PgClassExpression3254,PgClassExpression3256,First3270,PgSelectRows3271,PgSelectSingle3272,First3282,PgSelectRows3283,PgSelectSingle3284,First3294,PgSelectRows3295,PgSelectSingle3296,First3306,PgSelectRows3307,PgSelectSingle3308,PgClassExpression3310,PgClassExpression3312,PgClassExpression3314,PgClassExpression3316,PgClassExpression3318,PgClassExpression3320,PgClassExpression3322,PgClassExpression3324,PgClassExpression3326,PgClassExpression3328,PgClassExpression3330,PgClassExpression3332,PgClassExpression3334,PgClassExpression3336,PgClassExpression3338,PgClassExpression3340,PgClassExpression3342,First3350,PgSelectRows3351,PgSelectSingle3352,First3360,PgSelectRows3361,PgSelectSingle3362,PgClassExpression3364,PgClassExpression3366,Access3456,Access3458,Access3460,PgClassExpression3464,First3474,PgSelectRows3475,PgSelectSingle3476,Access3554,Access3556,Access3558,PgClassExpression3562,First3572,PgSelectRows3573,PgSelectSingle3574,PgClassExpression3616,PgClassExpression3618,PgClassExpression3642,PgClassExpression3664,PgClassExpression3686,PgClassExpression3706,List4403,Lambda4404,List4407,Lambda4408,List4411,Lambda4412,Access4414,List4415,Lambda4416,Access4418,List4419,Lambda4420,List4423,Lambda4424,List4427,Lambda4428,List4439,Lambda4440 bucket309
+    class Bucket309,PgClassExpression2818,PgClassExpression2956,PgClassExpression3086,PgClassExpression3120,PgClassExpression3146,PgClassExpression3172,PgClassExpression3198,PgClassExpression3220,PgClassExpression3222,PgClassExpression3224,PgClassExpression3226,PgClassExpression3228,PgClassExpression3230,PgClassExpression3232,PgClassExpression3234,PgClassExpression3236,PgClassExpression3238,PgClassExpression3240,PgClassExpression3242,PgClassExpression3244,PgClassExpression3246,PgClassExpression3248,PgClassExpression3250,PgClassExpression3252,PgClassExpression3254,PgClassExpression3256,First3270,PgSelectRows3271,PgSelectSingle3272,First3282,PgSelectRows3283,PgSelectSingle3284,First3294,PgSelectRows3295,PgSelectSingle3296,First3306,PgSelectRows3307,PgSelectSingle3308,PgClassExpression3310,PgClassExpression3312,PgClassExpression3314,PgClassExpression3316,PgClassExpression3318,PgClassExpression3320,PgClassExpression3322,PgClassExpression3324,PgClassExpression3326,PgClassExpression3328,PgClassExpression3330,PgClassExpression3332,PgClassExpression3334,PgClassExpression3336,PgClassExpression3338,PgClassExpression3340,PgClassExpression3342,First3350,PgSelectRows3351,PgSelectSingle3352,First3360,PgSelectRows3361,PgSelectSingle3362,PgClassExpression3364,PgClassExpression3366,Access3456,Access3458,Access3460,Access3462,PgClassExpression3464,First3474,PgSelectRows3475,PgSelectSingle3476,Access3496,Access3554,Access3556,Access3558,Access3560,PgClassExpression3562,First3572,PgSelectRows3573,PgSelectSingle3574,Access3590,Access3614,PgClassExpression3616,PgClassExpression3618,Access3640,PgClassExpression3642,Access3662,PgClassExpression3664,Access3684,PgClassExpression3686,PgClassExpression3706,List4403,Lambda4404,List4407,Lambda4408,List4411,Lambda4412,Access4414,List4415,Lambda4416,Access4418,List4419,Lambda4420,List4423,Lambda4424,List4427,Lambda4428,List4439,Lambda4440 bucket309
     classDef bucket310 stroke:#0000ff
-    class Bucket310 bucket310
+    class Bucket310,Access2819,Access2957 bucket310
     classDef bucket311 stroke:#7fff00
-    class Bucket311 bucket311
+    class Bucket311,Access2820,Access2958 bucket311
     classDef bucket312 stroke:#ff1493
-    class Bucket312 bucket312
+    class Bucket312,Access2821,Access2959 bucket312
     classDef bucket313 stroke:#808000
-    class Bucket313 bucket313
+    class Bucket313,Access2822,Access2960 bucket313
     classDef bucket314 stroke:#dda0dd
-    class Bucket314 bucket314
+    class Bucket314,Access2823,Access2961 bucket314
     classDef bucket315 stroke:#ff0000
-    class Bucket315 bucket315
+    class Bucket315,Access2824,Access2962 bucket315
     classDef bucket316 stroke:#ffff00
-    class Bucket316 bucket316
+    class Bucket316,Access2825,Access2963 bucket316
     classDef bucket317 stroke:#00ffff
-    class Bucket317 bucket317
+    class Bucket317,Access2826,Access2964 bucket317
     classDef bucket318 stroke:#4169e1
-    class Bucket318 bucket318
+    class Bucket318,Access2827,Access2965 bucket318
     classDef bucket319 stroke:#3cb371
-    class Bucket319 bucket319
+    class Bucket319,Access2828,Access2966 bucket319
     classDef bucket320 stroke:#a52a2a
-    class Bucket320 bucket320
+    class Bucket320,Access2829,Access2967 bucket320
     classDef bucket321 stroke:#ff00ff
-    class Bucket321 bucket321
+    class Bucket321,Access2830,Access2968 bucket321
     classDef bucket322 stroke:#f5deb3
     class Bucket322,PgClassExpression2831,PgClassExpression2969,PgClassExpression3087,PgClassExpression3121,PgClassExpression3147,PgClassExpression3173,PgClassExpression3199 bucket322
     classDef bucket323 stroke:#696969
@@ -7517,29 +8617,29 @@ graph TD
     classDef bucket327 stroke:#0000ff
     class Bucket327,PgClassExpression2836,PgClassExpression2974,PgClassExpression3092,PgClassExpression3126,PgClassExpression3152,PgClassExpression3178,PgClassExpression3204 bucket327
     classDef bucket328 stroke:#7fff00
-    class Bucket328 bucket328
+    class Bucket328,Access2837,Access2975 bucket328
     classDef bucket329 stroke:#ff1493
-    class Bucket329 bucket329
+    class Bucket329,Access2838,Access2976 bucket329
     classDef bucket330 stroke:#808000
-    class Bucket330 bucket330
+    class Bucket330,Access2839,Access2977 bucket330
     classDef bucket331 stroke:#dda0dd
-    class Bucket331 bucket331
+    class Bucket331,Access2840,Access2978 bucket331
     classDef bucket332 stroke:#ff0000
-    class Bucket332 bucket332
+    class Bucket332,Access2841,Access2979 bucket332
     classDef bucket333 stroke:#ffff00
-    class Bucket333 bucket333
+    class Bucket333,Access2842,Access2980 bucket333
     classDef bucket334 stroke:#00ffff
-    class Bucket334 bucket334
+    class Bucket334,Access2843,Access2981 bucket334
     classDef bucket335 stroke:#4169e1
-    class Bucket335 bucket335
+    class Bucket335,Access2844,Access2982 bucket335
     classDef bucket336 stroke:#3cb371
-    class Bucket336 bucket336
+    class Bucket336,Access2845,Access2983 bucket336
     classDef bucket337 stroke:#a52a2a
-    class Bucket337 bucket337
+    class Bucket337,Access2846,Access2984 bucket337
     classDef bucket338 stroke:#ff00ff
-    class Bucket338 bucket338
+    class Bucket338,Access2847,Access2985 bucket338
     classDef bucket339 stroke:#f5deb3
-    class Bucket339 bucket339
+    class Bucket339,Access2848,Access2986 bucket339
     classDef bucket340 stroke:#696969
     class Bucket340,PgClassExpression2849,PgClassExpression2987,PgClassExpression3093,PgClassExpression3127,PgClassExpression3153,PgClassExpression3179,PgClassExpression3205 bucket340
     classDef bucket341 stroke:#00bfff
@@ -7577,13 +8677,13 @@ graph TD
     classDef bucket357 stroke:#696969
     class Bucket357,First2936,PgSelectRows2937,PgSelectSingle2938,First3066,PgSelectRows3067,PgSelectSingle3068,PgClassExpression3118,Access4142,List4143,Lambda4144,Access4146,List4147,Lambda4148 bucket357
     classDef bucket358 stroke:#00bfff
-    class Bucket358 bucket358
+    class Bucket358,Access2943,Access3073 bucket358
     classDef bucket359 stroke:#7f007f
-    class Bucket359 bucket359
+    class Bucket359,Access2944,Access3074 bucket359
     classDef bucket360 stroke:#ffa500
-    class Bucket360 bucket360
+    class Bucket360,Access2945,Access3075 bucket360
     classDef bucket361 stroke:#0000ff
-    class Bucket361 bucket361
+    class Bucket361,Access2946,Access3076 bucket361
     classDef bucket362 stroke:#7fff00
     class Bucket362,PgClassExpression2947,PgClassExpression3077 bucket362
     classDef bucket363 stroke:#ff1493
@@ -7657,45 +8757,45 @@ graph TD
     classDef bucket397 stroke:#ff1493
     class Bucket397,__Item2798 bucket397
     classDef bucket398 stroke:#808000
-    class Bucket398 bucket398
+    class Bucket398,Access3381,Access3385,Access3389,Access3393,Access3397,Access3401 bucket398
     classDef bucket399 stroke:#dda0dd
-    class Bucket399 bucket399
+    class Bucket399,Access3382,Access3386,Access3390,Access3394,Access3398,Access3402 bucket399
     classDef bucket400 stroke:#ff0000
-    class Bucket400 bucket400
+    class Bucket400,Access3383,Access3387,Access3391,Access3395,Access3399,Access3403 bucket400
     classDef bucket401 stroke:#ffff00
-    class Bucket401 bucket401
+    class Bucket401,Access3384,Access3388,Access3392,Access3396,Access3400,Access3404 bucket401
     classDef bucket402 stroke:#00ffff
-    class Bucket402 bucket402
+    class Bucket402,Access3405,Access3503 bucket402
     classDef bucket403 stroke:#4169e1
-    class Bucket403 bucket403
+    class Bucket403,Access3406,Access3504 bucket403
     classDef bucket404 stroke:#3cb371
-    class Bucket404 bucket404
+    class Bucket404,Access3407,Access3505 bucket404
     classDef bucket405 stroke:#a52a2a
-    class Bucket405 bucket405
+    class Bucket405,Access3408,Access3506 bucket405
     classDef bucket406 stroke:#ff00ff
-    class Bucket406 bucket406
+    class Bucket406,Access3409,Access3507 bucket406
     classDef bucket407 stroke:#f5deb3
-    class Bucket407 bucket407
+    class Bucket407,Access3410,Access3508 bucket407
     classDef bucket408 stroke:#696969
-    class Bucket408 bucket408
+    class Bucket408,Access3411,Access3509 bucket408
     classDef bucket409 stroke:#00bfff
-    class Bucket409 bucket409
+    class Bucket409,Access3412,Access3510 bucket409
     classDef bucket410 stroke:#7f007f
-    class Bucket410 bucket410
+    class Bucket410,Access3413,Access3511 bucket410
     classDef bucket411 stroke:#ffa500
-    class Bucket411 bucket411
+    class Bucket411,Access3414,Access3512 bucket411
     classDef bucket412 stroke:#0000ff
-    class Bucket412 bucket412
+    class Bucket412,Access3415,Access3513 bucket412
     classDef bucket413 stroke:#7fff00
-    class Bucket413 bucket413
+    class Bucket413,Access3416,Access3514 bucket413
     classDef bucket414 stroke:#ff1493
-    class Bucket414 bucket414
+    class Bucket414,Access3417,Access3515 bucket414
     classDef bucket415 stroke:#808000
-    class Bucket415 bucket415
+    class Bucket415,Access3418,Access3516 bucket415
     classDef bucket416 stroke:#dda0dd
-    class Bucket416 bucket416
+    class Bucket416,Access3419,Access3517 bucket416
     classDef bucket417 stroke:#ff0000
-    class Bucket417 bucket417
+    class Bucket417,Access3420,Access3518 bucket417
     classDef bucket418 stroke:#ffff00
     class Bucket418,PgClassExpression3421,PgClassExpression3519,PgClassExpression3597,PgClassExpression3623,PgClassExpression3645,PgClassExpression3667,PgClassExpression3689 bucket418
     classDef bucket419 stroke:#00ffff
@@ -7713,37 +8813,37 @@ graph TD
     classDef bucket425 stroke:#696969
     class Bucket425,PgClassExpression3428,PgClassExpression3526,PgClassExpression3604,PgClassExpression3630,PgClassExpression3652,PgClassExpression3674,PgClassExpression3696 bucket425
     classDef bucket426 stroke:#00bfff
-    class Bucket426 bucket426
+    class Bucket426,Access3429,Access3527 bucket426
     classDef bucket427 stroke:#7f007f
-    class Bucket427 bucket427
+    class Bucket427,Access3430,Access3528 bucket427
     classDef bucket428 stroke:#ffa500
-    class Bucket428 bucket428
+    class Bucket428,Access3431,Access3529 bucket428
     classDef bucket429 stroke:#0000ff
-    class Bucket429 bucket429
+    class Bucket429,Access3432,Access3530 bucket429
     classDef bucket430 stroke:#7fff00
-    class Bucket430 bucket430
+    class Bucket430,Access3433,Access3531 bucket430
     classDef bucket431 stroke:#ff1493
-    class Bucket431 bucket431
+    class Bucket431,Access3434,Access3532 bucket431
     classDef bucket432 stroke:#808000
-    class Bucket432 bucket432
+    class Bucket432,Access3435,Access3533 bucket432
     classDef bucket433 stroke:#dda0dd
-    class Bucket433 bucket433
+    class Bucket433,Access3436,Access3534 bucket433
     classDef bucket434 stroke:#ff0000
-    class Bucket434 bucket434
+    class Bucket434,Access3437,Access3535 bucket434
     classDef bucket435 stroke:#ffff00
-    class Bucket435 bucket435
+    class Bucket435,Access3438,Access3536 bucket435
     classDef bucket436 stroke:#00ffff
-    class Bucket436 bucket436
+    class Bucket436,Access3439,Access3537 bucket436
     classDef bucket437 stroke:#4169e1
-    class Bucket437 bucket437
+    class Bucket437,Access3440,Access3538 bucket437
     classDef bucket438 stroke:#3cb371
-    class Bucket438 bucket438
+    class Bucket438,Access3441,Access3539 bucket438
     classDef bucket439 stroke:#a52a2a
-    class Bucket439 bucket439
+    class Bucket439,Access3442,Access3540 bucket439
     classDef bucket440 stroke:#ff00ff
-    class Bucket440 bucket440
+    class Bucket440,Access3443,Access3541 bucket440
     classDef bucket441 stroke:#f5deb3
-    class Bucket441 bucket441
+    class Bucket441,Access3444,Access3542 bucket441
     classDef bucket442 stroke:#696969
     class Bucket442,PgClassExpression3445,PgClassExpression3543,PgClassExpression3605,PgClassExpression3631,PgClassExpression3653,PgClassExpression3675,PgClassExpression3697 bucket442
     classDef bucket443 stroke:#00bfff
@@ -7773,9 +8873,9 @@ graph TD
     classDef bucket455 stroke:#3cb371
     class Bucket455,First3492,PgSelectRows3493,PgSelectSingle3494,First3586,PgSelectRows3587,PgSelectSingle3588,PgClassExpression3622,Access4430,List4431,Lambda4432,Access4434,List4435,Lambda4436 bucket455
     classDef bucket456 stroke:#a52a2a
-    class Bucket456 bucket456
+    class Bucket456,Access3497,Access3591 bucket456
     classDef bucket457 stroke:#ff00ff
-    class Bucket457 bucket457
+    class Bucket457,Access3498,Access3592 bucket457
     classDef bucket458 stroke:#f5deb3
     class Bucket458,PgClassExpression3499,PgClassExpression3593 bucket458
     classDef bucket459 stroke:#696969
@@ -7813,25 +8913,25 @@ graph TD
     classDef bucket475 stroke:#f5deb3
     class Bucket475,__Item3380 bucket475
     classDef bucket476 stroke:#696969
-    class Bucket476 bucket476
+    class Bucket476,Access3709,Access3711,Access3713,Access3715,Access3717,Access3719 bucket476
     classDef bucket477 stroke:#00bfff
-    class Bucket477 bucket477
+    class Bucket477,Access3710,Access3712,Access3714,Access3716,Access3718,Access3720 bucket477
     classDef bucket478 stroke:#7f007f
-    class Bucket478 bucket478
+    class Bucket478,Access3721,Access3745 bucket478
     classDef bucket479 stroke:#ffa500
-    class Bucket479 bucket479
+    class Bucket479,Access3722,Access3746 bucket479
     classDef bucket480 stroke:#0000ff
-    class Bucket480 bucket480
+    class Bucket480,Access3723,Access3747 bucket480
     classDef bucket481 stroke:#7fff00
-    class Bucket481 bucket481
+    class Bucket481,Access3724,Access3748 bucket481
     classDef bucket482 stroke:#ff1493
-    class Bucket482 bucket482
+    class Bucket482,Access3725,Access3749 bucket482
     classDef bucket483 stroke:#808000
-    class Bucket483 bucket483
+    class Bucket483,Access3726,Access3750 bucket483
     classDef bucket484 stroke:#dda0dd
-    class Bucket484 bucket484
+    class Bucket484,Access3727,Access3751 bucket484
     classDef bucket485 stroke:#ff0000
-    class Bucket485 bucket485
+    class Bucket485,Access3728,Access3752 bucket485
     classDef bucket486 stroke:#ffff00
     class Bucket486,PgClassExpression3729,PgClassExpression3753,PgClassExpression3769,PgClassExpression3777,PgClassExpression3785,PgClassExpression3793,PgClassExpression3801 bucket486
     classDef bucket487 stroke:#00ffff
@@ -7841,21 +8941,21 @@ graph TD
     classDef bucket489 stroke:#3cb371
     class Bucket489,PgClassExpression3732,PgClassExpression3756,PgClassExpression3772,PgClassExpression3780,PgClassExpression3788,PgClassExpression3796,PgClassExpression3804 bucket489
     classDef bucket490 stroke:#a52a2a
-    class Bucket490 bucket490
+    class Bucket490,Access3733,Access3757 bucket490
     classDef bucket491 stroke:#ff00ff
-    class Bucket491 bucket491
+    class Bucket491,Access3734,Access3758 bucket491
     classDef bucket492 stroke:#f5deb3
-    class Bucket492 bucket492
+    class Bucket492,Access3735,Access3759 bucket492
     classDef bucket493 stroke:#696969
-    class Bucket493 bucket493
+    class Bucket493,Access3736,Access3760 bucket493
     classDef bucket494 stroke:#00bfff
-    class Bucket494 bucket494
+    class Bucket494,Access3737,Access3761 bucket494
     classDef bucket495 stroke:#7f007f
-    class Bucket495 bucket495
+    class Bucket495,Access3738,Access3762 bucket495
     classDef bucket496 stroke:#ffa500
-    class Bucket496 bucket496
+    class Bucket496,Access3739,Access3763 bucket496
     classDef bucket497 stroke:#0000ff
-    class Bucket497 bucket497
+    class Bucket497,Access3740,Access3764 bucket497
     classDef bucket498 stroke:#7fff00
     class Bucket498,PgClassExpression3741,PgClassExpression3765,PgClassExpression3773,PgClassExpression3781,PgClassExpression3789,PgClassExpression3797,PgClassExpression3805 bucket498
     classDef bucket499 stroke:#ff1493


### PR DESCRIPTION
eval means that we can't run in situations where eval is forbidden, for example cloudflare workers. As such, I've removed tamedevil from the core of `grafast` - we still use it when building the schema for PostGraphile, but you can then export the schema as executable code, and that code should no longer invoke `eval()` or `new Function()`. This does mean we've traded a small amount of performance and the plan diagrams are a smidge more verbose, but I think it's worth it in terms of compatibility (and also avoiding the "discomfort" that some may feel about running eval in production).